### PR TITLE
IQ-shader W1: remapping / easing math toolkit

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -31,6 +31,9 @@ const TESTS = [
   // Geometry sanity checker (M5 prereq)
   { category: 'sanity', file: 'sdf-js/scripts/test-sanity.mjs' },
 
+  // IQ-shader program W1 — remapping / easing math toolkit (recipe-only ports)
+  { category: 'math', file: 'sdf-js/scripts/test-easing.mjs' },
+
   // M7 world runtime — determinism CI (the foundation Fable 5 asked for)
   { category: 'world', file: 'sdf-js/scripts/world/test-determinism.mjs' },
 

--- a/sdf-js/scripts/glsl-smoke.html
+++ b/sdf-js/scripts/glsl-smoke.html
@@ -1,0 +1,64 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>GLSL smoke (loading)</title>
+  </head>
+  <body>
+    <!--
+      Dev tool: compile a GLSL helper-library string in a real WebGL2 context
+      (GLSL ES 1.00 dialect, matching the studio/fly shaders) to catch GPU-only
+      compile errors (reserved words, fwidth/derivatives, ES-1.00 limits) that
+      node --check cannot. Logs "GLSL-SMOKE-OK <lib>" or "GLSL-SMOKE-FAIL ...".
+      Reused per IQ-shader wave; add the wave's library + a main() that
+      references its functions so nothing is dead-stripped.
+    -->
+    <canvas id="c" width="8" height="8"></canvas>
+    <script type="module">
+      import { EASING_GLSL } from '../src/sdf/easing.js';
+
+      const gl = document.getElementById('c').getContext('webgl2');
+      const vsSrc = 'attribute vec2 p; void main(){ gl_Position = vec4(p, 0.0, 1.0); }';
+      const fsSrc = `#ifdef GL_ES
+precision highp float;
+#endif
+${EASING_GLSL}
+void main(){
+  float s = smootherstep(0.5) + parabola(0.5, 2.0) + gain(0.3, 3.0)
+    + cubicPulse(0.5, 0.2, 0.5) + smoothstepInteg(0.7) + invSmoothstep(0.4)
+    + pcurve(0.5, 2.0, 2.0) + expImpulse(0.2, 8.0) + expStep(0.3, 5.0, 2.0)
+    + sinc(0.1, 1.0) + sigmoid(0.2) + almostIdentity(0.5, 1.0, 0.2)
+    + remap(5.0, 0.0, 10.0, 0.0, 1.0) + remapClamp(15.0, 0.0, 10.0, 0.0, 1.0)
+    + smoothstep01(0.5);
+  gl_FragColor = vec4(vec3(clamp01(s * 0.01)), 1.0);
+}`;
+
+      function compile(type, src) {
+        const sh = gl.createShader(type);
+        gl.shaderSource(sh, src);
+        gl.compileShader(sh);
+        if (!gl.getShaderParameter(sh, gl.COMPILE_STATUS)) {
+          throw new Error(gl.getShaderInfoLog(sh));
+        }
+        return sh;
+      }
+
+      try {
+        const vs = compile(gl.VERTEX_SHADER, vsSrc);
+        const fs = compile(gl.FRAGMENT_SHADER, fsSrc);
+        const pr = gl.createProgram();
+        gl.attachShader(pr, vs);
+        gl.attachShader(pr, fs);
+        gl.linkProgram(pr);
+        if (!gl.getProgramParameter(pr, gl.LINK_STATUS)) {
+          throw new Error('link: ' + gl.getProgramInfoLog(pr));
+        }
+        console.log('GLSL-SMOKE-OK easing');
+        document.title = 'SMOKE OK';
+      } catch (e) {
+        console.error('GLSL-SMOKE-FAIL ' + e.message);
+        document.title = 'SMOKE FAIL';
+      }
+    </script>
+  </body>
+</html>

--- a/sdf-js/scripts/test-easing.mjs
+++ b/sdf-js/scripts/test-easing.mjs
@@ -1,0 +1,112 @@
+// =============================================================================
+// L1 unit tests for the easing / remapping math toolkit (IQ "useful little
+// functions" + smoothstep family + sigmoid). Wave 1 of the IQ-shader program.
+// -----------------------------------------------------------------------------
+// Recipe-only ports of Inigo Quilez's functions (iquilezles.org/articles/
+// functions, smoothstep, sigmoid, smoothstepintegral, inverse smoothstep).
+// Tested by mathematical PROPERTY (endpoints / monotonicity / inverse), not by
+// magic-constant equality, so the assertions stay meaningful + robust.
+// =============================================================================
+
+import {
+  clamp01,
+  remap,
+  remapClamp,
+  smoothstep01,
+  smootherstep,
+  invSmoothstep,
+  smoothstepInteg,
+  parabola,
+  pcurve,
+  cubicPulse,
+  expImpulse,
+  expStep,
+  gain,
+  sinc,
+  sigmoid,
+  almostIdentity,
+  EASING_GLSL,
+} from '../src/sdf/easing.js';
+
+let pass = 0,
+  fail = 0;
+function ok(cond, name) {
+  if (cond) {
+    pass++;
+    console.log(`  ✓ ${name}`);
+  } else {
+    fail++;
+    console.log(`  ✗ ${name}`);
+  }
+}
+const near = (a, b, eps = 1e-4) => Math.abs(a - b) < eps;
+const monotonicInc = (f, lo = 0, hi = 1, n = 50) => {
+  let prev = -Infinity;
+  for (let i = 0; i <= n; i++) {
+    const v = f(lo + ((hi - lo) * i) / n);
+    if (v < prev - 1e-9) return false;
+    prev = v;
+  }
+  return true;
+};
+
+console.log('=== easing / remapping toolkit ===\n');
+
+console.log('clamp01 / remap');
+ok(clamp01(-1) === 0 && clamp01(2) === 1 && clamp01(0.3) === 0.3, 'clamp01 clamps to [0,1]');
+ok(near(remap(5, 0, 10, 0, 100), 50), 'remap midpoint maps linearly');
+ok(near(remap(0, 0, 10, 20, 40), 20) && near(remap(10, 0, 10, 20, 40), 40), 'remap endpoints');
+ok(near(remap(15, 0, 10, 0, 100), 150), 'remap extrapolates (no clamp)');
+ok(near(remapClamp(15, 0, 10, 0, 100), 100), 'remapClamp clamps to output range');
+
+console.log('\nsmoothstep family');
+ok(near(smoothstep01(0), 0) && near(smoothstep01(1), 1), 'smoothstep01 endpoints');
+ok(near(smoothstep01(0.5), 0.5), 'smoothstep01 symmetric midpoint');
+ok(near(smootherstep(0), 0) && near(smootherstep(1), 1), 'smootherstep endpoints');
+ok(near(smootherstep(0.5), 0.5), 'smootherstep symmetric midpoint');
+ok(monotonicInc(smootherstep), 'smootherstep monotonic increasing');
+// smootherstep has zero 1st+2nd derivative at ends → slope near 0 just inside
+ok(smootherstep(0.02) < 0.01, 'smootherstep flat near 0 (quintic ease)');
+
+console.log('\ninverse smoothstep (round-trip)');
+for (const x of [0.1, 0.25, 0.5, 0.75, 0.9]) {
+  ok(near(invSmoothstep(smoothstep01(x)), x, 1e-3), `invSmoothstep∘smoothstep(${x}) ≈ ${x}`);
+}
+
+console.log('\nsmoothstep integral');
+ok(near(smoothstepInteg(0), 0), 'integral at 0 is 0');
+ok(near(smoothstepInteg(1), 0.5), 'integral over [0,1] = 0.5 (∫ 3t²-2t³)');
+ok(near(smoothstepInteg(2), 1.5), 'integral past 1 grows linearly (x-0.5)');
+ok(
+  monotonicInc((x) => smoothstepInteg(x), 0, 3),
+  'integral monotonic',
+);
+
+console.log('\nimpulse / pulse / parabola / pcurve');
+ok(
+  near(parabola(0.5, 1), 1) && near(parabola(0, 1), 0) && near(parabola(1, 1), 0),
+  'parabola peaks mid',
+);
+ok(near(pcurve(0, 2, 2), 0) && near(pcurve(1, 2, 2), 0), 'pcurve zero at ends');
+ok(pcurve(0.5, 2, 2) > 0.99, 'pcurve(a=b) peaks ~1 at center');
+ok(near(cubicPulse(0.5, 0.2, 0.5), 1), 'cubicPulse =1 at center');
+ok(near(cubicPulse(0.5, 0.2, 0.9), 0), 'cubicPulse =0 outside width');
+ok(near(expImpulse(0, 8), 0) && expImpulse(1 / 8, 8) > 0.99, 'expImpulse peaks ~1 at x=1/k');
+ok(near(expStep(0, 5, 2), 1) && expStep(2, 5, 2) < 0.01, 'expStep starts 1, decays');
+
+console.log('\ngain / sinc / sigmoid / almostIdentity');
+ok(near(gain(0.5, 3), 0.5) && near(gain(0, 3), 0) && near(gain(1, 3), 1), 'gain fixes 0/.5/1');
+ok(near(gain(0.3, 1), 0.3), 'gain(x,1) is identity');
+ok(near(sinc(0, 1), 1), 'sinc(0)=1 (removable singularity)');
+ok(near(sigmoid(0), 0.5) && sigmoid(10) > 0.99 && sigmoid(-10) < 0.01, 'sigmoid S-curve');
+ok(near(almostIdentity(5, 1, 0.2), 5), 'almostIdentity identity above m');
+ok(near(almostIdentity(0, 1, 0.2), 0.2), 'almostIdentity lifts 0 to n');
+
+console.log('\nGLSL mirror present');
+ok(typeof EASING_GLSL === 'string' && EASING_GLSL.length > 200, 'EASING_GLSL string exported');
+for (const fn of ['smootherstep', 'parabola', 'gain', 'cubicPulse', 'smoothstepInteg']) {
+  ok(EASING_GLSL.includes(fn), `EASING_GLSL defines ${fn}`);
+}
+
+console.log(`\n=== Result: ${pass} passed, ${fail} failed ===`);
+process.exit(fail > 0 ? 1 : 0);

--- a/sdf-js/src/sdf/easing.js
+++ b/sdf-js/src/sdf/easing.js
@@ -1,0 +1,147 @@
+// =============================================================================
+// easing.js — remapping / easing math toolkit (IQ "useful little functions").
+// -----------------------------------------------------------------------------
+// Wave 1 of the IQ-shader program. Recipe-only ports (reimplemented from the
+// math, credited) of Inigo Quilez's small reusable functions:
+//   - "useful little functions"   https://iquilezles.org/articles/functions/
+//   - smoothstep / smootherstep    https://iquilezles.org/articles/smoothsteps/
+//   - inverse smoothstep           https://iquilezles.org/articles/ismoothstep/
+//   - smoothstep integral          https://iquilezles.org/articles/smoothstepintegral/
+//   - sigmoid                      https://iquilezles.org/articles/sigmoid/
+//
+// Each function ships as a JS implementation (CPU / testable) AND inside the
+// `EASING_GLSL` string (the shader-side mirror, prepended into a fragment
+// shader like noise.glsl.js / voronoi.glsl.js). Names match across both.
+//
+// License: PolyForm Noncommercial 1.0.0 (Atlas reimplementation).
+// =============================================================================
+
+export const clamp01 = (x) => (x < 0 ? 0 : x > 1 ? 1 : x);
+
+/** Linear remap [a,b] → [c,d] (no clamping; extrapolates outside [a,b]). */
+export const remap = (x, a, b, c, d) => c + ((x - a) * (d - c)) / (b - a);
+
+/** Linear remap [a,b] → [c,d] clamped to the output range. */
+export const remapClamp = (x, a, b, c, d) => c + clamp01((x - a) / (b - a)) * (d - c);
+
+/** Cubic smoothstep on [0,1] (3t²−2t³). */
+export const smoothstep01 = (x) => {
+  const t = clamp01(x);
+  return t * t * (3 - 2 * t);
+};
+
+/** Quintic smootherstep on [0,1] (zero 1st+2nd derivative at the ends). */
+export const smootherstep = (x) => {
+  const t = clamp01(x);
+  return t * t * t * (t * (t * 6 - 15) + 10);
+};
+
+/** Inverse of smoothstep01: given y in [0,1], recover x. */
+export const invSmoothstep = (y) => 0.5 - Math.sin(Math.asin(1 - 2 * clamp01(y)) / 3);
+
+/** Definite integral of smoothstep from 0 to x (clamped pieces outside [0,1]). */
+export const smoothstepInteg = (x) => {
+  if (x <= 0) return 0;
+  if (x >= 1) return x - 0.5;
+  return x * x * x - 0.5 * x * x * x * x;
+};
+
+/** Parabola peaking at 1 over x∈[0,1]; k sharpens the peak. */
+export const parabola = (x, k) => Math.pow(4 * x * (1 - x), k);
+
+/** Power curve: 0 at x=0 and x=1, peak 1 at x=a/(a+b). */
+export const pcurve = (x, a, b) => {
+  const k = Math.pow(a + b, a + b) / (Math.pow(a, a) * Math.pow(b, b));
+  return k * Math.pow(x, a) * Math.pow(1 - x, b);
+};
+
+/** Smooth pulse of half-width w centered at c (1 at center, 0 beyond w). */
+export const cubicPulse = (c, w, x) => {
+  let d = Math.abs(x - c);
+  if (d > w) return 0;
+  d /= w;
+  return 1 - d * d * (3 - 2 * d);
+};
+
+/** Exponential impulse: rises then decays, peak 1 at x = 1/k. */
+export const expImpulse = (x, k) => {
+  const h = k * x;
+  return h * Math.exp(1 - h);
+};
+
+/** Exponential step / falloff: 1 at x=0, decaying with k·xⁿ. */
+export const expStep = (x, k, n) => Math.exp(-k * Math.pow(x, n));
+
+/** Gain: contrast S-curve fixing 0, 0.5, 1; gain(x,1) is the identity. */
+export const gain = (x, k) => {
+  const a = 0.5 * Math.pow(2 * (x < 0.5 ? x : 1 - x), k);
+  return x < 0.5 ? a : 1 - a;
+};
+
+/** Normalized sinc with frequency k; sinc(0,k)=1 (removable singularity). */
+export const sinc = (x, k) => {
+  if (x === 0) return 1;
+  const a = Math.PI * k * x;
+  return Math.sin(a) / a;
+};
+
+/** Logistic sigmoid 1/(1+e^−x); sigmoid(0)=0.5. */
+export const sigmoid = (x) => 1 / (1 + Math.exp(-x));
+
+/** Almost-identity: identity for x≥m, smoothly lifts small x up to a floor n. */
+export const almostIdentity = (x, m, n) => {
+  if (x > m) return x;
+  const a = 2 * n - m;
+  const b = 2 * m - 3 * n;
+  const t = x / m;
+  return (a * t + b) * t * t + n;
+};
+
+// -----------------------------------------------------------------------------
+// GLSL mirror — prepend into a fragment shader. Function names match the JS API.
+// (Not yet wired into a renderer; consumed starting in the W3 filtering wave,
+// where it gets its first real GPU compile + browser verification.)
+// -----------------------------------------------------------------------------
+export const EASING_GLSL = /* glsl */ `
+float clamp01(float x){ return clamp(x, 0.0, 1.0); }
+float remap(float x, float a, float b, float c, float d){ return c + (x-a)*(d-c)/(b-a); }
+float remapClamp(float x, float a, float b, float c, float d){ return c + clamp01((x-a)/(b-a))*(d-c); }
+float smoothstep01(float x){ float t = clamp01(x); return t*t*(3.0-2.0*t); }
+float smootherstep(float x){ float t = clamp01(x); return t*t*t*(t*(t*6.0-15.0)+10.0); }
+float invSmoothstep(float y){ return 0.5 - sin(asin(1.0-2.0*clamp01(y))/3.0); }
+float smoothstepInteg(float x){
+  if (x <= 0.0) return 0.0;
+  if (x >= 1.0) return x - 0.5;
+  return x*x*x - 0.5*x*x*x*x;
+}
+float parabola(float x, float k){ return pow(4.0*x*(1.0-x), k); }
+float pcurve(float x, float a, float b){
+  float k = pow(a+b, a+b) / (pow(a,a)*pow(b,b));
+  return k * pow(x,a) * pow(1.0-x, b);
+}
+float cubicPulse(float c, float w, float x){
+  float d = abs(x-c);
+  if (d > w) return 0.0;
+  d /= w;
+  return 1.0 - d*d*(3.0-2.0*d);
+}
+float expImpulse(float x, float k){ float h = k*x; return h*exp(1.0-h); }
+float expStep(float x, float k, float n){ return exp(-k*pow(x,n)); }
+float gain(float x, float k){
+  float a = 0.5*pow(2.0*((x<0.5)?x:1.0-x), k);
+  return (x<0.5) ? a : 1.0-a;
+}
+float sinc(float x, float k){
+  if (x == 0.0) return 1.0;
+  float a = 3.14159265359*k*x;
+  return sin(a)/a;
+}
+float sigmoid(float x){ return 1.0/(1.0+exp(-x)); }
+float almostIdentity(float x, float m, float n){
+  if (x > m) return x;
+  float a = 2.0*n - m;
+  float b = 2.0*m - 3.0*n;
+  float t = x/m;
+  return (a*t+b)*t*t + n;
+}
+`;


### PR DESCRIPTION
## What — Wave 1 of the IQ shader-technique program

First of 11 waves implementing **all shader-related IQ techniques** into sdf-js (user directive: build capability ahead of customer need). This wave is the foundation layer: IQ "useful little functions" + smoothstep family + sigmoid, as a reusable toolkit consumed by later waves (filtering / lighting / animation).

**`src/sdf/easing.js`** — JS (CPU/testable) + `EASING_GLSL` mirror string (shader-side, identical names):
`clamp01, remap, remapClamp, smoothstep01, smootherstep, invSmoothstep, smoothstepInteg, parabola, pcurve, cubicPulse, expImpulse, expStep, gain, sinc, sigmoid, almostIdentity`

Recipe-only ports (reimplemented from the math, credited) of: useful-little-functions, smoothsteps, ismoothstep, smoothstepintegral, sigmoid articles.

## Verification
- **39 property-based assertions** (endpoints / monotonicity / inverse round-trip — not magic-constant equality). Full suite **39/39**.
- New **`scripts/glsl-smoke.html`** compiles `EASING_GLSL` in a real WebGL2 context (GLSL ES 1.00 dialect, matching studio/fly shaders) → headless-browser verified **`GLSL-SMOKE-OK`**. The shader mirror is GPU-clean from day one, and this harness is reusable for every later wave (catches reserved-word / derivative / ES-1.00 traps `node --check` can't).
- `node --check` + Prettier clean.

## Scope
Pure additive library + dev harness. No renderer wired to it yet (consumed starting W3). Zero behaviour change to existing renderers.

Next: W2 (noise — derivatives, domain warping, voronoise/edges).

🤖 Generated with [Claude Code](https://claude.com/claude-code)