### PR TITLE
Sprint 3b: circle-family shape atoms + thin-atom auto-frame fix

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -105,6 +105,10 @@ const TESTS = [
   { category: 'shapes', file: 'sdf-js/scripts/test-diamond-3d.mjs' },
   { category: 'shapes', file: 'sdf-js/scripts/test-gear-3d.mjs' },
   { category: 'shapes', file: 'sdf-js/scripts/test-cube-segmented-3d.mjs' },
+  { category: 'shapes', file: 'sdf-js/scripts/test-circle-frame-3d.mjs' },
+  { category: 'shapes', file: 'sdf-js/scripts/test-circle-stack-3d.mjs' },
+  { category: 'shapes', file: 'sdf-js/scripts/test-circle-segmented-3d.mjs' },
+  { category: 'shapes', file: 'sdf-js/scripts/test-circle-loop-3d.mjs' },
 
   // Layer 1 public API extracted from compositor.js (used by Layer 2 / MCP / tests)
   { category: 'api', file: 'sdf-js/scripts/test-compositor-api.mjs' },

--- a/sdf-js/examples/compositor/compositor.js
+++ b/sdf-js/examples/compositor/compositor.js
@@ -1997,7 +1997,10 @@ function runActiveGpuRenderer({ keepCamera = false } = {}) {
     if (!keepCamera && scene !== _lastStudioFramedScene && sdf && sdf.f) {
       _lastStudioFramedScene = scene;
       try {
-        const bb = bbox3FromSDF((p) => sdf.f(p), { radius: 12, res: 40 });
+        // iso > 0 (sample where the SDF is within ~0.12 of a surface) so THIN
+        // atoms — flat rings, arrow shafts, gear teeth — aren't missed between
+        // grid samples; the bbox inflates ~iso, negligible for framing.
+        const bb = bbox3FromSDF((p) => sdf.f(p), { radius: 10, res: 56, iso: 0.12 });
         const maxDim = Math.max(bb.size[0], bb.size[1], bb.size[2]);
         if (!bb.empty && maxDim > 0.05 && maxDim < 20) {
           const fit = cameraFitFromBBox(bb.min, bb.max, 1.1, 1.3);

--- a/sdf-js/examples/compositor/demo-lifts/circle-frame-3d.json
+++ b/sdf-js/examples/compositor/demo-lifts/circle-frame-3d.json
@@ -1,0 +1,39 @@
+{
+  "id": "circle-frame-3d",
+  "title": "Circle · Frame",
+  "prompt": "circle-frame-3d atom showcase.",
+  "code2d": "// Synthetic showcase.\nexport const render = (ctx) => {};",
+  "sceneData": {
+    "v": 1,
+    "name": "circle-frame-3d",
+    "source": { "format": "synthetic", "prompt": "circle-frame-3d" },
+    "subjects": [
+      {
+        "id": "s",
+        "type": "circle-frame-3d",
+        "args": { "radius": 0.7 },
+        "transform": { "translate": [0, 0.7, 0] },
+        "material": "silver"
+      }
+    ],
+    "defaults": {
+      "camera": {
+        "yaw": 0.5,
+        "pitch": 0.3,
+        "distance": 6,
+        "focal": 1.5,
+        "targetX": 0,
+        "targetY": 0.7,
+        "targetZ": 0
+      },
+      "light": { "azimuth": 0.6, "altitude": 0.55, "distance": 25, "intensity": 1.2 },
+      "shadow": { "enabled": true, "mode": "darken", "strength": 0.4 }
+    }
+  },
+  "meta": {
+    "generatedAt": "2026-06-21",
+    "model": "synthetic",
+    "pattern": "circle-frame-3d",
+    "costUSD": 0
+  }
+}

--- a/sdf-js/examples/compositor/demo-lifts/circle-loop-3d.json
+++ b/sdf-js/examples/compositor/demo-lifts/circle-loop-3d.json
@@ -1,0 +1,39 @@
+{
+  "id": "circle-loop-3d",
+  "title": "Circle · Loop",
+  "prompt": "circle-loop-3d atom showcase.",
+  "code2d": "// Synthetic showcase.\nexport const render = (ctx) => {};",
+  "sceneData": {
+    "v": 1,
+    "name": "circle-loop-3d",
+    "source": { "format": "synthetic", "prompt": "circle-loop-3d" },
+    "subjects": [
+      {
+        "id": "s",
+        "type": "circle-loop-3d",
+        "args": { "segments": 4 },
+        "transform": { "translate": [0, 0.7, 0] },
+        "material": "silver"
+      }
+    ],
+    "defaults": {
+      "camera": {
+        "yaw": 0.5,
+        "pitch": 0.3,
+        "distance": 6,
+        "focal": 1.5,
+        "targetX": 0,
+        "targetY": 0.7,
+        "targetZ": 0
+      },
+      "light": { "azimuth": 0.6, "altitude": 0.55, "distance": 25, "intensity": 1.2 },
+      "shadow": { "enabled": true, "mode": "darken", "strength": 0.4 }
+    }
+  },
+  "meta": {
+    "generatedAt": "2026-06-21",
+    "model": "synthetic",
+    "pattern": "circle-loop-3d",
+    "costUSD": 0
+  }
+}

--- a/sdf-js/examples/compositor/demo-lifts/circle-segmented-3d.json
+++ b/sdf-js/examples/compositor/demo-lifts/circle-segmented-3d.json
@@ -1,0 +1,39 @@
+{
+  "id": "circle-segmented-3d",
+  "title": "Circle · Segmented",
+  "prompt": "circle-segmented-3d atom showcase.",
+  "code2d": "// Synthetic showcase.\nexport const render = (ctx) => {};",
+  "sceneData": {
+    "v": 1,
+    "name": "circle-segmented-3d",
+    "source": { "format": "synthetic", "prompt": "circle-segmented-3d" },
+    "subjects": [
+      {
+        "id": "s",
+        "type": "circle-segmented-3d",
+        "args": { "segments": 6 },
+        "transform": { "translate": [0, 0.7, 0] },
+        "material": "silver"
+      }
+    ],
+    "defaults": {
+      "camera": {
+        "yaw": 0.5,
+        "pitch": 0.3,
+        "distance": 6,
+        "focal": 1.5,
+        "targetX": 0,
+        "targetY": 0.7,
+        "targetZ": 0
+      },
+      "light": { "azimuth": 0.6, "altitude": 0.55, "distance": 25, "intensity": 1.2 },
+      "shadow": { "enabled": true, "mode": "darken", "strength": 0.4 }
+    }
+  },
+  "meta": {
+    "generatedAt": "2026-06-21",
+    "model": "synthetic",
+    "pattern": "circle-segmented-3d",
+    "costUSD": 0
+  }
+}

--- a/sdf-js/examples/compositor/demo-lifts/circle-stack-3d.json
+++ b/sdf-js/examples/compositor/demo-lifts/circle-stack-3d.json
@@ -1,0 +1,39 @@
+{
+  "id": "circle-stack-3d",
+  "title": "Circle · Stack",
+  "prompt": "circle-stack-3d atom showcase.",
+  "code2d": "// Synthetic showcase.\nexport const render = (ctx) => {};",
+  "sceneData": {
+    "v": 1,
+    "name": "circle-stack-3d",
+    "source": { "format": "synthetic", "prompt": "circle-stack-3d" },
+    "subjects": [
+      {
+        "id": "s",
+        "type": "circle-stack-3d",
+        "args": { "count": 4 },
+        "transform": { "translate": [0, 0.7, 0] },
+        "material": "silver"
+      }
+    ],
+    "defaults": {
+      "camera": {
+        "yaw": 0.5,
+        "pitch": 0.3,
+        "distance": 6,
+        "focal": 1.5,
+        "targetX": 0,
+        "targetY": 0.7,
+        "targetZ": 0
+      },
+      "light": { "azimuth": 0.6, "altitude": 0.55, "distance": 25, "intensity": 1.2 },
+      "shadow": { "enabled": true, "mode": "darken", "strength": 0.4 }
+    }
+  },
+  "meta": {
+    "generatedAt": "2026-06-21",
+    "model": "synthetic",
+    "pattern": "circle-stack-3d",
+    "costUSD": 0
+  }
+}

--- a/sdf-js/examples/compositor/demo-lifts/index.json
+++ b/sdf-js/examples/compositor/demo-lifts/index.json
@@ -288,6 +288,46 @@
       "file": "cube-segmented-3d.json",
       "renderer": "studio",
       "prompt": "Cube · Segmented"
+    },
+    {
+      "id": "circle-frame-3d",
+      "title": "Circle · Frame",
+      "thesisPoint": "Atlas Shape atom (Sprint 3 circle family) — composite atom, studio auto-framed.",
+      "category": "primitive-showcase",
+      "status": "ready",
+      "file": "circle-frame-3d.json",
+      "renderer": "studio",
+      "prompt": "Circle · Frame"
+    },
+    {
+      "id": "circle-stack-3d",
+      "title": "Circle · Stack",
+      "thesisPoint": "Atlas Shape atom (Sprint 3 circle family) — composite atom, studio auto-framed.",
+      "category": "primitive-showcase",
+      "status": "ready",
+      "file": "circle-stack-3d.json",
+      "renderer": "studio",
+      "prompt": "Circle · Stack"
+    },
+    {
+      "id": "circle-segmented-3d",
+      "title": "Circle · Segmented",
+      "thesisPoint": "Atlas Shape atom (Sprint 3 circle family) — composite atom, studio auto-framed.",
+      "category": "primitive-showcase",
+      "status": "ready",
+      "file": "circle-segmented-3d.json",
+      "renderer": "studio",
+      "prompt": "Circle · Segmented"
+    },
+    {
+      "id": "circle-loop-3d",
+      "title": "Circle · Loop",
+      "thesisPoint": "Atlas Shape atom (Sprint 3 circle family) — composite atom, studio auto-framed.",
+      "category": "primitive-showcase",
+      "status": "ready",
+      "file": "circle-loop-3d.json",
+      "renderer": "studio",
+      "prompt": "Circle · Loop"
     }
   ]
 }

--- a/sdf-js/scripts/test-circle-frame-3d.mjs
+++ b/sdf-js/scripts/test-circle-frame-3d.mjs
@@ -1,0 +1,33 @@
+import { circleFrame3dSDF } from '../src/scene/components/shapes/circle-frame-3d.js';
+import { compile } from '../src/scene/compile.js';
+import { compileSDF3ToGLSL } from '../src/sdf/sdf3.compile.js';
+let pass = 0,
+  fail = 0;
+const ok = (c, n) => (c ? (pass++, console.log(`  ✓ ${n}`)) : (fail++, console.log(`  ✗ ${n}`)));
+console.log('=== circle-frame-3d ===\n');
+{
+  const sdf = circleFrame3dSDF(); // radius 0.7, frame 0.12, backing on
+  ok(sdf.f([0.7, 0, 0]) < 0, 'ring centreline (XY) inside');
+  ok(sdf.f([0, 0, 0]) < 0, 'centre on backing disk inside');
+  ok(sdf.f([2, 0, 0]) > 0, 'far outside');
+  const open = circleFrame3dSDF({ back: false });
+  ok(open.f([0, 0, 0]) > 0, 'back=false → centre is open (outside)');
+  ok(open.f([0.7, 0, 0]) < 0, 'back=false → ring still solid');
+}
+{
+  const scene = {
+    v: 1,
+    defaults: {
+      camera: { yaw: 0.4, pitch: 0.2, distance: 6, focal: 1.5, targetX: 0, targetY: 0, targetZ: 0 },
+      light: { altitude: 0.5, azimuth: 0.6, distance: 8, intensity: 1.1 },
+    },
+    subjects: [{ type: 'circle-frame-3d', id: 'cf', args: {}, region: 'object' }],
+  };
+  const compiled = compile(scene);
+  ok(compiled.sdf.f([0, 0, 0]) < 0, 'compiled frame backing inside');
+  const glsl = compileSDF3ToGLSL(compiled.sdf, { time: 'u_time' });
+  const s = typeof glsl === 'string' ? glsl : glsl.expr || JSON.stringify(glsl);
+  ok(s.includes('sdTorus'), 'GLSL has sdTorus (ring)');
+}
+console.log(`\n=== Result: ${pass} passed, ${fail} failed ===`);
+process.exit(fail > 0 ? 1 : 0);

--- a/sdf-js/scripts/test-circle-loop-3d.mjs
+++ b/sdf-js/scripts/test-circle-loop-3d.mjs
@@ -1,0 +1,33 @@
+import { circleLoop3dSDF } from '../src/scene/components/shapes/circle-loop-3d.js';
+import { compile } from '../src/scene/compile.js';
+import { compileSDF3ToGLSL } from '../src/sdf/sdf3.compile.js';
+let pass = 0,
+  fail = 0;
+const ok = (c, n) => (c ? (pass++, console.log(`  ✓ ${n}`)) : (fail++, console.log(`  ✗ ${n}`)));
+console.log('=== circle-loop-3d ===\n');
+{
+  // segments 4, radius 0.7, tube 0.07; ring in XZ, arrows tangential
+  const sdf = circleLoop3dSDF();
+  ok(sdf.f([0, 0, 0.7]) < 0, 'ring centreline (angle 90°) inside');
+  ok(sdf.f([0.7, 0, 0.1]) < 0, 'arrowhead near +X tip inside');
+  ok(sdf.f([0, 0, 0]) > 0, 'centre (loop hole) outside');
+  ok(sdf.f([0, 1, 0]) > 0, 'above the loop outside');
+  ok(sdf.f([3, 0, 0]) > 0, 'far outside');
+}
+{
+  const scene = {
+    v: 1,
+    defaults: {
+      camera: { yaw: 0.4, pitch: 0.2, distance: 6, focal: 1.5, targetX: 0, targetY: 0, targetZ: 0 },
+      light: { altitude: 0.5, azimuth: 0.6, distance: 8, intensity: 1.1 },
+    },
+    subjects: [{ type: 'circle-loop-3d', id: 'cl', args: { segments: 4 }, region: 'object' }],
+  };
+  const compiled = compile(scene);
+  ok(compiled.sdf.f([0, 0, 0.7]) < 0, 'compiled loop ring inside');
+  const glsl = compileSDF3ToGLSL(compiled.sdf, { time: 'u_time' });
+  const s = typeof glsl === 'string' ? glsl : glsl.expr || JSON.stringify(glsl);
+  ok(s.includes('sdTorus'), 'GLSL has sdTorus (ring)');
+}
+console.log(`\n=== Result: ${pass} passed, ${fail} failed ===`);
+process.exit(fail > 0 ? 1 : 0);

--- a/sdf-js/scripts/test-circle-segmented-3d.mjs
+++ b/sdf-js/scripts/test-circle-segmented-3d.mjs
@@ -1,0 +1,35 @@
+import { circleSegmented3dSDF } from '../src/scene/components/shapes/circle-segmented-3d.js';
+import { compile } from '../src/scene/compile.js';
+import { compileSDF3ToGLSL } from '../src/sdf/sdf3.compile.js';
+let pass = 0,
+  fail = 0;
+const ok = (c, n) => (c ? (pass++, console.log(`  ✓ ${n}`)) : (fail++, console.log(`  ✗ ${n}`)));
+console.log('=== circle-segmented-3d ===\n');
+{
+  // segments 6, outer 0.8, inner 0.44, slots at angles 0,60,…
+  const sdf = circleSegmented3dSDF();
+  ok(sdf.f([0.52, 0, 0.3]) < 0, 'segment body (≈30°, between slots) inside');
+  ok(sdf.f([0.6, 0, 0]) > 0, 'on a radial slot (angle 0) → gap, outside');
+  ok(sdf.f([0, 0, 0]) > 0, 'centre hole outside');
+  ok(sdf.f([2, 0, 0]) > 0, 'far outside');
+}
+{
+  const scene = {
+    v: 1,
+    defaults: {
+      camera: { yaw: 0.4, pitch: 0.2, distance: 6, focal: 1.5, targetX: 0, targetY: 0, targetZ: 0 },
+      light: { altitude: 0.5, azimuth: 0.6, distance: 8, intensity: 1.1 },
+    },
+    subjects: [
+      { type: 'circle-segmented-3d', id: 'cseg', args: { segments: 6 }, region: 'object' },
+    ],
+  };
+  const compiled = compile(scene);
+  ok(compiled.sdf.f([0.52, 0, 0.3]) < 0, 'compiled segment body inside');
+  ok(compiled.sdf.f([0, 0, 0]) > 0, 'compiled centre hole outside');
+  const glsl = compileSDF3ToGLSL(compiled.sdf, { time: 'u_time' });
+  const s = typeof glsl === 'string' ? glsl : glsl.expr || JSON.stringify(glsl);
+  ok(s.includes('opDifference'), 'GLSL has opDifference (slots/hole)');
+}
+console.log(`\n=== Result: ${pass} passed, ${fail} failed ===`);
+process.exit(fail > 0 ? 1 : 0);

--- a/sdf-js/scripts/test-circle-stack-3d.mjs
+++ b/sdf-js/scripts/test-circle-stack-3d.mjs
@@ -1,0 +1,32 @@
+import { circleStack3dSDF } from '../src/scene/components/shapes/circle-stack-3d.js';
+import { compile } from '../src/scene/compile.js';
+import { compileSDF3ToGLSL } from '../src/sdf/sdf3.compile.js';
+let pass = 0,
+  fail = 0;
+const ok = (c, n) => (c ? (pass++, console.log(`  ✓ ${n}`)) : (fail++, console.log(`  ✗ ${n}`)));
+console.log('=== circle-stack-3d ===\n');
+{
+  // count 4, diskHeight 0.18, gap 0.06 → stride 0.24, y = −0.36,−0.12,0.12,0.36
+  const sdf = circleStack3dSDF();
+  ok(sdf.f([0, -0.36, 0]) < 0, 'bottom disk centre inside');
+  ok(sdf.f([0, 0.36, 0]) < 0, 'top disk centre inside');
+  ok(sdf.f([0, -0.24, 0]) > 0, 'gap between disks 0 and 1 outside');
+  ok(sdf.f([0, 2, 0]) > 0, 'far above outside');
+}
+{
+  const scene = {
+    v: 1,
+    defaults: {
+      camera: { yaw: 0.4, pitch: 0.2, distance: 6, focal: 1.5, targetX: 0, targetY: 0, targetZ: 0 },
+      light: { altitude: 0.5, azimuth: 0.6, distance: 8, intensity: 1.1 },
+    },
+    subjects: [{ type: 'circle-stack-3d', id: 'cs', args: { count: 3 }, region: 'object' }],
+  };
+  const compiled = compile(scene);
+  ok(compiled.sdf.f([0, 0, 0]) < 0, 'compiled stack middle disk inside');
+  const glsl = compileSDF3ToGLSL(compiled.sdf, { time: 'u_time' });
+  const s = typeof glsl === 'string' ? glsl : glsl.expr || JSON.stringify(glsl);
+  ok(s.includes('sdCylinder'), 'GLSL has sdCylinder (disks)');
+}
+console.log(`\n=== Result: ${pass} passed, ${fail} failed ===`);
+process.exit(fail > 0 ? 1 : 0);

--- a/sdf-js/src/scene/compile.js
+++ b/sdf-js/src/scene/compile.js
@@ -125,6 +125,10 @@ import { arrow3dSDF } from './components/shapes/arrow-3d.js';
 import { diamond3dSDF } from './components/shapes/diamond-3d.js';
 import { gear3dSDF } from './components/shapes/gear-3d.js';
 import { cubeSegmented3dSDF } from './components/shapes/cube-segmented-3d.js';
+import { circleFrame3dSDF } from './components/shapes/circle-frame-3d.js';
+import { circleStack3dSDF } from './components/shapes/circle-stack-3d.js';
+import { circleSegmented3dSDF } from './components/shapes/circle-segmented-3d.js';
+import { circleLoop3dSDF } from './components/shapes/circle-loop-3d.js';
 import { terrainCanyonSDF } from './components/community/iq-canyon.js';
 import { proceduralCitySDF } from './components/community/otavio-skyline.js';
 import { terrainErodedRuneSDF, bakeHeightmap } from './components/community/rune-erosion-filter.js';
@@ -497,6 +501,37 @@ const PRIMITIVE_FACTORIES = {
       size: a.size ?? 1.2,
       gap: a.gap ?? 0.08,
       axis: a.axis ?? 'x',
+    }),
+  'circle-frame-3d': (a) =>
+    circleFrame3dSDF({
+      radius: a.radius ?? 0.7,
+      frameWidth: a.frameWidth ?? a.tube ?? 0.12,
+      backDepth: a.backDepth ?? a.depth ?? 0.06,
+      back: a.back ?? true,
+    }),
+  'circle-stack-3d': (a) =>
+    circleStack3dSDF({
+      count: a.count ?? 4,
+      radius: a.radius ?? 0.7,
+      taper: a.taper ?? 0.85,
+      diskHeight: a.diskHeight ?? a.thickness ?? 0.18,
+      gap: a.gap ?? 0.06,
+    }),
+  'circle-segmented-3d': (a) =>
+    circleSegmented3dSDF({
+      segments: a.segments ?? a.count ?? 6,
+      radius: a.radius ?? 0.8,
+      innerRatio: a.innerRatio ?? 0.55,
+      thickness: a.thickness ?? a.depth ?? 0.2,
+      gapWidth: a.gapWidth ?? 0.12,
+    }),
+  'circle-loop-3d': (a) =>
+    circleLoop3dSDF({
+      segments: a.segments ?? a.count ?? 4,
+      radius: a.radius ?? 0.7,
+      tube: a.tube ?? 0.07,
+      headLength: a.headLength ?? 0.34,
+      headRadius: a.headRadius ?? 0.16,
     }),
   link: (a) =>
     linkSDF({

--- a/sdf-js/src/scene/components/shapes/circle-frame-3d.js
+++ b/sdf-js/src/scene/components/shapes/circle-frame-3d.js
@@ -1,0 +1,55 @@
+// =============================================================================
+// circle-frame-3d.js — round photo/avatar frame (Atlas Shape atom, Sprint 3).
+// -----------------------------------------------------------------------------
+// A torus ring facing +Z + a thin recessed backing disk — the "drop a headshot
+// / image here" circle. Covers PresentationLoad "Circle Image Infographics".
+// Composite atom from torus + cylinder + union (GLSL-emit registered).
+// =============================================================================
+
+import { torus, cylinder } from '../../../sdf/d3.js';
+import { union } from '../../../sdf/dn.js';
+
+/**
+ * @param {object} opts
+ * @param {number} [opts.radius=0.7]      ring centreline radius
+ * @param {number} [opts.frameWidth=0.12] ring tube radius (frame thickness)
+ * @param {number} [opts.backDepth=0.06]  backing-disk thickness (Z)
+ * @param {boolean} [opts.back=true]      include the backing disk
+ * @returns {SDF3}
+ */
+export function circleFrame3dSDF({
+  radius = 0.7,
+  frameWidth = 0.12,
+  backDepth = 0.06,
+  back = true,
+} = {}) {
+  // torus defaults to the XZ plane (axis Y); rotate to face +Z (ring in XY).
+  const ring = torus(radius, frameWidth).rotate(Math.PI / 2, [1, 0, 0]);
+  if (!back) return ring;
+  // backing disk: cylinder (axis Y) rotated so its axis is Z → thin disk in XY.
+  const backing = cylinder(radius - frameWidth * 0.5, backDepth).rotate(Math.PI / 2, [1, 0, 0]);
+  return union(ring, backing);
+}
+
+export const circleFrame3dSpec = {
+  type: 'circle-frame-3d',
+  category: 'shapes',
+  args: {
+    radius: { type: 'number', default: 0.7, doc: 'Ring centreline radius' },
+    frameWidth: { type: 'number', default: 0.12, doc: 'Ring tube radius' },
+    backDepth: { type: 'number', default: 0.06, doc: 'Backing disk thickness' },
+    back: { type: 'boolean', default: true, doc: 'Include backing disk' },
+  },
+  examples: [
+    { name: 'Avatar frame', args: {} },
+    { name: 'Open ring', args: { back: false } },
+    { name: 'Thick bezel', args: { frameWidth: 0.2 } },
+  ],
+  description: 'Round image / avatar frame (ring + backing) — team, profile, photo',
+  source: {
+    author: 'Atlas',
+    builtAt: '2026-06-21',
+    builder: 'Sprint 3 circle family — taxonomy shapes/',
+    license: 'PolyForm Noncommercial 1.0.0',
+  },
+};

--- a/sdf-js/src/scene/components/shapes/circle-loop-3d.js
+++ b/sdf-js/src/scene/components/shapes/circle-loop-3d.js
@@ -1,0 +1,61 @@
+// =============================================================================
+// circle-loop-3d.js — cycle / loop arrows (Atlas Shape atom, Sprint 3).
+// -----------------------------------------------------------------------------
+// A ring (torus) with N cone arrowheads placed tangentially around it, reading
+// as a rotating cycle. Covers PresentationLoad "Circle Charts Looping" (process
+// cycle, PDCA, lifecycle). Composite atom from torus + cone + modPolar + union.
+// =============================================================================
+
+import { torus, cone, modPolar } from '../../../sdf/d3.js';
+import { union } from '../../../sdf/dn.js';
+
+/**
+ * @param {object} opts
+ * @param {number} [opts.segments=4]     number of arrowheads around the loop
+ * @param {number} [opts.radius=0.7]     ring centreline radius
+ * @param {number} [opts.tube=0.07]      ring tube radius
+ * @param {number} [opts.headLength=0.34] arrowhead length
+ * @param {number} [opts.headRadius=0.16] arrowhead base radius
+ * @returns {SDF3}
+ */
+export function circleLoop3dSDF({
+  segments = 4,
+  radius = 0.7,
+  tube = 0.07,
+  headLength = 0.34,
+  headRadius = 0.16,
+} = {}) {
+  const N = Math.max(2, Math.floor(segments));
+  const ring = torus(radius, tube); // flat in XZ (axis Y)
+  // Cone points +Y; rotate +90° about X → points +Z (tangent at the +X point);
+  // modPolar repeats it tangentially around the loop.
+  const arrow = cone(headLength, headRadius)
+    .rotate(Math.PI / 2, [1, 0, 0])
+    .translate([radius, 0, 0]);
+  const arrows = modPolar(arrow, { axis: 'y', repetitions: N });
+  return union(ring, arrows);
+}
+
+export const circleLoop3dSpec = {
+  type: 'circle-loop-3d',
+  category: 'shapes',
+  args: {
+    segments: { type: 'number', default: 4, doc: 'Number of arrowheads (≥2)' },
+    radius: { type: 'number', default: 0.7, doc: 'Ring centreline radius' },
+    tube: { type: 'number', default: 0.07, doc: 'Ring tube radius' },
+    headLength: { type: 'number', default: 0.34, doc: 'Arrowhead length' },
+    headRadius: { type: 'number', default: 0.16, doc: 'Arrowhead base radius' },
+  },
+  examples: [
+    { name: 'PDCA cycle (4)', args: { segments: 4 } },
+    { name: 'Lifecycle (3)', args: { segments: 3 } },
+    { name: 'Continuous (6)', args: { segments: 6, headLength: 0.26 } },
+  ],
+  description: 'Looping cycle arrows — process cycle, PDCA, lifecycle, iteration',
+  source: {
+    author: 'Atlas',
+    builtAt: '2026-06-21',
+    builder: 'Sprint 3 circle family — taxonomy shapes/',
+    license: 'PolyForm Noncommercial 1.0.0',
+  },
+};

--- a/sdf-js/src/scene/components/shapes/circle-segmented-3d.js
+++ b/sdf-js/src/scene/components/shapes/circle-segmented-3d.js
@@ -1,0 +1,62 @@
+// =============================================================================
+// circle-segmented-3d.js — segmented donut ring (Atlas Shape atom, Sprint 3).
+// -----------------------------------------------------------------------------
+// A flat annulus (lying in XZ, thin in Y) cut into N arc segments by radial
+// gaps. Covers PresentationLoad "3D Circles Segmented". Composite atom from
+// cylinder + box + modPolar + difference (all GLSL-emit registered; same
+// difference+modPolar path as gear-3d, GPU-verified).
+// =============================================================================
+
+import { cylinder, box, modPolar } from '../../../sdf/d3.js';
+import { difference } from '../../../sdf/dn.js';
+
+/**
+ * @param {object} opts
+ * @param {number} [opts.segments=6]   number of arc segments (clamped ≥2)
+ * @param {number} [opts.radius=0.8]   outer radius
+ * @param {number} [opts.innerRatio=0.55] inner radius as a fraction of outer
+ * @param {number} [opts.thickness=0.2] Y extent
+ * @param {number} [opts.gapWidth=0.12] tangential gap width
+ * @returns {SDF3}
+ */
+export function circleSegmented3dSDF({
+  segments = 6,
+  radius = 0.8,
+  innerRatio = 0.55,
+  thickness = 0.2,
+  gapWidth = 0.12,
+} = {}) {
+  const N = Math.max(2, Math.floor(segments));
+  const ring = difference(
+    cylinder(radius, thickness),
+    cylinder(radius * innerRatio, thickness * 1.2),
+  );
+  // Radial slot at +X (long in X, full in Y, thin in Z=tangential), repeated.
+  const slot = box([radius * 2.4, thickness * 1.4, gapWidth]);
+  const slots = modPolar(slot, { axis: 'y', repetitions: N });
+  return difference(ring, slots);
+}
+
+export const circleSegmented3dSpec = {
+  type: 'circle-segmented-3d',
+  category: 'shapes',
+  args: {
+    segments: { type: 'number', default: 6, doc: 'Number of arc segments (≥2)' },
+    radius: { type: 'number', default: 0.8, doc: 'Outer radius' },
+    innerRatio: { type: 'number', default: 0.55, doc: 'Inner / outer radius' },
+    thickness: { type: 'number', default: 0.2, doc: 'Y extent' },
+    gapWidth: { type: 'number', default: 0.12, doc: 'Tangential gap width' },
+  },
+  examples: [
+    { name: 'Segmented ring (6)', args: { segments: 6 } },
+    { name: 'Dial (12)', args: { segments: 12, gapWidth: 0.06 } },
+    { name: 'Quad ring', args: { segments: 4, gapWidth: 0.2 } },
+  ],
+  description: 'Segmented donut ring — share split, phases of a cycle, dial',
+  source: {
+    author: 'Atlas',
+    builtAt: '2026-06-21',
+    builder: 'Sprint 3 circle family — taxonomy shapes/',
+    license: 'PolyForm Noncommercial 1.0.0',
+  },
+};

--- a/sdf-js/src/scene/components/shapes/circle-stack-3d.js
+++ b/sdf-js/src/scene/components/shapes/circle-stack-3d.js
@@ -1,0 +1,62 @@
+// =============================================================================
+// circle-stack-3d.js — stacked disks (Atlas Shape atom, Sprint 3).
+// -----------------------------------------------------------------------------
+// N coin-like cylinders stacked along Y, optionally tapering in radius — a
+// layered-disk / tiered infographic. Covers PresentationLoad "3D Circle Shapes"
+// (multi-circle stack). Composite atom from cylinder + union.
+// =============================================================================
+
+import { cylinder } from '../../../sdf/d3.js';
+import { union } from '../../../sdf/dn.js';
+
+/**
+ * @param {object} opts
+ * @param {number} [opts.count=4]        number of disks (clamped ≥1)
+ * @param {number} [opts.radius=0.7]     bottom disk radius
+ * @param {number} [opts.taper=0.85]     radius multiplier per disk going up
+ * @param {number} [opts.diskHeight=0.18] disk thickness
+ * @param {number} [opts.gap=0.06]       gap between disks
+ * @returns {SDF3}
+ */
+export function circleStack3dSDF({
+  count = 4,
+  radius = 0.7,
+  taper = 0.85,
+  diskHeight = 0.18,
+  gap = 0.06,
+} = {}) {
+  const N = Math.max(1, Math.floor(count));
+  const stride = diskHeight + gap;
+  const offset = ((N - 1) / 2) * stride;
+  const disks = [];
+  for (let i = 0; i < N; i++) {
+    const r = radius * Math.pow(taper, i);
+    const y = i * stride - offset;
+    disks.push(cylinder(r, diskHeight).translate([0, y, 0]));
+  }
+  return disks.length === 1 ? disks[0] : union(...disks);
+}
+
+export const circleStack3dSpec = {
+  type: 'circle-stack-3d',
+  category: 'shapes',
+  args: {
+    count: { type: 'number', default: 4, doc: 'Number of disks (≥1)' },
+    radius: { type: 'number', default: 0.7, doc: 'Bottom disk radius' },
+    taper: { type: 'number', default: 0.85, doc: 'Radius × per disk upward' },
+    diskHeight: { type: 'number', default: 0.18, doc: 'Disk thickness' },
+    gap: { type: 'number', default: 0.06, doc: 'Gap between disks' },
+  },
+  examples: [
+    { name: 'Tiered stack', args: { count: 4 } },
+    { name: 'Coin pile', args: { count: 6, taper: 1.0, gap: 0.02 } },
+    { name: 'Wedding cake', args: { count: 3, taper: 0.7, diskHeight: 0.3 } },
+  ],
+  description: 'Stacked / tiered disks — layers, levels, accumulation',
+  source: {
+    author: 'Atlas',
+    builtAt: '2026-06-21',
+    builder: 'Sprint 3 circle family — taxonomy shapes/',
+    license: 'PolyForm Noncommercial 1.0.0',
+  },
+};

--- a/sdf-js/src/scene/spec.js
+++ b/sdf-js/src/scene/spec.js
@@ -208,6 +208,11 @@ export const PRIMITIVE_TYPES = new Set([
   'diamond-3d',
   'gear-3d',
   'cube-segmented-3d',
+  // Sprint 3 circle family — torus/cylinder/cone/box + union/difference/modPolar.
+  'circle-frame-3d',
+  'circle-stack-3d',
+  'circle-segmented-3d',
+  'circle-loop-3d',
   // Rune Skovbo Johansen's Advanced Terrain Erosion Filter (MPL-2.0 — see
   // src/scene/components/community/rune-erosion-filter.js). CPU-baked
   // heightmap uploaded to GPU as sampler2D u_heightmap. Box-bounded bonsai


### PR DESCRIPTION
## What

4 composite Shape atoms completing the circle group (cube-3d tradition), each with a studio-auto-framed gallery demo:

| atom | build | use |
| --- | --- | --- |
| `circle-frame-3d` | torus ring (XY) + backing disk | avatar / photo frame |
| `circle-stack-3d` | N tapering stacked cylinders | tiers / layers |
| `circle-segmented-3d` | annulus − N radial slots (`difference`+`modPolar`) | dial / share split |
| `circle-loop-3d` | torus + N tangential cone arrows (`modPolar`) | process cycle / PDCA |

## Also: thin-atom auto-frame fix (compositor.js)
`bbox3FromSDF` now samples with **`iso = 0.12`** (finer grid radius 10 / res 56) so **thin** atoms — flat rings, arrow shafts, gear teeth — that are thinner than the old 0.6 grid cell are no longer missed (which had left them at studio's default low pose). circle-loop now auto-frames correctly.

## Verification
- CPU probes per atom (segment body vs slot vs centre-hole; ring vs arrowhead vs hole; tapered stack; framed ring + open variant) + compile + GLSL emit. Full suite **59/59**.
- **Real-browser GPU**: verified **circle-loop** (torus + cone + modPolar) — 0 console errors, renders ring + 4 tangential arrows, auto-frames centred. Others use simpler proven primitives + the same auto-frame path.
- `node --check` + Prettier clean.

SHAPES taxonomy now: cube · sphere×4 · arrow · diamond · gear · cube-segmented · circle×4. Remaining: puzzle-piece, then the **CHARTS** family.

🤖 Generated with [Claude Code](https://claude.com/claude-code)