### PR TITLE
IQ-shader W6: bounds / auto-framing toolkit

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -41,6 +41,8 @@ const TESTS = [
   { category: 'math', file: 'sdf-js/scripts/test-lighting.mjs' },
   // IQ-shader program W5 — SDFs with analytic gradients (sdg*)
   { category: 'math', file: 'sdf-js/scripts/test-sdg.mjs' },
+  // IQ-shader program W6 — bounds / auto-framing (bbox, camera-fit, bounding vol)
+  { category: 'math', file: 'sdf-js/scripts/test-bounds.mjs' },
 
   // M7 world runtime — determinism CI (the foundation Fable 5 asked for)
   { category: 'world', file: 'sdf-js/scripts/world/test-determinism.mjs' },

--- a/sdf-js/scripts/glsl-smoke.html
+++ b/sdf-js/scripts/glsl-smoke.html
@@ -20,6 +20,7 @@
       import { FILTER_GLSL } from '../src/sdf/filter.js';
       import { LIGHTING_GLSL } from '../src/sdf/lighting.js';
       import { SDG_GLSL } from '../src/sdf/sdg.js';
+      import { BOUNDS_GLSL } from '../src/sdf/bounds.js';
 
       const gl = document.getElementById('c').getContext('webgl2');
       const vsSrc = 'attribute vec2 p; void main(){ gl_Position = vec4(p, 0.0, 1.0); }';
@@ -31,6 +32,7 @@ ${NOISE_GLSL}
 ${FILTER_GLSL}
 ${LIGHTING_GLSL}
 ${SDG_GLSL}
+${BOUNDS_GLSL}
 void main(){
   float s = smootherstep(0.5) + parabola(0.5, 2.0) + gain(0.3, 3.0)
     + cubicPulse(0.5, 0.2, 0.5) + smoothstepInteg(0.7) + invSmoothstep(0.4)
@@ -59,6 +61,8 @@ void main(){
     + sdgSegment(p, vec2(-1.0, 0.0), vec2(1.0, 0.0)).z
     + sdgSphere(vec3(p, 0.5), 1.0).x + sdgBox3(vec3(p, 0.5), vec3(1.0, 0.7, 0.5)).y
     + sdgTorus(vec3(p, 0.5), 1.0, 0.3).z;
+  s += sphereProjRadius(5.0, 1.0, 1.5) + sdBoxLinf(vec3(p, 0.5), vec3(1.0))
+    + sdBoundingBox(vec3(p, 0.5), vec3(-1.5), vec3(1.5));
   gl_FragColor = vec4(vec3(clamp01(s * 0.01)), 1.0);
 }`;
 
@@ -82,7 +86,7 @@ void main(){
         if (!gl.getProgramParameter(pr, gl.LINK_STATUS)) {
           throw new Error('link: ' + gl.getProgramInfoLog(pr));
         }
-        console.log('GLSL-SMOKE-OK easing+noise+filter+lighting+sdg');
+        console.log('GLSL-SMOKE-OK easing+noise+filter+lighting+sdg+bounds');
         document.title = 'SMOKE OK';
       } catch (e) {
         console.error('GLSL-SMOKE-FAIL ' + e.message);

--- a/sdf-js/scripts/test-bounds.mjs
+++ b/sdf-js/scripts/test-bounds.mjs
@@ -1,0 +1,122 @@
+// =============================================================================
+// L1 unit tests for the bounds / auto-framing toolkit (IQ bounding articles).
+// Wave 6 of the IQ-shader program.
+// -----------------------------------------------------------------------------
+// Recipe-only ports / applications of Inigo Quilez:
+//   3D / 2D bounding boxes   https://iquilezles.org/articles/diskbbox/ (family)
+//   sphere projection        https://iquilezles.org/articles/sphereproj/
+//   SDF bounding volumes     https://iquilezles.org/articles/sdfbounding/
+//   L∞-norm SDFs             https://iquilezles.org/articles/distfunctions2dlinf/
+//
+// Headline: bbox(SDF) → camera-fit, so any atom/deck auto-frames (no more
+// hand-scaling subjects to suit a fixed studio camera).
+// =============================================================================
+
+import {
+  bbox3FromSDF,
+  cameraFitFromBBox,
+  sphereProjRadius,
+  boundedSDF,
+  sdBoxLinf,
+  BOUNDS_GLSL,
+} from '../src/sdf/bounds.js';
+
+let pass = 0,
+  fail = 0;
+function ok(cond, name) {
+  if (cond) {
+    pass++;
+    console.log(`  ✓ ${name}`);
+  } else {
+    fail++;
+    console.log(`  ✗ ${name}`);
+  }
+}
+const near = (a, b, eps = 0.2) => Math.abs(a - b) < eps;
+
+// Test SDFs (p = [x,y,z]).
+const sphere =
+  (r, c = [0, 0, 0]) =>
+  (p) =>
+    Math.hypot(p[0] - c[0], p[1] - c[1], p[2] - c[2]) - r;
+const box =
+  (b, c = [0, 0, 0]) =>
+  (p) => {
+    const q = [
+      Math.abs(p[0] - c[0]) - b[0],
+      Math.abs(p[1] - c[1]) - b[1],
+      Math.abs(p[2] - c[2]) - b[2],
+    ];
+    const o = Math.hypot(Math.max(q[0], 0), Math.max(q[1], 0), Math.max(q[2], 0));
+    return o + Math.min(Math.max(q[0], q[1], q[2]), 0);
+  };
+
+console.log('=== bounds / auto-framing toolkit ===\n');
+
+console.log('bbox3FromSDF');
+{
+  const bb = bbox3FromSDF(sphere(1), { radius: 3, res: 48 });
+  ok(
+    near(bb.min[0], -1) && near(bb.max[0], 1),
+    `unit sphere x-extent ≈ ±1 (${bb.min[0].toFixed(2)}..${bb.max[0].toFixed(2)})`,
+  );
+  ok(near(bb.min[1], -1) && near(bb.max[1], 1), 'unit sphere y-extent ≈ ±1');
+  ok(near(bb.min[2], -1) && near(bb.max[2], 1), 'unit sphere z-extent ≈ ±1');
+}
+{
+  const bb = bbox3FromSDF(box([0.5, 0.8, 0.3], [1, 0, 0]), { radius: 3, res: 48 });
+  ok(
+    near(bb.center[0], 1) && near(bb.center[1], 0) && near(bb.center[2], 0),
+    'translated box center ≈ [1,0,0]',
+  );
+  ok(
+    near(bb.size[0], 1.0) && near(bb.size[1], 1.6) && near(bb.size[2], 0.6),
+    `box size ≈ [1,1.6,0.6]`,
+  );
+}
+
+console.log('\ncameraFitFromBBox');
+{
+  const small = cameraFitFromBBox([-1, -1, -1], [1, 1, 1], 1.0);
+  const big = cameraFitFromBBox([-3, -3, -3], [3, 3, 3], 1.0);
+  ok(near(small.target[0], 0) && near(small.target[1], 0), 'camera target = bbox center');
+  ok(big.distance > small.distance, 'bigger bbox → larger fit distance');
+  ok(near(big.distance / small.distance, 3, 0.2), 'fit distance scales with bbox size');
+  const wider = cameraFitFromBBox([-1, -1, -1], [1, 1, 1], 0.5); // narrower FOV
+  ok(wider.distance > small.distance, 'narrower FOV → larger fit distance');
+}
+
+console.log('\nsphereProjRadius');
+{
+  const close = sphereProjRadius(3, 1, 1.5);
+  const far = sphereProjRadius(10, 1, 1.5);
+  ok(close > far, 'closer sphere projects larger');
+  ok(close > 0 && far > 0, 'projected radius positive');
+}
+
+console.log('\nboundedSDF (bounding-volume acceleration)');
+{
+  const bmin = [-1.5, -1.5, -1.5],
+    bmax = [1.5, 1.5, 1.5];
+  const f = boundedSDF(sphere(1), bmin, bmax);
+  ok(near(f([0, 0, 0]), sphere(1)([0, 0, 0]), 1e-9), 'inside bbox → exact SDF');
+  const farP = [5, 0, 0];
+  ok(f(farP) <= sphere(1)(farP) + 1e-9, 'outside bbox → conservative lower bound (≤ true SDF)');
+  ok(f(farP) > 0, 'outside bbox → positive distance');
+}
+
+console.log('\nL∞ box (Chebyshev)');
+{
+  ok(sdBoxLinf(0, 0, 0, 1, 1, 1) < 0, 'center inside');
+  ok(near(sdBoxLinf(1, 1, 1, 1, 1, 1), 0, 1e-9), 'corner on surface');
+  ok(sdBoxLinf(2, 0, 0, 1, 1, 1) > 0, 'outside positive');
+}
+
+console.log('\nGLSL mirror present');
+ok(typeof BOUNDS_GLSL === 'string' && BOUNDS_GLSL.length > 100, 'BOUNDS_GLSL exported');
+for (const fn of ['sphereProjRadius', 'sdBoxLinf', 'sdBoundingBox']) {
+  ok(BOUNDS_GLSL.includes(fn), `BOUNDS_GLSL defines ${fn}`);
+}
+
+console.log(`\n=== Result: ${pass} passed, ${fail} failed ===`);
+process.exit(fail > 0 ? 1 : 0);

--- a/sdf-js/src/sdf/bounds.js
+++ b/sdf-js/src/sdf/bounds.js
@@ -1,0 +1,126 @@
+// =============================================================================
+// bounds.js — bounding / auto-framing toolkit (IQ bounding articles). Wave 6.
+// -----------------------------------------------------------------------------
+// Recipe-only ports / applications of Inigo Quilez:
+//   bounding boxes        https://iquilezles.org/articles/diskbbox/ (family)
+//   sphere projection     https://iquilezles.org/articles/sphereproj/
+//   SDF bounding volumes  https://iquilezles.org/articles/sdfbounding/
+//   L∞-norm SDFs          https://iquilezles.org/articles/distfunctions2dlinf/
+//
+// Headline: bbox(SDF) → camera-fit, so any atom/deck auto-frames in the studio
+// stage instead of being hand-scaled to a fixed camera (the W-studio pain).
+// bbox3FromSDF + cameraFitFromBBox run CPU-side at load; the analytic helpers
+// (sphereProjRadius / sdBoxLinf / sdBoundingBox) also ship in BOUNDS_GLSL.
+//
+// License: PolyForm Noncommercial 1.0.0 (Atlas reimplementation).
+// =============================================================================
+
+/** Sample an SDF (p→dist) over a cube and return its axis-aligned bounding box.
+ *  Approximate (grid-based) — tightens to ~half a cell. Returns {min,max,center,size}. */
+export function bbox3FromSDF(sdfFn, opts = {}) {
+  const R = opts.radius ?? 3;
+  const res = opts.res ?? 48;
+  const iso = opts.iso ?? 0;
+  const step = (2 * R) / res;
+  const min = [Infinity, Infinity, Infinity];
+  const max = [-Infinity, -Infinity, -Infinity];
+  let found = false;
+  for (let i = 0; i <= res; i++) {
+    const x = -R + i * step;
+    for (let j = 0; j <= res; j++) {
+      const y = -R + j * step;
+      for (let k = 0; k <= res; k++) {
+        const z = -R + k * step;
+        if (sdfFn([x, y, z]) <= iso) {
+          found = true;
+          if (x < min[0]) min[0] = x;
+          if (x > max[0]) max[0] = x;
+          if (y < min[1]) min[1] = y;
+          if (y > max[1]) max[1] = y;
+          if (z < min[2]) min[2] = z;
+          if (z > max[2]) max[2] = z;
+        }
+      }
+    }
+  }
+  if (!found) {
+    return { min: [0, 0, 0], max: [0, 0, 0], center: [0, 0, 0], size: [0, 0, 0], empty: true };
+  }
+  const h = step * 0.5; // the surface lies up to half a cell past the last inside sample
+  for (let a = 0; a < 3; a++) {
+    min[a] -= h;
+    max[a] += h;
+  }
+  const center = [(min[0] + max[0]) / 2, (min[1] + max[1]) / 2, (min[2] + max[2]) / 2];
+  const size = [max[0] - min[0], max[1] - min[1], max[2] - min[2]];
+  return { min, max, center, size };
+}
+
+/** Camera target + distance that frames a bbox's bounding sphere in a vertical
+ *  FOV. margin > 1 leaves headroom. Returns {target:[x,y,z], distance}. */
+export function cameraFitFromBBox(min, max, fovY = 1.0, margin = 1.15) {
+  const center = [(min[0] + max[0]) / 2, (min[1] + max[1]) / 2, (min[2] + max[2]) / 2];
+  const dx = max[0] - min[0],
+    dy = max[1] - min[1],
+    dz = max[2] - min[2];
+  const radius = 0.5 * Math.hypot(dx, dy, dz);
+  const distance = (margin * radius) / Math.sin(fovY / 2);
+  return { target: center, distance };
+}
+
+/** Screen-space radius of a sphere at view-space distance zDist (tangent-cone
+ *  projection). Closer / bigger spheres project larger. */
+export function sphereProjRadius(zDist, sphereRadius, focal) {
+  return (
+    (focal * sphereRadius) / Math.sqrt(Math.max(zDist * zDist - sphereRadius * sphereRadius, 1e-6))
+  );
+}
+
+// Signed distance to an axis-aligned box [bmin,bmax].
+function aabbDist(p, bmin, bmax) {
+  const cx = (bmin[0] + bmax[0]) / 2,
+    cy = (bmin[1] + bmax[1]) / 2,
+    cz = (bmin[2] + bmax[2]) / 2;
+  const hx = (bmax[0] - bmin[0]) / 2,
+    hy = (bmax[1] - bmin[1]) / 2,
+    hz = (bmax[2] - bmin[2]) / 2;
+  const qx = Math.abs(p[0] - cx) - hx,
+    qy = Math.abs(p[1] - cy) - hy,
+    qz = Math.abs(p[2] - cz) - hz;
+  const o = Math.hypot(Math.max(qx, 0), Math.max(qy, 0), Math.max(qz, 0));
+  return o + Math.min(Math.max(qx, qy, qz), 0);
+}
+
+/** Wrap an SDF in an AABB bounding volume: outside the box, return the cheap
+ *  (conservative, ≤ true) distance to the box so a sphere-tracer can skip ahead;
+ *  inside, evaluate the real SDF. Accelerates expensive multi-primitive atoms. */
+export function boundedSDF(sdfFn, bmin, bmax) {
+  return (p) => {
+    const db = aabbDist(p, bmin, bmax);
+    return db > 0 ? db : sdfFn(p);
+  };
+}
+
+/** L∞ (Chebyshev-norm) box: max(|p|−b). 0 on the surface, <0 inside. */
+export function sdBoxLinf(px, py, pz, bx, by, bz) {
+  return Math.max(Math.abs(px) - bx, Math.abs(py) - by, Math.abs(pz) - bz);
+}
+
+// -----------------------------------------------------------------------------
+// GLSL mirror (the helpers usable inside a shader; bbox/camera-fit are CPU-only).
+// -----------------------------------------------------------------------------
+export const BOUNDS_GLSL = /* glsl */ `
+float sphereProjRadius(float zDist, float sr, float focal){
+  return focal*sr/sqrt(max(zDist*zDist - sr*sr, 1e-6));
+}
+float sdBoxLinf(vec3 p, vec3 b){
+  vec3 w = abs(p) - b;
+  return max(w.x, max(w.y, w.z));
+}
+float sdBoundingBox(vec3 p, vec3 bmin, vec3 bmax){
+  vec3 c = (bmin + bmax) * 0.5;
+  vec3 h = (bmax - bmin) * 0.5;
+  vec3 q = abs(p - c) - h;
+  return length(max(q, 0.0)) + min(max(q.x, max(q.y, q.z)), 0.0);
+}
+`;


### PR DESCRIPTION
## What — Wave 6 of the IQ shader-technique program (★★★★★ auto-framing)

The auto-framing headline: `bbox(SDF)` → camera-fit, so any atom/deck frames itself in the studio stage instead of being hand-scaled to a fixed camera (the pain from the studio-quality session). Recipe-only ports / applications of IQ bounding articles. JS + `BOUNDS_GLSL` mirror.

**`src/sdf/bounds.js`** — IQ #7/#8, #57, #108, #6:
| function | purpose |
| --- | --- |
| `bbox3FromSDF` | grid-sampled AABB of any `p→dist` SDF |
| `cameraFitFromBBox` | target + distance to frame a bbox in a vertical FOV |
| `sphereProjRadius` | sphere screen-projection bounding radius |
| `boundedSDF` | AABB bounding-volume wrapper (conservative early-out for tracers) |
| `sdBoxLinf` | L∞ (Chebyshev) box |

## Verification
- **21 assertions** — unit-sphere bbox ≈ ±1, translated box center+size recovered; camera-fit distance scales with bbox size and grows for narrower FOV; sphere projection monotonic; `boundedSDF` exact inside / conservative-lower-bound outside; L∞ box sign.
- `BOUNDS_GLSL` compiles + links with the W1–5 libraries → **`GLSL-SMOKE-OK easing+noise+filter+lighting+sdg+bounds`** (headless).
- Full suite **45/45**, `node --check` + Prettier clean.

## Scope
`bbox3FromSDF` + `cameraFitFromBBox` are CPU-side (run at load); a later pass can wire them into studio so demos auto-frame. Additive library, zero behaviour change.

Next: W7 (intersectors & sphere math).

🤖 Generated with [Claude Code](https://claude.com/claude-code)