### PR TITLE
Sprint 4b: tree / mindmap / timeline chart atoms

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -114,6 +114,9 @@ const TESTS = [
   { category: 'diagram', file: 'sdf-js/scripts/test-relationship-graph-3d.mjs' },
   { category: 'diagram', file: 'sdf-js/scripts/test-org-chart-3d.mjs' },
   { category: 'diagram', file: 'sdf-js/scripts/test-flow-chart-3d.mjs' },
+  { category: 'diagram', file: 'sdf-js/scripts/test-tree-diagram-3d.mjs' },
+  { category: 'diagram', file: 'sdf-js/scripts/test-mindmap-3d.mjs' },
+  { category: 'diagram', file: 'sdf-js/scripts/test-timeline-3d.mjs' },
 
   // Layer 1 public API extracted from compositor.js (used by Layer 2 / MCP / tests)
   { category: 'api', file: 'sdf-js/scripts/test-compositor-api.mjs' },

--- a/sdf-js/examples/compositor/demo-lifts/index.json
+++ b/sdf-js/examples/compositor/demo-lifts/index.json
@@ -358,6 +358,36 @@
       "file": "flow-chart-3d.json",
       "renderer": "studio",
       "prompt": "Diagram · Flow Chart"
+    },
+    {
+      "id": "tree-diagram-3d",
+      "title": "Diagram · Tree",
+      "thesisPoint": "Atlas node-edge chart atom (Sprint 4b) — nodes + capsule edges, studio auto-framed.",
+      "category": "primitive-showcase",
+      "status": "ready",
+      "file": "tree-diagram-3d.json",
+      "renderer": "studio",
+      "prompt": "Diagram · Tree"
+    },
+    {
+      "id": "mindmap-3d",
+      "title": "Diagram · Mind Map",
+      "thesisPoint": "Atlas node-edge chart atom (Sprint 4b) — nodes + capsule edges, studio auto-framed.",
+      "category": "primitive-showcase",
+      "status": "ready",
+      "file": "mindmap-3d.json",
+      "renderer": "studio",
+      "prompt": "Diagram · Mind Map"
+    },
+    {
+      "id": "timeline-3d",
+      "title": "Diagram · Timeline",
+      "thesisPoint": "Atlas node-edge chart atom (Sprint 4b) — nodes + capsule edges, studio auto-framed.",
+      "category": "primitive-showcase",
+      "status": "ready",
+      "file": "timeline-3d.json",
+      "renderer": "studio",
+      "prompt": "Diagram · Timeline"
     }
   ]
 }

--- a/sdf-js/examples/compositor/demo-lifts/mindmap-3d.json
+++ b/sdf-js/examples/compositor/demo-lifts/mindmap-3d.json
@@ -1,0 +1,39 @@
+{
+  "id": "mindmap-3d",
+  "title": "Diagram · Mind Map",
+  "prompt": "mindmap-3d atom showcase.",
+  "code2d": "// Synthetic showcase.\nexport const render = (ctx) => {};",
+  "sceneData": {
+    "v": 1,
+    "name": "mindmap-3d",
+    "source": { "format": "synthetic", "prompt": "mindmap-3d" },
+    "subjects": [
+      {
+        "id": "s",
+        "type": "mindmap-3d",
+        "args": { "branches": 5 },
+        "transform": { "translate": [0, 0.5, 0] },
+        "material": "silver"
+      }
+    ],
+    "defaults": {
+      "camera": {
+        "yaw": 0.5,
+        "pitch": 0.3,
+        "distance": 8,
+        "focal": 1.5,
+        "targetX": 0,
+        "targetY": 0.5,
+        "targetZ": 0
+      },
+      "light": { "azimuth": 0.6, "altitude": 0.55, "distance": 25, "intensity": 1.2 },
+      "shadow": { "enabled": true, "mode": "darken", "strength": 0.4 }
+    }
+  },
+  "meta": {
+    "generatedAt": "2026-06-21",
+    "model": "synthetic",
+    "pattern": "mindmap-3d",
+    "costUSD": 0
+  }
+}

--- a/sdf-js/examples/compositor/demo-lifts/timeline-3d.json
+++ b/sdf-js/examples/compositor/demo-lifts/timeline-3d.json
@@ -1,0 +1,39 @@
+{
+  "id": "timeline-3d",
+  "title": "Diagram · Timeline",
+  "prompt": "timeline-3d atom showcase.",
+  "code2d": "// Synthetic showcase.\nexport const render = (ctx) => {};",
+  "sceneData": {
+    "v": 1,
+    "name": "timeline-3d",
+    "source": { "format": "synthetic", "prompt": "timeline-3d" },
+    "subjects": [
+      {
+        "id": "s",
+        "type": "timeline-3d",
+        "args": { "count": 5 },
+        "transform": { "translate": [0, 0.7, 0] },
+        "material": "silver"
+      }
+    ],
+    "defaults": {
+      "camera": {
+        "yaw": 0.5,
+        "pitch": 0.3,
+        "distance": 8,
+        "focal": 1.5,
+        "targetX": 0,
+        "targetY": 0.7,
+        "targetZ": 0
+      },
+      "light": { "azimuth": 0.6, "altitude": 0.55, "distance": 25, "intensity": 1.2 },
+      "shadow": { "enabled": true, "mode": "darken", "strength": 0.4 }
+    }
+  },
+  "meta": {
+    "generatedAt": "2026-06-21",
+    "model": "synthetic",
+    "pattern": "timeline-3d",
+    "costUSD": 0
+  }
+}

--- a/sdf-js/examples/compositor/demo-lifts/tree-diagram-3d.json
+++ b/sdf-js/examples/compositor/demo-lifts/tree-diagram-3d.json
@@ -1,0 +1,39 @@
+{
+  "id": "tree-diagram-3d",
+  "title": "Diagram · Tree",
+  "prompt": "tree-diagram-3d atom showcase.",
+  "code2d": "// Synthetic showcase.\nexport const render = (ctx) => {};",
+  "sceneData": {
+    "v": 1,
+    "name": "tree-diagram-3d",
+    "source": { "format": "synthetic", "prompt": "tree-diagram-3d" },
+    "subjects": [
+      {
+        "id": "s",
+        "type": "tree-diagram-3d",
+        "args": { "levels": 3, "branching": 2 },
+        "transform": { "translate": [0, 0.6, 0] },
+        "material": "silver"
+      }
+    ],
+    "defaults": {
+      "camera": {
+        "yaw": 0.5,
+        "pitch": 0.3,
+        "distance": 8,
+        "focal": 1.5,
+        "targetX": 0,
+        "targetY": 0.6,
+        "targetZ": 0
+      },
+      "light": { "azimuth": 0.6, "altitude": 0.55, "distance": 25, "intensity": 1.2 },
+      "shadow": { "enabled": true, "mode": "darken", "strength": 0.4 }
+    }
+  },
+  "meta": {
+    "generatedAt": "2026-06-21",
+    "model": "synthetic",
+    "pattern": "tree-diagram-3d",
+    "costUSD": 0
+  }
+}

--- a/sdf-js/scripts/test-mindmap-3d.mjs
+++ b/sdf-js/scripts/test-mindmap-3d.mjs
@@ -1,0 +1,32 @@
+import { mindmap3dSDF } from '../src/scene/components/charts/diagrams/mindmap-3d.js';
+import { compile } from '../src/scene/compile.js';
+import { compileSDF3ToGLSL } from '../src/sdf/sdf3.compile.js';
+let pass = 0,
+  fail = 0;
+const ok = (c, n) => (c ? (pass++, console.log(`  ✓ ${n}`)) : (fail++, console.log(`  ✗ ${n}`)));
+console.log('=== mindmap-3d ===\n');
+{
+  // branches 5, mainDist 1.1; branch 0 at angle 0 → [1.1,0,0]
+  const sdf = mindmap3dSDF();
+  ok(sdf.f([0, 0, 0]) < 0, 'central node inside');
+  ok(sdf.f([1.1, 0, 0]) < 0, 'branch 0 node inside');
+  ok(sdf.f([0.55, 0, 0]) < 0, 'centre→branch edge midpoint inside');
+  ok(sdf.f([4, 0, 0]) > 0, 'far outside');
+}
+{
+  const scene = {
+    v: 1,
+    defaults: {
+      camera: { yaw: 0.4, pitch: 0.2, distance: 6, focal: 1.5, targetX: 0, targetY: 0, targetZ: 0 },
+      light: { altitude: 0.5, azimuth: 0.6, distance: 8, intensity: 1.1 },
+    },
+    subjects: [{ type: 'mindmap-3d', id: 'mm', args: { branches: 5 }, region: 'object' }],
+  };
+  const compiled = compile(scene);
+  ok(compiled.sdf.f([0, 0, 0]) < 0, 'compiled centre inside');
+  const glsl = compileSDF3ToGLSL(compiled.sdf, { time: 'u_time' });
+  const s = typeof glsl === 'string' ? glsl : glsl.expr || JSON.stringify(glsl);
+  ok(s.includes('sdSphere') && s.includes('sdCapsule'), 'GLSL has sdSphere + sdCapsule');
+}
+console.log(`\n=== Result: ${pass} passed, ${fail} failed ===`);
+process.exit(fail > 0 ? 1 : 0);

--- a/sdf-js/scripts/test-timeline-3d.mjs
+++ b/sdf-js/scripts/test-timeline-3d.mjs
@@ -1,0 +1,33 @@
+import { timeline3dSDF } from '../src/scene/components/charts/diagrams/timeline-3d.js';
+import { compile } from '../src/scene/compile.js';
+import { compileSDF3ToGLSL } from '../src/sdf/sdf3.compile.js';
+let pass = 0,
+  fail = 0;
+const ok = (c, n) => (c ? (pass++, console.log(`  ✓ ${n}`)) : (fail++, console.log(`  ✗ ${n}`)));
+console.log('=== timeline-3d ===\n');
+{
+  // count 5, axisLength 3.4 → half 1.7; marker 0 at x=-1.7, up (+y) stem 0.45
+  const sdf = timeline3dSDF();
+  ok(sdf.f([0, 0, 0]) < 0, 'axis midpoint inside');
+  ok(sdf.f([-1.7, 0.45, 0]) < 0, 'milestone 0 marker (above) inside');
+  ok(sdf.f([-0.85, -0.45, 0]) < 0, 'milestone 1 marker (below) inside');
+  ok(sdf.f([5, 0, 0]) > 0, 'far along axis outside');
+  ok(sdf.f([0, 2, 0]) > 0, 'high above outside');
+}
+{
+  const scene = {
+    v: 1,
+    defaults: {
+      camera: { yaw: 0.4, pitch: 0.2, distance: 6, focal: 1.5, targetX: 0, targetY: 0, targetZ: 0 },
+      light: { altitude: 0.5, azimuth: 0.6, distance: 8, intensity: 1.1 },
+    },
+    subjects: [{ type: 'timeline-3d', id: 'tl', args: { count: 5 }, region: 'object' }],
+  };
+  const compiled = compile(scene);
+  ok(compiled.sdf.f([0, 0, 0]) < 0, 'compiled axis inside');
+  const glsl = compileSDF3ToGLSL(compiled.sdf, { time: 'u_time' });
+  const s = typeof glsl === 'string' ? glsl : glsl.expr || JSON.stringify(glsl);
+  ok(s.includes('sdSphere') && s.includes('sdCapsule'), 'GLSL has sdSphere + sdCapsule');
+}
+console.log(`\n=== Result: ${pass} passed, ${fail} failed ===`);
+process.exit(fail > 0 ? 1 : 0);

--- a/sdf-js/scripts/test-tree-diagram-3d.mjs
+++ b/sdf-js/scripts/test-tree-diagram-3d.mjs
@@ -1,0 +1,34 @@
+import { treeDiagram3dSDF } from '../src/scene/components/charts/diagrams/tree-diagram-3d.js';
+import { compile } from '../src/scene/compile.js';
+import { compileSDF3ToGLSL } from '../src/sdf/sdf3.compile.js';
+let pass = 0,
+  fail = 0;
+const ok = (c, n) => (c ? (pass++, console.log(`  ✓ ${n}`)) : (fail++, console.log(`  ✗ ${n}`)));
+console.log('=== tree-diagram-3d ===\n');
+{
+  // levels 3, branching 2, levelWidth 0.95 → leftX -0.95; widest level (l=2) at x=0.95
+  const sdf = treeDiagram3dSDF();
+  ok(sdf.f([-0.95, 0, 0]) < 0, 'root (left) inside');
+  ok(sdf.f([0.95, 0, -0.975]) < 0, 'leaf (right, level 2) inside');
+  ok(sdf.f([-0.475, 0, -0.325]) < 0, 'root→child connector midpoint inside');
+  ok(sdf.f([5, 0, 0]) > 0, 'far outside');
+}
+{
+  const scene = {
+    v: 1,
+    defaults: {
+      camera: { yaw: 0.4, pitch: 0.2, distance: 6, focal: 1.5, targetX: 0, targetY: 0, targetZ: 0 },
+      light: { altitude: 0.5, azimuth: 0.6, distance: 8, intensity: 1.1 },
+    },
+    subjects: [
+      { type: 'tree-diagram-3d', id: 'td', args: { levels: 3, branching: 2 }, region: 'object' },
+    ],
+  };
+  const compiled = compile(scene);
+  ok(compiled.sdf.f([-0.95, 0, 0]) < 0, 'compiled root inside');
+  const glsl = compileSDF3ToGLSL(compiled.sdf, { time: 'u_time' });
+  const s = typeof glsl === 'string' ? glsl : glsl.expr || JSON.stringify(glsl);
+  ok(s.includes('sdSphere') && s.includes('sdCapsule'), 'GLSL has sdSphere + sdCapsule');
+}
+console.log(`\n=== Result: ${pass} passed, ${fail} failed ===`);
+process.exit(fail > 0 ? 1 : 0);

--- a/sdf-js/src/scene/compile.js
+++ b/sdf-js/src/scene/compile.js
@@ -132,6 +132,9 @@ import { circleLoop3dSDF } from './components/shapes/circle-loop-3d.js';
 import { relationshipGraph3dSDF } from './components/charts/diagrams/relationship-graph-3d.js';
 import { orgChart3dSDF } from './components/charts/diagrams/org-chart-3d.js';
 import { flowChart3dSDF } from './components/charts/diagrams/flow-chart-3d.js';
+import { treeDiagram3dSDF } from './components/charts/diagrams/tree-diagram-3d.js';
+import { mindmap3dSDF } from './components/charts/diagrams/mindmap-3d.js';
+import { timeline3dSDF } from './components/charts/diagrams/timeline-3d.js';
 import { terrainCanyonSDF } from './components/community/iq-canyon.js';
 import { proceduralCitySDF } from './components/community/otavio-skyline.js';
 import { terrainErodedRuneSDF, bakeHeightmap } from './components/community/rune-erosion-filter.js';
@@ -563,6 +566,36 @@ const PRIMITIVE_FACTORIES = {
       nodeD: a.nodeD ?? 0.2,
       gap: a.gap ?? 0.55,
       linkThickness: a.linkThickness ?? a.thickness ?? 0.05,
+    }),
+  'tree-diagram-3d': (a) =>
+    treeDiagram3dSDF({
+      levels: a.levels ?? a.depth ?? 3,
+      branching: a.branching ?? a.fanout ?? 2,
+      nodeRadius: a.nodeRadius ?? 0.18,
+      levelWidth: a.levelWidth ?? 0.95,
+      spread: a.spread ?? 2.6,
+      linkThickness: a.linkThickness ?? a.thickness ?? 0.04,
+    }),
+  'mindmap-3d': (a) =>
+    mindmap3dSDF({
+      branches: a.branches ?? a.count ?? 5,
+      centerRadius: a.centerRadius ?? 0.34,
+      branchRadius: a.branchRadius ?? 0.2,
+      leafRadius: a.leafRadius ?? 0.12,
+      mainDist: a.mainDist ?? 1.1,
+      leafDist: a.leafDist ?? 0.55,
+      leavesPerBranch: a.leavesPerBranch ?? 2,
+      linkThickness: a.linkThickness ?? a.thickness ?? 0.04,
+    }),
+  'timeline-3d': (a) =>
+    timeline3dSDF({
+      count: a.count ?? a.milestones ?? 5,
+      axisLength: a.axisLength ?? 3.4,
+      axisRadius: a.axisRadius ?? 0.05,
+      markerRadius: a.markerRadius ?? 0.16,
+      stemHeight: a.stemHeight ?? 0.45,
+      stemThickness: a.stemThickness ?? 0.035,
+      alternate: a.alternate ?? true,
     }),
   link: (a) =>
     linkSDF({

--- a/sdf-js/src/scene/components/charts/diagrams/mindmap-3d.js
+++ b/sdf-js/src/scene/components/charts/diagrams/mindmap-3d.js
@@ -1,0 +1,77 @@
+// =============================================================================
+// mindmap-3d.js — radial mind map (Atlas chart atom).
+// -----------------------------------------------------------------------------
+// A central node with N branches radiating out, each ending in a branch node
+// with a couple of leaf nodes. Covers PresentationLoad "Mindmaps". Same node-
+// edge family; composite atom (sphere + capsule + union).
+// =============================================================================
+
+import { sphere, capsule } from '../../../../sdf/d3.js';
+import { union } from '../../../../sdf/dn.js';
+
+/**
+ * @param {object} opts
+ * @param {number} [opts.branches=5]        main branches around the centre
+ * @param {number} [opts.centerRadius=0.34] central node radius
+ * @param {number} [opts.branchRadius=0.2]  branch node radius
+ * @param {number} [opts.leafRadius=0.12]   leaf node radius
+ * @param {number} [opts.mainDist=1.1]      centre→branch distance
+ * @param {number} [opts.leafDist=0.55]     branch→leaf distance
+ * @param {number} [opts.leavesPerBranch=2] leaves per branch
+ * @param {number} [opts.linkThickness=0.04] connector radius
+ * @returns {SDF3}
+ */
+export function mindmap3dSDF({
+  branches = 5,
+  centerRadius = 0.34,
+  branchRadius = 0.2,
+  leafRadius = 0.12,
+  mainDist = 1.1,
+  leafDist = 0.55,
+  leavesPerBranch = 2,
+  linkThickness = 0.04,
+} = {}) {
+  const K = Math.max(1, Math.floor(branches));
+  const Lf = Math.max(0, Math.floor(leavesPerBranch));
+  const parts = [sphere(centerRadius)];
+  for (let k = 0; k < K; k++) {
+    const a = (k / K) * Math.PI * 2;
+    const main = [mainDist * Math.cos(a), 0, mainDist * Math.sin(a)];
+    parts.push(capsule([0, 0, 0], main, linkThickness));
+    parts.push(sphere(branchRadius).translate(main));
+    for (let j = 0; j < Lf; j++) {
+      const aj = a + (j - (Lf - 1) / 2) * 0.45;
+      const leaf = [main[0] + leafDist * Math.cos(aj), 0, main[2] + leafDist * Math.sin(aj)];
+      parts.push(capsule(main, leaf, linkThickness));
+      parts.push(sphere(leafRadius).translate(leaf));
+    }
+  }
+  return parts.length === 1 ? parts[0] : union(...parts);
+}
+
+export const mindmap3dSpec = {
+  type: 'mindmap-3d',
+  category: 'charts/mindmaps',
+  args: {
+    branches: { type: 'number', default: 5, doc: 'Main branches around the centre' },
+    centerRadius: { type: 'number', default: 0.34, doc: 'Central node radius' },
+    branchRadius: { type: 'number', default: 0.2, doc: 'Branch node radius' },
+    leafRadius: { type: 'number', default: 0.12, doc: 'Leaf node radius' },
+    mainDist: { type: 'number', default: 1.1, doc: 'Centre→branch distance' },
+    leafDist: { type: 'number', default: 0.55, doc: 'Branch→leaf distance' },
+    leavesPerBranch: { type: 'number', default: 2, doc: 'Leaves per branch' },
+    linkThickness: { type: 'number', default: 0.04, doc: 'Connector radius' },
+  },
+  examples: [
+    { name: 'Mind map', args: { branches: 5 } },
+    { name: 'Hub and spokes', args: { branches: 6, leavesPerBranch: 0 } },
+    { name: 'Bushy', args: { branches: 4, leavesPerBranch: 3 } },
+  ],
+  description: 'Radial mind map (centre + branches + leaves) — brainstorm, topic breakdown',
+  source: {
+    author: 'Atlas',
+    builtAt: '2026-06-21',
+    builder: 'Sprint 4b charts — taxonomy charts/mindmaps/',
+    license: 'PolyForm Noncommercial 1.0.0',
+  },
+};

--- a/sdf-js/src/scene/components/charts/diagrams/timeline-3d.js
+++ b/sdf-js/src/scene/components/charts/diagrams/timeline-3d.js
@@ -1,0 +1,69 @@
+// =============================================================================
+// timeline-3d.js — horizontal timeline (Atlas chart atom).
+// -----------------------------------------------------------------------------
+// A horizontal axis with N milestone markers on stems, alternating above/below
+// the line. Covers PresentationLoad "Timelines". Same node-edge family;
+// composite atom (capsule axis + capsule stems + sphere markers + union).
+// =============================================================================
+
+import { sphere, capsule } from '../../../../sdf/d3.js';
+import { union } from '../../../../sdf/dn.js';
+
+/**
+ * @param {object} opts
+ * @param {number} [opts.count=5]          number of milestones (≥1)
+ * @param {number} [opts.axisLength=3.4]   length of the timeline axis (X)
+ * @param {number} [opts.axisRadius=0.05]  axis capsule radius
+ * @param {number} [opts.markerRadius=0.16] milestone node radius
+ * @param {number} [opts.stemHeight=0.45]  stem length from axis to node
+ * @param {number} [opts.stemThickness=0.035] stem capsule radius
+ * @param {boolean} [opts.alternate=true]  alternate markers above/below
+ * @returns {SDF3}
+ */
+export function timeline3dSDF({
+  count = 5,
+  axisLength = 3.4,
+  axisRadius = 0.05,
+  markerRadius = 0.16,
+  stemHeight = 0.45,
+  stemThickness = 0.035,
+  alternate = true,
+} = {}) {
+  const N = Math.max(1, Math.floor(count));
+  const half = axisLength / 2;
+  const parts = [capsule([-half, 0, 0], [half, 0, 0], axisRadius)];
+  for (let i = 0; i < N; i++) {
+    const x = N > 1 ? -half + (i / (N - 1)) * axisLength : 0;
+    const up = alternate ? (i % 2 === 0 ? 1 : -1) : 1;
+    const top = [x, up * stemHeight, 0];
+    parts.push(capsule([x, 0, 0], top, stemThickness));
+    parts.push(sphere(markerRadius).translate(top));
+  }
+  return union(...parts);
+}
+
+export const timeline3dSpec = {
+  type: 'timeline-3d',
+  category: 'charts/timelines',
+  args: {
+    count: { type: 'number', default: 5, doc: 'Number of milestones (≥1)' },
+    axisLength: { type: 'number', default: 3.4, doc: 'Length of the axis (X)' },
+    axisRadius: { type: 'number', default: 0.05, doc: 'Axis capsule radius' },
+    markerRadius: { type: 'number', default: 0.16, doc: 'Milestone node radius' },
+    stemHeight: { type: 'number', default: 0.45, doc: 'Stem length axis→node' },
+    stemThickness: { type: 'number', default: 0.035, doc: 'Stem capsule radius' },
+    alternate: { type: 'boolean', default: true, doc: 'Alternate markers above/below' },
+  },
+  examples: [
+    { name: 'Timeline', args: { count: 5 } },
+    { name: 'Roadmap (above)', args: { count: 4, alternate: false } },
+    { name: 'Dense history', args: { count: 8, axisLength: 4.5 } },
+  ],
+  description: 'Horizontal timeline (axis + milestone markers) — roadmap, history, schedule',
+  source: {
+    author: 'Atlas',
+    builtAt: '2026-06-21',
+    builder: 'Sprint 4b charts — taxonomy charts/timelines/',
+    license: 'PolyForm Noncommercial 1.0.0',
+  },
+};

--- a/sdf-js/src/scene/components/charts/diagrams/tree-diagram-3d.js
+++ b/sdf-js/src/scene/components/charts/diagrams/tree-diagram-3d.js
@@ -1,0 +1,77 @@
+// =============================================================================
+// tree-diagram-3d.js — left-to-right tree (Atlas chart atom).
+// -----------------------------------------------------------------------------
+// Sphere nodes in a branching tree that grows horizontally (root at left,
+// leaves at right) + capsule connectors. Covers PresentationLoad "Tree
+// Diagrams" — distinct from org-chart-3d (which is vertical, box cards). Same
+// node-edge family; composite atom (sphere + capsule + union).
+// =============================================================================
+
+import { sphere, capsule } from '../../../../sdf/d3.js';
+import { union } from '../../../../sdf/dn.js';
+
+const clampInt = (x, lo, hi) => Math.max(lo, Math.min(hi, Math.floor(x)));
+
+/**
+ * @param {object} opts
+ * @param {number} [opts.levels=3]        depth (1..5)
+ * @param {number} [opts.branching=2]     children per node (1..4)
+ * @param {number} [opts.nodeRadius=0.18] node sphere radius
+ * @param {number} [opts.levelWidth=0.95] horizontal gap between levels
+ * @param {number} [opts.spread=2.6]      total depth (Z) of the widest level
+ * @param {number} [opts.linkThickness=0.04] connector radius
+ * @returns {SDF3}
+ */
+export function treeDiagram3dSDF({
+  levels = 3,
+  branching = 2,
+  nodeRadius = 0.18,
+  levelWidth = 0.95,
+  spread = 2.6,
+  linkThickness = 0.04,
+} = {}) {
+  const L = clampInt(levels, 1, 5);
+  const B = clampInt(branching, 1, 4);
+  const leftX = -((L - 1) * levelWidth) / 2;
+  const nodeZ = (i, n) => ((i + 0.5) / n - 0.5) * spread;
+  const parts = [];
+  let prev = [];
+  for (let l = 0; l < L; l++) {
+    const n = Math.pow(B, l);
+    const x = leftX + l * levelWidth;
+    const pos = [];
+    for (let i = 0; i < n; i++) {
+      const p = [x, 0, nodeZ(i, n)];
+      pos.push(p);
+      parts.push(sphere(nodeRadius).translate(p));
+      if (l > 0) parts.push(capsule(prev[Math.floor(i / B)], p, linkThickness));
+    }
+    prev = pos;
+  }
+  return parts.length === 1 ? parts[0] : union(...parts);
+}
+
+export const treeDiagram3dSpec = {
+  type: 'tree-diagram-3d',
+  category: 'charts/hierarchy',
+  args: {
+    levels: { type: 'number', default: 3, min: 1, max: 5, doc: 'Depth' },
+    branching: { type: 'number', default: 2, min: 1, max: 4, doc: 'Children per node' },
+    nodeRadius: { type: 'number', default: 0.18, doc: 'Node sphere radius' },
+    levelWidth: { type: 'number', default: 0.95, doc: 'Horizontal gap between levels' },
+    spread: { type: 'number', default: 2.6, doc: 'Total depth of the widest level' },
+    linkThickness: { type: 'number', default: 0.04, doc: 'Connector radius' },
+  },
+  examples: [
+    { name: 'Binary tree', args: { levels: 3, branching: 2 } },
+    { name: 'Ternary', args: { levels: 3, branching: 3 } },
+    { name: 'Decision chain', args: { levels: 4, branching: 1 } },
+  ],
+  description: 'Left-to-right branching tree (sphere nodes + links) — taxonomy, decision tree',
+  source: {
+    author: 'Atlas',
+    builtAt: '2026-06-21',
+    builder: 'Sprint 4b charts — taxonomy charts/hierarchy/',
+    license: 'PolyForm Noncommercial 1.0.0',
+  },
+};

--- a/sdf-js/src/scene/spec.js
+++ b/sdf-js/src/scene/spec.js
@@ -217,6 +217,10 @@ export const PRIMITIVE_TYPES = new Set([
   'relationship-graph-3d',
   'org-chart-3d',
   'flow-chart-3d',
+  // Sprint 4b charts — tree / mindmap / timeline (sphere nodes + capsule edges).
+  'tree-diagram-3d',
+  'mindmap-3d',
+  'timeline-3d',
   // Rune Skovbo Johansen's Advanced Terrain Erosion Filter (MPL-2.0 — see
   // src/scene/components/community/rune-erosion-filter.js). CPU-baked
   // heightmap uploaded to GPU as sampler2D u_heightmap. Box-bounded bonsai


### PR DESCRIPTION
## What

Second **CHARTS** batch — three more node-edge diagram archetypes, each with a studio auto-framed gallery demo:

| atom | build | use |
| --- | --- | --- |
| `tree-diagram-3d` | sphere nodes in a **left-to-right** branching tree + capsule links | taxonomy / decision tree |
| `mindmap-3d` | central node + N radiating branches, each with leaf nodes | brainstorm / topic breakdown |
| `timeline-3d` | horizontal axis + milestone markers on alternating stems | roadmap / history / schedule |

`tree-diagram-3d` is deliberately distinct from `org-chart-3d` (vertical, box cards) — horizontal growth, sphere nodes. Composite atoms (sphere/capsule + `union`); GLSL emit comes free from the leaf primitives.

## Verification
- CPU probes per atom (root/leaf/connector; centre/branch/edge; axis/marker) + compile + GLSL emit. Full suite **66/66**.
- **Real-browser GPU**: verified **mindmap** (centre + 5 branches + leaves) and **timeline** (axis + 5 alternating markers) — 0 console errors. tree-diagram shares the same verified sphere+capsule path.
- Prettier clean.

Registered in compile.js / spec.js / run-tests.mjs; 3 gallery demos (`renderer: "studio"`).

CHARTS so far: relationship · org-chart · flow-chart · tree · mindmap · timeline. Next candidates: matrix-grid, progression/funnel, venn, fishbone, gantt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)