### PR TITLE
IQ-shader W11: cleanup (deferred items) + library index

### DIFF
--- a/docs/superpowers/specs/2026-06-20-iq-shader-library.md
+++ b/docs/superpowers/specs/2026-06-20-iq-shader-library.md
@@ -1,0 +1,52 @@
+# IQ shader-technique library (11-wave program)
+
+**Date:** 2026-06-20 · **Status:** complete (W1–W11 shipped)
+
+A comprehensive port of Inigo Quilez's shader/SDF techniques into sdf-js, built
+ahead of demand (per user directive — don't gate future capability on today's
+needs). Each module ships **JS** (CPU, fully node-tested) **+ a GLSL mirror
+string** (shader-side, identical names). All GLSL mirrors compile + link
+together in a real WebGL2 context — verified by `scripts/glsl-smoke.html`
+(headless, `GLSL-SMOKE-OK all 11 IQ-shader libraries`).
+
+Recipe-only ports ([[recipe-only-port-pattern]]): reimplemented from the math,
+credited, no source copied.
+
+## Modules (`src/sdf/`)
+
+| wave | module | exports (GLSL string) | covers |
+| --- | --- | --- | --- |
+| W1 | `easing.js` | `EASING_GLSL` | remap, smoothstep/smoother, sigmoid, inverse-smoothstep, smoothstep-integral, parabola, pcurve, cubicPulse, expImpulse/Step, gain, sinc, almostIdentity |
+| W2 | `noise.js` | `NOISE_GLSL` | value/gradient noise **+ analytic derivatives**, fbm+deriv, domain warping, voronoise, smooth voronoi, voronoi edges |
+| W3 | `filter.js` | `FILTER_GLSL` | ray-differential footprint, band-limited checker/grid/stripes/triangle, no-tile, biplanar, gamma sRGB↔linear, premult alpha, improved bilinear |
+| W4 | `lighting.js` | `LIGHTING_GLSL` | sphere AO + soft shadow (analytic), fresnel, hemisphere, outdoor 3-light model, better fog |
+| W5 | `sdg.js` | `SDG_GLSL` | SDFs returning analytic gradient — circle/box/segment (2D), sphere/box/torus (3D) |
+| W6 | `bounds.js` | `BOUNDS_GLSL` | bbox(SDF) + camera-fit (**auto-framing**), sphere projection, AABB bounding volume, L∞ box |
+| W7 | `intersect.js` | `INTERSECT_GLSL` | ray–sphere/box/plane/triangle, sphere density, inverse bilinear |
+| W8 | `fractal.js` | `FRACTAL_GLSL` | Mandelbrot/Julia (continuous iter), orbit trap, Mandelbulb DE, quaternion Julia DE, Menger, Sierpinski |
+| W9 | `effects.js` | `EFFECTS_GLSL` | 2D dynamic clouds, plane deformations, feedback blend, Game of Life |
+| W10 | `mathx.js` | `MATHX_GLSL` | quaternions, Fourier square, triangle/polygon area+normal, point-to-triangle distance, sphere UV |
+| W11 | `extra.js` | `EXTRA_GLSL` | exact ellipse distance, directional derivative, generic SDF AO, box shadow, Lyapunov exponent |
+
+Tests: `scripts/test-{easing,noise,filter,lighting,sdg,bounds,intersect,fractal,effects,mathx,extra}.mjs`
+(category `math` in `run-tests.mjs`). Derivative functions are checked against
+finite differences; SDFs against sign/|grad|=1; band-limited patterns against
+the w→0/w→∞ limits; fractals against set membership; everything deterministic.
+
+## Out of scope (renderer-integration, not library helpers)
+
+These IQ techniques need an accumulation/feedback framebuffer or depth buffer,
+so they belong to a future renderer feature, not a pure-function library:
+SSAO, per-vertex AO, multi-resolution AO, full analytic box occlusion,
+Budhabrot, popcorn, Lyapunov *fractal image*, IFS point clouds, bitmap orbit
+traps, depth-buffer raymarching. Also excluded from the whole program (non-
+shader): compression, size-coding, Mandelbrot pure set-math, IK, FM synthesis,
+mesh normals/compression, stereo/VR.
+
+## Not yet wired into a renderer
+
+Every module is additive and standalone. A follow-up pass can route existing
+renderers through them — e.g. studio's checker → `FILTER_GLSL.checkersFiltered`,
+studio auto-framing → `bounds.bbox3FromSDF`/`cameraFitFromBBox`, terrain shading
+→ `NOISE_GLSL` derivative noise, new fractal/effect atoms → `FRACTAL_GLSL` /
+`EFFECTS_GLSL`. That wiring is intentionally separate from these capability PRs.

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -51,6 +51,8 @@ const TESTS = [
   { category: 'math', file: 'sdf-js/scripts/test-effects.mjs' },
   // IQ-shader program W10 — math/rotation (quaternions, fourier, tri dist, uv)
   { category: 'math', file: 'sdf-js/scripts/test-mathx.mjs' },
+  // IQ-shader program W11 — cleanup (ellipse dist, box shadow, SDF AO, lyapunov)
+  { category: 'math', file: 'sdf-js/scripts/test-extra.mjs' },
 
   // M7 world runtime — determinism CI (the foundation Fable 5 asked for)
   { category: 'world', file: 'sdf-js/scripts/world/test-determinism.mjs' },

--- a/sdf-js/scripts/glsl-smoke.html
+++ b/sdf-js/scripts/glsl-smoke.html
@@ -25,6 +25,7 @@
       import { FRACTAL_GLSL } from '../src/sdf/fractal.js';
       import { EFFECTS_GLSL } from '../src/sdf/effects.js';
       import { MATHX_GLSL } from '../src/sdf/mathx.js';
+      import { EXTRA_GLSL } from '../src/sdf/extra.js';
 
       const gl = document.getElementById('c').getContext('webgl2');
       const vsSrc = 'attribute vec2 p; void main(){ gl_Position = vec4(p, 0.0, 1.0); }';
@@ -41,6 +42,7 @@ ${INTERSECT_GLSL}
 ${FRACTAL_GLSL}
 ${EFFECTS_GLSL}
 ${MATHX_GLSL}
+${EXTRA_GLSL}
 void main(){
   float s = smootherstep(0.5) + parabola(0.5, 2.0) + gain(0.3, 3.0)
     + cubicPulse(0.5, 0.2, 0.5) + smoothstepInteg(0.7) + invSmoothstep(0.4)
@@ -87,6 +89,8 @@ void main(){
     + triangleArea(vec3(0.0), vec3(1.0, 0.0, 0.0), vec3(0.0, 1.0, 0.0))
     + distToTriangle(vec3(p, 1.0), vec3(0.0), vec3(1.0, 0.0, 0.0), vec3(0.0, 1.0, 0.0))
     + sphereUV(vec3(p, 0.5)).x;
+  s += distToEllipse(p, vec2(2.0, 1.0))
+    + boxShadow(vec3(0.0, 0.0, -5.0), vec3(0.0, 0.0, 1.0), vec3(0.0), vec3(1.0), 100.0);
   gl_FragColor = vec4(vec3(clamp01(s * 0.01)), 1.0);
 }`;
 
@@ -110,7 +114,7 @@ void main(){
         if (!gl.getProgramParameter(pr, gl.LINK_STATUS)) {
           throw new Error('link: ' + gl.getProgramInfoLog(pr));
         }
-        console.log('GLSL-SMOKE-OK …+effects+mathx (all 10 libs)');
+        console.log('GLSL-SMOKE-OK all 11 IQ-shader libraries');
         document.title = 'SMOKE OK';
       } catch (e) {
         console.error('GLSL-SMOKE-FAIL ' + e.message);

--- a/sdf-js/scripts/test-extra.mjs
+++ b/sdf-js/scripts/test-extra.mjs
@@ -1,0 +1,95 @@
+// =============================================================================
+// L1 unit tests for the W11 cleanup toolkit (deferred IQ items). Final wave of
+// the IQ-shader program.
+// -----------------------------------------------------------------------------
+// Recipe-only ports of Inigo Quilez:
+//   distance to ellipse        https://iquilezles.org/articles/ellipsedist/
+//   directional derivative     https://iquilezles.org/articles/derivative/
+//   (generic SDF AO; box hard shadow via the W7 box intersector)
+//   Lyapunov exponent (logistic map) https://iquilezles.org/articles/lyapunov/
+//
+// Explicitly OUT OF SCOPE as pure functions (accumulation-buffer / depth-buffer
+// renderer techniques, not library helpers): SSAO, Budhabrot, popcorn, bitmap
+// orbit traps, IFS point clouds, full analytic box/multires AO.
+// =============================================================================
+
+import {
+  distToEllipse,
+  directionalDerivative,
+  sdfAO,
+  boxShadow,
+  lyapunovLogistic,
+  EXTRA_GLSL,
+} from '../src/sdf/extra.js';
+
+let pass = 0,
+  fail = 0;
+function ok(cond, name) {
+  if (cond) {
+    pass++;
+    console.log(`  ✓ ${name}`);
+  } else {
+    fail++;
+    console.log(`  ✗ ${name}`);
+  }
+}
+const near = (a, b, eps = 5e-3) => Math.abs(a - b) < eps;
+
+console.log('=== W11 cleanup toolkit ===\n');
+
+console.log('exact ellipse distance');
+{
+  const ab = [2, 1];
+  ok(near(distToEllipse(2, 0, ab[0], ab[1]), 0), 'point on ellipse (major axis) → 0');
+  ok(near(distToEllipse(0, 1, ab[0], ab[1]), 0), 'point on ellipse (minor axis) → 0');
+  ok(near(distToEllipse(3, 0, ab[0], ab[1]), 1, 0.02), 'point outside on major axis → ≈1');
+  ok(distToEllipse(0, 0, ab[0], ab[1]) < 0, 'centre is inside (negative)');
+  ok(distToEllipse(4, 4, ab[0], ab[1]) > 0, 'far point outside (positive)');
+}
+
+console.log('\ndirectional derivative of an SDF');
+{
+  const sphere = (p) => Math.hypot(p[0], p[1], p[2]) - 1; // unit sphere SDF
+  ok(
+    near(directionalDerivative(sphere, [2, 0, 0], [1, 0, 0]), 1, 1e-2),
+    'radial dir → +1 (distance grows)',
+  );
+  ok(near(directionalDerivative(sphere, [2, 0, 0], [0, 1, 0]), 0, 1e-2), 'tangential dir → ~0');
+}
+
+console.log('\ngeneric SDF ambient occlusion');
+{
+  // ground plane y=0 with a small sphere bump just above it
+  const scene = (p) => Math.min(p[1], Math.hypot(p[0], p[1] - 0.3, p[2]) - 0.25);
+  const aoUnder = sdfAO(scene, [0, 0, 0], [0, 1, 0]); // directly under the bump
+  const aoFar = sdfAO(scene, [3, 0, 0], [0, 1, 0]); // open ground
+  ok(aoUnder < aoFar, 'point under an occluder is darker than open ground');
+  ok(aoFar > 0.9, 'open ground ≈ unoccluded');
+  ok(aoUnder >= 0 && aoUnder <= 1, 'AO in [0,1]');
+}
+
+console.log('\nbox hard shadow (via intersector)');
+{
+  ok(
+    boxShadow([0, 0, -5], [0, 0, 1], [0, 0, 0], [1, 1, 1], 100) === 0,
+    'ray toward box → shadowed',
+  );
+  ok(boxShadow([0, 0, -5], [0, 0, -1], [0, 0, 0], [1, 1, 1], 100) === 1, 'ray away from box → lit');
+}
+
+console.log('\nLyapunov exponent (logistic map)');
+{
+  const chaotic = lyapunovLogistic(3.9, 500);
+  const stable = lyapunovLogistic(2.5, 500);
+  ok(chaotic > 0, 'r=3.9 (chaos) → positive Lyapunov exponent');
+  ok(stable < 0, 'r=2.5 (stable fixed point) → negative exponent');
+}
+
+console.log('\nGLSL mirror present');
+ok(typeof EXTRA_GLSL === 'string' && EXTRA_GLSL.length > 150, 'EXTRA_GLSL exported');
+for (const fn of ['distToEllipse', 'boxShadow']) {
+  ok(EXTRA_GLSL.includes(fn), `EXTRA_GLSL defines ${fn}`);
+}
+
+console.log(`\n=== Result: ${pass} passed, ${fail} failed ===`);
+process.exit(fail > 0 ? 1 : 0);

--- a/sdf-js/src/sdf/extra.js
+++ b/sdf-js/src/sdf/extra.js
@@ -1,0 +1,146 @@
+// =============================================================================
+// extra.js — W11 cleanup: the deferred IQ items expressible as pure functions.
+// -----------------------------------------------------------------------------
+// Final wave of the IQ-shader program. Recipe-only ports of Inigo Quilez:
+//   distance to ellipse     https://iquilezles.org/articles/ellipsedist/
+//   directional derivative  https://iquilezles.org/articles/derivative/
+//   Lyapunov exponent       https://iquilezles.org/articles/lyapunov/
+//   (+ generic SDF AO; box hard shadow via the W7 box intersector)
+//
+// OUT OF SCOPE as pure functions (accumulation-buffer / depth-buffer renderer
+// techniques — belong to a future fractal/AO renderer, not a math library):
+// SSAO, Budhabrot, popcorn, bitmap orbit traps, IFS point clouds, full analytic
+// box / multi-resolution AO.
+//
+// JS (CPU/testable) + GLSL mirror (EXTRA_GLSL). License: PolyForm Noncommercial.
+// =============================================================================
+
+import { iBox } from './intersect.js';
+
+const clamp01 = (x) => (x < 0 ? 0 : x > 1 ? 1 : x);
+
+/** Exact signed distance from point (px,py) to an axis-aligned ellipse with
+ *  semi-axes (ax,ay). IQ's robust closed form. Negative inside. */
+export function distToEllipse(px, py, ax, ay) {
+  let pxa = Math.abs(px),
+    pya = Math.abs(py);
+  let a = ax,
+    b = ay;
+  if (pxa > pya) {
+    [pxa, pya] = [pya, pxa];
+    [a, b] = [b, a];
+  }
+  const l = b * b - a * a;
+  const m = (a * pxa) / l,
+    m2 = m * m;
+  const n = (b * pya) / l,
+    n2 = n * n;
+  const c = (m2 + n2 - 1) / 3,
+    c3 = c * c * c;
+  const q = c3 + m2 * n2 * 2;
+  const d = c3 + m2 * n2;
+  const g = m + m * n2;
+  let co;
+  if (d < 0) {
+    const h = Math.acos(q / c3) / 3;
+    const s = Math.cos(h);
+    const t = Math.sin(h) * Math.sqrt(3);
+    const rx = Math.sqrt(-c * (s + t + 2) + m2);
+    const ry = Math.sqrt(-c * (s - t + 2) + m2);
+    co = (ry + Math.sign(l) * rx + Math.abs(g) / (rx * ry) - m) / 2;
+  } else {
+    const h = 2 * m * n * Math.sqrt(d);
+    const s = Math.sign(q + h) * Math.pow(Math.abs(q + h), 1 / 3);
+    const u = Math.sign(q - h) * Math.pow(Math.abs(q - h), 1 / 3);
+    const rx = -s - u - c * 4 + 2 * m2;
+    const ry = (s - u) * Math.sqrt(3);
+    const rm = Math.sqrt(rx * rx + ry * ry);
+    co = (ry / Math.sqrt(rm - rx) + (2 * g) / rm - m) / 2;
+  }
+  const rX = a * co,
+    rY = b * Math.sqrt(1 - co * co);
+  return Math.hypot(rX - pxa, rY - pya) * Math.sign(pya - rY);
+}
+
+/** Directional derivative of an SDF field along a (unit) direction. */
+export function directionalDerivative(sdfFn, p, dir, h = 1e-4) {
+  const a = sdfFn([p[0] + dir[0] * h, p[1] + dir[1] * h, p[2] + dir[2] * h]);
+  const b = sdfFn([p[0] - dir[0] * h, p[1] - dir[1] * h, p[2] - dir[2] * h]);
+  return (a - b) / (2 * h);
+}
+
+/** Generic IQ 5-tap ambient occlusion for any SDF, sampled along the normal. */
+export function sdfAO(sdfFn, p, n, opts = {}) {
+  const steps = opts.steps ?? 5;
+  const spread = opts.spread ?? 0.15;
+  let occ = 0,
+    sca = 1;
+  for (let i = 0; i < steps; i++) {
+    const h = 0.01 + (spread * i) / Math.max(steps - 1, 1);
+    const d = sdfFn([p[0] + n[0] * h, p[1] + n[1] * h, p[2] + n[2] * h]);
+    occ += (h - d) * sca;
+    sca *= 0.95;
+  }
+  return clamp01(1 - 1.8 * occ);
+}
+
+/** Hard shadow: 0 if the ray hits the box within (eps, maxT], else 1. */
+export function boxShadow(ro, rd, center, halfsize, maxT) {
+  const h = iBox(ro, rd, center, halfsize);
+  if (h && h[0] > 1e-3 && h[0] < maxT) return 0;
+  return 1;
+}
+
+/** Lyapunov exponent of the logistic map xₙ₊₁ = r·xₙ(1−xₙ) at parameter r.
+ *  Positive → chaotic, negative → stable (basis of Lyapunov fractals). */
+export function lyapunovLogistic(r, n) {
+  let x = 0.5;
+  for (let i = 0; i < 100; i++) x = r * x * (1 - x); // burn-in
+  let sum = 0;
+  for (let i = 0; i < n; i++) {
+    x = r * x * (1 - x);
+    sum += Math.log(Math.abs(r * (1 - 2 * x)) + 1e-30);
+  }
+  return sum / n;
+}
+
+// -----------------------------------------------------------------------------
+// GLSL mirror (boxShadow uses iBox from INTERSECT_GLSL, co-included earlier).
+// -----------------------------------------------------------------------------
+export const EXTRA_GLSL = /* glsl */ `
+float distToEllipse(vec2 p, vec2 ab){
+  p = abs(p);
+  if (p.x > p.y){ p = p.yx; ab = ab.yx; }
+  float l = ab.y*ab.y - ab.x*ab.x;
+  float m = ab.x*p.x/l; float m2 = m*m;
+  float n = ab.y*p.y/l; float n2 = n*n;
+  float c = (m2+n2-1.0)/3.0; float c3 = c*c*c;
+  float q = c3 + m2*n2*2.0;
+  float d = c3 + m2*n2;
+  float g = m + m*n2;
+  float co;
+  if (d < 0.0){
+    float h = acos(q/c3)/3.0;
+    float s = cos(h);
+    float t = sin(h)*sqrt(3.0);
+    float rx = sqrt(-c*(s + t + 2.0) + m2);
+    float ry = sqrt(-c*(s - t + 2.0) + m2);
+    co = (ry + sign(l)*rx + abs(g)/(rx*ry) - m)/2.0;
+  } else {
+    float h = 2.0*m*n*sqrt(d);
+    float s = sign(q+h)*pow(abs(q+h), 1.0/3.0);
+    float u = sign(q-h)*pow(abs(q-h), 1.0/3.0);
+    float rx = -s - u - c*4.0 + 2.0*m2;
+    float ry = (s - u)*sqrt(3.0);
+    float rm = sqrt(rx*rx + ry*ry);
+    co = (ry/sqrt(rm-rx) + 2.0*g/rm - m)/2.0;
+  }
+  vec2 r = ab*vec2(co, sqrt(1.0 - co*co));
+  return length(r - p)*sign(p.y - r.y);
+}
+float boxShadow(vec3 ro, vec3 rd, vec3 ce, vec3 rad, float maxT){
+  vec2 h = iBox(ro, rd, ce, rad);
+  if (h.x > 1e-3 && h.x < maxT && h.x <= h.y) return 0.0;
+  return 1.0;
+}
+`;


### PR DESCRIPTION
## What — Wave 11 (final) of the IQ shader-technique program

The deferred IQ items that **are** expressible as pure functions, plus the index doc for the whole program. JS + `EXTRA_GLSL` mirror.

**`src/sdf/extra.js`:**
| function | purpose |
| --- | --- |
| `distToEllipse` | exact signed distance to an ellipse (IQ robust closed form) |
| `directionalDerivative` | directional derivative of any SDF field |
| `sdfAO` | generic 5-tap SDF ambient occlusion (any SDF) |
| `boxShadow` | hard shadow via the W7 box intersector |
| `lyapunovLogistic` | logistic-map Lyapunov exponent (Lyapunov-fractal scalar) |

Adds **`docs/superpowers/specs/2026-06-20-iq-shader-library.md`** — index of all 11 modules + the explicit out-of-scope list (SSAO / Budhabrot / popcorn / bitmap traps / box-AO / multires-AO — accumulation/depth-buffer renderer techniques, not library helpers).

## Verification
- **17 assertions** — ellipse point-on→0 / inside<0 / outside≈dist; directional deriv radial=+1 / tangential≈0; SDF AO darker under an occluder; box shadow toward=0 / away=1; Lyapunov +chaos / −stable.
- `EXTRA_GLSL` compiles + links with **every prior library** → **`GLSL-SMOKE-OK all 11 IQ-shader libraries`** (headless).
- Full suite **50/50**, `node --check` + Prettier clean.

## 🎉 Program complete
11 waves · 11 JS+GLSL modules (`easing, noise, filter, lighting, sdg, bounds, intersect, fractal, effects, mathx, extra`) · ~280 assertions · all GLSL co-compiles on a real GPU via the reusable `scripts/glsl-smoke.html` harness. Each module is additive (zero behaviour change); a later pass wires them into renderers.

Next: resume the 21-atom line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)