### PR TITLE
IQ-shader W5: SDFs with analytic gradients (sdg*)

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -39,6 +39,8 @@ const TESTS = [
   { category: 'math', file: 'sdf-js/scripts/test-filter.mjs' },
   // IQ-shader program W4 — lighting (sphere AO/shadow, outdoor model, fog)
   { category: 'math', file: 'sdf-js/scripts/test-lighting.mjs' },
+  // IQ-shader program W5 — SDFs with analytic gradients (sdg*)
+  { category: 'math', file: 'sdf-js/scripts/test-sdg.mjs' },
 
   // M7 world runtime — determinism CI (the foundation Fable 5 asked for)
   { category: 'world', file: 'sdf-js/scripts/world/test-determinism.mjs' },

--- a/sdf-js/scripts/glsl-smoke.html
+++ b/sdf-js/scripts/glsl-smoke.html
@@ -19,6 +19,7 @@
       import { NOISE_GLSL } from '../src/sdf/noise.js';
       import { FILTER_GLSL } from '../src/sdf/filter.js';
       import { LIGHTING_GLSL } from '../src/sdf/lighting.js';
+      import { SDG_GLSL } from '../src/sdf/sdg.js';
 
       const gl = document.getElementById('c').getContext('webgl2');
       const vsSrc = 'attribute vec2 p; void main(){ gl_Position = vec4(p, 0.0, 1.0); }';
@@ -29,6 +30,7 @@ ${EASING_GLSL}
 ${NOISE_GLSL}
 ${FILTER_GLSL}
 ${LIGHTING_GLSL}
+${SDG_GLSL}
 void main(){
   float s = smootherstep(0.5) + parabola(0.5, 2.0) + gain(0.3, 3.0)
     + cubicPulse(0.5, 0.2, 0.5) + smoothstepInteg(0.7) + invSmoothstep(0.4)
@@ -53,6 +55,10 @@ void main(){
         vec3(1.0), vec3(0.4, 0.6, 1.0), vec3(0.3, 0.25, 0.2)).x
     + betterFog(vec3(0.2, 0.5, 0.8), 100.0, vec3(0.0, 0.0, 1.0), vec3(1.0, 0.0, 0.0),
         vec3(0.7, 0.8, 0.9), vec3(1.0, 0.9, 0.7), 0.02).x;
+  s += sdgCircle(p, 1.0).x + sdgBox(p, vec2(1.0, 0.6)).y
+    + sdgSegment(p, vec2(-1.0, 0.0), vec2(1.0, 0.0)).z
+    + sdgSphere(vec3(p, 0.5), 1.0).x + sdgBox3(vec3(p, 0.5), vec3(1.0, 0.7, 0.5)).y
+    + sdgTorus(vec3(p, 0.5), 1.0, 0.3).z;
   gl_FragColor = vec4(vec3(clamp01(s * 0.01)), 1.0);
 }`;
 
@@ -76,7 +82,7 @@ void main(){
         if (!gl.getProgramParameter(pr, gl.LINK_STATUS)) {
           throw new Error('link: ' + gl.getProgramInfoLog(pr));
         }
-        console.log('GLSL-SMOKE-OK easing+noise+filter+lighting');
+        console.log('GLSL-SMOKE-OK easing+noise+filter+lighting+sdg');
         document.title = 'SMOKE OK';
       } catch (e) {
         console.error('GLSL-SMOKE-FAIL ' + e.message);

--- a/sdf-js/scripts/test-sdg.mjs
+++ b/sdf-js/scripts/test-sdg.mjs
@@ -1,0 +1,167 @@
+// =============================================================================
+// L1 unit tests for the SDF-with-gradient toolkit (IQ sdg articles). Wave 5 of
+// the IQ-shader program.
+// -----------------------------------------------------------------------------
+// Recipe-only ports of Inigo Quilez:
+//   2D SDFs and gradients  https://iquilezles.org/articles/distgradfunctions2d/
+//   3D SDFs and gradients  https://iquilezles.org/articles/distgradfunctions/
+//
+// Each sdg* returns [distance, ...gradient]. A true signed-distance field has a
+// UNIT gradient that points away from the surface, so the two invariants are:
+//   (1) the gradient ≈ central finite-difference of the distance channel
+//   (2) |gradient| ≈ 1 (away from the medial axis / surface)
+// =============================================================================
+
+import {
+  sdgCircle,
+  sdgBox,
+  sdgSegment,
+  sdgSphere,
+  sdgBox3,
+  sdgTorus,
+  SDG_GLSL,
+} from '../src/sdf/sdg.js';
+
+let pass = 0,
+  fail = 0;
+function ok(cond, name) {
+  if (cond) {
+    pass++;
+    console.log(`  ✓ ${name}`);
+  } else {
+    fail++;
+    console.log(`  ✗ ${name}`);
+  }
+}
+const near = (a, b, eps = 3e-3) => Math.abs(a - b) < eps;
+const len2 = (x, y) => Math.hypot(x, y);
+const len3 = (x, y, z) => Math.hypot(x, y, z);
+
+// Finite-difference gradient of the distance channel (index 0) of an sdg fn.
+function fd2(f, px, py, h = 1e-4) {
+  return [
+    (f(px + h, py)[0] - f(px - h, py)[0]) / (2 * h),
+    (f(px, py + h)[0] - f(px, py - h)[0]) / (2 * h),
+  ];
+}
+function fd3(f, px, py, pz, h = 1e-4) {
+  return [
+    (f(px + h, py, pz)[0] - f(px - h, py, pz)[0]) / (2 * h),
+    (f(px, py + h, pz)[0] - f(px, py - h, pz)[0]) / (2 * h),
+    (f(px, py, pz + h)[0] - f(px, py, pz - h)[0]) / (2 * h),
+  ];
+}
+
+console.log('=== SDF + gradient toolkit ===\n');
+
+console.log('2D circle');
+{
+  const f = (x, y) => sdgCircle(x, y, 1);
+  ok(f(2, 0)[0] > 0 && f(0, 0)[0] < 0, 'circle distance sign (outside>0, center<0)');
+  for (const [x, y] of [
+    [2, 0],
+    [1.5, 1.5],
+    [-2, 1],
+  ]) {
+    const g = f(x, y);
+    const d = fd2(f, x, y);
+    ok(near(g[1], d[0]) && near(g[2], d[1]), `sdgCircle grad ≈ FD at (${x},${y})`);
+    ok(near(len2(g[1], g[2]), 1, 1e-3), `sdgCircle |grad| ≈ 1 at (${x},${y})`);
+  }
+}
+
+console.log('\n2D box');
+{
+  const f = (x, y) => sdgBox(x, y, 1, 0.6);
+  ok(f(3, 0)[0] > 0 && f(0, 0)[0] < 0, 'box distance sign');
+  for (const [x, y] of [
+    [2, 0],
+    [1.4, 1.1],
+    [-2, -1.5],
+  ]) {
+    const g = f(x, y);
+    const d = fd2(f, x, y);
+    ok(near(g[1], d[0]) && near(g[2], d[1]), `sdgBox grad ≈ FD at (${x},${y})`);
+    ok(near(len2(g[1], g[2]), 1, 1e-3), `sdgBox |grad| ≈ 1 at (${x},${y})`);
+  }
+}
+
+console.log('\n2D segment');
+{
+  const f = (x, y) => sdgSegment(x, y, -1, 0, 1, 0);
+  for (const [x, y] of [
+    [0, 1],
+    [1.5, 0.5],
+    [-1.5, -0.7],
+  ]) {
+    const g = f(x, y);
+    const d = fd2(f, x, y);
+    ok(near(g[1], d[0]) && near(g[2], d[1]), `sdgSegment grad ≈ FD at (${x},${y})`);
+    ok(near(len2(g[1], g[2]), 1, 1e-3), `sdgSegment |grad| ≈ 1 at (${x},${y})`);
+  }
+}
+
+console.log('\n3D sphere');
+{
+  const f = (x, y, z) => sdgSphere(x, y, z, 1);
+  ok(f(2, 0, 0)[0] > 0 && f(0, 0, 0)[0] < 0, 'sphere distance sign');
+  for (const [x, y, z] of [
+    [2, 0, 0],
+    [1, 1, 1],
+    [-1.5, 0.5, 1],
+  ]) {
+    const g = f(x, y, z);
+    const d = fd3(f, x, y, z);
+    ok(
+      near(g[1], d[0]) && near(g[2], d[1]) && near(g[3], d[2]),
+      `sdgSphere grad ≈ FD at (${x},${y},${z})`,
+    );
+    ok(near(len3(g[1], g[2], g[3]), 1, 1e-3), `sdgSphere |grad| ≈ 1`);
+  }
+}
+
+console.log('\n3D box');
+{
+  const f = (x, y, z) => sdgBox3(x, y, z, 1, 0.7, 0.5);
+  ok(f(3, 0, 0)[0] > 0 && f(0, 0, 0)[0] < 0, 'box3 distance sign');
+  for (const [x, y, z] of [
+    [2, 0, 0],
+    [1.4, 1.1, 0.9],
+    [-2, -1.5, 1.2],
+  ]) {
+    const g = f(x, y, z);
+    const d = fd3(f, x, y, z);
+    ok(
+      near(g[1], d[0]) && near(g[2], d[1]) && near(g[3], d[2]),
+      `sdgBox3 grad ≈ FD at (${x},${y},${z})`,
+    );
+    ok(near(len3(g[1], g[2], g[3]), 1, 1e-3), `sdgBox3 |grad| ≈ 1`);
+  }
+}
+
+console.log('\n3D torus');
+{
+  const f = (x, y, z) => sdgTorus(x, y, z, 1, 0.3);
+  for (const [x, y, z] of [
+    [2, 0, 0],
+    [1.2, 0.4, 0.3],
+    [0, 0.6, 1.3],
+  ]) {
+    const g = f(x, y, z);
+    const d = fd3(f, x, y, z);
+    ok(
+      near(g[1], d[0]) && near(g[2], d[1]) && near(g[3], d[2]),
+      `sdgTorus grad ≈ FD at (${x},${y},${z})`,
+    );
+    ok(near(len3(g[1], g[2], g[3]), 1, 1e-3), `sdgTorus |grad| ≈ 1`);
+  }
+}
+
+console.log('\nGLSL mirror present');
+ok(typeof SDG_GLSL === 'string' && SDG_GLSL.length > 300, 'SDG_GLSL exported');
+for (const fn of ['sdgCircle', 'sdgBox', 'sdgSegment', 'sdgSphere', 'sdgTorus']) {
+  ok(SDG_GLSL.includes(fn), `SDG_GLSL defines ${fn}`);
+}
+
+console.log(`\n=== Result: ${pass} passed, ${fail} failed ===`);
+process.exit(fail > 0 ? 1 : 0);

--- a/sdf-js/src/sdf/sdg.js
+++ b/sdf-js/src/sdf/sdg.js
@@ -1,0 +1,133 @@
+// =============================================================================
+// sdg.js — signed distance functions that also return their gradient (IQ).
+// -----------------------------------------------------------------------------
+// Wave 5 of the IQ-shader program. Recipe-only ports of Inigo Quilez:
+//   2D SDFs + gradients  https://iquilezles.org/articles/distgradfunctions2d/
+//   3D SDFs + gradients  https://iquilezles.org/articles/distgradfunctions/
+//
+// Each sdg* returns [distance, ...gradient]. The gradient is the analytic
+// surface normal / outline direction — exact, unit-length, and free of the
+// finite-difference artifacts that 4–6-tap numerical normals carry. Useful for
+// crisp 2D outlines/bevels and fast exact 3D normals.
+//
+// JS (CPU/testable) + GLSL mirror (SDG_GLSL). License: PolyForm Noncommercial.
+// =============================================================================
+
+const sgn = (x) => (x < 0 ? -1 : 1);
+
+// ---- 2D (return [d, gx, gy]) ------------------------------------------------
+
+export function sdgCircle(px, py, r) {
+  const l = Math.hypot(px, py) || 1e-20;
+  return [l - r, px / l, py / l];
+}
+
+export function sdgBox(px, py, bx, by) {
+  const wx = Math.abs(px) - bx,
+    wy = Math.abs(py) - by;
+  const sx = sgn(px),
+    sy = sgn(py);
+  const g = Math.max(wx, wy);
+  const qx = Math.max(wx, 0),
+    qy = Math.max(wy, 0);
+  const l = Math.hypot(qx, qy) || 1e-20;
+  if (g > 0) return [l, (sx * qx) / l, (sy * qy) / l];
+  return wx > wy ? [g, sx, 0] : [g, 0, sy];
+}
+
+export function sdgSegment(px, py, ax, ay, bx, by) {
+  const pax = px - ax,
+    pay = py - ay;
+  const bax = bx - ax,
+    bay = by - ay;
+  const h = Math.max(0, Math.min(1, (pax * bax + pay * bay) / (bax * bax + bay * bay)));
+  const qx = pax - h * bax,
+    qy = pay - h * bay;
+  const d = Math.hypot(qx, qy) || 1e-20;
+  return [d, qx / d, qy / d];
+}
+
+// ---- 3D (return [d, nx, ny, nz]) --------------------------------------------
+
+export function sdgSphere(px, py, pz, r) {
+  const l = Math.hypot(px, py, pz) || 1e-20;
+  return [l - r, px / l, py / l, pz / l];
+}
+
+export function sdgBox3(px, py, pz, bx, by, bz) {
+  const wx = Math.abs(px) - bx,
+    wy = Math.abs(py) - by,
+    wz = Math.abs(pz) - bz;
+  const sx = sgn(px),
+    sy = sgn(py),
+    sz = sgn(pz);
+  const g = Math.max(wx, wy, wz);
+  if (g > 0) {
+    const qx = Math.max(wx, 0),
+      qy = Math.max(wy, 0),
+      qz = Math.max(wz, 0);
+    const l = Math.hypot(qx, qy, qz) || 1e-20;
+    return [l, (sx * qx) / l, (sy * qy) / l, (sz * qz) / l];
+  }
+  // inside: gradient points along the nearest face (dominant axis)
+  if (wx >= wy && wx >= wz) return [g, sx, 0, 0];
+  if (wy >= wx && wy >= wz) return [g, 0, sy, 0];
+  return [g, 0, 0, sz];
+}
+
+export function sdgTorus(px, py, pz, R, r) {
+  const lxz = Math.hypot(px, pz) || 1e-20;
+  const qx = lxz - R,
+    qy = py;
+  const k = Math.hypot(qx, qy) || 1e-20;
+  return [k - r, (qx / k) * (px / lxz), qy / k, (qx / k) * (pz / lxz)];
+}
+
+// -----------------------------------------------------------------------------
+// GLSL mirror.
+// -----------------------------------------------------------------------------
+export const SDG_GLSL = /* glsl */ `
+vec3 sdgCircle(vec2 p, float r){
+  float l = max(length(p), 1e-20);
+  return vec3(l - r, p/l);
+}
+vec3 sdgBox(vec2 p, vec2 b){
+  vec2 w = abs(p) - b;
+  vec2 s = vec2(p.x < 0.0 ? -1.0 : 1.0, p.y < 0.0 ? -1.0 : 1.0);
+  float g = max(w.x, w.y);
+  vec2 q = max(w, 0.0);
+  float l = max(length(q), 1e-20);
+  if (g > 0.0) return vec3(l, s*q/l);
+  return (w.x > w.y) ? vec3(g, s.x, 0.0) : vec3(g, 0.0, s.y);
+}
+vec3 sdgSegment(vec2 p, vec2 a, vec2 b){
+  vec2 pa = p-a, ba = b-a;
+  float h = clamp(dot(pa,ba)/dot(ba,ba), 0.0, 1.0);
+  vec2 q = pa - h*ba;
+  float d = max(length(q), 1e-20);
+  return vec3(d, q/d);
+}
+vec4 sdgSphere(vec3 p, float r){
+  float l = max(length(p), 1e-20);
+  return vec4(l - r, p/l);
+}
+vec4 sdgBox3(vec3 p, vec3 b){
+  vec3 w = abs(p) - b;
+  vec3 s = vec3(p.x<0.0?-1.0:1.0, p.y<0.0?-1.0:1.0, p.z<0.0?-1.0:1.0);
+  float g = max(w.x, max(w.y, w.z));
+  if (g > 0.0){
+    vec3 q = max(w, 0.0);
+    float l = max(length(q), 1e-20);
+    return vec4(l, s*q/l);
+  }
+  if (w.x >= w.y && w.x >= w.z) return vec4(g, s.x, 0.0, 0.0);
+  if (w.y >= w.x && w.y >= w.z) return vec4(g, 0.0, s.y, 0.0);
+  return vec4(g, 0.0, 0.0, s.z);
+}
+vec4 sdgTorus(vec3 p, float R, float r){
+  float lxz = max(length(p.xz), 1e-20);
+  vec2 q = vec2(lxz - R, p.y);
+  float k = max(length(q), 1e-20);
+  return vec4(k - r, (q.x/k)*(p.x/lxz), q.y/k, (q.x/k)*(p.z/lxz));
+}
+`;


### PR DESCRIPTION
## What — Wave 5 of the IQ shader-technique program

Signed distance functions that **also return their exact gradient** — the analytic surface normal / outline direction, free of finite-difference artifacts. Recipe-only ports of IQ #4/#5. JS (CPU/testable) + `SDG_GLSL` mirror.

**`src/sdf/sdg.js`** — each returns `[distance, ...gradient]`:
- 2D: `sdgCircle`, `sdgBox`, `sdgSegment` → `[d, gx, gy]`
- 3D: `sdgSphere`, `sdgBox3`, `sdgTorus` → `[d, nx, ny, nz]`

## Verification
- **46 assertions** — the two defining SDF invariants checked at multiple points per primitive:
  1. gradient ≈ central **finite-difference** of the distance channel
  2. **|gradient| ≈ 1** (unit length, as a true distance field requires)
  
  plus distance-sign correctness.
- `SDG_GLSL` compiles + links with the W1–4 libraries → **`GLSL-SMOKE-OK easing+noise+filter+lighting+sdg`** (headless).
- Full suite **43/43**, `node --check` + Prettier clean.

## Use cases
Crisp 2D outlines/bevels (editorial text & shapes) and fast **exact** 3D normals without 4–6-tap numerical differencing.

## Scope
Additive library. Not yet wired into a renderer. Zero behaviour change.

Next: W6 (★★★★★ SDF bounds + auto-framing — bbox → camera fit, fixes the manual-scale pain; sphere projection; bounding volumes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)