### PR TITLE
IQ-shader W10: math / rotation toolkit

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -49,6 +49,8 @@ const TESTS = [
   { category: 'math', file: 'sdf-js/scripts/test-fractal.mjs' },
   // IQ-shader program W9 — procedural effects (clouds, deform, feedback, life)
   { category: 'math', file: 'sdf-js/scripts/test-effects.mjs' },
+  // IQ-shader program W10 — math/rotation (quaternions, fourier, tri dist, uv)
+  { category: 'math', file: 'sdf-js/scripts/test-mathx.mjs' },
 
   // M7 world runtime — determinism CI (the foundation Fable 5 asked for)
   { category: 'world', file: 'sdf-js/scripts/world/test-determinism.mjs' },

--- a/sdf-js/scripts/glsl-smoke.html
+++ b/sdf-js/scripts/glsl-smoke.html
@@ -24,6 +24,7 @@
       import { INTERSECT_GLSL } from '../src/sdf/intersect.js';
       import { FRACTAL_GLSL } from '../src/sdf/fractal.js';
       import { EFFECTS_GLSL } from '../src/sdf/effects.js';
+      import { MATHX_GLSL } from '../src/sdf/mathx.js';
 
       const gl = document.getElementById('c').getContext('webgl2');
       const vsSrc = 'attribute vec2 p; void main(){ gl_Position = vec4(p, 0.0, 1.0); }';
@@ -39,6 +40,7 @@ ${BOUNDS_GLSL}
 ${INTERSECT_GLSL}
 ${FRACTAL_GLSL}
 ${EFFECTS_GLSL}
+${MATHX_GLSL}
 void main(){
   float s = smootherstep(0.5) + parabola(0.5, 2.0) + gain(0.3, 3.0)
     + cubicPulse(0.5, 0.2, 0.5) + smoothstepInteg(0.7) + invSmoothstep(0.4)
@@ -80,6 +82,11 @@ void main(){
     + mengerSDF(vec3(p, 0.5), 3) + sierpinskiSDF(vec3(p, 0.5), 6);
   s += clouds2D(p, 1.0) + planeDeformPolar(p).x + planeDeformTwist(p, 0.5).y
     + feedbackBlend(vec3(0.2), vec3(0.8), 0.5).x + lifeRule(1.0, 2.0);
+  s += qRotate(qFromAxisAngle(vec3(0.0, 0.0, 1.0), 1.57), vec3(p, 0.5)).y
+    + qMul(vec4(0.0, 0.0, 0.0, 1.0), vec4(0.0, 0.0, 0.0, 1.0)).w + fourierSquare(0.25, 8)
+    + triangleArea(vec3(0.0), vec3(1.0, 0.0, 0.0), vec3(0.0, 1.0, 0.0))
+    + distToTriangle(vec3(p, 1.0), vec3(0.0), vec3(1.0, 0.0, 0.0), vec3(0.0, 1.0, 0.0))
+    + sphereUV(vec3(p, 0.5)).x;
   gl_FragColor = vec4(vec3(clamp01(s * 0.01)), 1.0);
 }`;
 
@@ -103,7 +110,7 @@ void main(){
         if (!gl.getProgramParameter(pr, gl.LINK_STATUS)) {
           throw new Error('link: ' + gl.getProgramInfoLog(pr));
         }
-        console.log('GLSL-SMOKE-OK …+fractal+effects');
+        console.log('GLSL-SMOKE-OK …+effects+mathx (all 10 libs)');
         document.title = 'SMOKE OK';
       } catch (e) {
         console.error('GLSL-SMOKE-FAIL ' + e.message);

--- a/sdf-js/scripts/test-mathx.mjs
+++ b/sdf-js/scripts/test-mathx.mjs
@@ -1,0 +1,120 @@
+// =============================================================================
+// L1 unit tests for the math / rotation toolkit (IQ "useful maths" articles).
+// Wave 10 of the IQ-shader program.
+// -----------------------------------------------------------------------------
+// Recipe-only ports of Inigo Quilez:
+//   quaternions             https://iquilezles.org/articles/quaternions/
+//   Fourier series          https://iquilezles.org/articles/fourier/
+//   distance to triangle    https://iquilezles.org/articles/triangledistance/
+//   area of a triangle      https://iquilezles.org/articles/trianglearea/
+//   normals/areas polygons  https://iquilezles.org/articles/polygonnormals/
+//   patched sphere          https://iquilezles.org/articles/patchedsphere/
+// =============================================================================
+
+import {
+  qFromAxisAngle,
+  qMul,
+  qConj,
+  qRotate,
+  fourierSquare,
+  triangleArea,
+  polygonAreaNormal,
+  distToTriangle,
+  sphereUV,
+  MATHX_GLSL,
+} from '../src/sdf/mathx.js';
+
+let pass = 0,
+  fail = 0;
+function ok(cond, name) {
+  if (cond) {
+    pass++;
+    console.log(`  ✓ ${name}`);
+  } else {
+    fail++;
+    console.log(`  ✗ ${name}`);
+  }
+}
+const near = (a, b, eps = 1e-4) => Math.abs(a - b) < eps;
+const inRange = (v, lo, hi) => v >= lo - 1e-9 && v <= hi + 1e-9;
+
+console.log('=== math / rotation toolkit ===\n');
+
+console.log('quaternions');
+{
+  const q = qFromAxisAngle([0, 0, 1], Math.PI / 2); // 90° about +Z
+  const r = qRotate(q, [1, 0, 0]);
+  ok(near(r[0], 0) && near(r[1], 1) && near(r[2], 0), '90° about Z maps +X → +Y');
+  const r2 = qRotate(qFromAxisAngle([1, 0, 0], Math.PI / 2), [0, 1, 0]);
+  ok(near(r2[0], 0) && near(r2[1], 0) && near(r2[2], 1), '90° about X maps +Y → +Z');
+  // identity quaternion leaves vectors unchanged
+  const id = [0, 0, 0, 1];
+  const ri = qRotate(id, [0.3, 0.5, 0.7]);
+  ok(near(ri[0], 0.3) && near(ri[1], 0.5) && near(ri[2], 0.7), 'identity quaternion = no rotation');
+  // q * conj(q) = identity (w=1, xyz=0)
+  const p = qMul(q, qConj(q));
+  ok(near(p[0], 0) && near(p[1], 0) && near(p[2], 0) && near(p[3], 1), 'q·conj(q) = identity');
+  // composing two 45° Z rotations == one 90°
+  const h = qFromAxisAngle([0, 0, 1], Math.PI / 4);
+  const hh = qMul(h, h);
+  const rc = qRotate(hh, [1, 0, 0]);
+  ok(near(rc[0], 0, 1e-4) && near(rc[1], 1, 1e-4), 'two 45° rotations compose to 90°');
+}
+
+console.log('\nFourier square wave');
+{
+  const coarse = fourierSquare(0.25, 3);
+  const fine = fourierSquare(0.25, 80);
+  ok(Math.abs(fine - 1) < Math.abs(coarse - 1), 'more terms → closer to +1 on the plateau');
+  ok(near(fourierSquare(0.25, 200), 1, 0.02), 'converges to +1 at x=0.25');
+  ok(near(fourierSquare(0.75, 200), -1, 0.02), 'converges to −1 at x=0.75');
+}
+
+console.log('\ntriangle area + polygon normal/area');
+{
+  ok(near(triangleArea([0, 0, 0], [1, 0, 0], [0, 1, 0]), 0.5), 'unit right triangle area = 0.5');
+  const sq = polygonAreaNormal([
+    [0, 0, 0],
+    [1, 0, 0],
+    [1, 1, 0],
+    [0, 1, 0],
+  ]);
+  ok(near(sq.area, 1), 'unit square polygon area = 1');
+  ok(
+    near(Math.abs(sq.normal[2]), 1) && near(sq.normal[0], 0) && near(sq.normal[1], 0),
+    'XY square normal is ±Z',
+  );
+}
+
+console.log('\npoint-to-triangle distance');
+{
+  const a = [0, 0, 0],
+    b = [1, 0, 0],
+    c = [0, 1, 0];
+  ok(near(distToTriangle([0.3, 0.3, 1], a, b, c), 1), 'point 1 above interior → distance 1');
+  ok(near(distToTriangle([0.25, 0.25, 0], a, b, c), 0), 'point on the triangle → 0');
+  ok(distToTriangle([5, 5, 0], a, b, c) > 1, 'far in-plane point → large distance');
+}
+
+console.log('\nsphere UV (patched / equirectangular)');
+{
+  for (const d of [
+    [1, 0, 0],
+    [0, 1, 0],
+    [0, 0, 1],
+    [-1, 0, 0],
+  ]) {
+    const uv = sphereUV(d);
+    ok(inRange(uv[0], 0, 1) && inRange(uv[1], 0, 1), `sphereUV(${d}) in [0,1]²`);
+  }
+  ok(sphereUV([1, 0, 0])[0] === sphereUV([1, 0, 0])[0], 'deterministic');
+}
+
+console.log('\nGLSL mirror present');
+ok(typeof MATHX_GLSL === 'string' && MATHX_GLSL.length > 300, 'MATHX_GLSL exported');
+for (const fn of ['qMul', 'qRotate', 'fourierSquare', 'triangleArea', 'distToTriangle']) {
+  ok(MATHX_GLSL.includes(fn), `MATHX_GLSL defines ${fn}`);
+}
+
+console.log(`\n=== Result: ${pass} passed, ${fail} failed ===`);
+process.exit(fail > 0 ? 1 : 0);

--- a/sdf-js/src/sdf/mathx.js
+++ b/sdf-js/src/sdf/mathx.js
@@ -1,0 +1,182 @@
+// =============================================================================
+// mathx.js — math / rotation toolkit (IQ "useful maths" articles). Wave 10.
+// -----------------------------------------------------------------------------
+// Recipe-only ports of Inigo Quilez:
+//   quaternions          https://iquilezles.org/articles/quaternions/
+//   Fourier series       https://iquilezles.org/articles/fourier/
+//   distance to triangle https://iquilezles.org/articles/triangledistance/
+//   triangle area        https://iquilezles.org/articles/trianglearea/
+//   polygon normals/area https://iquilezles.org/articles/polygonnormals/
+//   patched sphere (uv)  https://iquilezles.org/articles/patchedsphere/
+//
+// Quaternion convention: q = [x, y, z, w] (vector part first, scalar last).
+// JS (CPU/testable) + GLSL mirror (MATHX_GLSL). License: PolyForm Noncommercial.
+// =============================================================================
+
+const sub = (a, b) => [a[0] - b[0], a[1] - b[1], a[2] - b[2]];
+const cross = (a, b) => [
+  a[1] * b[2] - a[2] * b[1],
+  a[2] * b[0] - a[0] * b[2],
+  a[0] * b[1] - a[1] * b[0],
+];
+const dot = (a, b) => a[0] * b[0] + a[1] * b[1] + a[2] * b[2];
+const clamp = (x, lo, hi) => Math.max(lo, Math.min(hi, x));
+
+// ---- Quaternions ------------------------------------------------------------
+
+export function qFromAxisAngle(axis, angle) {
+  const l = Math.hypot(axis[0], axis[1], axis[2]) || 1;
+  const s = Math.sin(angle / 2);
+  return [(axis[0] / l) * s, (axis[1] / l) * s, (axis[2] / l) * s, Math.cos(angle / 2)];
+}
+
+export function qMul(a, b) {
+  return [
+    a[3] * b[0] + a[0] * b[3] + a[1] * b[2] - a[2] * b[1],
+    a[3] * b[1] - a[0] * b[2] + a[1] * b[3] + a[2] * b[0],
+    a[3] * b[2] + a[0] * b[1] - a[1] * b[0] + a[2] * b[3],
+    a[3] * b[3] - a[0] * b[0] - a[1] * b[1] - a[2] * b[2],
+  ];
+}
+
+export const qConj = (q) => [-q[0], -q[1], -q[2], q[3]];
+
+/** Rotate a 3-vector by quaternion q (q · v · q*). */
+export function qRotate(q, v) {
+  const r = qMul(qMul(q, [v[0], v[1], v[2], 0]), qConj(q));
+  return [r[0], r[1], r[2]];
+}
+
+// ---- Fourier series ---------------------------------------------------------
+
+/** Square wave (period 1, ±1) approximated by its Fourier series (odd harmonics). */
+export function fourierSquare(x, terms) {
+  let s = 0;
+  for (let k = 1; k <= 2 * terms; k += 2) {
+    s += Math.sin(2 * Math.PI * k * x) / k;
+  }
+  return (4 / Math.PI) * s;
+}
+
+// ---- Areas / normals --------------------------------------------------------
+
+/** Area of triangle (a,b,c) in 3D. */
+export function triangleArea(a, b, c) {
+  const n = cross(sub(b, a), sub(c, a));
+  return 0.5 * Math.hypot(n[0], n[1], n[2]);
+}
+
+/** Newell's method: area + unit normal of an arbitrary (planar-ish) polygon. */
+export function polygonAreaNormal(verts) {
+  let nx = 0,
+    ny = 0,
+    nz = 0;
+  const m = verts.length;
+  for (let i = 0; i < m; i++) {
+    const c = verts[i],
+      n = verts[(i + 1) % m];
+    nx += (c[1] - n[1]) * (c[2] + n[2]);
+    ny += (c[2] - n[2]) * (c[0] + n[0]);
+    nz += (c[0] - n[0]) * (c[1] + n[1]);
+  }
+  const len = Math.hypot(nx, ny, nz) || 1;
+  return { area: 0.5 * Math.hypot(nx, ny, nz), normal: [nx / len, ny / len, nz / len] };
+}
+
+// ---- Point-to-triangle distance (IQ udTriangle) -----------------------------
+
+const dot2 = (v) => dot(v, v);
+
+export function distToTriangle(p, a, b, c) {
+  const ba = sub(b, a),
+    pa = sub(p, a);
+  const cb = sub(c, b),
+    pb = sub(p, b);
+  const ac = sub(a, c),
+    pc = sub(p, c);
+  const nor = cross(ba, ac);
+  const sign =
+    Math.sign(dot(cross(ba, nor), pa)) +
+    Math.sign(dot(cross(cb, nor), pb)) +
+    Math.sign(dot(cross(ac, nor), pc));
+  let d;
+  if (sign < 2) {
+    const e = (edge, q) => {
+      const t = clamp(dot(edge, q) / dot2(edge), 0, 1);
+      return dot2([edge[0] * t - q[0], edge[1] * t - q[1], edge[2] * t - q[2]]);
+    };
+    d = Math.min(e(ba, pa), e(cb, pb), e(ac, pc));
+  } else {
+    d = (dot(nor, pa) * dot(nor, pa)) / dot2(nor);
+  }
+  return Math.sqrt(d);
+}
+
+// ---- Sphere UV (equirectangular patch mapping) ------------------------------
+
+/** Map a direction to equirectangular sphere UV ∈ [0,1]². */
+export function sphereUV(dir) {
+  const l = Math.hypot(dir[0], dir[1], dir[2]) || 1;
+  const x = dir[0] / l,
+    y = dir[1] / l,
+    z = dir[2] / l;
+  const u = 0.5 + Math.atan2(z, x) / (2 * Math.PI);
+  const v = 0.5 - Math.asin(clamp(y, -1, 1)) / Math.PI;
+  return [u, v];
+}
+
+// -----------------------------------------------------------------------------
+// GLSL mirror. Quaternion = vec4 (xyz, w).
+// -----------------------------------------------------------------------------
+export const MATHX_GLSL = /* glsl */ `
+vec4 qFromAxisAngle(vec3 axis, float angle){
+  float s = sin(angle*0.5);
+  return vec4(normalize(axis)*s, cos(angle*0.5));
+}
+vec4 qMul(vec4 a, vec4 b){
+  return vec4(
+    a.w*b.x + a.x*b.w + a.y*b.z - a.z*b.y,
+    a.w*b.y - a.x*b.z + a.y*b.w + a.z*b.x,
+    a.w*b.z + a.x*b.y - a.y*b.x + a.z*b.w,
+    a.w*b.w - a.x*b.x - a.y*b.y - a.z*b.z);
+}
+vec4 qConj(vec4 q){ return vec4(-q.xyz, q.w); }
+vec3 qRotate(vec4 q, vec3 v){
+  vec4 r = qMul(qMul(q, vec4(v, 0.0)), qConj(q));
+  return r.xyz;
+}
+float fourierSquare(float x, int terms){
+  float s = 0.0;
+  for (int i = 0; i < 512; i++){
+    if (i >= terms) break;
+    float k = float(2*i + 1);
+    s += sin(2.0*3.14159265*k*x)/k;
+  }
+  return (4.0/3.14159265)*s;
+}
+float triangleArea(vec3 a, vec3 b, vec3 c){
+  return 0.5*length(cross(b-a, c-a));
+}
+float dot2_(vec3 v){ return dot(v, v); }
+float distToTriangle(vec3 p, vec3 a, vec3 b, vec3 c){
+  vec3 ba = b-a, pa = p-a;
+  vec3 cb = c-b, pb = p-b;
+  vec3 ac = a-c, pc = p-c;
+  vec3 nor = cross(ba, ac);
+  float sgn = sign(dot(cross(ba,nor),pa)) + sign(dot(cross(cb,nor),pb)) + sign(dot(cross(ac,nor),pc));
+  float d;
+  if (sgn < 2.0){
+    d = min(min(
+      dot2_(ba*clamp(dot(ba,pa)/dot(ba,ba),0.0,1.0)-pa),
+      dot2_(cb*clamp(dot(cb,pb)/dot(cb,cb),0.0,1.0)-pb)),
+      dot2_(ac*clamp(dot(ac,pc)/dot(ac,ac),0.0,1.0)-pc));
+  } else {
+    d = dot(nor,pa)*dot(nor,pa)/dot(nor,nor);
+  }
+  return sqrt(d);
+}
+vec2 sphereUV(vec3 dir){
+  vec3 d = normalize(dir);
+  return vec2(0.5 + atan(d.z, d.x)/(2.0*3.14159265), 0.5 - asin(clamp(d.y,-1.0,1.0))/3.14159265);
+}
+`;


### PR DESCRIPTION
## What — Wave 10 of the IQ shader-technique program

Math & rotation, recipe-only ports of IQ "useful maths" articles. JS + `MATHX_GLSL` mirror.

**`src/sdf/mathx.js`** — IQ #115, #116, #118, #119, #123:
| function | purpose |
| --- | --- |
| `qFromAxisAngle` / `qMul` / `qConj` / `qRotate` | quaternion rotations (gimbal-lock-free camera/animation) |
| `fourierSquare` | square wave via Fourier series |
| `triangleArea` / `polygonAreaNormal` | 3D triangle area, Newell polygon area+normal |
| `distToTriangle` | unsigned point-to-triangle distance (mesh-SDF building block) |
| `sphereUV` | equirectangular sphere UV patch mapping |

## Verification
- **25 assertions** — quaternion axis rotations (X→Y, Y→Z), identity, q·conj(q)=I, two 45° compose to 90°; Fourier converges to ±1 on the plateaus; triangle/polygon area+normal; point-to-triangle distance (height above / 0 on surface); UV in [0,1]².
- `MATHX_GLSL` compiles + links with **all prior libraries** → **`GLSL-SMOKE-OK …+effects+mathx (all 10 libs)`** (headless).
- Full suite **49/49**, `node --check` + Prettier clean.

## Scope
Additive library. Zero behaviour change.

Next: **W11** (cleanup — deferred items: box/multires AO, SSAO, exact ellipse distance, Budhabrot/popcorn/Lyapunov; final review), then resume the 21 atoms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)