### PR TITLE
Sprint 9 (C) — chromotome integrated into Atlas branding-palettes (5 → 28 presets)

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -114,6 +114,7 @@ const TESTS = [
   { category: 'present', file: 'sdf-js/scripts/test-p5-sandbox.mjs' },
   { category: 'present', file: 'sdf-js/scripts/test-p5-idiom-registry.mjs' },
   { category: 'present', file: 'sdf-js/scripts/test-deck-model.mjs' },
+  { category: 'present', file: 'sdf-js/scripts/test-branding-palettes.mjs' },
   { category: 'present', file: 'sdf-js/scripts/test-waypoint-tween.mjs' },
   { category: 'present', file: 'sdf-js/scripts/test-pipeline.mjs' },
 ];

--- a/sdf-js/scripts/test-branding-palettes.mjs
+++ b/sdf-js/scripts/test-branding-palettes.mjs
@@ -1,0 +1,152 @@
+// =============================================================================
+// test-branding-palettes.mjs — Sprint 9: chromotome integration into Atlas branding
+// -----------------------------------------------------------------------------
+// Verifies: built-in 5 still present + chromotome 23 appended + getPalette
+// resolves both kinds + new fields (colors, stroke, source) on chromotome
+// palettes + backward-compat (existing 2-color consumers unchanged).
+// =============================================================================
+
+import {
+  BRANDING_PALETTES,
+  getPalette,
+  getPaletteFamilies,
+} from '../src/present/branding-palettes.js';
+import {
+  chromotomePaletteToBranding,
+  CHROMOTOME_BRANDING_PALETTES,
+} from '../src/present/chromotome-palettes-data.js';
+
+let pass = 0,
+  fail = 0;
+function ok(cond, name) {
+  if (cond) {
+    pass++;
+    console.log(`  ✓ ${name}`);
+  } else {
+    fail++;
+    console.log(`  ✗ ${name}`);
+  }
+}
+
+console.log('=== branding-palettes Sprint 9 smoke ===\n');
+
+console.log('--- built-in 5 still present (backward compat) ---');
+{
+  ok(Array.isArray(BRANDING_PALETTES), 'BRANDING_PALETTES is array');
+  const ids = BRANDING_PALETTES.slice(0, 5).map((p) => p.id);
+  const expected = ['mono-light', 'mono-dark', 'warm-paper', 'cool-mint', 'high-contrast'];
+  ok(
+    JSON.stringify(ids) === JSON.stringify(expected),
+    `first 5 are built-in in order (got ${ids.join(',')})`,
+  );
+  ok(
+    BRANDING_PALETTES[0].bg.length === 3 && BRANDING_PALETTES[0].silhouetteColor.length === 3,
+    'built-in shape unchanged: {bg, silhouetteColor} as [r,g,b]',
+  );
+  ok(
+    BRANDING_PALETTES[0].colors === undefined,
+    'built-in palettes have no colors[] field (backward compat)',
+  );
+}
+
+console.log('\n--- chromotome appended (Sprint 9) ---');
+{
+  ok(BRANDING_PALETTES.length >= 5 + 20, `total ≥ 25 palettes (got ${BRANDING_PALETTES.length})`);
+  ok(
+    BRANDING_PALETTES.length === 5 + CHROMOTOME_BRANDING_PALETTES.length,
+    `total = 5 + chromotome count (${5 + CHROMOTOME_BRANDING_PALETTES.length})`,
+  );
+
+  const chromo = BRANDING_PALETTES.slice(5);
+  ok(
+    chromo.every((p) => p.id.startsWith('chromotome:')),
+    'all appended palettes have chromotome: id prefix',
+  );
+  ok(
+    chromo.every((p) => Array.isArray(p.colors) && p.colors.length >= 3),
+    'every chromotome palette has colors[≥3]',
+  );
+  ok(
+    chromo.every((p) => p.colors.every((c) => Array.isArray(c) && c.length === 3)),
+    'every color is [r,g,b] tuple',
+  );
+  ok(
+    chromo.every((p) => p.bg.length === 3),
+    'bg converted to [r,g,b]',
+  );
+  ok(
+    chromo.every((p) => p.source && p.source.startsWith('chromotome:')),
+    'attribution preserved via source',
+  );
+}
+
+console.log('\n--- conversion correctness ---');
+{
+  // Test hex → rgb conversion via chromotomePaletteToBranding directly
+  const sample = chromotomePaletteToBranding({
+    name: 'test_red',
+    source: 'test',
+    colors: ['#ff0000', '#00ff00', '#0000ff'],
+    background: '#808080',
+    stroke: '#000000',
+  });
+  ok(
+    JSON.stringify(sample.colors) ===
+      JSON.stringify([
+        [255, 0, 0],
+        [0, 255, 0],
+        [0, 0, 255],
+      ]),
+    'colors hex → rgb correct',
+  );
+  ok(
+    JSON.stringify(sample.bg) === JSON.stringify([128, 128, 128]),
+    'bg hex → rgb correct (#808080 → [128,128,128])',
+  );
+  ok(
+    JSON.stringify(sample.silhouetteColor) === JSON.stringify([0, 0, 0]),
+    'silhouetteColor uses stroke when present',
+  );
+  ok(sample.id === 'chromotome:test_red', 'id namespaced');
+  ok(sample.label === 'Test Red', `label humanized (got "${sample.label}")`);
+
+  // Test fallback: no stroke → darkest color
+  const noStroke = chromotomePaletteToBranding({
+    name: 'no_stroke',
+    source: 'test',
+    colors: ['#ffffff', '#888888', '#222222'],
+    background: '#ffffff',
+  });
+  ok(
+    JSON.stringify(noStroke.silhouetteColor) === JSON.stringify([34, 34, 34]),
+    'silhouetteColor falls back to darkest color when no stroke',
+  );
+}
+
+console.log('\n--- getPalette resolution ---');
+{
+  ok(getPalette('mono-light').id === 'mono-light', 'built-in resolves by id');
+  ok(
+    getPalette('chromotome:hilda01').id === 'chromotome:hilda01',
+    'chromotome resolves by namespaced id',
+  );
+  ok(getPalette('nonsense').id === 'mono-light', 'unknown id falls back to first (mono-light)');
+}
+
+console.log('\n--- getPaletteFamilies ---');
+{
+  const fams = getPaletteFamilies();
+  ok(Array.isArray(fams), 'returns array');
+  ok(fams.length >= 5, `≥5 families (built-in + 4 chromotome sub-collections): ${fams.length}`);
+  const familyNames = fams.map((f) => f.family);
+  ok(familyNames.includes('built-in'), 'has built-in family');
+  ok(
+    familyNames.some((f) => f.startsWith('chromotome:')),
+    'has chromotome family',
+  );
+  const totalCount = fams.reduce((sum, f) => sum + f.count, 0);
+  ok(totalCount === BRANDING_PALETTES.length, 'family counts sum to total palettes');
+}
+
+console.log(`\n=== Result: ${pass} passed, ${fail} failed ===`);
+process.exit(fail > 0 ? 1 : 0);

--- a/sdf-js/src/present/branding-palettes.js
+++ b/sdf-js/src/present/branding-palettes.js
@@ -1,15 +1,30 @@
 // =============================================================================
-// branding-palettes.js — Atlas Present Sprint 2 curated palette presets
+// branding-palettes.js — Atlas Present curated palette presets
 // -----------------------------------------------------------------------------
-// 5 presets used by Swap Branding sub-panel. Each preset has:
+// Sprint 2 MVP: 5 simple 2-color presets ({bg, silhouetteColor}).
+// Sprint 9 extension: + ~23 multi-color palettes from kgolid's chromotome
+// library (vintage children's book / saturated animal / Indian textile /
+// mid-century modern). LLM-generated P5 sketches can use the richer multi-
+// color field for per-element coloring (KPI cards each in different palette
+// color, etc.); silhouette/lines/crayon/topo renderers still use just
+// {bg, silhouetteColor} for backward compat.
+//
+// Per preset shape:
 //   - id: stable string id (stored in visual.activeBranding)
 //   - label: UI display name
-//   - bg: background color (silhouette renderer background option)
-//   - silhouetteColor: [r,g,b] for silhouette renderer foreground
+//   - bg: [r,g,b] background color
+//   - silhouetteColor: [r,g,b] foreground (silhouette/lines/crayon/topo)
+//   - colors?: array of [r,g,b] tuples — multi-color palette (NEW Sprint 9,
+//     present on chromotome:* palettes, undefined on the 5 built-ins)
+//   - stroke?: [r,g,b] explicit stroke color (NEW Sprint 9, optional)
+//   - source?: attribution string for non-built-in palettes (NEW Sprint 9)
 //
-// Sprint 2 MVP keeps it simple: palettes affect silhouette/lines/crayon/topo
-// renderer color choice. More elaborate per-element coloring is Sprint 3+.
+// Backward compat: all existing renderers + iframe sketches that only read
+// {bg, silhouetteColor} continue to work unchanged. New consumers can
+// optionally read .colors[] for richer rendering.
 // =============================================================================
+
+import { CHROMOTOME_BRANDING_PALETTES } from './chromotome-palettes-data.js';
 
 /**
  * @typedef {object} BrandingPreset
@@ -17,15 +32,29 @@
  * @property {string} label
  * @property {[number,number,number]} bg
  * @property {[number,number,number]} silhouetteColor
+ * @property {Array<[number,number,number]>} [colors] — Sprint 9: multi-color palette
+ * @property {[number,number,number]} [stroke] — Sprint 9: explicit stroke
+ * @property {string} [source] — Sprint 9: attribution (e.g., 'chromotome:hilda')
  */
 
-export const BRANDING_PALETTES = [
+/**
+ * Built-in 5 simple presets — Sprint 2. Backward compat (existing code paths,
+ * existing localStorage activeBranding values like 'mono-light' resolve here).
+ */
+const BUILT_IN_PALETTES = [
   { id: 'mono-light', label: 'Mono Light', bg: [248, 248, 246], silhouetteColor: [40, 40, 40] },
   { id: 'mono-dark', label: 'Mono Dark', bg: [28, 28, 32], silhouetteColor: [220, 220, 220] },
   { id: 'warm-paper', label: 'Warm Paper', bg: [252, 244, 224], silhouetteColor: [80, 50, 30] },
   { id: 'cool-mint', label: 'Cool Mint', bg: [220, 240, 232], silhouetteColor: [40, 90, 80] },
   { id: 'high-contrast', label: 'High Contrast', bg: [255, 255, 255], silhouetteColor: [0, 0, 0] },
 ];
+
+/**
+ * Full palette library: 5 built-in simple + ~23 chromotome multi-color (Sprint 9).
+ * Iteration order: built-in first, then chromotome. Swap Branding menu cycles
+ * through in this order. Total: 28 palettes.
+ */
+export const BRANDING_PALETTES = [...BUILT_IN_PALETTES, ...CHROMOTOME_BRANDING_PALETTES];
 
 /**
  * Get a preset by id; fallback to first preset if id not found.
@@ -35,4 +64,20 @@ export const BRANDING_PALETTES = [
  */
 export function getPalette(id) {
   return BRANDING_PALETTES.find((p) => p.id === id) || BRANDING_PALETTES[0];
+}
+
+/**
+ * Sprint 9: Get the list of palette family groups for future UI sub-menu.
+ * Currently visual-panel just cycles through all 28 sequentially via Swap
+ * Branding button; future Sprint can add a family picker to skip ahead.
+ *
+ * @returns {Array<{family: string, count: number}>}
+ */
+export function getPaletteFamilies() {
+  const families = new Map();
+  for (const p of BRANDING_PALETTES) {
+    const fam = p.source ? p.source.split(':')[0] + ':' + p.source.split(':')[1] : 'built-in';
+    families.set(fam, (families.get(fam) || 0) + 1);
+  }
+  return [...families.entries()].map(([family, count]) => ({ family, count }));
 }

--- a/sdf-js/src/present/chromotome-palettes-data.js
+++ b/sdf-js/src/present/chromotome-palettes-data.js
@@ -1,0 +1,268 @@
+// =============================================================================
+// chromotome-palettes-data.js — Atlas Present Sprint 9 branding library extension
+// -----------------------------------------------------------------------------
+// Ports ~23 hand-curated palettes from Kjetil Midtgarden Golid (kgolid)'s
+// chromotome library (MIT licensed, github.com/kgolid/chromotome) into Atlas
+// Present's branding-palettes.js shape.
+//
+// Sprint 6 (PR #31) shipped the chromotome data as an iframe-side idiom
+// (sdf-js/examples/p5-idiom-registry/kgolid-chromotome-palettes.js) for
+// LLM to inline into args.code. Sprint 9 (this file) makes the SAME palettes
+// available as ATLAS-LEVEL branding presets, swappable via the Swap Branding
+// menu like the original 5 simple presets.
+//
+// Conversion from chromotome shape → Atlas branding shape:
+//   chromotome: { name, colors: ['#hex', ...], background: '#hex', stroke?: '#hex' }
+//   atlas:      { id, label, bg: [r,g,b], silhouetteColor: [r,g,b], colors?: [[r,g,b], ...], stroke?: [r,g,b], source }
+//
+// Rules:
+//   - id: 'chromotome:<name>' (namespaced to avoid collision with built-in ids)
+//   - label: humanized name (e.g., 'hilda01' → 'Hilda 01')
+//   - bg: hex(background) → [r,g,b]
+//   - silhouetteColor: hex(stroke) if present, else darkest color in colors[]
+//     (luminance-based) — gives reasonable fallback for renderers that only
+//     read silhouetteColor (silhouette/lines/crayon/topo)
+//   - colors: full multi-color array converted to [r,g,b] tuples — NEW field
+//     LLM-generated P5 sketches can use for per-element coloring (KPI cards
+//     each in different palette color)
+//   - stroke: explicit stroke when chromotome has it (some palettes do, some don't)
+//   - source: 'chromotome:<sub>' for attribution
+//
+// License + attribution preserved per palette via `source` field. Original
+// chromotome README + LICENSE: MIT (c) Kjetil Midtgarden Golid.
+// =============================================================================
+
+function _hexToRgb(hex) {
+  if (!hex || typeof hex !== 'string') return [0, 0, 0];
+  let s = hex.replace('#', '');
+  if (s.length === 3)
+    s = s
+      .split('')
+      .map((c) => c + c)
+      .join('');
+  if (s.length !== 6) return [0, 0, 0];
+  const r = parseInt(s.slice(0, 2), 16);
+  const g = parseInt(s.slice(2, 4), 16);
+  const b = parseInt(s.slice(4, 6), 16);
+  if (Number.isNaN(r) || Number.isNaN(g) || Number.isNaN(b)) return [0, 0, 0];
+  return [r, g, b];
+}
+
+function _luminance([r, g, b]) {
+  // sRGB relative luminance (ITU-R BT.709 coefficients)
+  return 0.2126 * r + 0.7152 * g + 0.0722 * b;
+}
+
+function _darkestColor(rgbColors) {
+  let best = rgbColors[0];
+  let bestLuma = _luminance(rgbColors[0]);
+  for (let i = 1; i < rgbColors.length; i++) {
+    const l = _luminance(rgbColors[i]);
+    if (l < bestLuma) {
+      bestLuma = l;
+      best = rgbColors[i];
+    }
+  }
+  return best;
+}
+
+function _humanizeName(name) {
+  // 'hilda01' → 'Hilda 01', 'rag-mysore' → 'Rag Mysore', 'kov_01' → 'Kov 01'
+  return name
+    .replace(/[-_]/g, ' ')
+    .replace(/(\D)(\d)/g, '$1 $2')
+    .split(' ')
+    .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+    .join(' ');
+}
+
+/**
+ * Convert one chromotome palette to Atlas branding shape.
+ * Exposed for testing; library exports the pre-converted list.
+ */
+export function chromotomePaletteToBranding(p) {
+  const colors = p.colors.map(_hexToRgb);
+  const bg = _hexToRgb(p.background);
+  const stroke = p.stroke ? _hexToRgb(p.stroke) : null;
+  const silhouetteColor = stroke || _darkestColor(colors);
+  return {
+    id: 'chromotome:' + p.name,
+    label: _humanizeName(p.name),
+    bg,
+    silhouetteColor,
+    colors,
+    stroke,
+    source: 'chromotome:' + (p.source || 'misc'),
+  };
+}
+
+// Source data: same 23 palettes as Sprint 6's iframe idiom file
+// (sdf-js/examples/p5-idiom-registry/kgolid-chromotome-palettes.js).
+// Duplicated here to keep this Layer 2 file independent of the registry.
+const _CHROMOTOME_SOURCE = [
+  // hilda (vintage children's book)
+  {
+    name: 'hilda01',
+    source: 'hilda',
+    colors: ['#ec5526', '#f4ac12', '#9ebbc1', '#f7f4e2'],
+    stroke: '#1e1b1e',
+    background: '#e7e8d4',
+  },
+  {
+    name: 'hilda02',
+    source: 'hilda',
+    colors: ['#eb5627', '#eebb20', '#4e9eb8', '#f7f5d0'],
+    stroke: '#201d13',
+    background: '#77c1c0',
+  },
+  {
+    name: 'hilda03',
+    source: 'hilda',
+    colors: ['#e95145', '#f8b917', '#b8bdc1', '#ffb2a2'],
+    stroke: '#010101',
+    background: '#6b7752',
+  },
+  {
+    name: 'hilda04',
+    source: 'hilda',
+    colors: ['#e95145', '#f6bf7a', '#589da1', '#f5d9bc'],
+    stroke: '#000001',
+    background: '#f5ede1',
+  },
+  {
+    name: 'hilda05',
+    source: 'hilda',
+    colors: ['#ff6555', '#ffb58f', '#d8eecf', '#8c4b47', '#bf7f93'],
+    stroke: '#2b0404',
+    background: '#ffda82',
+  },
+  {
+    name: 'hilda06',
+    source: 'hilda',
+    colors: ['#f75952', '#ffce84', '#74b7b2', '#f6f6f6', '#b17d71'],
+    stroke: '#0e0603',
+    background: '#f6ecd4',
+  },
+
+  // jung (saturated animal-inspired)
+  {
+    name: 'jung_bird',
+    source: 'jung',
+    colors: ['#fc3032', '#fed530', '#33c3fb', '#ff7bac', '#fda929'],
+    stroke: '#000000',
+    background: '#ffffff',
+  },
+  {
+    name: 'jung_horse',
+    source: 'jung',
+    colors: ['#e72e81', '#f0bf36', '#3056a2'],
+    stroke: '#000000',
+    background: '#ffffff',
+  },
+  {
+    name: 'jung_croc',
+    source: 'jung',
+    colors: ['#f13274', '#eed03e', '#405e7f', '#19a198'],
+    stroke: '#000000',
+    background: '#ffffff',
+  },
+  {
+    name: 'jung_hippo',
+    source: 'jung',
+    colors: ['#ff7bac', '#ff921e', '#3ea8f5', '#7ac943'],
+    stroke: '#000000',
+    background: '#ffffff',
+  },
+  {
+    name: 'jung_wolf',
+    source: 'jung',
+    colors: ['#e51c39', '#f1b844', '#36c4b7', '#666666'],
+    stroke: '#000000',
+    background: '#ffffff',
+  },
+
+  // ranganath (Indian textile / temple)
+  {
+    name: 'rag-mysore',
+    source: 'ranganath',
+    colors: ['#ec6c26', '#613a53', '#e8ac52', '#639aa0'],
+    background: '#d5cda1',
+  },
+  {
+    name: 'rag-gol',
+    source: 'ranganath',
+    colors: ['#d3693e', '#803528', '#f1b156', '#90a798'],
+    background: '#f0e0a4',
+  },
+  {
+    name: 'rag-belur',
+    source: 'ranganath',
+    colors: ['#f46e26', '#68485f', '#3d273a', '#535d55'],
+    background: '#dcd4a6',
+  },
+  {
+    name: 'rag-bangalore',
+    source: 'ranganath',
+    colors: ['#ea720e', '#ca5130', '#e9c25a', '#52534f'],
+    background: '#f9ecd3',
+  },
+  {
+    name: 'rag-taj',
+    source: 'ranganath',
+    colors: ['#ce565e', '#8e1752', '#f8a100', '#3ac1a6'],
+    background: '#efdea2',
+  },
+  {
+    name: 'rag-virupaksha',
+    source: 'ranganath',
+    colors: ['#f5736a', '#925951', '#feba4c', '#9d9b9d'],
+    background: '#eedfa2',
+  },
+
+  // kovecses (mid-century modern)
+  {
+    name: 'kov_01',
+    source: 'kovecses',
+    colors: ['#d24c23', '#7ba6bc', '#f0c667', '#ede2b3', '#672b35', '#142a36'],
+    stroke: '#132a37',
+    background: '#108266',
+  },
+  {
+    name: 'kov_02',
+    source: 'kovecses',
+    colors: ['#e8dccc', '#e94641', '#eeaeae'],
+    stroke: '#e8dccc',
+    background: '#6c96be',
+  },
+  {
+    name: 'kov_03',
+    source: 'kovecses',
+    colors: ['#e3937b', '#d93f1d', '#090d15', '#e6cca7'],
+    stroke: '#090d15',
+    background: '#558947',
+  },
+  {
+    name: 'kov_04',
+    source: 'kovecses',
+    colors: ['#d03718', '#292b36', '#33762f', '#ead7c9', '#ce7028', '#689d8d'],
+    stroke: '#292b36',
+    background: '#deb330',
+  },
+  {
+    name: 'kov_05',
+    source: 'kovecses',
+    colors: ['#de3f1a', '#de9232', '#007158', '#e6cdaf', '#869679'],
+    stroke: '#010006',
+    background: '#7aa5a6',
+  },
+  {
+    name: 'kov_06',
+    source: 'kovecses',
+    colors: ['#a87c2a', '#bdc9b1', '#f14616', '#ecbfaf', '#017724', '#0e2733', '#2b9ae9'],
+    stroke: '#292319',
+    background: '#dfd4c1',
+  },
+];
+
+/** Pre-converted Atlas branding shape — ready to import into BRANDING_PALETTES. */
+export const CHROMOTOME_BRANDING_PALETTES = _CHROMOTOME_SOURCE.map(chromotomePaletteToBranding);


### PR DESCRIPTION
## Summary

User chose **C** in PR #36 review: in-place upgrade Atlas Present's `branding-palettes.js` with kgolid's chromotome library. Sprint 9 ships the upgrade with backward compat preserved.

**Before**: 5 simple 2-color presets `{bg, silhouetteColor}` (mono-light / mono-dark / warm-paper / cool-mint / high-contrast).

**After**: 5 built-in + 23 chromotome multi-color palettes = **28 total** in Swap Branding cycle, with 4 cultural families (vintage children's book / saturated animal / Indian textile / mid-century modern).

## Architecture

- **NEW** `sdf-js/src/present/chromotome-palettes-data.js` — palettes data + conversion helper (chromotome shape → Atlas branding shape)
- **MODIFY** `sdf-js/src/present/branding-palettes.js` — concat built-in + chromotome, add `getPaletteFamilies()`
- **NEW** `sdf-js/scripts/test-branding-palettes.mjs` (25/25 pass) — backward compat + conversion + resolution + family grouping

## Backward compat preserved

- Existing 5 built-ins kept in same order with same ids → existing `localStorage.activeBranding` values like `'mono-light'` still resolve identically
- Existing renderers + iframe sketches that only read `{bg, silhouetteColor}` continue to work — new fields (`colors[]`, `stroke`, `source`) are optional
- API surface (`BRANDING_PALETTES`, `getPalette`) unchanged
- All existing tests pass: 55 → 56 npm test files (+1 new)

## New capabilities unlocked

LLM-generated P5 sketches in iframe can now use `window.__brandingPalette.colors[]` for **per-element coloring**:

```js
const palette = window.__brandingPalette;
for (let i = 0; i < kpiCards.length; i++) {
  const color = palette.colors ? palette.colors[i % palette.colors.length] : palette.silhouetteColor;
  fill(color[0], color[1], color[2]);
  rect(...);
}
```

## Conversion correctness

- Hex `#ec5526` → `[236, 85, 38]` with NaN guard
- `silhouetteColor` = stroke if present, else darkest color in palette (luminance-based ITU-R BT.709 coefficients)
- Humanized labels: `hilda01` → `Hilda 01`, `rag-mysore` → `Rag Mysore`
- Attribution preserved via `source: 'chromotome:hilda'` per palette

## Test plan

- [x] `node sdf-js/scripts/test-branding-palettes.mjs` — 25/25 pass
- [x] `npm test` — 56/56
- [x] Built-in 5 unchanged (id + shape + order)
- [x] 23 chromotome appended (all id-prefixed `chromotome:`)
- [x] Conversion correctness verified per-channel
- [ ] **Manual L3 (deferred to next sprint)**: visually verify cycling through 28 palettes in Swap Branding actually works in browser + new chromotome palettes look good on real visuals

## Sister to Sprint 6 idiom file

Sprint 6 (PR #31) shipped `sdf-js/examples/p5-idiom-registry/kgolid-chromotome-palettes.js` — same 23 palettes, but as **LLM-inlinable** iframe-side data. Sprint 9 makes them **Atlas-level** swappable presets. Two layers of access:

1. **Atlas branding system** (Sprint 9 this PR): user clicks Swap Branding → cycle through 28 presets
2. **LLM-inlined** (Sprint 6): LLM picks a chromotome palette in args.code for one specific variant

## Next sprint

Sprint 10 = REAL L3 verify v3.25 idiom adoption (per user "C 然后 A"). After this PR merges, I'll run the cases that should exercise new idioms (apparatus / voronoi / hooke / colonization / lindenmayer) and screenshot evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)