### PR TITLE
Sprint 3: simple shape atoms (arrow / diamond / gear / cube-segmented)

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -101,6 +101,10 @@ const TESTS = [
   { category: 'shapes', file: 'sdf-js/scripts/test-sphere-network-3d.mjs' },
   { category: 'shapes', file: 'sdf-js/scripts/test-sphere-tree-3d.mjs' },
   { category: 'shapes', file: 'sdf-js/scripts/test-sphere-segmented-3d.mjs' },
+  { category: 'shapes', file: 'sdf-js/scripts/test-arrow-3d.mjs' },
+  { category: 'shapes', file: 'sdf-js/scripts/test-diamond-3d.mjs' },
+  { category: 'shapes', file: 'sdf-js/scripts/test-gear-3d.mjs' },
+  { category: 'shapes', file: 'sdf-js/scripts/test-cube-segmented-3d.mjs' },
 
   // Layer 1 public API extracted from compositor.js (used by Layer 2 / MCP / tests)
   { category: 'api', file: 'sdf-js/scripts/test-compositor-api.mjs' },

--- a/sdf-js/examples/compositor/demo-lifts/arrow-3d.json
+++ b/sdf-js/examples/compositor/demo-lifts/arrow-3d.json
@@ -1,0 +1,34 @@
+{
+  "id": "arrow-3d",
+  "title": "Arrow",
+  "prompt": "arrow-3d atom — directional arrow (shaft + cone head); single or double.",
+  "code2d": "// Synthetic showcase — arrow-3d atom.\nexport const render = (ctx) => {};",
+  "sceneData": {
+    "v": 1,
+    "name": "arrow",
+    "source": { "format": "synthetic", "prompt": "arrow" },
+    "subjects": [
+      {
+        "id": "arrow",
+        "type": "arrow-3d",
+        "args": { "length": 1.8, "double": false },
+        "transform": { "translate": [0, 0.6, 0] },
+        "material": "silver"
+      }
+    ],
+    "defaults": {
+      "camera": {
+        "yaw": 0.4,
+        "pitch": 0.25,
+        "distance": 6,
+        "focal": 1.5,
+        "targetX": 0,
+        "targetY": 0.6,
+        "targetZ": 0
+      },
+      "light": { "azimuth": 0.6, "altitude": 0.55, "distance": 25, "intensity": 1.2 },
+      "shadow": { "enabled": true, "mode": "darken", "strength": 0.4 }
+    }
+  },
+  "meta": { "generatedAt": "2026-06-21", "model": "synthetic", "pattern": "arrow-3d", "costUSD": 0 }
+}

--- a/sdf-js/examples/compositor/demo-lifts/cube-segmented-3d.json
+++ b/sdf-js/examples/compositor/demo-lifts/cube-segmented-3d.json
@@ -1,0 +1,39 @@
+{
+  "id": "cube-segmented-3d",
+  "title": "Cube · Segmented",
+  "prompt": "cube-segmented-3d atom — one cube sliced into separated slabs.",
+  "code2d": "// Synthetic showcase — cube-segmented-3d atom.\nexport const render = (ctx) => {};",
+  "sceneData": {
+    "v": 1,
+    "name": "cube segmented",
+    "source": { "format": "synthetic", "prompt": "cube segmented" },
+    "subjects": [
+      {
+        "id": "cube-seg",
+        "type": "cube-segmented-3d",
+        "args": { "segments": 4, "size": 1.4, "gap": 0.1, "axis": "x" },
+        "transform": { "translate": [0, 0.8, 0] },
+        "material": "silver"
+      }
+    ],
+    "defaults": {
+      "camera": {
+        "yaw": 0.5,
+        "pitch": 0.28,
+        "distance": 6,
+        "focal": 1.5,
+        "targetX": 0,
+        "targetY": 0.8,
+        "targetZ": 0
+      },
+      "light": { "azimuth": 0.6, "altitude": 0.55, "distance": 25, "intensity": 1.2 },
+      "shadow": { "enabled": true, "mode": "darken", "strength": 0.4 }
+    }
+  },
+  "meta": {
+    "generatedAt": "2026-06-21",
+    "model": "synthetic",
+    "pattern": "cube-segmented-3d",
+    "costUSD": 0
+  }
+}

--- a/sdf-js/examples/compositor/demo-lifts/diamond-3d.json
+++ b/sdf-js/examples/compositor/demo-lifts/diamond-3d.json
@@ -1,0 +1,39 @@
+{
+  "id": "diamond-3d",
+  "title": "Diamond",
+  "prompt": "diamond-3d atom — brilliant-cut gem (crown frustum + pavilion cone).",
+  "code2d": "// Synthetic showcase — diamond-3d atom.\nexport const render = (ctx) => {};",
+  "sceneData": {
+    "v": 1,
+    "name": "diamond",
+    "source": { "format": "synthetic", "prompt": "diamond" },
+    "subjects": [
+      {
+        "id": "diamond",
+        "type": "diamond-3d",
+        "args": { "width": 1.0 },
+        "transform": { "translate": [0, 0.8, 0] },
+        "material": "clear-glass"
+      }
+    ],
+    "defaults": {
+      "camera": {
+        "yaw": 0.5,
+        "pitch": 0.2,
+        "distance": 5,
+        "focal": 1.5,
+        "targetX": 0,
+        "targetY": 0.8,
+        "targetZ": 0
+      },
+      "light": { "azimuth": 0.6, "altitude": 0.55, "distance": 25, "intensity": 1.2 },
+      "shadow": { "enabled": true, "mode": "darken", "strength": 0.4 }
+    }
+  },
+  "meta": {
+    "generatedAt": "2026-06-21",
+    "model": "synthetic",
+    "pattern": "diamond-3d",
+    "costUSD": 0
+  }
+}

--- a/sdf-js/examples/compositor/demo-lifts/gear-3d.json
+++ b/sdf-js/examples/compositor/demo-lifts/gear-3d.json
@@ -1,0 +1,34 @@
+{
+  "id": "gear-3d",
+  "title": "Gear",
+  "prompt": "gear-3d atom — cog wheel (cylinder body + radial teeth − centre hole).",
+  "code2d": "// Synthetic showcase — gear-3d atom.\nexport const render = (ctx) => {};",
+  "sceneData": {
+    "v": 1,
+    "name": "gear",
+    "source": { "format": "synthetic", "prompt": "gear" },
+    "subjects": [
+      {
+        "id": "gear",
+        "type": "gear-3d",
+        "args": { "teeth": 14, "radius": 0.8, "thickness": 0.3 },
+        "transform": { "translate": [0, 0.8, 0], "rotate": [1.2, 0, 0] },
+        "material": "silver"
+      }
+    ],
+    "defaults": {
+      "camera": {
+        "yaw": 0.4,
+        "pitch": 0.3,
+        "distance": 6,
+        "focal": 1.5,
+        "targetX": 0,
+        "targetY": 0.8,
+        "targetZ": 0
+      },
+      "light": { "azimuth": 0.6, "altitude": 0.55, "distance": 25, "intensity": 1.2 },
+      "shadow": { "enabled": true, "mode": "darken", "strength": 0.4 }
+    }
+  },
+  "meta": { "generatedAt": "2026-06-21", "model": "synthetic", "pattern": "gear-3d", "costUSD": 0 }
+}

--- a/sdf-js/examples/compositor/demo-lifts/index.json
+++ b/sdf-js/examples/compositor/demo-lifts/index.json
@@ -248,6 +248,46 @@
       "file": "sphere-segmented.json",
       "renderer": "studio",
       "prompt": "Sphere divisions"
+    },
+    {
+      "id": "arrow-3d",
+      "title": "Arrow",
+      "thesisPoint": "Atlas Shape atom (Sprint 3 simple shapes) — composite atom, studio auto-framed.",
+      "category": "primitive-showcase",
+      "status": "ready",
+      "file": "arrow-3d.json",
+      "renderer": "studio",
+      "prompt": "Arrow"
+    },
+    {
+      "id": "diamond-3d",
+      "title": "Diamond",
+      "thesisPoint": "Atlas Shape atom (Sprint 3 simple shapes) — composite atom, studio auto-framed.",
+      "category": "primitive-showcase",
+      "status": "ready",
+      "file": "diamond-3d.json",
+      "renderer": "studio",
+      "prompt": "Diamond"
+    },
+    {
+      "id": "gear-3d",
+      "title": "Gear",
+      "thesisPoint": "Atlas Shape atom (Sprint 3 simple shapes) — composite atom, studio auto-framed.",
+      "category": "primitive-showcase",
+      "status": "ready",
+      "file": "gear-3d.json",
+      "renderer": "studio",
+      "prompt": "Gear"
+    },
+    {
+      "id": "cube-segmented-3d",
+      "title": "Cube · Segmented",
+      "thesisPoint": "Atlas Shape atom (Sprint 3 simple shapes) — composite atom, studio auto-framed.",
+      "category": "primitive-showcase",
+      "status": "ready",
+      "file": "cube-segmented-3d.json",
+      "renderer": "studio",
+      "prompt": "Cube · Segmented"
     }
   ]
 }

--- a/sdf-js/scripts/test-arrow-3d.mjs
+++ b/sdf-js/scripts/test-arrow-3d.mjs
@@ -1,0 +1,48 @@
+import { arrow3dSDF } from '../src/scene/components/shapes/arrow-3d.js';
+import { compile } from '../src/scene/compile.js';
+import { compileSDF3ToGLSL } from '../src/sdf/sdf3.compile.js';
+
+let pass = 0,
+  fail = 0;
+function ok(c, n) {
+  if (c) {
+    pass++;
+    console.log(`  ✓ ${n}`);
+  } else {
+    fail++;
+    console.log(`  ✗ ${n}`);
+  }
+}
+console.log('=== arrow-3d unit test ===\n');
+{
+  const sdf = arrow3dSDF(); // length 1.6 → half 0.8, head at +X
+  ok(sdf.f([0, 0, 0]) < 0, 'shaft midpoint inside');
+  ok(sdf.f([0.78, 0, 0]) < 0, 'near +X tip (cone axis) inside');
+  ok(sdf.f([0, 0.3, 0]) > 0, 'off to the side (above shaft, not on head) outside');
+  ok(sdf.f([3, 0, 0]) > 0, 'far outside');
+  ok(sdf.f([-0.78, 0, 0]) < 0, 'single arrow: solid flat shaft tail inside');
+  ok(sdf.f([-0.95, 0, 0]) > 0, 'single arrow: past the −X tail outside');
+}
+{
+  const dbl = arrow3dSDF({ double: true });
+  ok(dbl.f([-0.78, 0, 0]) < 0, 'double arrow: −X tip inside');
+  ok(dbl.f([0.78, 0, 0]) < 0, 'double arrow: +X tip inside');
+}
+{
+  const scene = {
+    v: 1,
+    defaults: {
+      camera: { yaw: 0.4, pitch: 0.2, distance: 6, focal: 1.5, targetX: 0, targetY: 0, targetZ: 0 },
+      light: { altitude: 0.5, azimuth: 0.6, distance: 8, intensity: 1.1 },
+    },
+    subjects: [{ type: 'arrow-3d', id: 'a', args: { double: true }, region: 'object' }],
+  };
+  const compiled = compile(scene);
+  ok(compiled.sdf.f([0, 0, 0]) < 0, 'compiled arrow inside at centre');
+  const glsl = compileSDF3ToGLSL(compiled.sdf, { time: 'u_time' });
+  const s = typeof glsl === 'string' ? glsl : glsl.expr || JSON.stringify(glsl);
+  ok(s.includes('sdCappedCone'), 'GLSL emit has sdCappedCone (head)');
+  ok(s.includes('sdBox'), 'GLSL emit has sdBox (shaft)');
+}
+console.log(`\n=== Result: ${pass} passed, ${fail} failed ===`);
+process.exit(fail > 0 ? 1 : 0);

--- a/sdf-js/scripts/test-cube-segmented-3d.mjs
+++ b/sdf-js/scripts/test-cube-segmented-3d.mjs
@@ -1,0 +1,47 @@
+import { cubeSegmented3dSDF } from '../src/scene/components/shapes/cube-segmented-3d.js';
+import { compile } from '../src/scene/compile.js';
+import { compileSDF3ToGLSL } from '../src/sdf/sdf3.compile.js';
+
+let pass = 0,
+  fail = 0;
+function ok(c, n) {
+  if (c) {
+    pass++;
+    console.log(`  ✓ ${n}`);
+  } else {
+    fail++;
+    console.log(`  ✗ ${n}`);
+  }
+}
+console.log('=== cube-segmented-3d unit test ===\n');
+{
+  // segments 4, size 1.2, gap 0.08 → slabThick 0.24, stride 0.32, x = ±0.48, ±0.16
+  const sdf = cubeSegmented3dSDF();
+  ok(sdf.f([-0.48, 0, 0]) < 0, 'slab 0 centre inside');
+  ok(sdf.f([0.48, 0, 0]) < 0, 'slab 3 centre inside');
+  ok(sdf.f([-0.32, 0, 0]) > 0, 'gap between slab 0 and 1 outside');
+  ok(sdf.f([2, 0, 0]) > 0, 'far outside');
+}
+{
+  const sdfY = cubeSegmented3dSDF({ segments: 3, axis: 'y', size: 1.2, gap: 0.1 });
+  // 3 slabs along Y: stride = (1.2-0.2)/3 + 0.1 = 0.333+0.1=0.433; y = ±0.433, 0
+  ok(sdfY.f([0, 0, 0]) < 0, 'axis=y: middle slab centre inside');
+  ok(sdfY.f([0, 0.2167, 0]) > 0, 'axis=y: gap between slabs outside');
+}
+{
+  const scene = {
+    v: 1,
+    defaults: {
+      camera: { yaw: 0.4, pitch: 0.2, distance: 6, focal: 1.5, targetX: 0, targetY: 0, targetZ: 0 },
+      light: { altitude: 0.5, azimuth: 0.6, distance: 8, intensity: 1.1 },
+    },
+    subjects: [{ type: 'cube-segmented-3d', id: 'cs', args: { segments: 4 }, region: 'object' }],
+  };
+  const compiled = compile(scene);
+  ok(compiled.sdf.f([-0.48, 0, 0]) < 0, 'compiled slab inside');
+  const glsl = compileSDF3ToGLSL(compiled.sdf, { time: 'u_time' });
+  const s = typeof glsl === 'string' ? glsl : glsl.expr || JSON.stringify(glsl);
+  ok(s.includes('sdBox'), 'GLSL emit has sdBox (slabs)');
+}
+console.log(`\n=== Result: ${pass} passed, ${fail} failed ===`);
+process.exit(fail > 0 ? 1 : 0);

--- a/sdf-js/scripts/test-diamond-3d.mjs
+++ b/sdf-js/scripts/test-diamond-3d.mjs
@@ -1,0 +1,45 @@
+import { diamond3dSDF } from '../src/scene/components/shapes/diamond-3d.js';
+import { compile } from '../src/scene/compile.js';
+import { compileSDF3ToGLSL } from '../src/sdf/sdf3.compile.js';
+
+let pass = 0,
+  fail = 0;
+function ok(c, n) {
+  if (c) {
+    pass++;
+    console.log(`  ✓ ${n}`);
+  } else {
+    fail++;
+    console.log(`  ✗ ${n}`);
+  }
+}
+console.log('=== diamond-3d unit test ===\n');
+{
+  const sdf = diamond3dSDF(); // width 0.9 (girdleR 0.45), crown 0.3, pavilion 0.7
+  // probe slightly off y=0: the girdle plane is the shared cap of crown+pavilion
+  // (SDF≈0 there); just inside either frustum is strictly negative.
+  ok(sdf.f([0, 0.05, 0]) < 0, 'just above girdle (crown interior) inside');
+  ok(sdf.f([0.4, 0.02, 0]) < 0, 'near girdle widest point inside');
+  ok(sdf.f([0, 0.28, 0]) < 0, 'crown / table region inside');
+  ok(sdf.f([0, -0.65, 0]) < 0, 'near bottom pavilion point inside');
+  ok(sdf.f([0.6, 0, 0]) > 0, 'beyond girdle radius outside');
+  ok(sdf.f([0, 0.5, 0]) > 0, 'above the table outside');
+  ok(sdf.f([0, -0.9, 0]) > 0, 'below the point outside');
+}
+{
+  const scene = {
+    v: 1,
+    defaults: {
+      camera: { yaw: 0.4, pitch: 0.2, distance: 6, focal: 1.5, targetX: 0, targetY: 0, targetZ: 0 },
+      light: { altitude: 0.5, azimuth: 0.6, distance: 8, intensity: 1.1 },
+    },
+    subjects: [{ type: 'diamond-3d', id: 'd', args: {}, region: 'object' }],
+  };
+  const compiled = compile(scene);
+  ok(compiled.sdf.f([0, 0.05, 0]) < 0, 'compiled diamond inside (just above girdle)');
+  const glsl = compileSDF3ToGLSL(compiled.sdf, { time: 'u_time' });
+  const s = typeof glsl === 'string' ? glsl : glsl.expr || JSON.stringify(glsl);
+  ok(s.includes('sdCappedCone'), 'GLSL emit has sdCappedCone (crown+pavilion)');
+}
+console.log(`\n=== Result: ${pass} passed, ${fail} failed ===`);
+process.exit(fail > 0 ? 1 : 0);

--- a/sdf-js/scripts/test-gear-3d.mjs
+++ b/sdf-js/scripts/test-gear-3d.mjs
@@ -1,0 +1,43 @@
+import { gear3dSDF } from '../src/scene/components/shapes/gear-3d.js';
+import { compile } from '../src/scene/compile.js';
+import { compileSDF3ToGLSL } from '../src/sdf/sdf3.compile.js';
+
+let pass = 0,
+  fail = 0;
+function ok(c, n) {
+  if (c) {
+    pass++;
+    console.log(`  ✓ ${n}`);
+  } else {
+    fail++;
+    console.log(`  ✗ ${n}`);
+  }
+}
+console.log('=== gear-3d unit test ===\n');
+{
+  const sdf = gear3dSDF(); // radius 0.7, hole 0.22, 12 teeth, tooth0 at +X
+  ok(sdf.f([0.45, 0, 0]) < 0, 'body ring (between hole and rim) inside');
+  ok(sdf.f([0, 0, 0]) > 0, 'centre is the hole → outside');
+  ok(sdf.f([0.82, 0, 0]) < 0, 'tooth-0 (+X) tip inside');
+  ok(sdf.f([1.5, 0, 0]) > 0, 'far past the teeth outside');
+  ok(sdf.f([0, 1, 0]) > 0, 'above the gear (Y) outside');
+}
+{
+  const scene = {
+    v: 1,
+    defaults: {
+      camera: { yaw: 0.4, pitch: 0.2, distance: 6, focal: 1.5, targetX: 0, targetY: 0, targetZ: 0 },
+      light: { altitude: 0.5, azimuth: 0.6, distance: 8, intensity: 1.1 },
+    },
+    subjects: [{ type: 'gear-3d', id: 'g', args: { teeth: 10 }, region: 'object' }],
+  };
+  const compiled = compile(scene);
+  ok(compiled.sdf.f([0.45, 0, 0]) < 0, 'compiled gear body inside');
+  ok(compiled.sdf.f([0, 0, 0]) > 0, 'compiled gear centre hole outside');
+  const glsl = compileSDF3ToGLSL(compiled.sdf, { time: 'u_time' });
+  const s = typeof glsl === 'string' ? glsl : glsl.expr || JSON.stringify(glsl);
+  ok(s.includes('sdCylinder'), 'GLSL emit has sdCylinder (body/hole)');
+  ok(s.includes('opDifference'), 'GLSL emit has opDifference (centre hole)');
+}
+console.log(`\n=== Result: ${pass} passed, ${fail} failed ===`);
+process.exit(fail > 0 ? 1 : 0);

--- a/sdf-js/src/scene/compile.js
+++ b/sdf-js/src/scene/compile.js
@@ -121,6 +121,10 @@ import { sphereFill3dSDF } from './components/shapes/sphere-fill-3d.js';
 import { sphereNetwork3dSDF } from './components/shapes/sphere-network-3d.js';
 import { sphereTree3dSDF } from './components/shapes/sphere-tree-3d.js';
 import { sphereSegmented3dSDF } from './components/shapes/sphere-segmented-3d.js';
+import { arrow3dSDF } from './components/shapes/arrow-3d.js';
+import { diamond3dSDF } from './components/shapes/diamond-3d.js';
+import { gear3dSDF } from './components/shapes/gear-3d.js';
+import { cubeSegmented3dSDF } from './components/shapes/cube-segmented-3d.js';
 import { terrainCanyonSDF } from './components/community/iq-canyon.js';
 import { proceduralCitySDF } from './components/community/otavio-skyline.js';
 import { terrainErodedRuneSDF, bakeHeightmap } from './components/community/rune-erosion-filter.js';
@@ -461,6 +465,38 @@ const PRIMITIVE_FACTORIES = {
       radius: a.radius ?? 0.7,
       explode: a.explode ?? a.gap ?? 0.12,
       gapAngle: a.gapAngle ?? 0.06,
+    }),
+  'arrow-3d': (a) =>
+    arrow3dSDF({
+      length: a.length ?? 1.6,
+      shaftWidth: a.shaftWidth ?? a.width ?? 0.18,
+      headLength: a.headLength ?? 0.5,
+      headWidth: a.headWidth ?? 0.5,
+      depth: a.depth ?? 0.3,
+      double: a.double ?? false,
+    }),
+  'diamond-3d': (a) =>
+    diamond3dSDF({
+      width: a.width ?? 0.9,
+      crownHeight: a.crownHeight ?? 0.3,
+      pavilionHeight: a.pavilionHeight ?? 0.7,
+      tableRatio: a.tableRatio ?? 0.45,
+    }),
+  'gear-3d': (a) =>
+    gear3dSDF({
+      teeth: a.teeth ?? 12,
+      radius: a.radius ?? 0.7,
+      thickness: a.thickness ?? a.depth ?? 0.25,
+      toothDepth: a.toothDepth ?? 0.16,
+      toothWidth: a.toothWidth ?? 0.18,
+      holeRadius: a.holeRadius ?? 0.22,
+    }),
+  'cube-segmented-3d': (a) =>
+    cubeSegmented3dSDF({
+      segments: a.segments ?? a.count ?? 4,
+      size: a.size ?? 1.2,
+      gap: a.gap ?? 0.08,
+      axis: a.axis ?? 'x',
     }),
   link: (a) =>
     linkSDF({

--- a/sdf-js/src/scene/components/shapes/arrow-3d.js
+++ b/sdf-js/src/scene/components/shapes/arrow-3d.js
@@ -1,0 +1,79 @@
+// =============================================================================
+// arrow-3d.js — directional arrow (Atlas Shape atom, Sprint 3).
+// -----------------------------------------------------------------------------
+// Shaft (rounded box) + cone head, pointing +X. `double` adds a head on the −X
+// end too. Covers PresentationLoad "Arrow Toolbox 2D/3D". Composite atom from
+// shipped GLSL-emit primitives (rounded_box / cone / union).
+//
+// Spec: docs/superpowers/specs/2026-06-21-simple-shapes-design.md
+// =============================================================================
+
+import { cone, box } from '../../../sdf/d3.js';
+import { union } from '../../../sdf/dn.js';
+
+/**
+ * @param {object} opts
+ * @param {number} [opts.length=1.6]      total X span (tip to tail)
+ * @param {number} [opts.shaftWidth=0.18] shaft thickness (Y)
+ * @param {number} [opts.headLength=0.5]  arrowhead length (X)
+ * @param {number} [opts.headWidth=0.5]   arrowhead base width (Y)
+ * @param {number} [opts.depth=0.3]       Z thickness
+ * @param {boolean} [opts.double=false]   heads on both ends
+ * @returns {SDF3}
+ */
+export function arrow3dSDF({
+  length = 1.6,
+  shaftWidth = 0.18,
+  headLength = 0.5,
+  headWidth = 0.5,
+  depth = 0.3,
+  double = false,
+} = {}) {
+  const half = length / 2;
+  const headR = headWidth / 2;
+  // Cone points +Y (apex at +height/2); rotate −90° about Z → apex points +X.
+  const headPlus = cone(headLength, headR)
+    .rotate(-Math.PI / 2, [0, 0, 1])
+    .translate([half - headLength / 2, 0, 0]);
+
+  const parts = [headPlus];
+  if (double) {
+    const headMinus = cone(headLength, headR)
+      .rotate(Math.PI / 2, [0, 0, 1])
+      .translate([-half + headLength / 2, 0, 0]);
+    parts.push(headMinus);
+    // shaft spans between the two head bases
+    const shaftLen = Math.max(length - 2 * headLength, 0.01);
+    parts.push(box([shaftLen, shaftWidth, depth]));
+  } else {
+    const shaftLen = Math.max(length - headLength, 0.01);
+    // shaft spans −half … (half−headLength); centre at −headLength/2
+    parts.push(box([shaftLen, shaftWidth, depth]).translate([-headLength / 2, 0, 0]));
+  }
+  return parts.length === 1 ? parts[0] : union(...parts);
+}
+
+export const arrow3dSpec = {
+  type: 'arrow-3d',
+  category: 'shapes',
+  args: {
+    length: { type: 'number', default: 1.6, doc: 'Total X span tip→tail' },
+    shaftWidth: { type: 'number', default: 0.18, doc: 'Shaft thickness (Y)' },
+    headLength: { type: 'number', default: 0.5, doc: 'Arrowhead length (X)' },
+    headWidth: { type: 'number', default: 0.5, doc: 'Arrowhead base width (Y)' },
+    depth: { type: 'number', default: 0.3, doc: 'Z thickness' },
+    double: { type: 'boolean', default: false, doc: 'Heads on both ends' },
+  },
+  examples: [
+    { name: 'Single arrow', args: { double: false } },
+    { name: 'Double arrow', args: { double: true } },
+    { name: 'Stubby', args: { length: 1.0, headLength: 0.4, headWidth: 0.6 } },
+  ],
+  description: 'Directional arrow (single/double) — process flow, emphasis',
+  source: {
+    author: 'Atlas',
+    builtAt: '2026-06-21',
+    builder: 'Sprint 3 simple shape — taxonomy shapes/',
+    license: 'PolyForm Noncommercial 1.0.0',
+  },
+};

--- a/sdf-js/src/scene/components/shapes/cube-segmented-3d.js
+++ b/sdf-js/src/scene/components/shapes/cube-segmented-3d.js
@@ -1,0 +1,69 @@
+// =============================================================================
+// cube-segmented-3d.js — a cube sliced into segments (Atlas Shape atom, Sprint 3).
+// -----------------------------------------------------------------------------
+// One cube cut into N parallel slabs along an axis, separated by gaps (sliced-
+// bread / exploded-cube look). Covers PresentationLoad "3D Cubes Segmented".
+// Composite atom from box + union (GLSL-emit registered). Distinct from cube-3d,
+// which arranges N *separate* cubes — this is ONE cube subdivided.
+//
+// Spec: docs/superpowers/specs/2026-06-21-simple-shapes-design.md
+// =============================================================================
+
+import { box } from '../../../sdf/d3.js';
+import { union } from '../../../sdf/dn.js';
+
+/**
+ * @param {object} opts
+ * @param {number} [opts.segments=4]  number of slabs (clamped ≥1)
+ * @param {number} [opts.size=1.2]    total cube edge length
+ * @param {number} [opts.gap=0.08]    gap between slabs
+ * @param {string} [opts.axis='x']    slice axis: 'x' | 'y' | 'z'
+ * @returns {SDF3}
+ */
+export function cubeSegmented3dSDF({ segments = 4, size = 1.2, gap = 0.08, axis = 'x' } = {}) {
+  const N = Math.max(1, Math.floor(segments));
+  const slabThick = Math.max((size - (N - 1) * gap) / N, 0.01);
+  const stride = slabThick + gap;
+  const offset = ((N - 1) / 2) * stride;
+
+  const slabs = [];
+  for (let i = 0; i < N; i++) {
+    const c = i * stride - offset;
+    let dims, pos;
+    if (axis === 'y') {
+      dims = [size, slabThick, size];
+      pos = [0, c, 0];
+    } else if (axis === 'z') {
+      dims = [size, size, slabThick];
+      pos = [0, 0, c];
+    } else {
+      dims = [slabThick, size, size];
+      pos = [c, 0, 0];
+    }
+    slabs.push(box(dims).translate(pos));
+  }
+  return slabs.length === 1 ? slabs[0] : union(...slabs);
+}
+
+export const cubeSegmented3dSpec = {
+  type: 'cube-segmented-3d',
+  category: 'shapes',
+  args: {
+    segments: { type: 'number', default: 4, doc: 'Number of slabs (≥1)' },
+    size: { type: 'number', default: 1.2, doc: 'Total cube edge length' },
+    gap: { type: 'number', default: 0.08, doc: 'Gap between slabs' },
+    axis: { type: 'enum', values: ['x', 'y', 'z'], default: 'x' },
+  },
+  examples: [
+    { name: 'Sliced (4)', args: { segments: 4 } },
+    { name: 'Stacked layers', args: { segments: 5, axis: 'y' } },
+    { name: 'Two halves', args: { segments: 2, gap: 0.15 } },
+  ],
+  description: 'A cube sliced into separated slabs — phases, layers, breakdown',
+  source: {
+    author: 'Atlas',
+    builtAt: '2026-06-21',
+    builder: 'Sprint 3 simple shape — taxonomy shapes/',
+    license: 'PolyForm Noncommercial 1.0.0',
+  },
+};

--- a/sdf-js/src/scene/components/shapes/diamond-3d.js
+++ b/sdf-js/src/scene/components/shapes/diamond-3d.js
@@ -1,0 +1,58 @@
+// =============================================================================
+// diamond-3d.js — brilliant-cut gem (Atlas Shape atom, Sprint 3).
+// -----------------------------------------------------------------------------
+// Crown frustum (table → girdle) + pavilion cone (girdle → point), the classic
+// diamond silhouette. Covers PresentationLoad "Diamond Charts". Composite atom
+// from capped_cone + union (both GLSL-emit registered).
+//
+// Spec: docs/superpowers/specs/2026-06-21-simple-shapes-design.md
+// =============================================================================
+
+import { capped_cone } from '../../../sdf/d3.js';
+import { union } from '../../../sdf/dn.js';
+
+/**
+ * @param {object} opts
+ * @param {number} [opts.width=0.9]          girdle diameter (widest point)
+ * @param {number} [opts.crownHeight=0.3]    table → girdle height
+ * @param {number} [opts.pavilionHeight=0.7] girdle → bottom point height
+ * @param {number} [opts.tableRatio=0.45]    table radius as a fraction of girdle
+ * @returns {SDF3}
+ */
+export function diamond3dSDF({
+  width = 0.9,
+  crownHeight = 0.3,
+  pavilionHeight = 0.7,
+  tableRatio = 0.45,
+} = {}) {
+  const girdleR = width / 2;
+  const tableR = girdleR * tableRatio;
+  // Crown: frustum from the table (top, y=crownHeight) down to the girdle (y=0).
+  const crown = capped_cone([0, crownHeight, 0], [0, 0, 0], tableR, girdleR);
+  // Pavilion: cone from the girdle (y=0) to a point at the bottom.
+  const pavilion = capped_cone([0, 0, 0], [0, -pavilionHeight, 0], girdleR, 0.001);
+  return union(crown, pavilion);
+}
+
+export const diamond3dSpec = {
+  type: 'diamond-3d',
+  category: 'shapes',
+  args: {
+    width: { type: 'number', default: 0.9, doc: 'Girdle diameter (widest)' },
+    crownHeight: { type: 'number', default: 0.3, doc: 'Table→girdle height' },
+    pavilionHeight: { type: 'number', default: 0.7, doc: 'Girdle→point height' },
+    tableRatio: { type: 'number', default: 0.45, doc: 'Table radius / girdle radius' },
+  },
+  examples: [
+    { name: 'Brilliant', args: {} },
+    { name: 'Shallow', args: { crownHeight: 0.2, pavilionHeight: 0.4 } },
+    { name: 'Deep marquise', args: { width: 0.6, pavilionHeight: 1.0 } },
+  ],
+  description: 'Brilliant-cut diamond / gem — value, premium, achievement',
+  source: {
+    author: 'Atlas',
+    builtAt: '2026-06-21',
+    builder: 'Sprint 3 simple shape — taxonomy shapes/',
+    license: 'PolyForm Noncommercial 1.0.0',
+  },
+};

--- a/sdf-js/src/scene/components/shapes/gear-3d.js
+++ b/sdf-js/src/scene/components/shapes/gear-3d.js
@@ -1,0 +1,65 @@
+// =============================================================================
+// gear-3d.js — cog / gear wheel (Atlas Shape atom, Sprint 3).
+// -----------------------------------------------------------------------------
+// Cylinder body + N radial teeth (one box repeated via modPolar) − a centre
+// hole. Covers PresentationLoad "Gear Wheels 3D" (process / mechanism / config).
+// Composite atom from cylinder / box / modPolar / union / difference (all
+// GLSL-emit registered).
+//
+// Spec: docs/superpowers/specs/2026-06-21-simple-shapes-design.md
+// =============================================================================
+
+import { cylinder, box, modPolar } from '../../../sdf/d3.js';
+import { union, difference } from '../../../sdf/dn.js';
+
+/**
+ * @param {object} opts
+ * @param {number} [opts.teeth=12]        number of teeth
+ * @param {number} [opts.radius=0.7]      body radius (to tooth root)
+ * @param {number} [opts.thickness=0.25]  Y extent
+ * @param {number} [opts.toothDepth=0.16] how far teeth stick out past the rim
+ * @param {number} [opts.toothWidth=0.18] tangential tooth width
+ * @param {number} [opts.holeRadius=0.22] centre hole radius
+ * @returns {SDF3}
+ */
+export function gear3dSDF({
+  teeth = 12,
+  radius = 0.7,
+  thickness = 0.25,
+  toothDepth = 0.16,
+  toothWidth = 0.18,
+  holeRadius = 0.22,
+} = {}) {
+  const body = cylinder(radius, thickness);
+  // One tooth at +X rim, then repeated around Y into `teeth` copies.
+  const tooth = box([toothDepth * 2, toothWidth, thickness]).translate([radius, 0, 0]);
+  const teethRing = modPolar(tooth, { axis: 'y', repetitions: Math.max(3, Math.floor(teeth)) });
+  const solid = union(body, teethRing);
+  const hole = cylinder(holeRadius, thickness * 1.2);
+  return difference(solid, hole);
+}
+
+export const gear3dSpec = {
+  type: 'gear-3d',
+  category: 'shapes',
+  args: {
+    teeth: { type: 'number', default: 12, doc: 'Number of teeth (≥3)' },
+    radius: { type: 'number', default: 0.7, doc: 'Body radius to tooth root' },
+    thickness: { type: 'number', default: 0.25, doc: 'Y extent' },
+    toothDepth: { type: 'number', default: 0.16, doc: 'Tooth protrusion past rim' },
+    toothWidth: { type: 'number', default: 0.18, doc: 'Tangential tooth width' },
+    holeRadius: { type: 'number', default: 0.22, doc: 'Centre hole radius' },
+  },
+  examples: [
+    { name: 'Cog', args: { teeth: 12 } },
+    { name: 'Fine gear', args: { teeth: 24, toothDepth: 0.1, toothWidth: 0.1 } },
+    { name: 'Coarse wheel', args: { teeth: 8, radius: 0.8 } },
+  ],
+  description: 'Gear / cog wheel — process, mechanism, settings/config',
+  source: {
+    author: 'Atlas',
+    builtAt: '2026-06-21',
+    builder: 'Sprint 3 simple shape — taxonomy shapes/',
+    license: 'PolyForm Noncommercial 1.0.0',
+  },
+};

--- a/sdf-js/src/scene/spec.js
+++ b/sdf-js/src/scene/spec.js
@@ -202,6 +202,12 @@ export const PRIMITIVE_TYPES = new Set([
   'sphere-network-3d',
   'sphere-tree-3d',
   'sphere-segmented-3d',
+  // Atlas Shape atoms (2026-06-21) — Sprint 3 simple shapes. Composite atoms
+  // (box/cone/cylinder/octahedron/capped-cone + union/difference/modPolar).
+  'arrow-3d',
+  'diamond-3d',
+  'gear-3d',
+  'cube-segmented-3d',
   // Rune Skovbo Johansen's Advanced Terrain Erosion Filter (MPL-2.0 — see
   // src/scene/components/community/rune-erosion-filter.js). CPU-baked
   // heightmap uploaded to GPU as sampler2D u_heightmap. Box-bounded bonsai


### PR DESCRIPTION
## What — resumes the 21-atom line after the IQ-shader program

4 composite Shape atoms (cube-3d tradition: compose shipped GLSL-emit primitives, no hand-written GLSL), each with a gallery demo that **studio auto-frames** (the W12 wiring) at natural size.

| atom | build | PresentationLoad template |
| --- | --- | --- |
| `arrow-3d` | box shaft + cone head (single/double) | Arrow Toolbox 2D/3D |
| `diamond-3d` | crown frustum + pavilion cone (`capped_cone`) | Diamond Charts |
| `gear-3d` | cylinder body + `modPolar` teeth − centre hole | Gear Wheels 3D |
| `cube-segmented-3d` | one cube sliced into separated slabs | 3D Cubes Segmented |

Registered in `compile.js` / `spec.js` / `run-tests.mjs`; 4 demos added to the gallery `index.json`.

## Verification
- CPU probe assertions per atom (inside/outside of each defining feature — arrowhead/shaft, girdle/table/point, gear ring vs centre-hole vs tooth, slab vs gap) + compile + GLSL-emit. Full suite **55/55**.
- **Real-browser GPU**: verified the **gear** (`modPolar` + `difference` — the riskiest path) — compiles clean (0 console errors), renders teeth + centre hole, auto-frames. The other three use simpler proven primitives (box/cone/capped_cone) + pass CPU probes + GLSL-emit.
- `node --check` + Prettier clean.

SHAPES taxonomy now: cube · sphere×4 · arrow · diamond · gear · cube-segmented. Remaining: circle family, puzzle, + the CHARTS family.

🤖 Generated with [Claude Code](https://claude.com/claude-code)