### PR TITLE
Sprint 4: node-edge chart atoms (relationship graph / org chart / flow chart)

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -110,6 +110,11 @@ const TESTS = [
   { category: 'shapes', file: 'sdf-js/scripts/test-circle-segmented-3d.mjs' },
   { category: 'shapes', file: 'sdf-js/scripts/test-circle-loop-3d.mjs' },
 
+  // Sprint 4: node-edge chart atoms (relationship graph / org chart / flow chart).
+  { category: 'diagram', file: 'sdf-js/scripts/test-relationship-graph-3d.mjs' },
+  { category: 'diagram', file: 'sdf-js/scripts/test-org-chart-3d.mjs' },
+  { category: 'diagram', file: 'sdf-js/scripts/test-flow-chart-3d.mjs' },
+
   // Layer 1 public API extracted from compositor.js (used by Layer 2 / MCP / tests)
   { category: 'api', file: 'sdf-js/scripts/test-compositor-api.mjs' },
 

--- a/sdf-js/examples/compositor/demo-lifts/flow-chart-3d.json
+++ b/sdf-js/examples/compositor/demo-lifts/flow-chart-3d.json
@@ -1,0 +1,39 @@
+{
+  "id": "flow-chart-3d",
+  "title": "Diagram · Flow Chart",
+  "prompt": "flow-chart-3d atom showcase.",
+  "code2d": "// Synthetic showcase.\nexport const render = (ctx) => {};",
+  "sceneData": {
+    "v": 1,
+    "name": "flow-chart-3d",
+    "source": { "format": "synthetic", "prompt": "flow-chart-3d" },
+    "subjects": [
+      {
+        "id": "s",
+        "type": "flow-chart-3d",
+        "args": { "steps": 4 },
+        "transform": { "translate": [0, 0.6, 0] },
+        "material": "silver"
+      }
+    ],
+    "defaults": {
+      "camera": {
+        "yaw": 0.5,
+        "pitch": 0.3,
+        "distance": 8,
+        "focal": 1.5,
+        "targetX": 0,
+        "targetY": 0.6,
+        "targetZ": 0
+      },
+      "light": { "azimuth": 0.6, "altitude": 0.55, "distance": 25, "intensity": 1.2 },
+      "shadow": { "enabled": true, "mode": "darken", "strength": 0.4 }
+    }
+  },
+  "meta": {
+    "generatedAt": "2026-06-21",
+    "model": "synthetic",
+    "pattern": "flow-chart-3d",
+    "costUSD": 0
+  }
+}

--- a/sdf-js/examples/compositor/demo-lifts/index.json
+++ b/sdf-js/examples/compositor/demo-lifts/index.json
@@ -328,6 +328,36 @@
       "file": "circle-loop-3d.json",
       "renderer": "studio",
       "prompt": "Circle · Loop"
+    },
+    {
+      "id": "relationship-graph-3d",
+      "title": "Diagram · Relationship Graph",
+      "thesisPoint": "Atlas node-edge chart atom (Sprint 4) — nodes + capsule edges, studio auto-framed.",
+      "category": "primitive-showcase",
+      "status": "ready",
+      "file": "relationship-graph-3d.json",
+      "renderer": "studio",
+      "prompt": "Diagram · Relationship Graph"
+    },
+    {
+      "id": "org-chart-3d",
+      "title": "Diagram · Org Chart",
+      "thesisPoint": "Atlas node-edge chart atom (Sprint 4) — nodes + capsule edges, studio auto-framed.",
+      "category": "primitive-showcase",
+      "status": "ready",
+      "file": "org-chart-3d.json",
+      "renderer": "studio",
+      "prompt": "Diagram · Org Chart"
+    },
+    {
+      "id": "flow-chart-3d",
+      "title": "Diagram · Flow Chart",
+      "thesisPoint": "Atlas node-edge chart atom (Sprint 4) — nodes + capsule edges, studio auto-framed.",
+      "category": "primitive-showcase",
+      "status": "ready",
+      "file": "flow-chart-3d.json",
+      "renderer": "studio",
+      "prompt": "Diagram · Flow Chart"
     }
   ]
 }

--- a/sdf-js/examples/compositor/demo-lifts/org-chart-3d.json
+++ b/sdf-js/examples/compositor/demo-lifts/org-chart-3d.json
@@ -1,0 +1,39 @@
+{
+  "id": "org-chart-3d",
+  "title": "Diagram · Org Chart",
+  "prompt": "org-chart-3d atom showcase.",
+  "code2d": "// Synthetic showcase.\nexport const render = (ctx) => {};",
+  "sceneData": {
+    "v": 1,
+    "name": "org-chart-3d",
+    "source": { "format": "synthetic", "prompt": "org-chart-3d" },
+    "subjects": [
+      {
+        "id": "s",
+        "type": "org-chart-3d",
+        "args": { "levels": 3, "branching": 2 },
+        "transform": { "translate": [0, 1.1, 0] },
+        "material": "silver"
+      }
+    ],
+    "defaults": {
+      "camera": {
+        "yaw": 0.5,
+        "pitch": 0.3,
+        "distance": 8,
+        "focal": 1.5,
+        "targetX": 0,
+        "targetY": 1.1,
+        "targetZ": 0
+      },
+      "light": { "azimuth": 0.6, "altitude": 0.55, "distance": 25, "intensity": 1.2 },
+      "shadow": { "enabled": true, "mode": "darken", "strength": 0.4 }
+    }
+  },
+  "meta": {
+    "generatedAt": "2026-06-21",
+    "model": "synthetic",
+    "pattern": "org-chart-3d",
+    "costUSD": 0
+  }
+}

--- a/sdf-js/examples/compositor/demo-lifts/relationship-graph-3d.json
+++ b/sdf-js/examples/compositor/demo-lifts/relationship-graph-3d.json
@@ -1,0 +1,39 @@
+{
+  "id": "relationship-graph-3d",
+  "title": "Diagram · Relationship Graph",
+  "prompt": "relationship-graph-3d atom showcase.",
+  "code2d": "// Synthetic showcase.\nexport const render = (ctx) => {};",
+  "sceneData": {
+    "v": 1,
+    "name": "relationship-graph-3d",
+    "source": { "format": "synthetic", "prompt": "relationship-graph-3d" },
+    "subjects": [
+      {
+        "id": "s",
+        "type": "relationship-graph-3d",
+        "args": { "count": 6 },
+        "transform": { "translate": [0, 0.6, 0] },
+        "material": "silver"
+      }
+    ],
+    "defaults": {
+      "camera": {
+        "yaw": 0.5,
+        "pitch": 0.3,
+        "distance": 8,
+        "focal": 1.5,
+        "targetX": 0,
+        "targetY": 0.6,
+        "targetZ": 0
+      },
+      "light": { "azimuth": 0.6, "altitude": 0.55, "distance": 25, "intensity": 1.2 },
+      "shadow": { "enabled": true, "mode": "darken", "strength": 0.4 }
+    }
+  },
+  "meta": {
+    "generatedAt": "2026-06-21",
+    "model": "synthetic",
+    "pattern": "relationship-graph-3d",
+    "costUSD": 0
+  }
+}

--- a/sdf-js/scripts/test-flow-chart-3d.mjs
+++ b/sdf-js/scripts/test-flow-chart-3d.mjs
@@ -1,0 +1,36 @@
+import { flowChart3dSDF } from '../src/scene/components/charts/diagrams/flow-chart-3d.js';
+import { compile } from '../src/scene/compile.js';
+import { compileSDF3ToGLSL } from '../src/sdf/sdf3.compile.js';
+let pass = 0,
+  fail = 0;
+const ok = (c, n) => (c ? (pass++, console.log(`  ✓ ${n}`)) : (fail++, console.log(`  ✗ ${n}`)));
+console.log('=== flow-chart-3d ===\n');
+{
+  // steps 4, nodeW 0.6, gap 0.55 → stride 1.15, offset 1.725; step0 at x=-1.725
+  const sdf = flowChart3dSDF();
+  ok(sdf.f([-1.725, 0, 0]) < 0, 'step 0 box inside');
+  ok(sdf.f([-0.575, 0, 0]) < 0, 'step 1 box inside');
+  ok(sdf.f([-1.15, 0, 0]) < 0, 'arrow connector between steps 0–1 inside');
+  ok(sdf.f([5, 0, 0]) > 0, 'far outside');
+  ok(sdf.f([0, 2, 0]) > 0, 'above the row outside');
+}
+{
+  const scene = {
+    v: 1,
+    defaults: {
+      camera: { yaw: 0.4, pitch: 0.2, distance: 6, focal: 1.5, targetX: 0, targetY: 0, targetZ: 0 },
+      light: { altitude: 0.5, azimuth: 0.6, distance: 8, intensity: 1.1 },
+    },
+    subjects: [{ type: 'flow-chart-3d', id: 'fc', args: { steps: 4 }, region: 'object' }],
+  };
+  const compiled = compile(scene);
+  ok(compiled.sdf.f([-1.725, 0, 0]) < 0, 'compiled step inside');
+  const glsl = compileSDF3ToGLSL(compiled.sdf, { time: 'u_time' });
+  const s = typeof glsl === 'string' ? glsl : glsl.expr || JSON.stringify(glsl);
+  ok(
+    s.includes('sdBox') && s.includes('sdCapsule') && s.includes('sdCappedCone'),
+    'GLSL has box+capsule+cone',
+  );
+}
+console.log(`\n=== Result: ${pass} passed, ${fail} failed ===`);
+process.exit(fail > 0 ? 1 : 0);

--- a/sdf-js/scripts/test-org-chart-3d.mjs
+++ b/sdf-js/scripts/test-org-chart-3d.mjs
@@ -1,0 +1,34 @@
+import { orgChart3dSDF } from '../src/scene/components/charts/diagrams/org-chart-3d.js';
+import { compile } from '../src/scene/compile.js';
+import { compileSDF3ToGLSL } from '../src/sdf/sdf3.compile.js';
+let pass = 0,
+  fail = 0;
+const ok = (c, n) => (c ? (pass++, console.log(`  ✓ ${n}`)) : (fail++, console.log(`  ✗ ${n}`)));
+console.log('=== org-chart-3d ===\n');
+{
+  const sdf = orgChart3dSDF(); // levels 3, branching 2, levelHeight 0.9 → topY 0.9
+  ok(sdf.f([0, 0.9, 0]) < 0, 'root card (top centre) inside');
+  // level 1, node 0: nodeX(0,2) = (0.25-0.5)*3.4 = -0.85, y = 0
+  ok(sdf.f([-0.85, 0, 0]) < 0, 'level-1 card inside');
+  ok(sdf.f([-0.425, 0.45, 0]) < 0, 'root→child connector midpoint inside');
+  ok(sdf.f([5, 5, 5]) > 0, 'far outside');
+}
+{
+  const scene = {
+    v: 1,
+    defaults: {
+      camera: { yaw: 0.4, pitch: 0.2, distance: 6, focal: 1.5, targetX: 0, targetY: 0, targetZ: 0 },
+      light: { altitude: 0.5, azimuth: 0.6, distance: 8, intensity: 1.1 },
+    },
+    subjects: [
+      { type: 'org-chart-3d', id: 'org', args: { levels: 3, branching: 2 }, region: 'object' },
+    ],
+  };
+  const compiled = compile(scene);
+  ok(compiled.sdf.f([0, 0.9, 0]) < 0, 'compiled root inside');
+  const glsl = compileSDF3ToGLSL(compiled.sdf, { time: 'u_time' });
+  const s = typeof glsl === 'string' ? glsl : glsl.expr || JSON.stringify(glsl);
+  ok(s.includes('sdBox') && s.includes('sdCapsule'), 'GLSL has sdBox + sdCapsule');
+}
+console.log(`\n=== Result: ${pass} passed, ${fail} failed ===`);
+process.exit(fail > 0 ? 1 : 0);

--- a/sdf-js/scripts/test-relationship-graph-3d.mjs
+++ b/sdf-js/scripts/test-relationship-graph-3d.mjs
@@ -1,0 +1,33 @@
+import { relationshipGraph3dSDF } from '../src/scene/components/charts/diagrams/relationship-graph-3d.js';
+import { compile } from '../src/scene/compile.js';
+import { compileSDF3ToGLSL } from '../src/sdf/sdf3.compile.js';
+let pass = 0,
+  fail = 0;
+const ok = (c, n) => (c ? (pass++, console.log(`  ✓ ${n}`)) : (fail++, console.log(`  ✗ ${n}`)));
+console.log('=== relationship-graph-3d ===\n');
+{
+  const sdf = relationshipGraph3dSDF(); // 6 nodes, radius 1.3
+  ok(sdf.f([1.3, 0, 0]) < 0, 'node 0 (+X) inside');
+  // ring edge node0→node1 midpoint
+  const p1 = [1.3 * Math.cos((2 * Math.PI) / 6), 0, 1.3 * Math.sin((2 * Math.PI) / 6)];
+  ok(sdf.f([(1.3 + p1[0]) / 2, 0, p1[2] / 2]) < 0, 'ring edge 0→1 midpoint inside');
+  ok(sdf.f([0, 0, 0]) > 0, 'centre (no node, edges on perimeter) outside');
+  ok(sdf.f([3, 0, 0]) > 0, 'far outside');
+}
+{
+  const scene = {
+    v: 1,
+    defaults: {
+      camera: { yaw: 0.4, pitch: 0.2, distance: 6, focal: 1.5, targetX: 0, targetY: 0, targetZ: 0 },
+      light: { altitude: 0.5, azimuth: 0.6, distance: 8, intensity: 1.1 },
+    },
+    subjects: [{ type: 'relationship-graph-3d', id: 'rg', args: { count: 6 }, region: 'object' }],
+  };
+  const compiled = compile(scene);
+  ok(compiled.sdf.f([1.3, 0, 0]) < 0, 'compiled node inside');
+  const glsl = compileSDF3ToGLSL(compiled.sdf, { time: 'u_time' });
+  const s = typeof glsl === 'string' ? glsl : glsl.expr || JSON.stringify(glsl);
+  ok(s.includes('sdSphere') && s.includes('sdCapsule'), 'GLSL has sdSphere + sdCapsule');
+}
+console.log(`\n=== Result: ${pass} passed, ${fail} failed ===`);
+process.exit(fail > 0 ? 1 : 0);

--- a/sdf-js/src/scene/compile.js
+++ b/sdf-js/src/scene/compile.js
@@ -129,6 +129,9 @@ import { circleFrame3dSDF } from './components/shapes/circle-frame-3d.js';
 import { circleStack3dSDF } from './components/shapes/circle-stack-3d.js';
 import { circleSegmented3dSDF } from './components/shapes/circle-segmented-3d.js';
 import { circleLoop3dSDF } from './components/shapes/circle-loop-3d.js';
+import { relationshipGraph3dSDF } from './components/charts/diagrams/relationship-graph-3d.js';
+import { orgChart3dSDF } from './components/charts/diagrams/org-chart-3d.js';
+import { flowChart3dSDF } from './components/charts/diagrams/flow-chart-3d.js';
 import { terrainCanyonSDF } from './components/community/iq-canyon.js';
 import { proceduralCitySDF } from './components/community/otavio-skyline.js';
 import { terrainErodedRuneSDF, bakeHeightmap } from './components/community/rune-erosion-filter.js';
@@ -532,6 +535,34 @@ const PRIMITIVE_FACTORIES = {
       tube: a.tube ?? 0.07,
       headLength: a.headLength ?? 0.34,
       headRadius: a.headRadius ?? 0.16,
+    }),
+  'relationship-graph-3d': (a) =>
+    relationshipGraph3dSDF({
+      count: a.count ?? 6,
+      radius: a.radius ?? 1.3,
+      nodeRadius: a.nodeRadius ?? 0.26,
+      linkThickness: a.linkThickness ?? a.thickness ?? 0.05,
+      edges: a.edges ?? null,
+    }),
+  'org-chart-3d': (a) =>
+    orgChart3dSDF({
+      levels: a.levels ?? a.depth ?? 3,
+      branching: a.branching ?? a.fanout ?? 2,
+      nodeW: a.nodeW ?? 0.5,
+      nodeH: a.nodeH ?? 0.3,
+      nodeD: a.nodeD ?? 0.18,
+      levelHeight: a.levelHeight ?? 0.9,
+      spread: a.spread ?? a.width ?? 3.4,
+      linkThickness: a.linkThickness ?? a.thickness ?? 0.04,
+    }),
+  'flow-chart-3d': (a) =>
+    flowChart3dSDF({
+      steps: a.steps ?? a.count ?? 4,
+      nodeW: a.nodeW ?? 0.6,
+      nodeH: a.nodeH ?? 0.4,
+      nodeD: a.nodeD ?? 0.2,
+      gap: a.gap ?? 0.55,
+      linkThickness: a.linkThickness ?? a.thickness ?? 0.05,
     }),
   link: (a) =>
     linkSDF({

--- a/sdf-js/src/scene/components/charts/diagrams/flow-chart-3d.js
+++ b/sdf-js/src/scene/components/charts/diagrams/flow-chart-3d.js
@@ -1,0 +1,76 @@
+// =============================================================================
+// flow-chart-3d.js — linear process flow (Atlas chart atom).
+// -----------------------------------------------------------------------------
+// N box steps in a row connected by arrowed capsules (shaft + cone head), the
+// classic left-to-right process flow. Covers PresentationLoad "Flow Charts".
+// Composite atom (box + capsule + cone + union).
+// =============================================================================
+
+import { box, capsule, cone } from '../../../../sdf/d3.js';
+import { union } from '../../../../sdf/dn.js';
+
+/**
+ * @param {object} opts
+ * @param {number} [opts.steps=4]        number of step boxes (≥1)
+ * @param {number} [opts.nodeW=0.6]      step box width
+ * @param {number} [opts.nodeH=0.4]      step box height
+ * @param {number} [opts.nodeD=0.2]      step box depth
+ * @param {number} [opts.gap=0.55]       gap between steps (holds the arrow)
+ * @param {number} [opts.linkThickness=0.05] connector shaft radius
+ * @returns {SDF3}
+ */
+export function flowChart3dSDF({
+  steps = 4,
+  nodeW = 0.6,
+  nodeH = 0.4,
+  nodeD = 0.2,
+  gap = 0.55,
+  linkThickness = 0.05,
+} = {}) {
+  const N = Math.max(1, Math.floor(steps));
+  const stride = nodeW + gap;
+  const offset = ((N - 1) / 2) * stride;
+  const headLen = Math.min(0.18, gap * 0.5);
+  const parts = [];
+  for (let i = 0; i < N; i++) {
+    const x = i * stride - offset;
+    parts.push(box([nodeW, nodeH, nodeD]).translate([x, 0, 0]));
+    if (i > 0) {
+      const x0 = (i - 1) * stride - offset + nodeW / 2; // prev box right edge
+      const x1 = x - nodeW / 2; // this box left edge
+      // shaft up to the arrowhead, then a cone head pointing +X into this box
+      parts.push(capsule([x0, 0, 0], [x1 - headLen, 0, 0], linkThickness));
+      parts.push(
+        cone(headLen, linkThickness * 2.4)
+          .rotate(-Math.PI / 2, [0, 0, 1])
+          .translate([x1 - headLen / 2, 0, 0]),
+      );
+    }
+  }
+  return parts.length === 1 ? parts[0] : union(...parts);
+}
+
+export const flowChart3dSpec = {
+  type: 'flow-chart-3d',
+  category: 'charts/flow',
+  args: {
+    steps: { type: 'number', default: 4, doc: 'Number of step boxes (≥1)' },
+    nodeW: { type: 'number', default: 0.6, doc: 'Step box width' },
+    nodeH: { type: 'number', default: 0.4, doc: 'Step box height' },
+    nodeD: { type: 'number', default: 0.2, doc: 'Step box depth' },
+    gap: { type: 'number', default: 0.55, doc: 'Gap between steps' },
+    linkThickness: { type: 'number', default: 0.05, doc: 'Connector shaft radius' },
+  },
+  examples: [
+    { name: 'Process flow', args: { steps: 4 } },
+    { name: 'Two-step', args: { steps: 2 } },
+    { name: 'Long pipeline', args: { steps: 6, nodeW: 0.5 } },
+  ],
+  description: 'Left-to-right process flow (steps + arrows) — pipeline, workflow, stages',
+  source: {
+    author: 'Atlas',
+    builtAt: '2026-06-21',
+    builder: 'Sprint 4 node-edge charts — taxonomy charts/flow/',
+    license: 'PolyForm Noncommercial 1.0.0',
+  },
+};

--- a/sdf-js/src/scene/components/charts/diagrams/org-chart-3d.js
+++ b/sdf-js/src/scene/components/charts/diagrams/org-chart-3d.js
@@ -1,0 +1,83 @@
+// =============================================================================
+// org-chart-3d.js — top-down org chart (Atlas chart atom).
+// -----------------------------------------------------------------------------
+// Box-card nodes in a branching hierarchy + capsule connectors (parent→child).
+// Covers PresentationLoad "Hierarchy Charts (Org Chart 2D/3D)". Same layout as
+// sphere-tree-3d but with rectangular cards — the corporate org look.
+// Composite atom (box + capsule + union).
+// =============================================================================
+
+import { box, capsule } from '../../../../sdf/d3.js';
+import { union } from '../../../../sdf/dn.js';
+
+const clampInt = (x, lo, hi) => Math.max(lo, Math.min(hi, Math.floor(x)));
+
+/**
+ * @param {object} opts
+ * @param {number} [opts.levels=3]        hierarchy depth (1..5)
+ * @param {number} [opts.branching=2]     children per node (1..5)
+ * @param {number} [opts.nodeW=0.5]       card width
+ * @param {number} [opts.nodeH=0.3]       card height
+ * @param {number} [opts.nodeD=0.18]      card depth
+ * @param {number} [opts.levelHeight=0.9] vertical gap between levels
+ * @param {number} [opts.spread=3.4]      total width per level
+ * @param {number} [opts.linkThickness=0.04] connector radius
+ * @returns {SDF3}
+ */
+export function orgChart3dSDF({
+  levels = 3,
+  branching = 2,
+  nodeW = 0.5,
+  nodeH = 0.3,
+  nodeD = 0.18,
+  levelHeight = 0.9,
+  spread = 3.4,
+  linkThickness = 0.04,
+} = {}) {
+  const L = clampInt(levels, 1, 5);
+  const B = clampInt(branching, 1, 5);
+  const topY = ((L - 1) * levelHeight) / 2;
+  const nodeX = (i, n) => ((i + 0.5) / n - 0.5) * spread;
+  const parts = [];
+  let prev = [];
+  for (let l = 0; l < L; l++) {
+    const n = Math.pow(B, l);
+    const y = topY - l * levelHeight;
+    const pos = [];
+    for (let i = 0; i < n; i++) {
+      const p = [nodeX(i, n), y, 0];
+      pos.push(p);
+      parts.push(box([nodeW, nodeH, nodeD]).translate(p));
+      if (l > 0) parts.push(capsule(prev[Math.floor(i / B)], p, linkThickness));
+    }
+    prev = pos;
+  }
+  return parts.length === 1 ? parts[0] : union(...parts);
+}
+
+export const orgChart3dSpec = {
+  type: 'org-chart-3d',
+  category: 'charts/hierarchy',
+  args: {
+    levels: { type: 'number', default: 3, min: 1, max: 5, doc: 'Hierarchy depth' },
+    branching: { type: 'number', default: 2, min: 1, max: 5, doc: 'Children per node' },
+    nodeW: { type: 'number', default: 0.5, doc: 'Card width' },
+    nodeH: { type: 'number', default: 0.3, doc: 'Card height' },
+    nodeD: { type: 'number', default: 0.18, doc: 'Card depth' },
+    levelHeight: { type: 'number', default: 0.9, doc: 'Vertical gap between levels' },
+    spread: { type: 'number', default: 3.4, doc: 'Total width per level' },
+    linkThickness: { type: 'number', default: 0.04, doc: 'Connector radius' },
+  },
+  examples: [
+    { name: 'Org chart', args: { levels: 3, branching: 2 } },
+    { name: 'Wide team', args: { levels: 2, branching: 4 } },
+    { name: 'Deep chain', args: { levels: 4, branching: 1 } },
+  ],
+  description: 'Top-down org chart (box cards + connectors) — reporting lines, hierarchy',
+  source: {
+    author: 'Atlas',
+    builtAt: '2026-06-21',
+    builder: 'Sprint 4 node-edge charts — taxonomy charts/hierarchy/',
+    license: 'PolyForm Noncommercial 1.0.0',
+  },
+};

--- a/sdf-js/src/scene/components/charts/diagrams/relationship-graph-3d.js
+++ b/sdf-js/src/scene/components/charts/diagrams/relationship-graph-3d.js
@@ -1,0 +1,85 @@
+// =============================================================================
+// relationship-graph-3d.js — node-link relationship graph (Atlas chart atom).
+// -----------------------------------------------------------------------------
+// N sphere nodes on a ring + capsule edges (ring connectivity + a couple of
+// chords by default, or a caller-supplied adjacency list). Covers
+// PresentationLoad "Relationship Charts". Composite atom (sphere + capsule +
+// union) — same family as sphere-network-3d, but peer nodes rather than a hub.
+// =============================================================================
+
+import { sphere, capsule } from '../../../../sdf/d3.js';
+import { union } from '../../../../sdf/dn.js';
+
+function defaultEdges(n) {
+  const e = [];
+  for (let i = 0; i < n; i++) e.push([i, (i + 1) % n]); // ring
+  if (n >= 4) e.push([0, 2]); // a non-diameter chord → reads as a graph, not a polygon
+  if (n >= 6) e.push([3, 5]);
+  return e;
+}
+
+/**
+ * @param {object} opts
+ * @param {number} [opts.count=6]          number of nodes
+ * @param {number} [opts.radius=1.3]       ring layout radius
+ * @param {number} [opts.nodeRadius=0.26]  node sphere radius
+ * @param {number} [opts.linkThickness=0.05] edge capsule radius
+ * @param {number[][]} [opts.edges=null]   adjacency [[i,j],…] (default ring+chords)
+ * @returns {SDF3}
+ */
+export function relationshipGraph3dSDF({
+  count = 6,
+  radius = 1.3,
+  nodeRadius = 0.26,
+  linkThickness = 0.05,
+  edges = null,
+} = {}) {
+  const N = Math.max(2, Math.floor(count));
+  const pos = [];
+  for (let i = 0; i < N; i++) {
+    const a = (i / N) * Math.PI * 2;
+    pos.push([radius * Math.cos(a), 0, radius * Math.sin(a)]);
+  }
+  const E = edges || defaultEdges(N);
+  const parts = [];
+  for (const [i, j] of E) {
+    if (pos[i] && pos[j]) parts.push(capsule(pos[i], pos[j], linkThickness));
+  }
+  for (let i = 0; i < N; i++) parts.push(sphere(nodeRadius).translate(pos[i]));
+  return parts.length === 1 ? parts[0] : union(...parts);
+}
+
+export const relationshipGraph3dSpec = {
+  type: 'relationship-graph-3d',
+  category: 'charts/relationship',
+  args: {
+    count: { type: 'number', default: 6, doc: 'Number of nodes' },
+    radius: { type: 'number', default: 1.3, doc: 'Ring layout radius' },
+    nodeRadius: { type: 'number', default: 0.26, doc: 'Node sphere radius' },
+    linkThickness: { type: 'number', default: 0.05, doc: 'Edge capsule radius' },
+    edges: { type: 'array', default: null, doc: 'Adjacency [[i,j],…] (default ring+chords)' },
+  },
+  examples: [
+    { name: 'Relationship ring', args: { count: 6 } },
+    {
+      name: 'Star edges',
+      args: {
+        count: 5,
+        edges: [
+          [0, 1],
+          [0, 2],
+          [0, 3],
+          [0, 4],
+        ],
+      },
+    },
+    { name: 'Dense web', args: { count: 8 } },
+  ],
+  description: 'Node-link relationship graph (peer nodes + edges) — networks, associations',
+  source: {
+    author: 'Atlas',
+    builtAt: '2026-06-21',
+    builder: 'Sprint 4 node-edge charts — taxonomy charts/relationship/',
+    license: 'PolyForm Noncommercial 1.0.0',
+  },
+};

--- a/sdf-js/src/scene/spec.js
+++ b/sdf-js/src/scene/spec.js
@@ -213,6 +213,10 @@ export const PRIMITIVE_TYPES = new Set([
   'circle-stack-3d',
   'circle-segmented-3d',
   'circle-loop-3d',
+  // Sprint 4 node-edge charts — sphere/box nodes + capsule edges (+ cone arrows).
+  'relationship-graph-3d',
+  'org-chart-3d',
+  'flow-chart-3d',
   // Rune Skovbo Johansen's Advanced Terrain Erosion Filter (MPL-2.0 — see
   // src/scene/components/community/rune-erosion-filter.js). CPU-baked
   // heightmap uploaded to GPU as sampler2D u_heightmap. Box-bounded bonsai


### PR DESCRIPTION
## What

First batch of the **CHARTS** taxonomy family — node + capsule-edge diagrams (same composition family as `sphere-network` / `sphere-tree`), each with a studio auto-framed gallery demo:

| atom | build | use |
| --- | --- | --- |
| `relationship-graph-3d` | sphere nodes on a ring + capsule edges (ring + chords, or a caller-supplied adjacency list) | peer networks / associations |
| `org-chart-3d` | box-card nodes in a branching hierarchy + parent→child capsule connectors | reporting lines / org structure |
| `flow-chart-3d` | box steps in a row joined by arrowed capsules (shaft + cone head) | pipeline / workflow / stages |

Composite atoms (sphere/box + capsule + cone + `union`) — GLSL emit comes free from the leaf primitives.

## Verification
- CPU probes per atom (node vs edge-midpoint vs empty-centre; root/leaf/connector; step/arrow/gap) + compile + GLSL emit assertions. Full suite **63/63** (new `diagram` test category).
- **Real-browser GPU**: verified **org-chart** (7-box 3-level hierarchy + connectors, auto-framed) and **flow-chart** (4 steps + cone arrows) — 0 console errors. relationship-graph uses the same sphere+capsule path as the shipped sphere-network atom.
- Prettier clean.

Registered in compile.js / spec.js / run-tests.mjs; 3 gallery demos (`renderer: "studio"`).

CHARTS started: relationship · hierarchy · flow. Next candidates: tree-diagram, mindmap, timeline, matrix-grid, progression, funnel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)