### PR TITLE
W13 gap-fill: deferred ★★★ IQ items

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -53,6 +53,8 @@ const TESTS = [
   { category: 'math', file: 'sdf-js/scripts/test-mathx.mjs' },
   // IQ-shader program W11 — cleanup (ellipse dist, box shadow, SDF AO, lyapunov)
   { category: 'math', file: 'sdf-js/scripts/test-extra.mjs' },
+  // IQ-shader program W13 — gap-fill (2D bbox, multires/box AO, GI, implicit dist)
+  { category: 'math', file: 'sdf-js/scripts/test-gaps.mjs' },
 
   // M7 world runtime — determinism CI (the foundation Fable 5 asked for)
   { category: 'world', file: 'sdf-js/scripts/world/test-determinism.mjs' },

--- a/sdf-js/scripts/glsl-smoke.html
+++ b/sdf-js/scripts/glsl-smoke.html
@@ -26,6 +26,7 @@
       import { EFFECTS_GLSL } from '../src/sdf/effects.js';
       import { MATHX_GLSL } from '../src/sdf/mathx.js';
       import { EXTRA_GLSL } from '../src/sdf/extra.js';
+      import { GAPS_GLSL } from '../src/sdf/gaps.js';
 
       const gl = document.getElementById('c').getContext('webgl2');
       const vsSrc = 'attribute vec2 p; void main(){ gl_Position = vec4(p, 0.0, 1.0); }';
@@ -43,6 +44,7 @@ ${FRACTAL_GLSL}
 ${EFFECTS_GLSL}
 ${MATHX_GLSL}
 ${EXTRA_GLSL}
+${GAPS_GLSL}
 void main(){
   float s = smootherstep(0.5) + parabola(0.5, 2.0) + gain(0.3, 3.0)
     + cubicPulse(0.5, 0.2, 0.5) + smoothstepInteg(0.7) + invSmoothstep(0.4)
@@ -91,6 +93,9 @@ void main(){
     + sphereUV(vec3(p, 0.5)).x;
   s += distToEllipse(p, vec2(2.0, 1.0))
     + boxShadow(vec3(0.0, 0.0, -5.0), vec3(0.0, 0.0, 1.0), vec3(0.0), vec3(1.0), 100.0);
+  s += approxDistImplicit(2.0, 4.0)
+    + boxAO(vec3(0.0), vec3(0.0, 0.0, 1.0), vec3(0.0, 0.0, 1.3), vec3(0.5))
+    + simpleGI(vec3(0.0, 1.0, 0.0), vec3(0.4, 0.6, 1.0), vec3(0.3, 0.25, 0.2), 1.0).z;
   gl_FragColor = vec4(vec3(clamp01(s * 0.01)), 1.0);
 }`;
 
@@ -114,7 +119,7 @@ void main(){
         if (!gl.getProgramParameter(pr, gl.LINK_STATUS)) {
           throw new Error('link: ' + gl.getProgramInfoLog(pr));
         }
-        console.log('GLSL-SMOKE-OK all 11 IQ-shader libraries');
+        console.log('GLSL-SMOKE-OK all 12 IQ-shader libraries');
         document.title = 'SMOKE OK';
       } catch (e) {
         console.error('GLSL-SMOKE-FAIL ' + e.message);

--- a/sdf-js/scripts/test-gaps.mjs
+++ b/sdf-js/scripts/test-gaps.mjs
@@ -1,0 +1,92 @@
+// =============================================================================
+// L1 unit tests for the W13 gap-fill toolkit (deferred ★★★ IQ items).
+// -----------------------------------------------------------------------------
+// Recipe-only ports / applications of Inigo Quilez:
+//   2D bounding boxes        https://iquilezles.org/articles/diskbbox/
+//   multi-resolution AO      https://iquilezles.org/articles/multiresaocc/
+//   distance to implicits    https://iquilezles.org/articles/distance/
+//   box occlusion (approx)   https://iquilezles.org/articles/boxocclusion/
+//   simple global illum.     https://iquilezles.org/articles/simplegi/
+// =============================================================================
+
+import {
+  bbox2FromSDF,
+  multiresAO,
+  approxDistImplicit,
+  boxAO,
+  simpleGI,
+  GAPS_GLSL,
+} from '../src/sdf/gaps.js';
+
+let pass = 0,
+  fail = 0;
+function ok(cond, name) {
+  if (cond) {
+    pass++;
+    console.log(`  ✓ ${name}`);
+  } else {
+    fail++;
+    console.log(`  ✗ ${name}`);
+  }
+}
+const near = (a, b, eps = 0.2) => Math.abs(a - b) < eps;
+
+console.log('=== W13 gap-fill toolkit ===\n');
+
+console.log('2D bbox from SDF');
+{
+  const circle = (p) => Math.hypot(p[0], p[1]) - 1; // unit circle
+  const bb = bbox2FromSDF(circle, { radius: 3, res: 48 });
+  ok(near(bb.min[0], -1) && near(bb.max[0], 1), 'unit circle x-extent ≈ ±1');
+  ok(near(bb.min[1], -1) && near(bb.max[1], 1), 'unit circle y-extent ≈ ±1');
+  ok(near(bb.center[0], 0) && near(bb.size[0], 2), 'centre 0, size ≈ 2');
+}
+
+console.log('\nmulti-resolution SDF AO');
+{
+  const scene = (p) => Math.min(p[1], Math.hypot(p[0], p[1] - 0.3, p[2]) - 0.25);
+  const under = multiresAO(scene, [0, 0, 0], [0, 1, 0]);
+  const open = multiresAO(scene, [3, 0, 0], [0, 1, 0]);
+  ok(under < open, 'point under an occluder is darker');
+  ok(open > 0.9, 'open ground ≈ unoccluded');
+  ok(under >= 0 && under <= 1, 'AO in [0,1]');
+}
+
+console.log('\napprox distance to implicit (Lipschitz)');
+{
+  ok(near(approxDistImplicit(2, 4), 0.5, 1e-9), 'value/|grad| = 2/4 = 0.5');
+  ok(approxDistImplicit(1, 0) > 1e5, 'zero gradient → huge (guarded, finite)');
+  ok(Number.isFinite(approxDistImplicit(1, 0)), 'guarded result is finite');
+}
+
+console.log('\nbox AO (bounding-sphere approximation)');
+{
+  const pos = [0, 0, 0],
+    n = [0, 0, 1];
+  const aoNear = boxAO(pos, n, [0, 0, 1.3], [0.5, 0.5, 0.5]);
+  const aoFar = boxAO(pos, n, [0, 0, 20], [0.5, 0.5, 0.5]);
+  ok(aoNear < aoFar, 'near box occludes more than far');
+  ok(aoFar > 0.97, 'distant box ≈ unoccluded');
+  ok(near(boxAO(pos, n, [0, 0, -2], [0.5, 0.5, 0.5]), 1, 1e-3), 'box behind → no occlusion');
+}
+
+console.log('\nsimple GI (hemispheric sky/ground)');
+{
+  const sky = [0.4, 0.6, 1.0],
+    ground = [0.3, 0.25, 0.2];
+  const up = simpleGI([0, 1, 0], sky, ground, 1);
+  const down = simpleGI([0, -1, 0], sky, ground, 1);
+  ok(near(up[2], sky[2]) && up[2] > down[2], 'up-facing picks up sky (more blue)');
+  ok(near(down[0], ground[0]), 'down-facing picks up ground bounce');
+  const dim = simpleGI([0, 1, 0], sky, ground, 0.5);
+  ok(dim[2] < up[2], 'AO scales the GI down');
+}
+
+console.log('\nGLSL mirror present');
+ok(typeof GAPS_GLSL === 'string' && GAPS_GLSL.length > 150, 'GAPS_GLSL exported');
+for (const fn of ['boxAO', 'simpleGI', 'approxDistImplicit']) {
+  ok(GAPS_GLSL.includes(fn), `GAPS_GLSL defines ${fn}`);
+}
+
+console.log(`\n=== Result: ${pass} passed, ${fail} failed ===`);
+process.exit(fail > 0 ? 1 : 0);

--- a/sdf-js/src/sdf/gaps.js
+++ b/sdf-js/src/sdf/gaps.js
@@ -1,0 +1,107 @@
+// =============================================================================
+// gaps.js — W13 gap-fill: the deferred ★★★ IQ items, as pure functions.
+// -----------------------------------------------------------------------------
+// Recipe-only ports / applications of Inigo Quilez:
+//   2D bounding boxes      https://iquilezles.org/articles/diskbbox/
+//   multi-resolution AO    https://iquilezles.org/articles/multiresaocc/
+//   distance to implicits  https://iquilezles.org/articles/distance/
+//   box occlusion          https://iquilezles.org/articles/boxocclusion/
+//   simple global illum.   https://iquilezles.org/articles/simplegi/
+//
+// boxAO uses the box's bounding sphere with the (exact) W4 sphere occlusion — a
+// fast approximation; the full face-integral box occlusion is overkill for the
+// cube atoms. JS (CPU/testable) + GLSL mirror (GAPS_GLSL; boxAO calls sphereAO
+// from LIGHTING_GLSL, co-included earlier). License: PolyForm Noncommercial.
+// =============================================================================
+
+import { sphereAO } from './lighting.js';
+
+const clamp01 = (x) => (x < 0 ? 0 : x > 1 ? 1 : x);
+
+/** Grid-sampled 2D axis-aligned bounding box of an SDF (p=[x,y] → dist). */
+export function bbox2FromSDF(sdfFn, opts = {}) {
+  const R = opts.radius ?? 3;
+  const res = opts.res ?? 48;
+  const iso = opts.iso ?? 0;
+  const step = (2 * R) / res;
+  const min = [Infinity, Infinity];
+  const max = [-Infinity, -Infinity];
+  let found = false;
+  for (let i = 0; i <= res; i++) {
+    const x = -R + i * step;
+    for (let j = 0; j <= res; j++) {
+      const y = -R + j * step;
+      if (sdfFn([x, y]) <= iso) {
+        found = true;
+        if (x < min[0]) min[0] = x;
+        if (x > max[0]) max[0] = x;
+        if (y < min[1]) min[1] = y;
+        if (y > max[1]) max[1] = y;
+      }
+    }
+  }
+  if (!found) return { min: [0, 0], max: [0, 0], center: [0, 0], size: [0, 0], empty: true };
+  const h = step * 0.5;
+  min[0] -= h;
+  min[1] -= h;
+  max[0] += h;
+  max[1] += h;
+  const center = [(min[0] + max[0]) / 2, (min[1] + max[1]) / 2];
+  const size = [max[0] - min[0], max[1] - min[1]];
+  return { min, max, center, size };
+}
+
+/** Multi-resolution SDF ambient occlusion: combine occlusion across spatial
+ *  scales for a softer, less banded result than a single-radius tap set. */
+export function multiresAO(sdfFn, p, n, opts = {}) {
+  const scales = opts.scales ?? [0.04, 0.1, 0.25];
+  let occ = 0,
+    sca = 1,
+    total = 0;
+  for (const h of scales) {
+    const d = sdfFn([p[0] + n[0] * h, p[1] + n[1] * h, p[2] + n[2] * h]);
+    occ += (Math.max(0, h - d) / h) * sca;
+    total += sca;
+    sca *= 0.6;
+  }
+  return clamp01(1 - (1.5 * occ) / total);
+}
+
+/** Lipschitz distance estimate for an arbitrary implicit field: value / |∇f|.
+ *  Lets a sphere-tracer safely march any LLM-generated field, not just true SDFs. */
+export function approxDistImplicit(value, gradMag) {
+  return value / Math.max(gradMag, 1e-6);
+}
+
+/** Box ambient occlusion (bounding-sphere approximation via exact sphere AO). */
+export function boxAO(pos, nor, center, half) {
+  const r = Math.hypot(half[0], half[1], half[2]);
+  return sphereAO(pos, nor, center, r);
+}
+
+/** Simple hemispheric GI: ground-bounce ↔ sky-dome blend by normal.y, ×AO. */
+export function simpleGI(nor, skyColor, groundColor, ao) {
+  const t = 0.5 + 0.5 * nor[1];
+  return [
+    (groundColor[0] + (skyColor[0] - groundColor[0]) * t) * ao,
+    (groundColor[1] + (skyColor[1] - groundColor[1]) * t) * ao,
+    (groundColor[2] + (skyColor[2] - groundColor[2]) * t) * ao,
+  ];
+}
+
+// -----------------------------------------------------------------------------
+// GLSL mirror (boxAO uses sphereAO from LIGHTING_GLSL, co-included earlier).
+// bbox2 / multiresAO take a callback → CPU-only.
+// -----------------------------------------------------------------------------
+export const GAPS_GLSL = /* glsl */ `
+float approxDistImplicit(float value, float gradMag){
+  return value / max(gradMag, 1e-6);
+}
+float boxAO(vec3 pos, vec3 nor, vec3 ce, vec3 half_){
+  return sphereAO(pos, nor, vec4(ce, length(half_)));
+}
+vec3 simpleGI(vec3 nor, vec3 skyColor, vec3 groundColor, float ao){
+  float t = 0.5 + 0.5*nor.y;
+  return mix(groundColor, skyColor, t) * ao;
+}
+`;


### PR DESCRIPTION
## What — fills the deferred-but-tractable items from W4/W6/W8

The ★★★ items I earlier marked deferred that **are** expressible as pure functions. JS + `GAPS_GLSL` mirror.

**`src/sdf/gaps.js`** — IQ #7, #79, #61, #105, #83:
| function | purpose |
| --- | --- |
| `bbox2FromSDF` | 2D grid-sampled bounding box (layout / Atlas Present) |
| `multiresAO` | multi-resolution generic SDF ambient occlusion |
| `approxDistImplicit` | Lipschitz distance estimate `value/|∇f|` (safe-march any field) |
| `boxAO` | box occlusion (bounding-sphere approximation via exact W4 sphere AO) |
| `simpleGI` | hemispheric sky/ground GI blend × AO |

## Verification
- **19 assertions** — 2D circle bbox ≈ ±1; multires AO darker under an occluder / open ≈ 1; implicit distance = value/|grad| with a zero-grad guard; box AO near < far / behind = 1; GI up→sky, down→ground, scaled by AO.
- `GAPS_GLSL` compiles + links with **all** libraries (boxAO cross-calls `sphereAO` from `LIGHTING_GLSL`) → **`GLSL-SMOKE-OK all 12 IQ-shader libraries`** (headless).
- Full suite **51/51**, `node --check` + Prettier clean.

## 🏁 IQ-shader program fully complete
**12 library modules** (easing, noise, filter, lighting, sdg, bounds, intersect, fractal, effects, mathx, extra, gaps) + **2 renderer-wiring PRs** (auto-framing live in studio; checker + patterns routed through the filter library). The two ★★★★★ outcomes (auto-framing, AA) are now actually working in the app, not just library code.

Still genuinely out of scope (accumulation/depth-buffer renderer features, not library helpers): SSAO, Budhabrot, popcorn, bitmap orbit traps, IFS point clouds, full analytic box-face occlusion.

Next: resume the 21-atom line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)