### PR TITLE
IQ-shader W3: band-limited filtering / texturing toolkit

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -35,6 +35,8 @@ const TESTS = [
   { category: 'math', file: 'sdf-js/scripts/test-easing.mjs' },
   // IQ-shader program W2 — noise w/ analytic derivatives, warp, voronoise/edges
   { category: 'math', file: 'sdf-js/scripts/test-noise.mjs' },
+  // IQ-shader program W3 — band-limited filtering / texturing (checker/grid/etc)
+  { category: 'math', file: 'sdf-js/scripts/test-filter.mjs' },
 
   // M7 world runtime — determinism CI (the foundation Fable 5 asked for)
   { category: 'world', file: 'sdf-js/scripts/world/test-determinism.mjs' },

--- a/sdf-js/scripts/glsl-smoke.html
+++ b/sdf-js/scripts/glsl-smoke.html
@@ -17,6 +17,7 @@
     <script type="module">
       import { EASING_GLSL } from '../src/sdf/easing.js';
       import { NOISE_GLSL } from '../src/sdf/noise.js';
+      import { FILTER_GLSL } from '../src/sdf/filter.js';
 
       const gl = document.getElementById('c').getContext('webgl2');
       const vsSrc = 'attribute vec2 p; void main(){ gl_Position = vec4(p, 0.0, 1.0); }';
@@ -25,6 +26,7 @@ precision highp float;
 #endif
 ${EASING_GLSL}
 ${NOISE_GLSL}
+${FILTER_GLSL}
 void main(){
   float s = smootherstep(0.5) + parabola(0.5, 2.0) + gain(0.3, 3.0)
     + cubicPulse(0.5, 0.2, 0.5) + smoothstepInteg(0.7) + invSmoothstep(0.4)
@@ -36,6 +38,12 @@ void main(){
   s += valueNoiseD2(p).x + valueNoiseD3(vec3(p, 0.5)).x + gradientNoiseD2(p).x
     + fbmD2(p, 5).x + domainWarp2(p) + voronoise2(p, 1.0, 0.5)
     + voronoiSmooth2(p, 8.0) + voronoiEdges2(p).y;
+  s += checkersFiltered(p, vec2(0.01)) + gridFiltered(p, 0.05, vec2(0.01))
+    + triWaveFiltered(0.3, 0.1) + stripesFiltered(0.3, 0.1)
+    + filterWidth(5.0, 900.0, 0.5, 1.5) + biplanarWeights(vec3(0.1, 0.9, 0.05), 8.0).y
+    + srgbToLinear(vec3(0.5)).x + linearToSrgb(vec3(0.5)).x
+    + premultOver(vec3(1.0, 0.0, 0.0), 1.0, vec3(0.0, 0.0, 1.0), 1.0).x
+    + improvedBilinearUV(vec2(2.5)).x;
   gl_FragColor = vec4(vec3(clamp01(s * 0.01)), 1.0);
 }`;
 
@@ -59,7 +67,7 @@ void main(){
         if (!gl.getProgramParameter(pr, gl.LINK_STATUS)) {
           throw new Error('link: ' + gl.getProgramInfoLog(pr));
         }
-        console.log('GLSL-SMOKE-OK easing+noise');
+        console.log('GLSL-SMOKE-OK easing+noise+filter');
         document.title = 'SMOKE OK';
       } catch (e) {
         console.error('GLSL-SMOKE-FAIL ' + e.message);

--- a/sdf-js/scripts/test-filter.mjs
+++ b/sdf-js/scripts/test-filter.mjs
@@ -1,0 +1,136 @@
+// =============================================================================
+// L1 unit tests for the filtering / texturing toolkit (IQ texturing & filtering
+// articles). Wave 3 of the IQ-shader program.
+// -----------------------------------------------------------------------------
+// Recipe-only ports of Inigo Quilez:
+//   filterable / band-limited procedurals  https://iquilezles.org/articles/filterableprocedurals/
+//   (improved) analytic checker filtering   https://iquilezles.org/articles/checkerfiltering/
+//   ray differentials                       https://iquilezles.org/articles/filtering/
+//   texture repetition (no-tile)            https://iquilezles.org/articles/texturerepetition/
+//   biplanar mapping                        https://iquilezles.org/articles/biplanar/
+//   improved bilinear / hardware interp     https://iquilezles.org/articles/bilinear/ , /hwinterpolation/
+//   premultiplied alpha                     https://iquilezles.org/articles/premultipliedalpha/
+//   gamma-correct blurring                  https://iquilezles.org/articles/gamma/
+//
+// Core property of every band-limited pattern: as the filter width w → 0 it
+// reduces to the hard pattern; as w → large it converges to the pattern's mean.
+// =============================================================================
+
+import {
+  filterWidth,
+  triWave,
+  triWaveFiltered,
+  checkersFiltered,
+  gridFiltered,
+  stripesFiltered,
+  noTile,
+  biplanarWeights,
+  srgbToLinear,
+  linearToSrgb,
+  premultOver,
+  improvedBilinearUV,
+  FILTER_GLSL,
+} from '../src/sdf/filter.js';
+
+let pass = 0,
+  fail = 0;
+function ok(cond, name) {
+  if (cond) {
+    pass++;
+    console.log(`  ✓ ${name}`);
+  } else {
+    fail++;
+    console.log(`  ✗ ${name}`);
+  }
+}
+const near = (a, b, eps = 2e-3) => Math.abs(a - b) < eps;
+
+console.log('=== filtering / texturing toolkit ===\n');
+
+console.log('filterWidth (ray-differential footprint)');
+ok(filterWidth(10, 900, 0.5) > filterWidth(2, 900, 0.5), 'footprint grows with distance');
+ok(filterWidth(5, 900, 0.1) > filterWidth(5, 900, 0.9), 'footprint grows at grazing angle');
+ok(filterWidth(5, 1800, 0.5) < filterWidth(5, 900, 0.5), 'footprint shrinks at higher resolution');
+
+console.log('\ntriangle wave + band-limited triangle');
+ok(near(triWave(0), 1) && near(triWave(0.5), 0) && near(triWave(1), 1), 'triWave shape [1,0,1]');
+ok(near(triWaveFiltered(0.3, 1e-4), triWave(0.3), 5e-3), 'triWaveFiltered(w→0) ≈ triWave');
+ok(near(triWaveFiltered(0.3, 50), 0.5, 1e-2), 'triWaveFiltered(w→∞) → mean 0.5');
+ok(
+  triWaveFiltered(0.3, 0.2) > 0 && triWaveFiltered(0.3, 0.2) < 1,
+  'triWaveFiltered partial in (0,1)',
+);
+
+console.log('\nanalytic checker filtering');
+// hard checker at a tiny footprint: integer-cell parity → ~0 or ~1
+ok(
+  checkersFiltered(0.5, 0.5, 1e-4, 1e-4) < 0.05,
+  'checkersFiltered tight → near a tile (cell (0,0))',
+);
+ok(
+  checkersFiltered(1.5, 0.5, 1e-4, 1e-4) > 0.95,
+  'checkersFiltered tight → opposite tile (cell (1,0))',
+);
+ok(near(checkersFiltered(0.5, 0.5, 100, 100), 0.5, 2e-2), 'checkersFiltered wide → grey 0.5');
+
+console.log('\ngrid + stripes (filtered)');
+ok(gridFiltered(0.0, 0.0, 0.05, 1e-4, 1e-4) > 0.5, 'gridFiltered on a line → high');
+ok(gridFiltered(0.5, 0.5, 0.05, 1e-4, 1e-4) < 0.5, 'gridFiltered between lines → low');
+ok(
+  near(stripesFiltered(0.25, 1e-4), 0) || near(stripesFiltered(0.25, 1e-4), 1),
+  'stripesFiltered tight → 0/1',
+);
+ok(near(stripesFiltered(0.25, 50), 0.5, 2e-2), 'stripesFiltered wide → 0.5');
+
+console.log('\ntexture no-tile + biplanar weights');
+ok(noTile(2.1, 3.4, (x, y) => 0.42) === 0.42, 'noTile of a constant field is that constant');
+ok(
+  noTile(2.1, 3.4, (x, y) => Math.sin(x) * 0.5 + 0.5) ===
+    noTile(2.1, 3.4, (x, y) => Math.sin(x) * 0.5 + 0.5),
+  'noTile deterministic',
+);
+{
+  const w = biplanarWeights(0.1, 0.95, 0.05, 8); // mostly +Y
+  ok(near(w[0] + w[1] + w[2], 1, 1e-5), 'biplanar weights sum to 1');
+  ok(w[1] > w[0] && w[1] > w[2], 'biplanar dominant axis (Y) has largest weight');
+}
+
+console.log('\ngamma (sRGB ↔ linear)');
+ok(near(srgbToLinear(0), 0) && near(srgbToLinear(1), 1), 'srgbToLinear endpoints');
+ok(srgbToLinear(0.5) < 0.5, 'srgbToLinear darkens midtones (decoding)');
+for (const c of [0.05, 0.2, 0.5, 0.8])
+  ok(near(linearToSrgb(srgbToLinear(c)), c, 1e-4), `gamma round-trip ${c}`);
+
+console.log('\npremultiplied-alpha over');
+{
+  // opaque src over anything → src color, alpha 1
+  const r = premultOver([1, 0, 0], 1, [0, 0, 1], 1);
+  ok(near(r[0], 1) && near(r[1], 0) && near(r[2], 0) && near(r[3], 1), 'opaque src wins');
+  // zero-alpha src over dst → dst
+  const r2 = premultOver([1, 1, 1], 0, [0.2, 0.4, 0.6], 1);
+  ok(near(r2[0], 0.2) && near(r2[1], 0.4) && near(r2[2], 0.6), 'transparent src → dst shows');
+}
+
+console.log('\nimproved bilinear UV');
+{
+  const uv = improvedBilinearUV(2.5, 3.5, 64);
+  ok(Math.abs(uv[0] - 2.5) < 0.02 && Math.abs(uv[1] - 3.5) < 0.02, 'improvedBilinearUV near input');
+  // at an exact texel center the correction is ~0
+  const uv2 = improvedBilinearUV(2.0, 3.0, 64);
+  ok(near(uv2[0], 2.0, 1e-3) && near(uv2[1], 3.0, 1e-3), 'no correction at texel center');
+}
+
+console.log('\nGLSL mirror present');
+ok(typeof FILTER_GLSL === 'string' && FILTER_GLSL.length > 300, 'FILTER_GLSL exported');
+for (const fn of [
+  'checkersFiltered',
+  'gridFiltered',
+  'triWaveFiltered',
+  'biplanarWeights',
+  'srgbToLinear',
+]) {
+  ok(FILTER_GLSL.includes(fn), `FILTER_GLSL defines ${fn}`);
+}
+
+console.log(`\n=== Result: ${pass} passed, ${fail} failed ===`);
+process.exit(fail > 0 ? 1 : 0);

--- a/sdf-js/src/sdf/filter.js
+++ b/sdf-js/src/sdf/filter.js
@@ -1,0 +1,225 @@
+// =============================================================================
+// filter.js — filtering / texturing toolkit (IQ texturing & filtering articles).
+// -----------------------------------------------------------------------------
+// Wave 3 of the IQ-shader program. Recipe-only ports of Inigo Quilez:
+//   filterable / band-limited procedurals, (improved) analytic checker filtering,
+//   ray differentials, texture repetition (no-tile), biplanar mapping, improved
+//   bilinear / hardware interpolation, premultiplied alpha, gamma-correct blur.
+//
+// Every band-limited pattern is an analytic box-filter: integrate the periodic
+// signal, sample the integral at the two footprint edges, divide by the width.
+// As w → 0 it reduces to the hard pattern; as w → ∞ it converges to the mean.
+//
+// JS (CPU/testable) + a GLSL mirror string (FILTER_GLSL). License: PolyForm
+// Noncommercial 1.0.0 (Atlas reimplementation).
+// =============================================================================
+
+const fract = (x) => x - Math.floor(x);
+
+/** Analytic pixel footprint on a surface (ray differentials, no fwidth needed).
+ *  Grows with hit distance and with grazing angle (1/|rdY|), shrinks with res. */
+export function filterWidth(dist, resY, rdY, focal = 1.5) {
+  return (dist * (2.0 / Math.max(resY, 1))) / focal / Math.max(Math.abs(rdY), 0.12);
+}
+
+// ---- Triangle wave + band-limited triangle ----------------------------------
+
+/** Periodic triangle wave, range [0,1], period 1: tri(0)=1, tri(0.5)=0. */
+export const triWave = (x) => Math.abs(2 * fract(x) - 1);
+
+// Integral of triWave from 0 to x (per-period area = 0.5).
+function intTri(x) {
+  const fl = Math.floor(x);
+  const t = x - fl;
+  const f = t <= 0.5 ? t - t * t : t * t - t + 0.5;
+  return fl * 0.5 + f;
+}
+
+/** Band-limited triangle wave over footprint w (box filter). */
+export function triWaveFiltered(x, w) {
+  if (w < 1e-6) return triWave(x);
+  return (intTri(x + 0.5 * w) - intTri(x - 0.5 * w)) / w;
+}
+
+// ---- Analytic filtered checkerboard (IQ improved) ---------------------------
+
+/** Box-filtered XOR checkerboard. Period 2 in (x,y); returns 0..1, 0.5 at distance. */
+export function checkersFiltered(x, y, wx, wy) {
+  wx = Math.max(wx, 1e-5);
+  wy = Math.max(wy, 1e-5);
+  const ix =
+    (2 *
+      (Math.abs(fract((x - 0.5 * wx) * 0.5) - 0.5) - Math.abs(fract((x + 0.5 * wx) * 0.5) - 0.5))) /
+    wx;
+  const iy =
+    (2 *
+      (Math.abs(fract((y - 0.5 * wy) * 0.5) - 0.5) - Math.abs(fract((y + 0.5 * wy) * 0.5) - 0.5))) /
+    wy;
+  return 0.5 - 0.5 * ix * iy;
+}
+
+// ---- Filtered grid + stripes ------------------------------------------------
+
+const smoothstep = (e0, e1, x) => {
+  const t = Math.max(0, Math.min(1, (x - e0) / (e1 - e0)));
+  return t * t * (3 - 2 * t);
+};
+// Distance from x to the nearest integer, in [0,0.5].
+const distToInt = (x) => 0.5 - Math.abs(fract(x) - 0.5);
+
+/** Anti-aliased grid lines (1 on a line of half-width lw, 0 between), footprint w. */
+export function gridFiltered(x, y, lw, wx, wy) {
+  const lineX = 1 - smoothstep(lw, lw + Math.max(wx, 1e-4), distToInt(x));
+  const lineY = 1 - smoothstep(lw, lw + Math.max(wy, 1e-4), distToInt(y));
+  return Math.max(lineX, lineY);
+}
+
+// Integral of the 0/1 square wave (=1 for fract(x) ≥ 0.5) from 0 to x.
+function sqInt(x) {
+  const fl = Math.floor(x);
+  return fl * 0.5 + Math.max(0, x - fl - 0.5);
+}
+
+/** Band-limited 0/1 stripes over footprint w. */
+export function stripesFiltered(x, w) {
+  if (w < 1e-6) return fract(x) >= 0.5 ? 1 : 0;
+  return (sqInt(x + 0.5 * w) - sqInt(x - 0.5 * w)) / w;
+}
+
+// ---- Texture repetition breaker (no-tile) -----------------------------------
+
+function hashCell(x, y) {
+  let h = fract(Math.sin(x * 127.1 + y * 311.7) * 43758.5453);
+  return h;
+}
+
+/** IQ no-tile: blend per-cell offset samples of a procedural field to hide the
+ *  obvious lattice periodicity. A constant field stays constant. */
+export function noTile(x, y, fn) {
+  const ix = Math.floor(x),
+    iy = Math.floor(y);
+  const fx = x - ix,
+    fy = y - iy;
+  const wx = fx * fx * (3 - 2 * fx);
+  const wy = fy * fy * (3 - 2 * fy);
+  const sample = (cx, cy) => {
+    const h = hashCell(cx, cy);
+    return fn(x + h * 0.41 + cx * 0.0, y + fract(h * 7.3) * 0.41);
+  };
+  const s00 = sample(ix, iy);
+  const s10 = sample(ix + 1, iy);
+  const s01 = sample(ix, iy + 1);
+  const s11 = sample(ix + 1, iy + 1);
+  const top = s00 + (s10 - s00) * wx;
+  const bot = s01 + (s11 - s01) * wx;
+  return top + (bot - top) * wy;
+}
+
+// ---- Biplanar mapping weights ----------------------------------------------
+
+/** Biplanar projection weights: drop the smallest-normal axis, keep the two
+ *  dominant planes. k sharpens the blend. Returns [wx, wy, wz] summing to 1. */
+export function biplanarWeights(nx, ny, nz, k = 8) {
+  const a = [Math.abs(nx), Math.abs(ny), Math.abs(nz)];
+  let mi = 0;
+  if (a[1] < a[mi]) mi = 1;
+  if (a[2] < a[mi]) mi = 2;
+  const w = [Math.pow(a[0], k), Math.pow(a[1], k), Math.pow(a[2], k)];
+  w[mi] = 0;
+  const s = w[0] + w[1] + w[2] || 1;
+  return [w[0] / s, w[1] / s, w[2] / s];
+}
+
+// ---- Gamma (sRGB ↔ linear), for gamma-correct blending ----------------------
+
+export const srgbToLinear = (c) => (c <= 0.04045 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4));
+export const linearToSrgb = (c) =>
+  c <= 0.0031308 ? 12.92 * c : 1.055 * Math.pow(c, 1 / 2.4) - 0.055;
+
+// ---- Premultiplied-alpha "over" composite -----------------------------------
+
+/** Straight-alpha "over" computed via premultiplied math. Returns [r,g,b,a]. */
+export function premultOver(s, sa, d, da) {
+  const a = sa + da * (1 - sa);
+  if (a < 1e-9) return [0, 0, 0, 0];
+  return [
+    (s[0] * sa + d[0] * da * (1 - sa)) / a,
+    (s[1] * sa + d[1] * da * (1 - sa)) / a,
+    (s[2] * sa + d[2] * da * (1 - sa)) / a,
+    a,
+  ];
+}
+
+// ---- Improved bilinear / hardware interpolation -----------------------------
+
+/** Smooth the fractional part of a texel coordinate (quintic) so bilinear taps
+ *  read as higher-order. Texel-space in, texel-space out; identity at centers. */
+export function improvedBilinearUV(u, v) {
+  const q = (x) => {
+    const i = Math.floor(x),
+      f = x - i;
+    return i + f * f * f * (f * (f * 6 - 15) + 10);
+  };
+  return [q(u), q(v)];
+}
+
+// -----------------------------------------------------------------------------
+// GLSL mirror. (noTile needs a sampler callback → omitted here; use per-renderer.)
+// -----------------------------------------------------------------------------
+export const FILTER_GLSL = /* glsl */ `
+float filterWidth(float dist, float resY, float rdY, float focal){
+  return dist * (2.0/max(resY,1.0)) / focal / max(abs(rdY), 0.12);
+}
+float triWave(float x){ return abs(2.0*fract(x)-1.0); }
+float intTri(float x){
+  float fl = floor(x); float t = x - fl;
+  float f = (t <= 0.5) ? (t - t*t) : (t*t - t + 0.5);
+  return fl*0.5 + f;
+}
+float triWaveFiltered(float x, float w){
+  if (w < 1e-6) return triWave(x);
+  return (intTri(x + 0.5*w) - intTri(x - 0.5*w)) / w;
+}
+float checkersFiltered(vec2 p, vec2 w){
+  w = max(w, vec2(1e-5));
+  vec2 i = 2.0*(abs(fract((p-0.5*w)*0.5)-0.5) - abs(fract((p+0.5*w)*0.5)-0.5))/w;
+  return 0.5 - 0.5*i.x*i.y;
+}
+float distToInt(float x){ return 0.5 - abs(fract(x)-0.5); }
+float gridFiltered(vec2 p, float lw, vec2 w){
+  float lx = 1.0 - smoothstep(lw, lw+max(w.x,1e-4), distToInt(p.x));
+  float ly = 1.0 - smoothstep(lw, lw+max(w.y,1e-4), distToInt(p.y));
+  return max(lx, ly);
+}
+float sqInt(float x){ float fl = floor(x); return fl*0.5 + max(0.0, x - fl - 0.5); }
+float stripesFiltered(float x, float w){
+  if (w < 1e-6) return (fract(x) >= 0.5) ? 1.0 : 0.0;
+  return (sqInt(x + 0.5*w) - sqInt(x - 0.5*w)) / w;
+}
+vec3 biplanarWeights(vec3 n, float k){
+  vec3 a = abs(n);
+  vec3 w = pow(a, vec3(k));
+  // drop the smallest axis (keep the two dominant planes)
+  if (a.x <= a.y && a.x <= a.z) w.x = 0.0;
+  else if (a.y <= a.x && a.y <= a.z) w.y = 0.0;
+  else w.z = 0.0;
+  float s = w.x + w.y + w.z;
+  return w / max(s, 1e-6);
+}
+vec3 srgbToLinear(vec3 c){
+  return mix(c/12.92, pow((c+0.055)/1.055, vec3(2.4)), step(0.04045, c));
+}
+vec3 linearToSrgb(vec3 c){
+  return mix(12.92*c, 1.055*pow(c, vec3(1.0/2.4)) - 0.055, step(0.0031308, c));
+}
+vec4 premultOver(vec3 s, float sa, vec3 d, float da){
+  float a = sa + da*(1.0-sa);
+  if (a < 1e-9) return vec4(0.0);
+  vec3 rgb = (s*sa + d*da*(1.0-sa)) / a;
+  return vec4(rgb, a);
+}
+vec2 improvedBilinearUV(vec2 uv){
+  vec2 i = floor(uv), f = fract(uv);
+  return i + f*f*f*(f*(f*6.0-15.0)+10.0);
+}
+`;


### PR DESCRIPTION
## What — Wave 3 of the IQ shader-technique program (★★★★★)

The "clean like Shadertoy" layer: every procedural pattern band-limited so it anti-aliases instead of shimmering — generalizing the studio filtered-checker win to **all** patterns. Recipe-only ports of IQ texturing & filtering articles. JS (CPU/testable) + `FILTER_GLSL` mirror.

**`src/sdf/filter.js`** — IQ #65–76:
| function | purpose |
| --- | --- |
| `filterWidth` | analytic ray-differential footprint (distance + grazing, no `fwidth`) |
| `triWave` / `triWaveFiltered` | band-limited triangle (box-filter via integral) |
| `checkersFiltered` | IQ improved analytic checker (explicit footprint) |
| `gridFiltered` / `stripesFiltered` | anti-aliased grid lines / stripes |
| `noTile` | texture-repetition breaker (per-cell offset blend) |
| `biplanarWeights` | 2-dominant-plane projection weights |
| `srgbToLinear` / `linearToSrgb` | gamma-correct blending |
| `premultOver` | premultiplied-alpha "over" composite |
| `improvedBilinearUV` | quintic-smoothed texel interpolation |

## Verification
- **34 assertions.** Every band-limited pattern verified by the core property: **w→0 reduces to the hard pattern, w→large converges to the mean** (the definition of correct anti-aliasing) — checker, triangle, stripes all pass. Plus gamma round-trip, premult identities, biplanar normalization.
- `FILTER_GLSL` compiles + links with `EASING_GLSL` + `NOISE_GLSL` in a real WebGL2 context → **`GLSL-SMOKE-OK easing+noise+filter`** (headless).
- Full suite **41/41**, `node --check` + Prettier clean.

## Scope
Additive library. Not yet wired into a renderer (a later pass can route studio's checker + the pattern atoms through these). Zero behaviour change.

Next: W4 (lighting — outdoors model, fog, AO variants, GI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)