### PR TITLE
IQ-shader W4: lighting toolkit (sphere AO/shadow, outdoor model, fog)

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -37,6 +37,8 @@ const TESTS = [
   { category: 'math', file: 'sdf-js/scripts/test-noise.mjs' },
   // IQ-shader program W3 — band-limited filtering / texturing (checker/grid/etc)
   { category: 'math', file: 'sdf-js/scripts/test-filter.mjs' },
+  // IQ-shader program W4 — lighting (sphere AO/shadow, outdoor model, fog)
+  { category: 'math', file: 'sdf-js/scripts/test-lighting.mjs' },
 
   // M7 world runtime — determinism CI (the foundation Fable 5 asked for)
   { category: 'world', file: 'sdf-js/scripts/world/test-determinism.mjs' },

--- a/sdf-js/scripts/glsl-smoke.html
+++ b/sdf-js/scripts/glsl-smoke.html
@@ -18,6 +18,7 @@
       import { EASING_GLSL } from '../src/sdf/easing.js';
       import { NOISE_GLSL } from '../src/sdf/noise.js';
       import { FILTER_GLSL } from '../src/sdf/filter.js';
+      import { LIGHTING_GLSL } from '../src/sdf/lighting.js';
 
       const gl = document.getElementById('c').getContext('webgl2');
       const vsSrc = 'attribute vec2 p; void main(){ gl_Position = vec4(p, 0.0, 1.0); }';
@@ -27,6 +28,7 @@ precision highp float;
 ${EASING_GLSL}
 ${NOISE_GLSL}
 ${FILTER_GLSL}
+${LIGHTING_GLSL}
 void main(){
   float s = smootherstep(0.5) + parabola(0.5, 2.0) + gain(0.3, 3.0)
     + cubicPulse(0.5, 0.2, 0.5) + smoothstepInteg(0.7) + invSmoothstep(0.4)
@@ -44,6 +46,13 @@ void main(){
     + srgbToLinear(vec3(0.5)).x + linearToSrgb(vec3(0.5)).x
     + premultOver(vec3(1.0, 0.0, 0.0), 1.0, vec3(0.0, 0.0, 1.0), 1.0).x
     + improvedBilinearUV(vec2(2.5)).x;
+  s += sphereAO(vec3(0.0), vec3(0.0, 0.0, 1.0), vec4(0.0, 0.0, 1.2, 1.0))
+    + sphereSoftShadow(vec3(0.0), vec3(0.0, 0.0, 1.0), vec4(0.0, 0.0, 5.0, 1.0), 8.0)
+    + fresnelSchlick(0.5, 0.04) + hemisphereLight(0.5)
+    + outdoorLighting(vec3(0.0, 1.0, 0.0), vec3(0.0, 1.0, 0.0), 1.0, 1.0, vec3(1.0),
+        vec3(1.0), vec3(0.4, 0.6, 1.0), vec3(0.3, 0.25, 0.2)).x
+    + betterFog(vec3(0.2, 0.5, 0.8), 100.0, vec3(0.0, 0.0, 1.0), vec3(1.0, 0.0, 0.0),
+        vec3(0.7, 0.8, 0.9), vec3(1.0, 0.9, 0.7), 0.02).x;
   gl_FragColor = vec4(vec3(clamp01(s * 0.01)), 1.0);
 }`;
 
@@ -67,7 +76,7 @@ void main(){
         if (!gl.getProgramParameter(pr, gl.LINK_STATUS)) {
           throw new Error('link: ' + gl.getProgramInfoLog(pr));
         }
-        console.log('GLSL-SMOKE-OK easing+noise+filter');
+        console.log('GLSL-SMOKE-OK easing+noise+filter+lighting');
         document.title = 'SMOKE OK';
       } catch (e) {
         console.error('GLSL-SMOKE-FAIL ' + e.message);

--- a/sdf-js/scripts/test-lighting.mjs
+++ b/sdf-js/scripts/test-lighting.mjs
@@ -1,0 +1,125 @@
+// =============================================================================
+// L1 unit tests for the lighting toolkit (IQ lighting articles). Wave 4 of the
+// IQ-shader program.
+// -----------------------------------------------------------------------------
+// Recipe-only ports of Inigo Quilez:
+//   outdoors lighting     https://iquilezles.org/articles/outdoorslighting/
+//   better fog            https://iquilezles.org/articles/fog/
+//   sphere occlusion (AO) https://iquilezles.org/articles/sphereao/
+//   sphere soft shadow    https://iquilezles.org/articles/sphereshadow/
+//   (+ Schlick fresnel, hemisphere sky term)
+//
+// Analytic occlusion / shadow are closed-form → directly testable against the
+// physical expectation (near occluder darkens; behind/away does nothing).
+// =============================================================================
+
+import {
+  sphereAO,
+  sphereSoftShadow,
+  fresnelSchlick,
+  hemisphereLight,
+  outdoorLighting,
+  betterFog,
+  LIGHTING_GLSL,
+} from '../src/sdf/lighting.js';
+
+let pass = 0,
+  fail = 0;
+function ok(cond, name) {
+  if (cond) {
+    pass++;
+    console.log(`  ✓ ${name}`);
+  } else {
+    fail++;
+    console.log(`  ✗ ${name}`);
+  }
+}
+const near = (a, b, eps = 2e-3) => Math.abs(a - b) < eps;
+
+console.log('=== lighting toolkit ===\n');
+
+console.log('sphere analytic AO (1 = unoccluded)');
+{
+  const pos = [0, 0, 0],
+    nor = [0, 0, 1];
+  const aoNear = sphereAO(pos, nor, [0, 0, 1.2], 1);
+  const aoFar = sphereAO(pos, nor, [0, 0, 20], 1);
+  const aoBehind = sphereAO(pos, nor, [0, 0, -2], 1);
+  ok(aoNear < aoFar, 'near occluder darkens more than far');
+  ok(aoFar > 0.98, 'distant sphere ≈ unoccluded');
+  ok(near(aoBehind, 1, 1e-3), 'sphere behind the surface causes no occlusion');
+  ok(aoNear >= 0 && aoNear <= 1, 'AO in [0,1]');
+}
+
+console.log('\nsphere soft shadow (1 = lit, 0 = shadowed)');
+{
+  const toward = sphereSoftShadow([0, 0, 0], [0, 0, 1], [0, 0, 5], 1, 8);
+  const away = sphereSoftShadow([0, 0, 0], [0, 0, -1], [0, 0, 5], 1, 8);
+  ok(toward < 0.05, 'ray straight at the sphere → shadowed');
+  ok(near(away, 1, 1e-6), 'ray away from the sphere → fully lit');
+}
+
+console.log('\nSchlick fresnel');
+ok(near(fresnelSchlick(1, 0.04), 0.04), 'fresnel at normal incidence → F0');
+ok(near(fresnelSchlick(0, 0.04), 1), 'fresnel at grazing → 1');
+ok(fresnelSchlick(0.5, 0.04) > 0.04, 'fresnel rises off-axis');
+
+console.log('\nhemisphere sky term');
+ok(
+  near(hemisphereLight(1), 1) && near(hemisphereLight(-1), 0) && near(hemisphereLight(0), 0.5),
+  'hemisphere 0.5+0.5·n.y',
+);
+
+console.log('\noutdoor lighting composition');
+{
+  const nor = [0, 1, 0],
+    sun = [0, 1, 0],
+    alb = [1, 1, 1];
+  const sunCol = [1, 1, 1],
+    skyCol = [0.4, 0.6, 1],
+    bnc = [0.3, 0.25, 0.2];
+  const lit = outdoorLighting(nor, sun, 1, 1, alb, sunCol, skyCol, bnc);
+  const shadowed = outdoorLighting(nor, sun, 0, 1, alb, sunCol, skyCol, bnc);
+  ok(lit[0] > shadowed[0], 'sun visibility brightens');
+  const noAO = outdoorLighting(nor, sun, 1, 0, alb, sunCol, skyCol, bnc);
+  // with ao=0 only the sun term survives → exactly albedo*sunCol*ndotl*vis
+  ok(near(noAO[2], 1 * 1 * 1 * 1, 1e-6), 'ao=0 kills sky+bounce, leaves sun term');
+  ok(lit[2] > noAO[2], 'ambient (sky+bounce) adds light on top of sun');
+}
+
+console.log('\nbetter fog');
+{
+  const col = [0.2, 0.5, 0.8],
+    rd = [0, 0, 1],
+    sun = [1, 0, 0];
+  const fogCol = [0.7, 0.8, 0.9],
+    sunFog = [1, 0.9, 0.7];
+  const near0 = betterFog(col, 0, rd, sun, fogCol, sunFog, 0.02);
+  ok(
+    near(near0[0], col[0]) && near(near0[1], col[1]) && near(near0[2], col[2]),
+    'no fog at distance 0',
+  );
+  const far = betterFog(col, 1000, rd, sun, fogCol, sunFog, 0.02);
+  ok(
+    near(far[0], fogCol[0], 1e-2) && near(far[2], fogCol[2], 1e-2),
+    'fully fogged far → fog colour',
+  );
+  // sun-aligned ray gets the warm in-scatter colour
+  const alignedFar = betterFog(col, 1000, [1, 0, 0], [1, 0, 0], fogCol, sunFog, 0.02);
+  ok(alignedFar[0] > far[0], 'sun-aligned fog is warmer (more red)');
+}
+
+console.log('\nGLSL mirror present');
+ok(typeof LIGHTING_GLSL === 'string' && LIGHTING_GLSL.length > 300, 'LIGHTING_GLSL exported');
+for (const fn of [
+  'sphereAO',
+  'sphereSoftShadow',
+  'outdoorLighting',
+  'betterFog',
+  'fresnelSchlick',
+]) {
+  ok(LIGHTING_GLSL.includes(fn), `LIGHTING_GLSL defines ${fn}`);
+}
+
+console.log(`\n=== Result: ${pass} passed, ${fail} failed ===`);
+process.exit(fail > 0 ? 1 : 0);

--- a/sdf-js/src/sdf/lighting.js
+++ b/sdf-js/src/sdf/lighting.js
@@ -1,0 +1,158 @@
+// =============================================================================
+// lighting.js — lighting toolkit (IQ lighting articles). Wave 4 of the IQ-shader
+// program.
+// -----------------------------------------------------------------------------
+// Recipe-only ports of Inigo Quilez:
+//   sphere occlusion (analytic AO)  https://iquilezles.org/articles/sphereao/
+//   sphere soft shadow (analytic)   https://iquilezles.org/articles/sphereshadow/
+//   outdoors lighting               https://iquilezles.org/articles/outdoorslighting/
+//   better fog                      https://iquilezles.org/articles/fog/
+//   (+ Schlick fresnel, hemisphere sky term)
+//
+// The occlusion / shadow forms are closed-form (no scene sampling) → testable
+// against physical expectation. JS (CPU/testable) + GLSL mirror (LIGHTING_GLSL).
+// License: PolyForm Noncommercial 1.0.0 (Atlas reimplementation).
+//
+// Deferred to W11 (need screen-space depth or are mesh-only, not pure SDF math):
+// SSAO, per-vertex AO, multi-resolution AO, analytic box occlusion.
+// =============================================================================
+
+const clamp01 = (x) => (x < 0 ? 0 : x > 1 ? 1 : x);
+const smoothstep01 = (x) => {
+  const t = clamp01(x);
+  return t * t * (3 - 2 * t);
+};
+const dot3 = (a, b) => a[0] * b[0] + a[1] * b[1] + a[2] * b[2];
+
+// ---- Sphere analytic ambient occlusion --------------------------------------
+
+// IQ exact sphere occlusion ∈ [0,1] (1 = fully occluded over the hemisphere).
+function sphOcclusion(pos, nor, sc, sr) {
+  const dx = sc[0] - pos[0],
+    dy = sc[1] - pos[1],
+    dz = sc[2] - pos[2];
+  const l = Math.hypot(dx, dy, dz);
+  const nl = (nor[0] * dx + nor[1] * dy + nor[2] * dz) / l;
+  const h = l / sr;
+  const h2 = h * h;
+  const k2 = 1 - h2 * nl * nl;
+  let res = Math.max(0, nl) / h2;
+  if (k2 > 0.001 && h2 > 1 && 1 - nl * nl > 1e-6) {
+    res = nl * Math.acos(-nl * Math.sqrt((h2 - 1) / (1 - nl * nl))) - Math.sqrt(k2 * (h2 - 1));
+    res = (res / h2 + Math.atan(Math.sqrt(k2 / (h2 - 1)))) / Math.PI;
+  }
+  return res;
+}
+
+/** Sphere ambient-occlusion factor ∈ [0,1]; 1 = unoccluded, lower = more shadow. */
+export function sphereAO(pos, nor, sphereCenter, sphereRadius) {
+  return 1 - clamp01(sphOcclusion(pos, nor, sphereCenter, sphereRadius));
+}
+
+// ---- Sphere analytic soft shadow --------------------------------------------
+
+/** Soft shadow cast by a sphere along ray ro+t·rd ∈ [0,1]; 1 = lit, 0 = shadowed. */
+export function sphereSoftShadow(ro, rd, sphereCenter, sphereRadius, k) {
+  const ox = ro[0] - sphereCenter[0],
+    oy = ro[1] - sphereCenter[1],
+    oz = ro[2] - sphereCenter[2];
+  const b = ox * rd[0] + oy * rd[1] + oz * rd[2];
+  const c = ox * ox + oy * oy + oz * oz - sphereRadius * sphereRadius;
+  const h = b * b - c;
+  const d = Math.sqrt(Math.max(0, sphereRadius * sphereRadius - h)) - sphereRadius;
+  const t = -b - Math.sqrt(Math.max(0, h));
+  if (t < 0) return 1;
+  return smoothstep01((2.5 * k * d) / t);
+}
+
+// ---- Fresnel + hemisphere ---------------------------------------------------
+
+/** Schlick fresnel: F0 at normal incidence (cos=1) → 1 at grazing (cos=0). */
+export const fresnelSchlick = (cosTheta, F0) => F0 + (1 - F0) * Math.pow(1 - clamp01(cosTheta), 5);
+
+/** Hemisphere sky-dome factor: 0.5 + 0.5·n.y (1 facing up, 0 facing down). */
+export const hemisphereLight = (ny) => 0.5 + 0.5 * ny;
+
+// ---- Outdoors lighting model ------------------------------------------------
+
+/** IQ outdoor 3-term model: sun key (×visibility) + sky dome (×AO) + ground
+ *  bounce (×AO). Returns linear RGB. All ambient terms are AO-modulated so
+ *  crevices darken (the thing flat single-light shading lacks). */
+export function outdoorLighting(nor, sunDir, sunVis, ao, albedo, sunCol, skyCol, bounceCol) {
+  const ndl = Math.max(0, dot3(nor, sunDir));
+  const sky = 0.5 + 0.5 * nor[1];
+  const bounce = clamp01(0.5 - 0.5 * nor[1]);
+  const out = [0, 0, 0];
+  for (let i = 0; i < 3; i++) {
+    out[i] =
+      albedo[i] * sunCol[i] * ndl * sunVis +
+      albedo[i] * skyCol[i] * sky * ao +
+      albedo[i] * bounceCol[i] * bounce * ao;
+  }
+  return out;
+}
+
+// ---- Better fog (distance extinction + sun in-scatter) ----------------------
+
+/** IQ better fog: extinction by distance + warm in-scatter toward the sun. */
+export function betterFog(col, dist, rd, sunDir, fogCol, sunFogCol, density) {
+  const fogAmount = 1 - Math.exp(-dist * density);
+  const sunAmount = Math.max(0, dot3(rd, sunDir));
+  const k = Math.pow(sunAmount, 8);
+  const out = [0, 0, 0];
+  for (let i = 0; i < 3; i++) {
+    const fc = fogCol[i] + (sunFogCol[i] - fogCol[i]) * k;
+    out[i] = col[i] + (fc - col[i]) * fogAmount;
+  }
+  return out;
+}
+
+// -----------------------------------------------------------------------------
+// GLSL mirror.
+// -----------------------------------------------------------------------------
+export const LIGHTING_GLSL = /* glsl */ `
+float sphOcclusion(vec3 pos, vec3 nor, vec4 sph){
+  vec3 di = sph.xyz - pos;
+  float l = length(di);
+  float nl = dot(nor, di/l);
+  float h = l/sph.w;
+  float h2 = h*h;
+  float k2 = 1.0 - h2*nl*nl;
+  float res = max(0.0, nl)/h2;
+  if (k2 > 0.001 && h2 > 1.0 && (1.0-nl*nl) > 1e-6){
+    res = nl*acos(-nl*sqrt((h2-1.0)/(1.0-nl*nl))) - sqrt(k2*(h2-1.0));
+    res = (res/h2 + atan(sqrt(k2/(h2-1.0))))/3.14159265;
+  }
+  return res;
+}
+float sphereAO(vec3 pos, vec3 nor, vec4 sph){
+  return 1.0 - clamp(sphOcclusion(pos, nor, sph), 0.0, 1.0);
+}
+float sphereSoftShadow(vec3 ro, vec3 rd, vec4 sph, float k){
+  vec3 oc = ro - sph.xyz;
+  float b = dot(oc, rd);
+  float c = dot(oc, oc) - sph.w*sph.w;
+  float h = b*b - c;
+  float d = sqrt(max(0.0, sph.w*sph.w - h)) - sph.w;
+  float t = -b - sqrt(max(0.0, h));
+  if (t < 0.0) return 1.0;
+  return smoothstep(0.0, 1.0, 2.5*k*d/t);
+}
+float fresnelSchlick(float cosTheta, float F0){
+  return F0 + (1.0-F0)*pow(1.0 - clamp(cosTheta,0.0,1.0), 5.0);
+}
+float hemisphereLight(float ny){ return 0.5 + 0.5*ny; }
+vec3 outdoorLighting(vec3 nor, vec3 sunDir, float sunVis, float ao, vec3 albedo,
+                     vec3 sunCol, vec3 skyCol, vec3 bounceCol){
+  float ndl = max(0.0, dot(nor, sunDir));
+  float sky = 0.5 + 0.5*nor.y;
+  float bounce = clamp(0.5 - 0.5*nor.y, 0.0, 1.0);
+  return albedo*sunCol*ndl*sunVis + albedo*skyCol*sky*ao + albedo*bounceCol*bounce*ao;
+}
+vec3 betterFog(vec3 col, float dist, vec3 rd, vec3 sunDir, vec3 fogCol, vec3 sunFogCol, float density){
+  float fogAmount = 1.0 - exp(-dist*density);
+  float sunAmount = max(0.0, dot(rd, sunDir));
+  vec3 fc = mix(fogCol, sunFogCol, pow(sunAmount, 8.0));
+  return mix(col, fc, fogAmount);
+}
+`;


### PR DESCRIPTION
## What — Wave 4 of the IQ shader-technique program

Lighting, recipe-only ports of IQ articles. JS (CPU/testable) + `LIGHTING_GLSL` mirror.

**`src/sdf/lighting.js`** — IQ #24, #77, #78, #104:
| function | purpose |
| --- | --- |
| `sphereAO` | analytic sphere ambient occlusion (closed form) |
| `sphereSoftShadow` | analytic sphere soft shadow (closed form) |
| `fresnelSchlick` | Schlick fresnel |
| `hemisphereLight` | sky-dome term (0.5 + 0.5·n.y) |
| `outdoorLighting` | 3-term model — sun key ×visibility + sky ×AO + bounce ×AO |
| `betterFog` | distance extinction + warm sun in-scatter |

## Verification
- **22 assertions**, occlusion/shadow checked against physics (near occluder darkens, behind/away does nothing; ray-at-sphere → shadowed, ray-away → lit); fresnel endpoints; outdoor model (sun brightens, AO gates ambient); fog (none at d=0, → fog colour far, warmer when sun-aligned).
- `LIGHTING_GLSL` compiles + links with the W1–3 libraries → **`GLSL-SMOKE-OK easing+noise+filter+lighting`** (headless).
- Full suite **42/42**, `node --check` + Prettier clean.

## Deferred to W11
SSAO, per-vertex AO, multi-resolution AO, analytic box occlusion — these need a depth buffer or are mesh-only (not pure SDF math), so they belong in the cleanup wave.

## Scope
Additive library. Not yet wired into a renderer. Zero behaviour change.

Next: W5 (SDF + analytic gradients — exact normals / AA / outlines).

🤖 Generated with [Claude Code](https://claude.com/claude-code)