### PR TITLE
IQ-shader W9: procedural-effects toolkit

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -47,6 +47,8 @@ const TESTS = [
   { category: 'math', file: 'sdf-js/scripts/test-intersect.mjs' },
   // IQ-shader program W8 — fractals (mandelbrot/bulb, quaternion julia, menger…)
   { category: 'math', file: 'sdf-js/scripts/test-fractal.mjs' },
+  // IQ-shader program W9 — procedural effects (clouds, deform, feedback, life)
+  { category: 'math', file: 'sdf-js/scripts/test-effects.mjs' },
 
   // M7 world runtime — determinism CI (the foundation Fable 5 asked for)
   { category: 'world', file: 'sdf-js/scripts/world/test-determinism.mjs' },

--- a/sdf-js/scripts/glsl-smoke.html
+++ b/sdf-js/scripts/glsl-smoke.html
@@ -23,6 +23,7 @@
       import { BOUNDS_GLSL } from '../src/sdf/bounds.js';
       import { INTERSECT_GLSL } from '../src/sdf/intersect.js';
       import { FRACTAL_GLSL } from '../src/sdf/fractal.js';
+      import { EFFECTS_GLSL } from '../src/sdf/effects.js';
 
       const gl = document.getElementById('c').getContext('webgl2');
       const vsSrc = 'attribute vec2 p; void main(){ gl_Position = vec4(p, 0.0, 1.0); }';
@@ -37,6 +38,7 @@ ${SDG_GLSL}
 ${BOUNDS_GLSL}
 ${INTERSECT_GLSL}
 ${FRACTAL_GLSL}
+${EFFECTS_GLSL}
 void main(){
   float s = smootherstep(0.5) + parabola(0.5, 2.0) + gain(0.3, 3.0)
     + cubicPulse(0.5, 0.2, 0.5) + smoothstepInteg(0.7) + invSmoothstep(0.4)
@@ -76,6 +78,8 @@ void main(){
   s += mandelbrot2(p * 0.3, 64) + mandelbrotTrap(p * 0.3, 32)
     + mandelbulbDE(vec3(p, 0.5), 8.0, 6) + juliaQuatDE(vec3(p, 0.5), vec4(-0.2, 0.6, 0.2, 0.2), 8)
     + mengerSDF(vec3(p, 0.5), 3) + sierpinskiSDF(vec3(p, 0.5), 6);
+  s += clouds2D(p, 1.0) + planeDeformPolar(p).x + planeDeformTwist(p, 0.5).y
+    + feedbackBlend(vec3(0.2), vec3(0.8), 0.5).x + lifeRule(1.0, 2.0);
   gl_FragColor = vec4(vec3(clamp01(s * 0.01)), 1.0);
 }`;
 
@@ -99,7 +103,7 @@ void main(){
         if (!gl.getProgramParameter(pr, gl.LINK_STATUS)) {
           throw new Error('link: ' + gl.getProgramInfoLog(pr));
         }
-        console.log('GLSL-SMOKE-OK …+intersect+fractal');
+        console.log('GLSL-SMOKE-OK …+fractal+effects');
         document.title = 'SMOKE OK';
       } catch (e) {
         console.error('GLSL-SMOKE-FAIL ' + e.message);

--- a/sdf-js/scripts/test-effects.mjs
+++ b/sdf-js/scripts/test-effects.mjs
@@ -1,0 +1,107 @@
+// =============================================================================
+// L1 unit tests for the procedural-effects toolkit (IQ "simple oldschool
+// effects" articles). Wave 9 of the IQ-shader program.
+// -----------------------------------------------------------------------------
+// Recipe-only ports of Inigo Quilez:
+//   2D dynamic clouds   https://iquilezles.org/articles/dynclouds/
+//   plane deformations  https://iquilezles.org/articles/deform/
+//   feedback effect     https://iquilezles.org/articles/feedbackeffect/
+//   Game of Life        https://iquilezles.org/articles/gameoflife/
+// =============================================================================
+
+import {
+  clouds2D,
+  planeDeformPolar,
+  planeDeformTwist,
+  feedbackBlend,
+  lifeRule,
+  lifeStep,
+  EFFECTS_GLSL,
+} from '../src/sdf/effects.js';
+
+let pass = 0,
+  fail = 0;
+function ok(cond, name) {
+  if (cond) {
+    pass++;
+    console.log(`  ✓ ${name}`);
+  } else {
+    fail++;
+    console.log(`  ✗ ${name}`);
+  }
+}
+const near = (a, b, eps = 1e-6) => Math.abs(a - b) < eps;
+const inRange = (v, lo, hi) => v >= lo - 1e-9 && v <= hi + 1e-9;
+
+console.log('=== procedural-effects toolkit ===\n');
+
+console.log('2D dynamic clouds');
+{
+  ok(clouds2D(1.3, 2.7, 0) === clouds2D(1.3, 2.7, 0), 'deterministic for fixed (x,y,t)');
+  let mn = Infinity,
+    mx = -Infinity;
+  for (let i = 0; i < 300; i++) {
+    const v = clouds2D(i * 0.31, i * 0.57, 0);
+    mn = Math.min(mn, v);
+    mx = Math.max(mx, v);
+  }
+  ok(
+    inRange(mn, 0, 1) && inRange(mx, 0, 1) && mx - mn > 0.3,
+    `clouds in [0,1], varied (${mn.toFixed(2)}..${mx.toFixed(2)})`,
+  );
+  ok(clouds2D(1.3, 2.7, 0) !== clouds2D(1.3, 2.7, 5), 'animates with time');
+}
+
+console.log('\nplane deformations');
+{
+  ok(planeDeformPolar(1, 0).every(Number.isFinite), 'polar deform finite');
+  // twist with k=0 is the identity
+  const id = planeDeformTwist(1.3, 0.7, 0);
+  ok(near(id[0], 1.3, 1e-9) && near(id[1], 0.7, 1e-9), 'twist k=0 → identity');
+  // twist preserves radius
+  const tw = planeDeformTwist(1.3, 0.7, 0.9);
+  ok(near(Math.hypot(tw[0], tw[1]), Math.hypot(1.3, 0.7), 1e-6), 'twist preserves radius');
+}
+
+console.log('\nfeedback blend');
+{
+  ok(near(feedbackBlend(0.2, 0.8, 0), 0.8), 'decay 0 → current frame');
+  ok(near(feedbackBlend(0.2, 0.8, 1), 0.2), 'decay 1 → previous frame (full trail)');
+  ok(near(feedbackBlend(0.2, 0.8, 0.5), 0.5), 'decay 0.5 → average');
+}
+
+console.log('\nConway rule');
+{
+  ok(lifeRule(1, 2) === 1 && lifeRule(1, 3) === 1, 'live cell with 2–3 neighbours survives');
+  ok(lifeRule(1, 1) === 0 && lifeRule(1, 4) === 0, 'live cell dies (under/over-population)');
+  ok(lifeRule(0, 3) === 1, 'dead cell with exactly 3 neighbours is born');
+  ok(lifeRule(0, 2) === 0, 'dead cell with 2 neighbours stays dead');
+}
+
+console.log('\nGame of Life step (toroidal)');
+{
+  // 3x3 blinker: horizontal row → vertical column after one step
+  // grid 5x5, blinker centred at (2,2)
+  const w = 5,
+    h = 5;
+  const g = new Array(w * h).fill(0);
+  g[2 * w + 1] = g[2 * w + 2] = g[2 * w + 3] = 1; // row (1,2),(2,2),(3,2)
+  const n = lifeStep(g, w, h);
+  // after one step it should be a vertical bar: (2,1),(2,2),(2,3)
+  ok(n[1 * w + 2] === 1 && n[2 * w + 2] === 1 && n[3 * w + 2] === 1, 'blinker → vertical');
+  ok(n[2 * w + 1] === 0 && n[2 * w + 3] === 0, 'blinker arms cleared');
+  // block (still life) is stable
+  const b = new Array(w * h).fill(0);
+  b[1 * w + 1] = b[1 * w + 2] = b[2 * w + 1] = b[2 * w + 2] = 1;
+  const nb = lifeStep(b, w, h);
+  ok(nb.join('') === b.join(''), 'block still-life is stable');
+}
+
+console.log('\nGLSL mirror present');
+ok(typeof EFFECTS_GLSL === 'string' && EFFECTS_GLSL.length > 200, 'EFFECTS_GLSL exported');
+for (const fn of ['clouds2D', 'planeDeformTwist', 'feedbackBlend', 'lifeRule']) {
+  ok(EFFECTS_GLSL.includes(fn), `EFFECTS_GLSL defines ${fn}`);
+}
+
+console.log(`\n=== Result: ${pass} passed, ${fail} failed ===`);
+process.exit(fail > 0 ? 1 : 0);

--- a/sdf-js/src/sdf/effects.js
+++ b/sdf-js/src/sdf/effects.js
@@ -1,0 +1,108 @@
+// =============================================================================
+// effects.js — procedural "simple oldschool effects" toolkit (IQ). Wave 9.
+// -----------------------------------------------------------------------------
+// Recipe-only ports of Inigo Quilez:
+//   2D dynamic clouds   https://iquilezles.org/articles/dynclouds/
+//   plane deformations  https://iquilezles.org/articles/deform/
+//   feedback effect     https://iquilezles.org/articles/feedbackeffect/
+//   Game of Life        https://iquilezles.org/articles/gameoflife/
+//
+// JS (CPU/testable) + GLSL mirror (EFFECTS_GLSL). The GLSL clouds2D calls
+// valueNoiseD2 from the W2 noise library (co-included before this one).
+// License: PolyForm Noncommercial 1.0.0 (Atlas reimplementation).
+// =============================================================================
+
+import { valueNoise2 } from './noise.js';
+
+/** Animated 2D cloud density ∈ [0,1] (fbm of value noise, drifting with time). */
+export function clouds2D(x, y, t) {
+  let v = 0,
+    amp = 0.5,
+    freq = 1;
+  let fx = x + t * 0.1;
+  const fy = y;
+  for (let i = 0; i < 5; i++) {
+    v += amp * valueNoise2(fx * freq, fy * freq);
+    amp *= 0.5;
+    freq *= 2;
+    fx += t * 0.02;
+  }
+  return Math.max(0, Math.min(1, v * 1.4 - 0.2));
+}
+
+/** Tunnel-style polar plane deformation → [angle/π, radial-depth]. */
+export function planeDeformPolar(x, y) {
+  const r = Math.hypot(x, y);
+  const a = Math.atan2(y, x);
+  return [a / Math.PI, 0.3 / (r + 1e-6)];
+}
+
+/** Radius-dependent twist deformation; k=0 is the identity, radius preserved. */
+export function planeDeformTwist(x, y, k) {
+  const r = Math.hypot(x, y);
+  const a = Math.atan2(y, x) + k * r;
+  return [r * Math.cos(a), r * Math.sin(a)];
+}
+
+/** Feedback / trail blend: decay 0 = current frame, 1 = previous frame. */
+export function feedbackBlend(prev, cur, decay) {
+  return cur + (prev - cur) * decay;
+}
+
+/** Conway's Game of Life rule for one cell (alive 0/1, live-neighbour count). */
+export function lifeRule(alive, n) {
+  if (alive) return n === 2 || n === 3 ? 1 : 0;
+  return n === 3 ? 1 : 0;
+}
+
+/** One Game-of-Life generation over a flat w×h grid (toroidal wrap). */
+export function lifeStep(grid, w, h) {
+  const out = new Array(w * h);
+  for (let y = 0; y < h; y++) {
+    for (let x = 0; x < w; x++) {
+      let n = 0;
+      for (let dy = -1; dy <= 1; dy++) {
+        for (let dx = -1; dx <= 1; dx++) {
+          if (dx === 0 && dy === 0) continue;
+          const nx = (x + dx + w) % w;
+          const ny = (y + dy + h) % h;
+          n += grid[ny * w + nx];
+        }
+      }
+      out[y * w + x] = lifeRule(grid[y * w + x], n);
+    }
+  }
+  return out;
+}
+
+// -----------------------------------------------------------------------------
+// GLSL mirror (clouds2D uses valueNoiseD2 from NOISE_GLSL, included earlier).
+// -----------------------------------------------------------------------------
+export const EFFECTS_GLSL = /* glsl */ `
+float clouds2D(vec2 p, float t){
+  float v = 0.0, amp = 0.5, freq = 1.0;
+  vec2 q = vec2(p.x + t*0.1, p.y);
+  for (int i = 0; i < 5; i++){
+    v += amp * valueNoiseD2(q*freq).x;
+    amp *= 0.5; freq *= 2.0; q.x += t*0.02;
+  }
+  return clamp(v*1.4 - 0.2, 0.0, 1.0);
+}
+vec2 planeDeformPolar(vec2 p){
+  float r = length(p);
+  float a = atan(p.y, p.x);
+  return vec2(a/3.14159265, 0.3/(r + 1e-6));
+}
+vec2 planeDeformTwist(vec2 p, float k){
+  float r = length(p);
+  float a = atan(p.y, p.x) + k*r;
+  return vec2(r*cos(a), r*sin(a));
+}
+vec3 feedbackBlend(vec3 prev, vec3 cur, float decay){
+  return mix(cur, prev, decay);
+}
+float lifeRule(float alive, float n){
+  if (alive > 0.5) return (n == 2.0 || n == 3.0) ? 1.0 : 0.0;
+  return (n == 3.0) ? 1.0 : 0.0;
+}
+`;


### PR DESCRIPTION
## What — Wave 9 of the IQ shader-technique program

Procedural "simple oldschool effects", recipe-only ports of IQ articles. JS + `EFFECTS_GLSL` mirror (clouds2D reuses `valueNoiseD2` from the W2 noise library — cross-library composition).

**`src/sdf/effects.js`** — IQ #96, #98, #99, #101:
| function | purpose |
| --- | --- |
| `clouds2D` | animated 2D cloud density (fbm of value noise, drifts with time) |
| `planeDeformPolar` / `planeDeformTwist` | coordinate-space warps |
| `feedbackBlend` | trail / feedback frame blend |
| `lifeRule` / `lifeStep` | Conway Game of Life (rule + toroidal grid step) |

## Verification
- **21 assertions** — clouds in [0,1] / varied / animates with time; twist is identity at k=0 and preserves radius; feedback endpoints; the **exact Conway rule table**; blinker oscillates to vertical + block still-life stays stable.
- `EFFECTS_GLSL` compiles + links with W1–8 (cross-library `clouds2D → valueNoiseD2`) → **`GLSL-SMOKE-OK …+fractal+effects`** (headless).
- Full suite **48/48**, `node --check` + Prettier clean.

## Scope
Additive library. Zero behaviour change.

Next: W10 (math/rotation — quaternions, Fourier series, patched sphere, polygon normal/area).

🤖 Generated with [Claude Code](https://claude.com/claude-code)