### PR TITLE
Image→3D showcases (fill deck + shape categories) + instant studio entry perf fix

### DIFF
--- a/sdf-js/examples/compositor/compositor.js
+++ b/sdf-js/examples/compositor/compositor.js
@@ -1996,34 +1996,46 @@ function runActiveGpuRenderer({ keepCamera = false } = {}) {
     // studio's neutral default pose.
     if (!keepCamera && scene !== _lastStudioFramedScene && sdf && sdf.f) {
       _lastStudioFramedScene = scene;
-      try {
-        // iso > 0 (sample where the SDF is within ~0.12 of a surface) so THIN
-        // atoms — flat rings, arrow shafts, gear teeth — aren't missed between
-        // grid samples; the bbox inflates ~iso, negligible for framing.
-        const bb = bbox3FromSDF((p) => sdf.f(p), { radius: 10, res: 56, iso: 0.12 });
-        const maxDim = Math.max(bb.size[0], bb.size[1], bb.size[2]);
-        if (!bb.empty && maxDim > 0.05 && maxDim < 20) {
-          const fit = cameraFitFromBBox(bb.min, bb.max, 1.1, 1.3);
-          const yaw = 0.5;
-          const pitch = 0.32; // downward in studio's convention (fwd.y = −sin pitch)
-          const cp = Math.cos(pitch),
-            sp = Math.sin(pitch),
-            cy = Math.cos(yaw),
-            sy = Math.sin(yaw);
-          const fwd = [sy * cp, -sp, cy * cp];
-          st.setCamState({
-            position: [
-              fit.target[0] - fwd[0] * fit.distance,
-              fit.target[1] - fwd[1] * fit.distance,
-              fit.target[2] - fwd[2] * fit.distance,
-            ],
-            yaw,
-            pitch,
-          });
+      const framedScene = scene;
+      // Auto-framing is a CPU bbox sweep (tens of thousands of sdf.f evals) — at
+      // the old radius:10/res:56 it cost ~95ms and froze scene entry, which read
+      // as "slow load vs Shadertoy". Fix: (1) DEFER off the critical path so the
+      // first studio frame paints immediately (≈1ms below), bbox + camera fit run
+      // next frame then re-render; (2) cheaper sweep — a smaller search radius
+      // gives FINER cells (better thin-atom capture) at far fewer evals.
+      requestAnimationFrame(() => {
+        if (framedScene !== _lastStudioFramedScene) return; // a newer scene loaded; abort
+        try {
+          // radius 6 (covers translated atoms) × res 36 → cell ~0.33; iso 0.2 so
+          // THIN atoms (flat rings / arrow shafts / gear teeth) still register.
+          const bb = bbox3FromSDF((p) => sdf.f(p), { radius: 6, res: 36, iso: 0.2 });
+          const maxDim = Math.max(bb.size[0], bb.size[1], bb.size[2]);
+          // maxDim ≥ ~11 means the sweep hit its boundary (unbounded SDF / ground
+          // plane) → keep studio's neutral default pose.
+          if (!bb.empty && maxDim > 0.05 && maxDim < 11) {
+            const fit = cameraFitFromBBox(bb.min, bb.max, 1.1, 1.3);
+            const yaw = 0.5;
+            const pitch = 0.32; // downward in studio's convention (fwd.y = −sin pitch)
+            const cp = Math.cos(pitch),
+              sp = Math.sin(pitch),
+              cy = Math.cos(yaw),
+              sy = Math.sin(yaw);
+            const fwd = [sy * cp, -sp, cy * cp];
+            st.setCamState({
+              position: [
+                fit.target[0] - fwd[0] * fit.distance,
+                fit.target[1] - fwd[1] * fit.distance,
+                fit.target[2] - fwd[2] * fit.distance,
+              ],
+              yaw,
+              pitch,
+            });
+            st.render(sdf); // re-render with the fitted camera (studio is on-demand)
+          }
+        } catch (e) {
+          /* unbounded SDF / eval error → keep studio's default pose */
         }
-      } catch (e) {
-        /* unbounded SDF / eval error → keep studio's default pose */
-      }
+      });
     }
     if (st.setPostFx) {
       st.setPostFx(

--- a/sdf-js/examples/compositor/demo-lifts/fill-slide-01.json
+++ b/sdf-js/examples/compositor/demo-lifts/fill-slide-01.json
@@ -1,0 +1,140 @@
+{
+  "id": "fill-slide-01",
+  "title": "Fill Levels · Cover (20/40/80)",
+  "prompt": "kpi-hero: Cover — three glass fill spheres at 20/40/80%, increasing in size.",
+  "code2d": "// vision-authored from PDF slide (D0961 3D Spheres Fill Levels).",
+  "sceneData": {
+    "v": 1,
+    "name": "kpi-hero: Fill Levels · Cover (20/40/80)",
+    "source": {
+      "format": "vision-authored",
+      "prompt": "Cover — three glass fill spheres at 20/40/80%, increasing in size."
+    },
+    "subjects": [
+      {
+        "id": "liq0",
+        "type": "sphere-fill-3d",
+        "args": {
+          "levels": [0.2],
+          "radius": 0.46,
+          "cage": false,
+          "fillScale": 1
+        },
+        "transform": {
+          "translate": [-1.75, 0.9, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.72,
+          "metal": 0.3,
+          "glow": 0
+        }
+      },
+      {
+        "id": "emp0",
+        "type": "cut-sphere",
+        "args": {
+          "radius": 0.46,
+          "h": -0.276
+        },
+        "transform": {
+          "translate": [-1.75, 0.9, 0]
+        },
+        "material": "porcelain"
+      },
+      {
+        "id": "liq1",
+        "type": "sphere-fill-3d",
+        "args": {
+          "levels": [0.4],
+          "radius": 0.64,
+          "cage": false,
+          "fillScale": 1
+        },
+        "transform": {
+          "translate": [-0.35, 0.9, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.72,
+          "metal": 0.3,
+          "glow": 0
+        }
+      },
+      {
+        "id": "emp1",
+        "type": "cut-sphere",
+        "args": {
+          "radius": 0.64,
+          "h": -0.12799999999999997
+        },
+        "transform": {
+          "translate": [-0.35, 0.9, 0]
+        },
+        "material": "porcelain"
+      },
+      {
+        "id": "liq2",
+        "type": "sphere-fill-3d",
+        "args": {
+          "levels": [0.8],
+          "radius": 0.92,
+          "cage": false,
+          "fillScale": 1
+        },
+        "transform": {
+          "translate": [1.5, 0.9, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.72,
+          "metal": 0.3,
+          "glow": 0
+        }
+      },
+      {
+        "id": "emp2",
+        "type": "cut-sphere",
+        "args": {
+          "radius": 0.92,
+          "h": 0.5520000000000002
+        },
+        "transform": {
+          "translate": [1.5, 0.9, 0]
+        },
+        "material": "porcelain"
+      }
+    ],
+    "defaults": {
+      "camera": {
+        "yaw": 0.5,
+        "pitch": 0.28,
+        "distance": 10,
+        "focal": 1.5,
+        "targetX": 0,
+        "targetY": 0.9,
+        "targetZ": 0
+      },
+      "light": {
+        "azimuth": 0.6,
+        "altitude": 0.55,
+        "distance": 25,
+        "intensity": 1.2
+      },
+      "shadow": {
+        "enabled": true,
+        "mode": "darken",
+        "strength": 0.4
+      }
+    }
+  },
+  "meta": {
+    "generatedAt": "2026-06-21",
+    "model": "vision-authored",
+    "pattern": "kpi-hero",
+    "costUSD": 0
+  }
+}

--- a/sdf-js/examples/compositor/demo-lifts/fill-slide-02.json
+++ b/sdf-js/examples/compositor/demo-lifts/fill-slide-02.json
@@ -1,0 +1,172 @@
+{
+  "id": "fill-slide-02",
+  "title": "Fill Levels · Row of 4 (20/60/80/90)",
+  "prompt": "compare: A row of four fill spheres at 20/60/80/90%.",
+  "code2d": "// vision-authored from PDF slide (D0961 3D Spheres Fill Levels).",
+  "sceneData": {
+    "v": 1,
+    "name": "compare: Fill Levels · Row of 4 (20/60/80/90)",
+    "source": {
+      "format": "vision-authored",
+      "prompt": "A row of four fill spheres at 20/60/80/90%."
+    },
+    "subjects": [
+      {
+        "id": "liq0",
+        "type": "sphere-fill-3d",
+        "args": {
+          "levels": [0.2],
+          "radius": 0.55,
+          "cage": false,
+          "fillScale": 1
+        },
+        "transform": {
+          "translate": [-2.4000000000000004, 0.9, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.72,
+          "metal": 0.3,
+          "glow": 0
+        }
+      },
+      {
+        "id": "emp0",
+        "type": "cut-sphere",
+        "args": {
+          "radius": 0.55,
+          "h": -0.33
+        },
+        "transform": {
+          "translate": [-2.4000000000000004, 0.9, 0]
+        },
+        "material": "porcelain"
+      },
+      {
+        "id": "liq1",
+        "type": "sphere-fill-3d",
+        "args": {
+          "levels": [0.6],
+          "radius": 0.55,
+          "cage": false,
+          "fillScale": 1
+        },
+        "transform": {
+          "translate": [-0.8000000000000003, 0.9, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.72,
+          "metal": 0.3,
+          "glow": 0
+        }
+      },
+      {
+        "id": "emp1",
+        "type": "cut-sphere",
+        "args": {
+          "radius": 0.55,
+          "h": 0.10999999999999999
+        },
+        "transform": {
+          "translate": [-0.8000000000000003, 0.9, 0]
+        },
+        "material": "porcelain"
+      },
+      {
+        "id": "liq2",
+        "type": "sphere-fill-3d",
+        "args": {
+          "levels": [0.8],
+          "radius": 0.55,
+          "cage": false,
+          "fillScale": 1
+        },
+        "transform": {
+          "translate": [0.7999999999999998, 0.9, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.72,
+          "metal": 0.3,
+          "glow": 0
+        }
+      },
+      {
+        "id": "emp2",
+        "type": "cut-sphere",
+        "args": {
+          "radius": 0.55,
+          "h": 0.33000000000000007
+        },
+        "transform": {
+          "translate": [0.7999999999999998, 0.9, 0]
+        },
+        "material": "porcelain"
+      },
+      {
+        "id": "liq3",
+        "type": "sphere-fill-3d",
+        "args": {
+          "levels": [0.9],
+          "radius": 0.55,
+          "cage": false,
+          "fillScale": 1
+        },
+        "transform": {
+          "translate": [2.4000000000000004, 0.9, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.72,
+          "metal": 0.3,
+          "glow": 0
+        }
+      },
+      {
+        "id": "emp3",
+        "type": "cut-sphere",
+        "args": {
+          "radius": 0.55,
+          "h": 0.44000000000000006
+        },
+        "transform": {
+          "translate": [2.4000000000000004, 0.9, 0]
+        },
+        "material": "porcelain"
+      }
+    ],
+    "defaults": {
+      "camera": {
+        "yaw": 0.5,
+        "pitch": 0.28,
+        "distance": 10,
+        "focal": 1.5,
+        "targetX": 0,
+        "targetY": 0.9,
+        "targetZ": 0
+      },
+      "light": {
+        "azimuth": 0.6,
+        "altitude": 0.55,
+        "distance": 25,
+        "intensity": 1.2
+      },
+      "shadow": {
+        "enabled": true,
+        "mode": "darken",
+        "strength": 0.4
+      }
+    }
+  },
+  "meta": {
+    "generatedAt": "2026-06-21",
+    "model": "vision-authored",
+    "pattern": "compare",
+    "costUSD": 0
+  }
+}

--- a/sdf-js/examples/compositor/demo-lifts/fill-slide-03.json
+++ b/sdf-js/examples/compositor/demo-lifts/fill-slide-03.json
@@ -1,0 +1,170 @@
+{
+  "id": "fill-slide-03",
+  "title": "Fill Levels · Framed row + arrows (10/60/50)",
+  "prompt": "sequence: Three framed fill spheres 10/60/50% connected left-to-right by arrows.",
+  "code2d": "// vision-authored from PDF slide (D0961 3D Spheres Fill Levels).",
+  "sceneData": {
+    "v": 1,
+    "name": "sequence: Fill Levels · Framed row + arrows (10/60/50)",
+    "source": {
+      "format": "vision-authored",
+      "prompt": "Three framed fill spheres 10/60/50% connected left-to-right by arrows."
+    },
+    "subjects": [
+      {
+        "id": "liq0",
+        "type": "sphere-fill-3d",
+        "args": {
+          "levels": [0.1],
+          "radius": 0.7,
+          "cage": false,
+          "fillScale": 1
+        },
+        "transform": {
+          "translate": [-2.4, 0.9, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.72,
+          "metal": 0.3,
+          "glow": 0
+        }
+      },
+      {
+        "id": "emp0",
+        "type": "cut-sphere",
+        "args": {
+          "radius": 0.7,
+          "h": -0.5599999999999999
+        },
+        "transform": {
+          "translate": [-2.4, 0.9, 0]
+        },
+        "material": "porcelain"
+      },
+      {
+        "id": "liq1",
+        "type": "sphere-fill-3d",
+        "args": {
+          "levels": [0.6],
+          "radius": 0.7,
+          "cage": false,
+          "fillScale": 1
+        },
+        "transform": {
+          "translate": [0, 0.9, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.72,
+          "metal": 0.3,
+          "glow": 0
+        }
+      },
+      {
+        "id": "emp1",
+        "type": "cut-sphere",
+        "args": {
+          "radius": 0.7,
+          "h": 0.13999999999999996
+        },
+        "transform": {
+          "translate": [0, 0.9, 0]
+        },
+        "material": "porcelain"
+      },
+      {
+        "id": "liq2",
+        "type": "sphere-fill-3d",
+        "args": {
+          "levels": [0.5],
+          "radius": 0.7,
+          "cage": false,
+          "fillScale": 1
+        },
+        "transform": {
+          "translate": [2.4, 0.9, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.72,
+          "metal": 0.3,
+          "glow": 0
+        }
+      },
+      {
+        "id": "emp2",
+        "type": "cut-sphere",
+        "args": {
+          "radius": 0.7,
+          "h": 0
+        },
+        "transform": {
+          "translate": [2.4, 0.9, 0]
+        },
+        "material": "porcelain"
+      },
+      {
+        "id": "arrow0",
+        "type": "arrow-3d",
+        "args": {
+          "length": 0.9,
+          "shaftWidth": 0.1,
+          "headLength": 0.28,
+          "headWidth": 0.34,
+          "depth": 0.18
+        },
+        "transform": {
+          "translate": [-1.2, 0.9, 0]
+        },
+        "material": "silver"
+      },
+      {
+        "id": "arrow1",
+        "type": "arrow-3d",
+        "args": {
+          "length": 0.9,
+          "shaftWidth": 0.1,
+          "headLength": 0.28,
+          "headWidth": 0.34,
+          "depth": 0.18
+        },
+        "transform": {
+          "translate": [1.2, 0.9, 0]
+        },
+        "material": "silver"
+      }
+    ],
+    "defaults": {
+      "camera": {
+        "yaw": 0.5,
+        "pitch": 0.28,
+        "distance": 10,
+        "focal": 1.5,
+        "targetX": 0,
+        "targetY": 0.9,
+        "targetZ": 0
+      },
+      "light": {
+        "azimuth": 0.6,
+        "altitude": 0.55,
+        "distance": 25,
+        "intensity": 1.2
+      },
+      "shadow": {
+        "enabled": true,
+        "mode": "darken",
+        "strength": 0.4
+      }
+    }
+  },
+  "meta": {
+    "generatedAt": "2026-06-21",
+    "model": "vision-authored",
+    "pattern": "sequence",
+    "costUSD": 0
+  }
+}

--- a/sdf-js/examples/compositor/demo-lifts/fill-slide-04.json
+++ b/sdf-js/examples/compositor/demo-lifts/fill-slide-04.json
@@ -1,0 +1,76 @@
+{
+  "id": "fill-slide-04",
+  "title": "Fill Levels · Hero 60%",
+  "prompt": "kpi-hero: A single large fill sphere at 60% with two callout text blocks.",
+  "code2d": "// vision-authored from PDF slide (D0961 3D Spheres Fill Levels).",
+  "sceneData": {
+    "v": 1,
+    "name": "kpi-hero: Fill Levels · Hero 60%",
+    "source": {
+      "format": "vision-authored",
+      "prompt": "A single large fill sphere at 60% with two callout text blocks."
+    },
+    "subjects": [
+      {
+        "id": "liq0",
+        "type": "sphere-fill-3d",
+        "args": {
+          "levels": [0.6],
+          "radius": 1.05,
+          "cage": false,
+          "fillScale": 1
+        },
+        "transform": {
+          "translate": [0, 1, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.72,
+          "metal": 0.3,
+          "glow": 0
+        }
+      },
+      {
+        "id": "emp0",
+        "type": "cut-sphere",
+        "args": {
+          "radius": 1.05,
+          "h": 0.20999999999999996
+        },
+        "transform": {
+          "translate": [0, 1, 0]
+        },
+        "material": "porcelain"
+      }
+    ],
+    "defaults": {
+      "camera": {
+        "yaw": 0.5,
+        "pitch": 0.28,
+        "distance": 10,
+        "focal": 1.5,
+        "targetX": 0,
+        "targetY": 1,
+        "targetZ": 0
+      },
+      "light": {
+        "azimuth": 0.6,
+        "altitude": 0.55,
+        "distance": 25,
+        "intensity": 1.2
+      },
+      "shadow": {
+        "enabled": true,
+        "mode": "darken",
+        "strength": 0.4
+      }
+    }
+  },
+  "meta": {
+    "generatedAt": "2026-06-21",
+    "model": "vision-authored",
+    "pattern": "kpi-hero",
+    "costUSD": 0
+  }
+}

--- a/sdf-js/examples/compositor/demo-lifts/fill-slide-05.json
+++ b/sdf-js/examples/compositor/demo-lifts/fill-slide-05.json
@@ -1,0 +1,64 @@
+{
+  "id": "fill-slide-05",
+  "title": "Fill Levels · Hero 100% + legend",
+  "prompt": "kpi-hero: A single full (100%) fill sphere with a side legend.",
+  "code2d": "// vision-authored from PDF slide (D0961 3D Spheres Fill Levels).",
+  "sceneData": {
+    "v": 1,
+    "name": "kpi-hero: Fill Levels · Hero 100% + legend",
+    "source": {
+      "format": "vision-authored",
+      "prompt": "A single full (100%) fill sphere with a side legend."
+    },
+    "subjects": [
+      {
+        "id": "liq0",
+        "type": "sphere-fill-3d",
+        "args": {
+          "levels": [1],
+          "radius": 1.05,
+          "cage": false,
+          "fillScale": 1
+        },
+        "transform": {
+          "translate": [0, 1, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.72,
+          "metal": 0.3,
+          "glow": 0
+        }
+      }
+    ],
+    "defaults": {
+      "camera": {
+        "yaw": 0.5,
+        "pitch": 0.28,
+        "distance": 10,
+        "focal": 1.5,
+        "targetX": 0,
+        "targetY": 1,
+        "targetZ": 0
+      },
+      "light": {
+        "azimuth": 0.6,
+        "altitude": 0.55,
+        "distance": 25,
+        "intensity": 1.2
+      },
+      "shadow": {
+        "enabled": true,
+        "mode": "darken",
+        "strength": 0.4
+      }
+    }
+  },
+  "meta": {
+    "generatedAt": "2026-06-21",
+    "model": "vision-authored",
+    "pattern": "kpi-hero",
+    "costUSD": 0
+  }
+}

--- a/sdf-js/examples/compositor/demo-lifts/fill-slide-06.json
+++ b/sdf-js/examples/compositor/demo-lifts/fill-slide-06.json
@@ -1,0 +1,192 @@
+{
+  "id": "fill-slide-06",
+  "title": "Fill Levels · Cluster of 5 (50/20/100/40/80)",
+  "prompt": "compare: Five varied-size fill spheres clustered around a large 100% sphere.",
+  "code2d": "// vision-authored from PDF slide (D0961 3D Spheres Fill Levels).",
+  "sceneData": {
+    "v": 1,
+    "name": "compare: Fill Levels · Cluster of 5 (50/20/100/40/80)",
+    "source": {
+      "format": "vision-authored",
+      "prompt": "Five varied-size fill spheres clustered around a large 100% sphere."
+    },
+    "subjects": [
+      {
+        "id": "liq0",
+        "type": "sphere-fill-3d",
+        "args": {
+          "levels": [1],
+          "radius": 0.95,
+          "cage": false,
+          "fillScale": 1
+        },
+        "transform": {
+          "translate": [0, 0.95, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.72,
+          "metal": 0.3,
+          "glow": 0
+        }
+      },
+      {
+        "id": "liq1",
+        "type": "sphere-fill-3d",
+        "args": {
+          "levels": [0.5],
+          "radius": 0.6,
+          "cage": false,
+          "fillScale": 1
+        },
+        "transform": {
+          "translate": [-2.15, 0.7, 0.2]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.72,
+          "metal": 0.3,
+          "glow": 0
+        }
+      },
+      {
+        "id": "emp1",
+        "type": "cut-sphere",
+        "args": {
+          "radius": 0.6,
+          "h": 0
+        },
+        "transform": {
+          "translate": [-2.15, 0.7, 0.2]
+        },
+        "material": "porcelain"
+      },
+      {
+        "id": "liq2",
+        "type": "sphere-fill-3d",
+        "args": {
+          "levels": [0.2],
+          "radius": 0.42,
+          "cage": false,
+          "fillScale": 1
+        },
+        "transform": {
+          "translate": [-1.05, 1.35, -0.3]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.72,
+          "metal": 0.3,
+          "glow": 0
+        }
+      },
+      {
+        "id": "emp2",
+        "type": "cut-sphere",
+        "args": {
+          "radius": 0.42,
+          "h": -0.252
+        },
+        "transform": {
+          "translate": [-1.05, 1.35, -0.3]
+        },
+        "material": "porcelain"
+      },
+      {
+        "id": "liq3",
+        "type": "sphere-fill-3d",
+        "args": {
+          "levels": [0.4],
+          "radius": 0.42,
+          "cage": false,
+          "fillScale": 1
+        },
+        "transform": {
+          "translate": [1.05, 1.35, -0.3]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.72,
+          "metal": 0.3,
+          "glow": 0
+        }
+      },
+      {
+        "id": "emp3",
+        "type": "cut-sphere",
+        "args": {
+          "radius": 0.42,
+          "h": -0.08399999999999998
+        },
+        "transform": {
+          "translate": [1.05, 1.35, -0.3]
+        },
+        "material": "porcelain"
+      },
+      {
+        "id": "liq4",
+        "type": "sphere-fill-3d",
+        "args": {
+          "levels": [0.8],
+          "radius": 0.6,
+          "cage": false,
+          "fillScale": 1
+        },
+        "transform": {
+          "translate": [2.15, 0.7, 0.2]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.72,
+          "metal": 0.3,
+          "glow": 0
+        }
+      },
+      {
+        "id": "emp4",
+        "type": "cut-sphere",
+        "args": {
+          "radius": 0.6,
+          "h": 0.36000000000000004
+        },
+        "transform": {
+          "translate": [2.15, 0.7, 0.2]
+        },
+        "material": "porcelain"
+      }
+    ],
+    "defaults": {
+      "camera": {
+        "yaw": 0.5,
+        "pitch": 0.28,
+        "distance": 10,
+        "focal": 1.5,
+        "targetX": 0,
+        "targetY": 1.01,
+        "targetZ": 0
+      },
+      "light": {
+        "azimuth": 0.6,
+        "altitude": 0.55,
+        "distance": 25,
+        "intensity": 1.2
+      },
+      "shadow": {
+        "enabled": true,
+        "mode": "darken",
+        "strength": 0.4
+      }
+    }
+  },
+  "meta": {
+    "generatedAt": "2026-06-21",
+    "model": "vision-authored",
+    "pattern": "compare",
+    "costUSD": 0
+  }
+}

--- a/sdf-js/examples/compositor/demo-lifts/fill-slide-07.json
+++ b/sdf-js/examples/compositor/demo-lifts/fill-slide-07.json
@@ -1,0 +1,128 @@
+{
+  "id": "fill-slide-07",
+  "title": "Fill Levels · Row of 3 (50/100/80)",
+  "prompt": "compare: A row of three fill spheres 50/100/80%, the middle one largest.",
+  "code2d": "// vision-authored from PDF slide (D0961 3D Spheres Fill Levels).",
+  "sceneData": {
+    "v": 1,
+    "name": "compare: Fill Levels · Row of 3 (50/100/80)",
+    "source": {
+      "format": "vision-authored",
+      "prompt": "A row of three fill spheres 50/100/80%, the middle one largest."
+    },
+    "subjects": [
+      {
+        "id": "liq0",
+        "type": "sphere-fill-3d",
+        "args": {
+          "levels": [0.5],
+          "radius": 0.62,
+          "cage": false,
+          "fillScale": 1
+        },
+        "transform": {
+          "translate": [-1.9, 0.85, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.72,
+          "metal": 0.3,
+          "glow": 0
+        }
+      },
+      {
+        "id": "emp0",
+        "type": "cut-sphere",
+        "args": {
+          "radius": 0.62,
+          "h": 0
+        },
+        "transform": {
+          "translate": [-1.9, 0.85, 0]
+        },
+        "material": "porcelain"
+      },
+      {
+        "id": "liq1",
+        "type": "sphere-fill-3d",
+        "args": {
+          "levels": [1],
+          "radius": 0.85,
+          "cage": false,
+          "fillScale": 1
+        },
+        "transform": {
+          "translate": [0, 1, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.72,
+          "metal": 0.3,
+          "glow": 0
+        }
+      },
+      {
+        "id": "liq2",
+        "type": "sphere-fill-3d",
+        "args": {
+          "levels": [0.8],
+          "radius": 0.62,
+          "cage": false,
+          "fillScale": 1
+        },
+        "transform": {
+          "translate": [1.9, 0.85, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.72,
+          "metal": 0.3,
+          "glow": 0
+        }
+      },
+      {
+        "id": "emp2",
+        "type": "cut-sphere",
+        "args": {
+          "radius": 0.62,
+          "h": 0.37200000000000005
+        },
+        "transform": {
+          "translate": [1.9, 0.85, 0]
+        },
+        "material": "porcelain"
+      }
+    ],
+    "defaults": {
+      "camera": {
+        "yaw": 0.5,
+        "pitch": 0.28,
+        "distance": 10,
+        "focal": 1.5,
+        "targetX": 0,
+        "targetY": 0.9,
+        "targetZ": 0
+      },
+      "light": {
+        "azimuth": 0.6,
+        "altitude": 0.55,
+        "distance": 25,
+        "intensity": 1.2
+      },
+      "shadow": {
+        "enabled": true,
+        "mode": "darken",
+        "strength": 0.4
+      }
+    }
+  },
+  "meta": {
+    "generatedAt": "2026-06-21",
+    "model": "vision-authored",
+    "pattern": "compare",
+    "costUSD": 0
+  }
+}

--- a/sdf-js/examples/compositor/demo-lifts/fill-slide-08.json
+++ b/sdf-js/examples/compositor/demo-lifts/fill-slide-08.json
@@ -1,0 +1,140 @@
+{
+  "id": "fill-slide-08",
+  "title": "Fill Levels · Cluster of 3 (60/50/80)",
+  "prompt": "compare: Three overlapping varied-size fill spheres 60/50/80%.",
+  "code2d": "// vision-authored from PDF slide (D0961 3D Spheres Fill Levels).",
+  "sceneData": {
+    "v": 1,
+    "name": "compare: Fill Levels · Cluster of 3 (60/50/80)",
+    "source": {
+      "format": "vision-authored",
+      "prompt": "Three overlapping varied-size fill spheres 60/50/80%."
+    },
+    "subjects": [
+      {
+        "id": "liq0",
+        "type": "sphere-fill-3d",
+        "args": {
+          "levels": [0.6],
+          "radius": 0.78,
+          "cage": false,
+          "fillScale": 1
+        },
+        "transform": {
+          "translate": [-1.35, 0.95, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.72,
+          "metal": 0.3,
+          "glow": 0
+        }
+      },
+      {
+        "id": "emp0",
+        "type": "cut-sphere",
+        "args": {
+          "radius": 0.78,
+          "h": 0.15599999999999997
+        },
+        "transform": {
+          "translate": [-1.35, 0.95, 0]
+        },
+        "material": "porcelain"
+      },
+      {
+        "id": "liq1",
+        "type": "sphere-fill-3d",
+        "args": {
+          "levels": [0.5],
+          "radius": 0.55,
+          "cage": false,
+          "fillScale": 1
+        },
+        "transform": {
+          "translate": [0.1, 0.7, 0.25]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.72,
+          "metal": 0.3,
+          "glow": 0
+        }
+      },
+      {
+        "id": "emp1",
+        "type": "cut-sphere",
+        "args": {
+          "radius": 0.55,
+          "h": 0
+        },
+        "transform": {
+          "translate": [0.1, 0.7, 0.25]
+        },
+        "material": "porcelain"
+      },
+      {
+        "id": "liq2",
+        "type": "sphere-fill-3d",
+        "args": {
+          "levels": [0.8],
+          "radius": 0.72,
+          "cage": false,
+          "fillScale": 1
+        },
+        "transform": {
+          "translate": [1.4, 1, -0.1]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.72,
+          "metal": 0.3,
+          "glow": 0
+        }
+      },
+      {
+        "id": "emp2",
+        "type": "cut-sphere",
+        "args": {
+          "radius": 0.72,
+          "h": 0.43200000000000005
+        },
+        "transform": {
+          "translate": [1.4, 1, -0.1]
+        },
+        "material": "porcelain"
+      }
+    ],
+    "defaults": {
+      "camera": {
+        "yaw": 0.5,
+        "pitch": 0.28,
+        "distance": 10,
+        "focal": 1.5,
+        "targetX": 0,
+        "targetY": 0.8833333333333333,
+        "targetZ": 0
+      },
+      "light": {
+        "azimuth": 0.6,
+        "altitude": 0.55,
+        "distance": 25,
+        "intensity": 1.2
+      },
+      "shadow": {
+        "enabled": true,
+        "mode": "darken",
+        "strength": 0.4
+      }
+    }
+  },
+  "meta": {
+    "generatedAt": "2026-06-21",
+    "model": "vision-authored",
+    "pattern": "compare",
+    "costUSD": 0
+  }
+}

--- a/sdf-js/examples/compositor/demo-lifts/fill-slide-09.json
+++ b/sdf-js/examples/compositor/demo-lifts/fill-slide-09.json
@@ -1,0 +1,204 @@
+{
+  "id": "fill-slide-09",
+  "title": "Fill Levels · Row of 5 (10..90)",
+  "prompt": "compare: A row of five small fill spheres rising 10/30/50/70/90%.",
+  "code2d": "// vision-authored from PDF slide (D0961 3D Spheres Fill Levels).",
+  "sceneData": {
+    "v": 1,
+    "name": "compare: Fill Levels · Row of 5 (10..90)",
+    "source": {
+      "format": "vision-authored",
+      "prompt": "A row of five small fill spheres rising 10/30/50/70/90%."
+    },
+    "subjects": [
+      {
+        "id": "liq0",
+        "type": "sphere-fill-3d",
+        "args": {
+          "levels": [0.1],
+          "radius": 0.45,
+          "cage": false,
+          "fillScale": 1
+        },
+        "transform": {
+          "translate": [-2.5, 0.8, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.72,
+          "metal": 0.3,
+          "glow": 0
+        }
+      },
+      {
+        "id": "emp0",
+        "type": "cut-sphere",
+        "args": {
+          "radius": 0.45,
+          "h": -0.36000000000000004
+        },
+        "transform": {
+          "translate": [-2.5, 0.8, 0]
+        },
+        "material": "porcelain"
+      },
+      {
+        "id": "liq1",
+        "type": "sphere-fill-3d",
+        "args": {
+          "levels": [0.3],
+          "radius": 0.45,
+          "cage": false,
+          "fillScale": 1
+        },
+        "transform": {
+          "translate": [-1.25, 0.8, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.72,
+          "metal": 0.3,
+          "glow": 0
+        }
+      },
+      {
+        "id": "emp1",
+        "type": "cut-sphere",
+        "args": {
+          "radius": 0.45,
+          "h": -0.18000000000000002
+        },
+        "transform": {
+          "translate": [-1.25, 0.8, 0]
+        },
+        "material": "porcelain"
+      },
+      {
+        "id": "liq2",
+        "type": "sphere-fill-3d",
+        "args": {
+          "levels": [0.5],
+          "radius": 0.45,
+          "cage": false,
+          "fillScale": 1
+        },
+        "transform": {
+          "translate": [0, 0.8, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.72,
+          "metal": 0.3,
+          "glow": 0
+        }
+      },
+      {
+        "id": "emp2",
+        "type": "cut-sphere",
+        "args": {
+          "radius": 0.45,
+          "h": 0
+        },
+        "transform": {
+          "translate": [0, 0.8, 0]
+        },
+        "material": "porcelain"
+      },
+      {
+        "id": "liq3",
+        "type": "sphere-fill-3d",
+        "args": {
+          "levels": [0.7],
+          "radius": 0.45,
+          "cage": false,
+          "fillScale": 1
+        },
+        "transform": {
+          "translate": [1.25, 0.8, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.72,
+          "metal": 0.3,
+          "glow": 0
+        }
+      },
+      {
+        "id": "emp3",
+        "type": "cut-sphere",
+        "args": {
+          "radius": 0.45,
+          "h": 0.17999999999999997
+        },
+        "transform": {
+          "translate": [1.25, 0.8, 0]
+        },
+        "material": "porcelain"
+      },
+      {
+        "id": "liq4",
+        "type": "sphere-fill-3d",
+        "args": {
+          "levels": [0.9],
+          "radius": 0.45,
+          "cage": false,
+          "fillScale": 1
+        },
+        "transform": {
+          "translate": [2.5, 0.8, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.72,
+          "metal": 0.3,
+          "glow": 0
+        }
+      },
+      {
+        "id": "emp4",
+        "type": "cut-sphere",
+        "args": {
+          "radius": 0.45,
+          "h": 0.36000000000000004
+        },
+        "transform": {
+          "translate": [2.5, 0.8, 0]
+        },
+        "material": "porcelain"
+      }
+    ],
+    "defaults": {
+      "camera": {
+        "yaw": 0.5,
+        "pitch": 0.28,
+        "distance": 10,
+        "focal": 1.5,
+        "targetX": 0,
+        "targetY": 0.8,
+        "targetZ": 0
+      },
+      "light": {
+        "azimuth": 0.6,
+        "altitude": 0.55,
+        "distance": 25,
+        "intensity": 1.2
+      },
+      "shadow": {
+        "enabled": true,
+        "mode": "darken",
+        "strength": 0.4
+      }
+    }
+  },
+  "meta": {
+    "generatedAt": "2026-06-21",
+    "model": "vision-authored",
+    "pattern": "compare",
+    "costUSD": 0
+  }
+}

--- a/sdf-js/examples/compositor/demo-lifts/fill-slide-10.json
+++ b/sdf-js/examples/compositor/demo-lifts/fill-slide-10.json
@@ -1,0 +1,236 @@
+{
+  "id": "fill-slide-10",
+  "title": "Fill Levels · Grid of 6 (framed)",
+  "prompt": "list: A grid of six framed fill spheres at mixed levels.",
+  "code2d": "// vision-authored from PDF slide (D0961 3D Spheres Fill Levels).",
+  "sceneData": {
+    "v": 1,
+    "name": "list: Fill Levels · Grid of 6 (framed)",
+    "source": {
+      "format": "vision-authored",
+      "prompt": "A grid of six framed fill spheres at mixed levels."
+    },
+    "subjects": [
+      {
+        "id": "liq0",
+        "type": "sphere-fill-3d",
+        "args": {
+          "levels": [0.55],
+          "radius": 0.5,
+          "cage": false,
+          "fillScale": 1
+        },
+        "transform": {
+          "translate": [-1.5, 1.8, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.72,
+          "metal": 0.3,
+          "glow": 0
+        }
+      },
+      {
+        "id": "emp0",
+        "type": "cut-sphere",
+        "args": {
+          "radius": 0.5,
+          "h": 0.050000000000000044
+        },
+        "transform": {
+          "translate": [-1.5, 1.8, 0]
+        },
+        "material": "porcelain"
+      },
+      {
+        "id": "liq1",
+        "type": "sphere-fill-3d",
+        "args": {
+          "levels": [0.75],
+          "radius": 0.5,
+          "cage": false,
+          "fillScale": 1
+        },
+        "transform": {
+          "translate": [0, 1.8, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.72,
+          "metal": 0.3,
+          "glow": 0
+        }
+      },
+      {
+        "id": "emp1",
+        "type": "cut-sphere",
+        "args": {
+          "radius": 0.5,
+          "h": 0.25
+        },
+        "transform": {
+          "translate": [0, 1.8, 0]
+        },
+        "material": "porcelain"
+      },
+      {
+        "id": "liq2",
+        "type": "sphere-fill-3d",
+        "args": {
+          "levels": [0.6],
+          "radius": 0.5,
+          "cage": false,
+          "fillScale": 1
+        },
+        "transform": {
+          "translate": [1.5, 1.8, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.72,
+          "metal": 0.3,
+          "glow": 0
+        }
+      },
+      {
+        "id": "emp2",
+        "type": "cut-sphere",
+        "args": {
+          "radius": 0.5,
+          "h": 0.09999999999999998
+        },
+        "transform": {
+          "translate": [1.5, 1.8, 0]
+        },
+        "material": "porcelain"
+      },
+      {
+        "id": "liq3",
+        "type": "sphere-fill-3d",
+        "args": {
+          "levels": [0.2],
+          "radius": 0.5,
+          "cage": false,
+          "fillScale": 1
+        },
+        "transform": {
+          "translate": [-1.5, 0.19999999999999996, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.72,
+          "metal": 0.3,
+          "glow": 0
+        }
+      },
+      {
+        "id": "emp3",
+        "type": "cut-sphere",
+        "args": {
+          "radius": 0.5,
+          "h": -0.3
+        },
+        "transform": {
+          "translate": [-1.5, 0.19999999999999996, 0]
+        },
+        "material": "porcelain"
+      },
+      {
+        "id": "liq4",
+        "type": "sphere-fill-3d",
+        "args": {
+          "levels": [0.4],
+          "radius": 0.5,
+          "cage": false,
+          "fillScale": 1
+        },
+        "transform": {
+          "translate": [0, 0.19999999999999996, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.72,
+          "metal": 0.3,
+          "glow": 0
+        }
+      },
+      {
+        "id": "emp4",
+        "type": "cut-sphere",
+        "args": {
+          "radius": 0.5,
+          "h": -0.09999999999999998
+        },
+        "transform": {
+          "translate": [0, 0.19999999999999996, 0]
+        },
+        "material": "porcelain"
+      },
+      {
+        "id": "liq5",
+        "type": "sphere-fill-3d",
+        "args": {
+          "levels": [0.65],
+          "radius": 0.5,
+          "cage": false,
+          "fillScale": 1
+        },
+        "transform": {
+          "translate": [1.5, 0.19999999999999996, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.72,
+          "metal": 0.3,
+          "glow": 0
+        }
+      },
+      {
+        "id": "emp5",
+        "type": "cut-sphere",
+        "args": {
+          "radius": 0.5,
+          "h": 0.15000000000000002
+        },
+        "transform": {
+          "translate": [1.5, 0.19999999999999996, 0]
+        },
+        "material": "porcelain"
+      }
+    ],
+    "defaults": {
+      "camera": {
+        "yaw": 0.5,
+        "pitch": 0.28,
+        "distance": 10,
+        "focal": 1.5,
+        "targetX": 0,
+        "targetY": 1.0000000000000002,
+        "targetZ": 0
+      },
+      "light": {
+        "azimuth": 0.6,
+        "altitude": 0.55,
+        "distance": 25,
+        "intensity": 1.2
+      },
+      "shadow": {
+        "enabled": true,
+        "mode": "darken",
+        "strength": 0.4
+      }
+    }
+  },
+  "meta": {
+    "generatedAt": "2026-06-21",
+    "model": "vision-authored",
+    "pattern": "list",
+    "costUSD": 0
+  }
+}

--- a/sdf-js/examples/compositor/demo-lifts/fill-slide-11.json
+++ b/sdf-js/examples/compositor/demo-lifts/fill-slide-11.json
@@ -1,0 +1,76 @@
+{
+  "id": "fill-slide-11",
+  "title": "Fill Levels · Hero 30% + list",
+  "prompt": "kpi-hero: A single large fill sphere at 30% with a 4-item side list.",
+  "code2d": "// vision-authored from PDF slide (D0961 3D Spheres Fill Levels).",
+  "sceneData": {
+    "v": 1,
+    "name": "kpi-hero: Fill Levels · Hero 30% + list",
+    "source": {
+      "format": "vision-authored",
+      "prompt": "A single large fill sphere at 30% with a 4-item side list."
+    },
+    "subjects": [
+      {
+        "id": "liq0",
+        "type": "sphere-fill-3d",
+        "args": {
+          "levels": [0.3],
+          "radius": 1.05,
+          "cage": false,
+          "fillScale": 1
+        },
+        "transform": {
+          "translate": [0, 1, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.72,
+          "metal": 0.3,
+          "glow": 0
+        }
+      },
+      {
+        "id": "emp0",
+        "type": "cut-sphere",
+        "args": {
+          "radius": 1.05,
+          "h": -0.42000000000000004
+        },
+        "transform": {
+          "translate": [0, 1, 0]
+        },
+        "material": "porcelain"
+      }
+    ],
+    "defaults": {
+      "camera": {
+        "yaw": 0.5,
+        "pitch": 0.28,
+        "distance": 10,
+        "focal": 1.5,
+        "targetX": 0,
+        "targetY": 1,
+        "targetZ": 0
+      },
+      "light": {
+        "azimuth": 0.6,
+        "altitude": 0.55,
+        "distance": 25,
+        "intensity": 1.2
+      },
+      "shadow": {
+        "enabled": true,
+        "mode": "darken",
+        "strength": 0.4
+      }
+    }
+  },
+  "meta": {
+    "generatedAt": "2026-06-21",
+    "model": "vision-authored",
+    "pattern": "kpi-hero",
+    "costUSD": 0
+  }
+}

--- a/sdf-js/examples/compositor/demo-lifts/fill-slide-12.json
+++ b/sdf-js/examples/compositor/demo-lifts/fill-slide-12.json
@@ -1,0 +1,204 @@
+{
+  "id": "fill-slide-12",
+  "title": "Fill Levels · Row of 5 + captions",
+  "prompt": "compare: A row of five fill spheres 20/40/60/50/80% over caption columns.",
+  "code2d": "// vision-authored from PDF slide (D0961 3D Spheres Fill Levels).",
+  "sceneData": {
+    "v": 1,
+    "name": "compare: Fill Levels · Row of 5 + captions",
+    "source": {
+      "format": "vision-authored",
+      "prompt": "A row of five fill spheres 20/40/60/50/80% over caption columns."
+    },
+    "subjects": [
+      {
+        "id": "liq0",
+        "type": "sphere-fill-3d",
+        "args": {
+          "levels": [0.2],
+          "radius": 0.5,
+          "cage": false,
+          "fillScale": 1
+        },
+        "transform": {
+          "translate": [-2.8, 0.85, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.72,
+          "metal": 0.3,
+          "glow": 0
+        }
+      },
+      {
+        "id": "emp0",
+        "type": "cut-sphere",
+        "args": {
+          "radius": 0.5,
+          "h": -0.3
+        },
+        "transform": {
+          "translate": [-2.8, 0.85, 0]
+        },
+        "material": "porcelain"
+      },
+      {
+        "id": "liq1",
+        "type": "sphere-fill-3d",
+        "args": {
+          "levels": [0.4],
+          "radius": 0.5,
+          "cage": false,
+          "fillScale": 1
+        },
+        "transform": {
+          "translate": [-1.4, 0.85, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.72,
+          "metal": 0.3,
+          "glow": 0
+        }
+      },
+      {
+        "id": "emp1",
+        "type": "cut-sphere",
+        "args": {
+          "radius": 0.5,
+          "h": -0.09999999999999998
+        },
+        "transform": {
+          "translate": [-1.4, 0.85, 0]
+        },
+        "material": "porcelain"
+      },
+      {
+        "id": "liq2",
+        "type": "sphere-fill-3d",
+        "args": {
+          "levels": [0.6],
+          "radius": 0.5,
+          "cage": false,
+          "fillScale": 1
+        },
+        "transform": {
+          "translate": [0, 0.85, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.72,
+          "metal": 0.3,
+          "glow": 0
+        }
+      },
+      {
+        "id": "emp2",
+        "type": "cut-sphere",
+        "args": {
+          "radius": 0.5,
+          "h": 0.09999999999999998
+        },
+        "transform": {
+          "translate": [0, 0.85, 0]
+        },
+        "material": "porcelain"
+      },
+      {
+        "id": "liq3",
+        "type": "sphere-fill-3d",
+        "args": {
+          "levels": [0.5],
+          "radius": 0.5,
+          "cage": false,
+          "fillScale": 1
+        },
+        "transform": {
+          "translate": [1.3999999999999995, 0.85, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.72,
+          "metal": 0.3,
+          "glow": 0
+        }
+      },
+      {
+        "id": "emp3",
+        "type": "cut-sphere",
+        "args": {
+          "radius": 0.5,
+          "h": 0
+        },
+        "transform": {
+          "translate": [1.3999999999999995, 0.85, 0]
+        },
+        "material": "porcelain"
+      },
+      {
+        "id": "liq4",
+        "type": "sphere-fill-3d",
+        "args": {
+          "levels": [0.8],
+          "radius": 0.5,
+          "cage": false,
+          "fillScale": 1
+        },
+        "transform": {
+          "translate": [2.8, 0.85, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.72,
+          "metal": 0.3,
+          "glow": 0
+        }
+      },
+      {
+        "id": "emp4",
+        "type": "cut-sphere",
+        "args": {
+          "radius": 0.5,
+          "h": 0.30000000000000004
+        },
+        "transform": {
+          "translate": [2.8, 0.85, 0]
+        },
+        "material": "porcelain"
+      }
+    ],
+    "defaults": {
+      "camera": {
+        "yaw": 0.5,
+        "pitch": 0.28,
+        "distance": 10,
+        "focal": 1.5,
+        "targetX": 0,
+        "targetY": 0.85,
+        "targetZ": 0
+      },
+      "light": {
+        "azimuth": 0.6,
+        "altitude": 0.55,
+        "distance": 25,
+        "intensity": 1.2
+      },
+      "shadow": {
+        "enabled": true,
+        "mode": "darken",
+        "strength": 0.4
+      }
+    }
+  },
+  "meta": {
+    "generatedAt": "2026-06-21",
+    "model": "vision-authored",
+    "pattern": "compare",
+    "costUSD": 0
+  }
+}

--- a/sdf-js/examples/compositor/demo-lifts/fill-slide-13.json
+++ b/sdf-js/examples/compositor/demo-lifts/fill-slide-13.json
@@ -1,0 +1,76 @@
+{
+  "id": "fill-slide-13",
+  "title": "Fill Levels · Hero 90% + list",
+  "prompt": "kpi-hero: A single large fill sphere at 90% with a side list.",
+  "code2d": "// vision-authored from PDF slide (D0961 3D Spheres Fill Levels).",
+  "sceneData": {
+    "v": 1,
+    "name": "kpi-hero: Fill Levels · Hero 90% + list",
+    "source": {
+      "format": "vision-authored",
+      "prompt": "A single large fill sphere at 90% with a side list."
+    },
+    "subjects": [
+      {
+        "id": "liq0",
+        "type": "sphere-fill-3d",
+        "args": {
+          "levels": [0.9],
+          "radius": 1.05,
+          "cage": false,
+          "fillScale": 1
+        },
+        "transform": {
+          "translate": [0, 1, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.72,
+          "metal": 0.3,
+          "glow": 0
+        }
+      },
+      {
+        "id": "emp0",
+        "type": "cut-sphere",
+        "args": {
+          "radius": 1.05,
+          "h": 0.8400000000000001
+        },
+        "transform": {
+          "translate": [0, 1, 0]
+        },
+        "material": "porcelain"
+      }
+    ],
+    "defaults": {
+      "camera": {
+        "yaw": 0.5,
+        "pitch": 0.28,
+        "distance": 10,
+        "focal": 1.5,
+        "targetX": 0,
+        "targetY": 1,
+        "targetZ": 0
+      },
+      "light": {
+        "azimuth": 0.6,
+        "altitude": 0.55,
+        "distance": 25,
+        "intensity": 1.2
+      },
+      "shadow": {
+        "enabled": true,
+        "mode": "darken",
+        "strength": 0.4
+      }
+    }
+  },
+  "meta": {
+    "generatedAt": "2026-06-21",
+    "model": "vision-authored",
+    "pattern": "kpi-hero",
+    "costUSD": 0
+  }
+}

--- a/sdf-js/examples/compositor/demo-lifts/fill-slide-14.json
+++ b/sdf-js/examples/compositor/demo-lifts/fill-slide-14.json
@@ -1,0 +1,172 @@
+{
+  "id": "fill-slide-14",
+  "title": "Fill Levels · Bullet list of 4",
+  "prompt": "list: A vertical list of four items, each marked by a small fill sphere.",
+  "code2d": "// vision-authored from PDF slide (D0961 3D Spheres Fill Levels).",
+  "sceneData": {
+    "v": 1,
+    "name": "list: Fill Levels · Bullet list of 4",
+    "source": {
+      "format": "vision-authored",
+      "prompt": "A vertical list of four items, each marked by a small fill sphere."
+    },
+    "subjects": [
+      {
+        "id": "liq0",
+        "type": "sphere-fill-3d",
+        "args": {
+          "levels": [0.4],
+          "radius": 0.34,
+          "cage": false,
+          "fillScale": 1
+        },
+        "transform": {
+          "translate": [-1.6, 2.595, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.72,
+          "metal": 0.3,
+          "glow": 0
+        }
+      },
+      {
+        "id": "emp0",
+        "type": "cut-sphere",
+        "args": {
+          "radius": 0.34,
+          "h": -0.06799999999999999
+        },
+        "transform": {
+          "translate": [-1.6, 2.595, 0]
+        },
+        "material": "porcelain"
+      },
+      {
+        "id": "liq1",
+        "type": "sphere-fill-3d",
+        "args": {
+          "levels": [0.6],
+          "radius": 0.34,
+          "cage": false,
+          "fillScale": 1
+        },
+        "transform": {
+          "translate": [-1.6, 1.465, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.72,
+          "metal": 0.3,
+          "glow": 0
+        }
+      },
+      {
+        "id": "emp1",
+        "type": "cut-sphere",
+        "args": {
+          "radius": 0.34,
+          "h": 0.06799999999999999
+        },
+        "transform": {
+          "translate": [-1.6, 1.465, 0]
+        },
+        "material": "porcelain"
+      },
+      {
+        "id": "liq2",
+        "type": "sphere-fill-3d",
+        "args": {
+          "levels": [0.5],
+          "radius": 0.34,
+          "cage": false,
+          "fillScale": 1
+        },
+        "transform": {
+          "translate": [-1.6, 0.33499999999999996, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.72,
+          "metal": 0.3,
+          "glow": 0
+        }
+      },
+      {
+        "id": "emp2",
+        "type": "cut-sphere",
+        "args": {
+          "radius": 0.34,
+          "h": 0
+        },
+        "transform": {
+          "translate": [-1.6, 0.33499999999999996, 0]
+        },
+        "material": "porcelain"
+      },
+      {
+        "id": "liq3",
+        "type": "sphere-fill-3d",
+        "args": {
+          "levels": [0.7],
+          "radius": 0.34,
+          "cage": false,
+          "fillScale": 1
+        },
+        "transform": {
+          "translate": [-1.6, -0.7950000000000004, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.72,
+          "metal": 0.3,
+          "glow": 0
+        }
+      },
+      {
+        "id": "emp3",
+        "type": "cut-sphere",
+        "args": {
+          "radius": 0.34,
+          "h": 0.13599999999999998
+        },
+        "transform": {
+          "translate": [-1.6, -0.7950000000000004, 0]
+        },
+        "material": "porcelain"
+      }
+    ],
+    "defaults": {
+      "camera": {
+        "yaw": 0.5,
+        "pitch": 0.28,
+        "distance": 10,
+        "focal": 1.5,
+        "targetX": 0,
+        "targetY": 0.9,
+        "targetZ": 0
+      },
+      "light": {
+        "azimuth": 0.6,
+        "altitude": 0.55,
+        "distance": 25,
+        "intensity": 1.2
+      },
+      "shadow": {
+        "enabled": true,
+        "mode": "darken",
+        "strength": 0.4
+      }
+    }
+  },
+  "meta": {
+    "generatedAt": "2026-06-21",
+    "model": "vision-authored",
+    "pattern": "list",
+    "costUSD": 0
+  }
+}

--- a/sdf-js/examples/compositor/demo-lifts/fill-slide-15.json
+++ b/sdf-js/examples/compositor/demo-lifts/fill-slide-15.json
@@ -1,0 +1,64 @@
+{
+  "id": "fill-slide-15",
+  "title": "Fill Levels · Hero 100% + 4 labels",
+  "prompt": "kpi-hero: A single full fill sphere with four surrounding labels.",
+  "code2d": "// vision-authored from PDF slide (D0961 3D Spheres Fill Levels).",
+  "sceneData": {
+    "v": 1,
+    "name": "kpi-hero: Fill Levels · Hero 100% + 4 labels",
+    "source": {
+      "format": "vision-authored",
+      "prompt": "A single full fill sphere with four surrounding labels."
+    },
+    "subjects": [
+      {
+        "id": "liq0",
+        "type": "sphere-fill-3d",
+        "args": {
+          "levels": [1],
+          "radius": 1.1,
+          "cage": false,
+          "fillScale": 1
+        },
+        "transform": {
+          "translate": [0, 1, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.72,
+          "metal": 0.3,
+          "glow": 0
+        }
+      }
+    ],
+    "defaults": {
+      "camera": {
+        "yaw": 0.5,
+        "pitch": 0.28,
+        "distance": 10,
+        "focal": 1.5,
+        "targetX": 0,
+        "targetY": 1,
+        "targetZ": 0
+      },
+      "light": {
+        "azimuth": 0.6,
+        "altitude": 0.55,
+        "distance": 25,
+        "intensity": 1.2
+      },
+      "shadow": {
+        "enabled": true,
+        "mode": "darken",
+        "strength": 0.4
+      }
+    }
+  },
+  "meta": {
+    "generatedAt": "2026-06-21",
+    "model": "vision-authored",
+    "pattern": "kpi-hero",
+    "costUSD": 0
+  }
+}

--- a/sdf-js/examples/compositor/demo-lifts/fill-slide-16.json
+++ b/sdf-js/examples/compositor/demo-lifts/fill-slide-16.json
@@ -1,0 +1,140 @@
+{
+  "id": "fill-slide-16",
+  "title": "Fill Levels · Vertical 3 (30/80/70)",
+  "prompt": "list: Three fill spheres stacked vertically 30/80/70% with connector lines.",
+  "code2d": "// vision-authored from PDF slide (D0961 3D Spheres Fill Levels).",
+  "sceneData": {
+    "v": 1,
+    "name": "list: Fill Levels · Vertical 3 (30/80/70)",
+    "source": {
+      "format": "vision-authored",
+      "prompt": "Three fill spheres stacked vertically 30/80/70% with connector lines."
+    },
+    "subjects": [
+      {
+        "id": "liq0",
+        "type": "sphere-fill-3d",
+        "args": {
+          "levels": [0.3],
+          "radius": 0.5,
+          "cage": false,
+          "fillScale": 1
+        },
+        "transform": {
+          "translate": [-1.8, 2.3499999999999996, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.72,
+          "metal": 0.3,
+          "glow": 0
+        }
+      },
+      {
+        "id": "emp0",
+        "type": "cut-sphere",
+        "args": {
+          "radius": 0.5,
+          "h": -0.2
+        },
+        "transform": {
+          "translate": [-1.8, 2.3499999999999996, 0]
+        },
+        "material": "porcelain"
+      },
+      {
+        "id": "liq1",
+        "type": "sphere-fill-3d",
+        "args": {
+          "levels": [0.8],
+          "radius": 0.5,
+          "cage": false,
+          "fillScale": 1
+        },
+        "transform": {
+          "translate": [-1.8, 0.9499999999999997, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.72,
+          "metal": 0.3,
+          "glow": 0
+        }
+      },
+      {
+        "id": "emp1",
+        "type": "cut-sphere",
+        "args": {
+          "radius": 0.5,
+          "h": 0.30000000000000004
+        },
+        "transform": {
+          "translate": [-1.8, 0.9499999999999997, 0]
+        },
+        "material": "porcelain"
+      },
+      {
+        "id": "liq2",
+        "type": "sphere-fill-3d",
+        "args": {
+          "levels": [0.7],
+          "radius": 0.5,
+          "cage": false,
+          "fillScale": 1
+        },
+        "transform": {
+          "translate": [-1.8, -0.4500000000000002, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.72,
+          "metal": 0.3,
+          "glow": 0
+        }
+      },
+      {
+        "id": "emp2",
+        "type": "cut-sphere",
+        "args": {
+          "radius": 0.5,
+          "h": 0.19999999999999996
+        },
+        "transform": {
+          "translate": [-1.8, -0.4500000000000002, 0]
+        },
+        "material": "porcelain"
+      }
+    ],
+    "defaults": {
+      "camera": {
+        "yaw": 0.5,
+        "pitch": 0.28,
+        "distance": 10,
+        "focal": 1.5,
+        "targetX": 0,
+        "targetY": 0.9499999999999997,
+        "targetZ": 0
+      },
+      "light": {
+        "azimuth": 0.6,
+        "altitude": 0.55,
+        "distance": 25,
+        "intensity": 1.2
+      },
+      "shadow": {
+        "enabled": true,
+        "mode": "darken",
+        "strength": 0.4
+      }
+    }
+  },
+  "meta": {
+    "generatedAt": "2026-06-21",
+    "model": "vision-authored",
+    "pattern": "list",
+    "costUSD": 0
+  }
+}

--- a/sdf-js/examples/compositor/demo-lifts/fill-slide-17.json
+++ b/sdf-js/examples/compositor/demo-lifts/fill-slide-17.json
@@ -1,0 +1,108 @@
+{
+  "id": "fill-slide-17",
+  "title": "Fill Levels · Two heroes (80/90)",
+  "prompt": "compare: Two large fill spheres 80% and 90% stacked with side text.",
+  "code2d": "// vision-authored from PDF slide (D0961 3D Spheres Fill Levels).",
+  "sceneData": {
+    "v": 1,
+    "name": "compare: Fill Levels · Two heroes (80/90)",
+    "source": {
+      "format": "vision-authored",
+      "prompt": "Two large fill spheres 80% and 90% stacked with side text."
+    },
+    "subjects": [
+      {
+        "id": "liq0",
+        "type": "sphere-fill-3d",
+        "args": {
+          "levels": [0.8],
+          "radius": 0.7,
+          "cage": false,
+          "fillScale": 1
+        },
+        "transform": {
+          "translate": [-1.4, 1.45, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.72,
+          "metal": 0.3,
+          "glow": 0
+        }
+      },
+      {
+        "id": "emp0",
+        "type": "cut-sphere",
+        "args": {
+          "radius": 0.7,
+          "h": 0.42000000000000004
+        },
+        "transform": {
+          "translate": [-1.4, 1.45, 0]
+        },
+        "material": "porcelain"
+      },
+      {
+        "id": "liq1",
+        "type": "sphere-fill-3d",
+        "args": {
+          "levels": [0.9],
+          "radius": 0.75,
+          "cage": false,
+          "fillScale": 1
+        },
+        "transform": {
+          "translate": [-1.4, -0.05, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.72,
+          "metal": 0.3,
+          "glow": 0
+        }
+      },
+      {
+        "id": "emp1",
+        "type": "cut-sphere",
+        "args": {
+          "radius": 0.75,
+          "h": 0.6000000000000001
+        },
+        "transform": {
+          "translate": [-1.4, -0.05, 0]
+        },
+        "material": "porcelain"
+      }
+    ],
+    "defaults": {
+      "camera": {
+        "yaw": 0.5,
+        "pitch": 0.28,
+        "distance": 10,
+        "focal": 1.5,
+        "targetX": 0,
+        "targetY": 0.7,
+        "targetZ": 0
+      },
+      "light": {
+        "azimuth": 0.6,
+        "altitude": 0.55,
+        "distance": 25,
+        "intensity": 1.2
+      },
+      "shadow": {
+        "enabled": true,
+        "mode": "darken",
+        "strength": 0.4
+      }
+    }
+  },
+  "meta": {
+    "generatedAt": "2026-06-21",
+    "model": "vision-authored",
+    "pattern": "compare",
+    "costUSD": 0
+  }
+}

--- a/sdf-js/examples/compositor/demo-lifts/fill-slide-18.json
+++ b/sdf-js/examples/compositor/demo-lifts/fill-slide-18.json
@@ -1,0 +1,288 @@
+{
+  "id": "fill-slide-18",
+  "title": "Fill Levels · Progression grid 2×4",
+  "prompt": "sequence: Two rows of four spheres showing a fill progression up to 100%.",
+  "code2d": "// vision-authored from PDF slide (D0961 3D Spheres Fill Levels).",
+  "sceneData": {
+    "v": 1,
+    "name": "sequence: Fill Levels · Progression grid 2×4",
+    "source": {
+      "format": "vision-authored",
+      "prompt": "Two rows of four spheres showing a fill progression up to 100%."
+    },
+    "subjects": [
+      {
+        "id": "liq0",
+        "type": "sphere-fill-3d",
+        "args": {
+          "levels": [0.15],
+          "radius": 0.42,
+          "cage": false,
+          "fillScale": 1
+        },
+        "transform": {
+          "translate": [-1.935, 1.695, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.72,
+          "metal": 0.3,
+          "glow": 0
+        }
+      },
+      {
+        "id": "emp0",
+        "type": "cut-sphere",
+        "args": {
+          "radius": 0.42,
+          "h": -0.294
+        },
+        "transform": {
+          "translate": [-1.935, 1.695, 0]
+        },
+        "material": "porcelain"
+      },
+      {
+        "id": "liq1",
+        "type": "sphere-fill-3d",
+        "args": {
+          "levels": [0.25],
+          "radius": 0.42,
+          "cage": false,
+          "fillScale": 1
+        },
+        "transform": {
+          "translate": [-0.645, 1.695, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.72,
+          "metal": 0.3,
+          "glow": 0
+        }
+      },
+      {
+        "id": "emp1",
+        "type": "cut-sphere",
+        "args": {
+          "radius": 0.42,
+          "h": -0.21
+        },
+        "transform": {
+          "translate": [-0.645, 1.695, 0]
+        },
+        "material": "porcelain"
+      },
+      {
+        "id": "liq2",
+        "type": "sphere-fill-3d",
+        "args": {
+          "levels": [0.35],
+          "radius": 0.42,
+          "cage": false,
+          "fillScale": 1
+        },
+        "transform": {
+          "translate": [0.645, 1.695, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.72,
+          "metal": 0.3,
+          "glow": 0
+        }
+      },
+      {
+        "id": "emp2",
+        "type": "cut-sphere",
+        "args": {
+          "radius": 0.42,
+          "h": -0.126
+        },
+        "transform": {
+          "translate": [0.645, 1.695, 0]
+        },
+        "material": "porcelain"
+      },
+      {
+        "id": "liq3",
+        "type": "sphere-fill-3d",
+        "args": {
+          "levels": [0.45],
+          "radius": 0.42,
+          "cage": false,
+          "fillScale": 1
+        },
+        "transform": {
+          "translate": [1.935, 1.695, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.72,
+          "metal": 0.3,
+          "glow": 0
+        }
+      },
+      {
+        "id": "emp3",
+        "type": "cut-sphere",
+        "args": {
+          "radius": 0.42,
+          "h": -0.04199999999999999
+        },
+        "transform": {
+          "translate": [1.935, 1.695, 0]
+        },
+        "material": "porcelain"
+      },
+      {
+        "id": "liq4",
+        "type": "sphere-fill-3d",
+        "args": {
+          "levels": [0.6],
+          "radius": 0.42,
+          "cage": false,
+          "fillScale": 1
+        },
+        "transform": {
+          "translate": [-1.935, 0.30499999999999994, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.72,
+          "metal": 0.3,
+          "glow": 0
+        }
+      },
+      {
+        "id": "emp4",
+        "type": "cut-sphere",
+        "args": {
+          "radius": 0.42,
+          "h": 0.08399999999999998
+        },
+        "transform": {
+          "translate": [-1.935, 0.30499999999999994, 0]
+        },
+        "material": "porcelain"
+      },
+      {
+        "id": "liq5",
+        "type": "sphere-fill-3d",
+        "args": {
+          "levels": [0.8],
+          "radius": 0.42,
+          "cage": false,
+          "fillScale": 1
+        },
+        "transform": {
+          "translate": [-0.645, 0.30499999999999994, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.72,
+          "metal": 0.3,
+          "glow": 0
+        }
+      },
+      {
+        "id": "emp5",
+        "type": "cut-sphere",
+        "args": {
+          "radius": 0.42,
+          "h": 0.252
+        },
+        "transform": {
+          "translate": [-0.645, 0.30499999999999994, 0]
+        },
+        "material": "porcelain"
+      },
+      {
+        "id": "liq6",
+        "type": "sphere-fill-3d",
+        "args": {
+          "levels": [0.9],
+          "radius": 0.42,
+          "cage": false,
+          "fillScale": 1
+        },
+        "transform": {
+          "translate": [0.645, 0.30499999999999994, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.72,
+          "metal": 0.3,
+          "glow": 0
+        }
+      },
+      {
+        "id": "emp6",
+        "type": "cut-sphere",
+        "args": {
+          "radius": 0.42,
+          "h": 0.336
+        },
+        "transform": {
+          "translate": [0.645, 0.30499999999999994, 0]
+        },
+        "material": "porcelain"
+      },
+      {
+        "id": "liq7",
+        "type": "sphere-fill-3d",
+        "args": {
+          "levels": [1],
+          "radius": 0.42,
+          "cage": false,
+          "fillScale": 1
+        },
+        "transform": {
+          "translate": [1.935, 0.30499999999999994, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.72,
+          "metal": 0.3,
+          "glow": 0
+        }
+      }
+    ],
+    "defaults": {
+      "camera": {
+        "yaw": 0.5,
+        "pitch": 0.28,
+        "distance": 10,
+        "focal": 1.5,
+        "targetX": 0,
+        "targetY": 0.9999999999999999,
+        "targetZ": 0
+      },
+      "light": {
+        "azimuth": 0.6,
+        "altitude": 0.55,
+        "distance": 25,
+        "intensity": 1.2
+      },
+      "shadow": {
+        "enabled": true,
+        "mode": "darken",
+        "strength": 0.4
+      }
+    }
+  },
+  "meta": {
+    "generatedAt": "2026-06-21",
+    "model": "vision-authored",
+    "pattern": "sequence",
+    "costUSD": 0
+  }
+}

--- a/sdf-js/examples/compositor/demo-lifts/fill-slide-19.json
+++ b/sdf-js/examples/compositor/demo-lifts/fill-slide-19.json
@@ -1,0 +1,192 @@
+{
+  "id": "fill-slide-19",
+  "title": "Fill Levels · Row of 5 (20..100)",
+  "prompt": "sequence: A clean row of five fill spheres rising 20/40/60/80/100%.",
+  "code2d": "// vision-authored from PDF slide (D0961 3D Spheres Fill Levels).",
+  "sceneData": {
+    "v": 1,
+    "name": "sequence: Fill Levels · Row of 5 (20..100)",
+    "source": {
+      "format": "vision-authored",
+      "prompt": "A clean row of five fill spheres rising 20/40/60/80/100%."
+    },
+    "subjects": [
+      {
+        "id": "liq0",
+        "type": "sphere-fill-3d",
+        "args": {
+          "levels": [0.2],
+          "radius": 0.5,
+          "cage": false,
+          "fillScale": 1
+        },
+        "transform": {
+          "translate": [-2.8, 0.85, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.72,
+          "metal": 0.3,
+          "glow": 0
+        }
+      },
+      {
+        "id": "emp0",
+        "type": "cut-sphere",
+        "args": {
+          "radius": 0.5,
+          "h": -0.3
+        },
+        "transform": {
+          "translate": [-2.8, 0.85, 0]
+        },
+        "material": "porcelain"
+      },
+      {
+        "id": "liq1",
+        "type": "sphere-fill-3d",
+        "args": {
+          "levels": [0.4],
+          "radius": 0.5,
+          "cage": false,
+          "fillScale": 1
+        },
+        "transform": {
+          "translate": [-1.4, 0.85, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.72,
+          "metal": 0.3,
+          "glow": 0
+        }
+      },
+      {
+        "id": "emp1",
+        "type": "cut-sphere",
+        "args": {
+          "radius": 0.5,
+          "h": -0.09999999999999998
+        },
+        "transform": {
+          "translate": [-1.4, 0.85, 0]
+        },
+        "material": "porcelain"
+      },
+      {
+        "id": "liq2",
+        "type": "sphere-fill-3d",
+        "args": {
+          "levels": [0.6],
+          "radius": 0.5,
+          "cage": false,
+          "fillScale": 1
+        },
+        "transform": {
+          "translate": [0, 0.85, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.72,
+          "metal": 0.3,
+          "glow": 0
+        }
+      },
+      {
+        "id": "emp2",
+        "type": "cut-sphere",
+        "args": {
+          "radius": 0.5,
+          "h": 0.09999999999999998
+        },
+        "transform": {
+          "translate": [0, 0.85, 0]
+        },
+        "material": "porcelain"
+      },
+      {
+        "id": "liq3",
+        "type": "sphere-fill-3d",
+        "args": {
+          "levels": [0.8],
+          "radius": 0.5,
+          "cage": false,
+          "fillScale": 1
+        },
+        "transform": {
+          "translate": [1.3999999999999995, 0.85, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.72,
+          "metal": 0.3,
+          "glow": 0
+        }
+      },
+      {
+        "id": "emp3",
+        "type": "cut-sphere",
+        "args": {
+          "radius": 0.5,
+          "h": 0.30000000000000004
+        },
+        "transform": {
+          "translate": [1.3999999999999995, 0.85, 0]
+        },
+        "material": "porcelain"
+      },
+      {
+        "id": "liq4",
+        "type": "sphere-fill-3d",
+        "args": {
+          "levels": [1],
+          "radius": 0.5,
+          "cage": false,
+          "fillScale": 1
+        },
+        "transform": {
+          "translate": [2.8, 0.85, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.72,
+          "metal": 0.3,
+          "glow": 0
+        }
+      }
+    ],
+    "defaults": {
+      "camera": {
+        "yaw": 0.5,
+        "pitch": 0.28,
+        "distance": 10,
+        "focal": 1.5,
+        "targetX": 0,
+        "targetY": 0.85,
+        "targetZ": 0
+      },
+      "light": {
+        "azimuth": 0.6,
+        "altitude": 0.55,
+        "distance": 25,
+        "intensity": 1.2
+      },
+      "shadow": {
+        "enabled": true,
+        "mode": "darken",
+        "strength": 0.4
+      }
+    }
+  },
+  "meta": {
+    "generatedAt": "2026-06-21",
+    "model": "vision-authored",
+    "pattern": "sequence",
+    "costUSD": 0
+  }
+}

--- a/sdf-js/examples/compositor/demo-lifts/fill-slide-20.json
+++ b/sdf-js/examples/compositor/demo-lifts/fill-slide-20.json
@@ -1,0 +1,352 @@
+{
+  "id": "fill-slide-20",
+  "title": "Fill Levels · Grid 2×5",
+  "prompt": "list: Two rows of five fill spheres at mixed levels.",
+  "code2d": "// vision-authored from PDF slide (D0961 3D Spheres Fill Levels).",
+  "sceneData": {
+    "v": 1,
+    "name": "list: Fill Levels · Grid 2×5",
+    "source": {
+      "format": "vision-authored",
+      "prompt": "Two rows of five fill spheres at mixed levels."
+    },
+    "subjects": [
+      {
+        "id": "liq0",
+        "type": "sphere-fill-3d",
+        "args": {
+          "levels": [0.1],
+          "radius": 0.4,
+          "cage": false,
+          "fillScale": 1
+        },
+        "transform": {
+          "translate": [-2.3, 1.6, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.72,
+          "metal": 0.3,
+          "glow": 0
+        }
+      },
+      {
+        "id": "emp0",
+        "type": "cut-sphere",
+        "args": {
+          "radius": 0.4,
+          "h": -0.32000000000000006
+        },
+        "transform": {
+          "translate": [-2.3, 1.6, 0]
+        },
+        "material": "porcelain"
+      },
+      {
+        "id": "liq1",
+        "type": "sphere-fill-3d",
+        "args": {
+          "levels": [0.3],
+          "radius": 0.4,
+          "cage": false,
+          "fillScale": 1
+        },
+        "transform": {
+          "translate": [-1.15, 1.6, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.72,
+          "metal": 0.3,
+          "glow": 0
+        }
+      },
+      {
+        "id": "emp1",
+        "type": "cut-sphere",
+        "args": {
+          "radius": 0.4,
+          "h": -0.16000000000000003
+        },
+        "transform": {
+          "translate": [-1.15, 1.6, 0]
+        },
+        "material": "porcelain"
+      },
+      {
+        "id": "liq2",
+        "type": "sphere-fill-3d",
+        "args": {
+          "levels": [0.5],
+          "radius": 0.4,
+          "cage": false,
+          "fillScale": 1
+        },
+        "transform": {
+          "translate": [0, 1.6, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.72,
+          "metal": 0.3,
+          "glow": 0
+        }
+      },
+      {
+        "id": "emp2",
+        "type": "cut-sphere",
+        "args": {
+          "radius": 0.4,
+          "h": 0
+        },
+        "transform": {
+          "translate": [0, 1.6, 0]
+        },
+        "material": "porcelain"
+      },
+      {
+        "id": "liq3",
+        "type": "sphere-fill-3d",
+        "args": {
+          "levels": [0.7],
+          "radius": 0.4,
+          "cage": false,
+          "fillScale": 1
+        },
+        "transform": {
+          "translate": [1.15, 1.6, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.72,
+          "metal": 0.3,
+          "glow": 0
+        }
+      },
+      {
+        "id": "emp3",
+        "type": "cut-sphere",
+        "args": {
+          "radius": 0.4,
+          "h": 0.15999999999999998
+        },
+        "transform": {
+          "translate": [1.15, 1.6, 0]
+        },
+        "material": "porcelain"
+      },
+      {
+        "id": "liq4",
+        "type": "sphere-fill-3d",
+        "args": {
+          "levels": [0.9],
+          "radius": 0.4,
+          "cage": false,
+          "fillScale": 1
+        },
+        "transform": {
+          "translate": [2.3, 1.6, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.72,
+          "metal": 0.3,
+          "glow": 0
+        }
+      },
+      {
+        "id": "emp4",
+        "type": "cut-sphere",
+        "args": {
+          "radius": 0.4,
+          "h": 0.32000000000000006
+        },
+        "transform": {
+          "translate": [2.3, 1.6, 0]
+        },
+        "material": "porcelain"
+      },
+      {
+        "id": "liq5",
+        "type": "sphere-fill-3d",
+        "args": {
+          "levels": [0.2],
+          "radius": 0.4,
+          "cage": false,
+          "fillScale": 1
+        },
+        "transform": {
+          "translate": [-2.3, 0.30000000000000004, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.72,
+          "metal": 0.3,
+          "glow": 0
+        }
+      },
+      {
+        "id": "emp5",
+        "type": "cut-sphere",
+        "args": {
+          "radius": 0.4,
+          "h": -0.24
+        },
+        "transform": {
+          "translate": [-2.3, 0.30000000000000004, 0]
+        },
+        "material": "porcelain"
+      },
+      {
+        "id": "liq6",
+        "type": "sphere-fill-3d",
+        "args": {
+          "levels": [0.45],
+          "radius": 0.4,
+          "cage": false,
+          "fillScale": 1
+        },
+        "transform": {
+          "translate": [-1.15, 0.30000000000000004, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.72,
+          "metal": 0.3,
+          "glow": 0
+        }
+      },
+      {
+        "id": "emp6",
+        "type": "cut-sphere",
+        "args": {
+          "radius": 0.4,
+          "h": -0.039999999999999994
+        },
+        "transform": {
+          "translate": [-1.15, 0.30000000000000004, 0]
+        },
+        "material": "porcelain"
+      },
+      {
+        "id": "liq7",
+        "type": "sphere-fill-3d",
+        "args": {
+          "levels": [0.65],
+          "radius": 0.4,
+          "cage": false,
+          "fillScale": 1
+        },
+        "transform": {
+          "translate": [0, 0.30000000000000004, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.72,
+          "metal": 0.3,
+          "glow": 0
+        }
+      },
+      {
+        "id": "emp7",
+        "type": "cut-sphere",
+        "args": {
+          "radius": 0.4,
+          "h": 0.12000000000000002
+        },
+        "transform": {
+          "translate": [0, 0.30000000000000004, 0]
+        },
+        "material": "porcelain"
+      },
+      {
+        "id": "liq8",
+        "type": "sphere-fill-3d",
+        "args": {
+          "levels": [0.8],
+          "radius": 0.4,
+          "cage": false,
+          "fillScale": 1
+        },
+        "transform": {
+          "translate": [1.15, 0.30000000000000004, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.72,
+          "metal": 0.3,
+          "glow": 0
+        }
+      },
+      {
+        "id": "emp8",
+        "type": "cut-sphere",
+        "args": {
+          "radius": 0.4,
+          "h": 0.24000000000000005
+        },
+        "transform": {
+          "translate": [1.15, 0.30000000000000004, 0]
+        },
+        "material": "porcelain"
+      },
+      {
+        "id": "liq9",
+        "type": "sphere-fill-3d",
+        "args": {
+          "levels": [1],
+          "radius": 0.4,
+          "cage": false,
+          "fillScale": 1
+        },
+        "transform": {
+          "translate": [2.3, 0.30000000000000004, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.72,
+          "metal": 0.3,
+          "glow": 0
+        }
+      }
+    ],
+    "defaults": {
+      "camera": {
+        "yaw": 0.5,
+        "pitch": 0.28,
+        "distance": 10,
+        "focal": 1.5,
+        "targetX": 0,
+        "targetY": 0.9500000000000004,
+        "targetZ": 0
+      },
+      "light": {
+        "azimuth": 0.6,
+        "altitude": 0.55,
+        "distance": 25,
+        "intensity": 1.2
+      },
+      "shadow": {
+        "enabled": true,
+        "mode": "darken",
+        "strength": 0.4
+      }
+    }
+  },
+  "meta": {
+    "generatedAt": "2026-06-21",
+    "model": "vision-authored",
+    "pattern": "list",
+    "costUSD": 0
+  }
+}

--- a/sdf-js/examples/compositor/demo-lifts/index.json
+++ b/sdf-js/examples/compositor/demo-lifts/index.json
@@ -528,6 +528,336 @@
       "file": "puzzle-piece-3d.json",
       "renderer": "studio",
       "prompt": "Shape · Puzzle Piece"
+    },
+    {
+      "id": "fill-slide-01",
+      "title": "Fill Levels · Cover (20/40/80)",
+      "thesisPoint": "Vision-authored lift of PDF chart slide (D0961 3D Spheres Fill Levels) — sphere-fill-3d atom, studio auto-framed.",
+      "category": "presentation-slide",
+      "status": "ready",
+      "file": "fill-slide-01.json",
+      "renderer": "studio",
+      "prompt": "Fill Levels · Cover (20/40/80)"
+    },
+    {
+      "id": "fill-slide-02",
+      "title": "Fill Levels · Row of 4",
+      "thesisPoint": "Vision-authored lift of PDF chart slide (D0961 3D Spheres Fill Levels) — sphere-fill-3d atom, studio auto-framed.",
+      "category": "presentation-slide",
+      "status": "ready",
+      "file": "fill-slide-02.json",
+      "renderer": "studio",
+      "prompt": "Fill Levels · Row of 4"
+    },
+    {
+      "id": "fill-slide-06",
+      "title": "Fill Levels · Cluster of 5",
+      "thesisPoint": "Vision-authored lift of PDF chart slide (D0961 3D Spheres Fill Levels) — sphere-fill-3d atom, studio auto-framed.",
+      "category": "presentation-slide",
+      "status": "ready",
+      "file": "fill-slide-06.json",
+      "renderer": "studio",
+      "prompt": "Fill Levels · Cluster of 5"
+    },
+    {
+      "id": "fill-slide-03",
+      "title": "Fill Levels · Framed row + arrows (10/60/50)",
+      "thesisPoint": "Vision-authored lift of PDF chart slide (D0961 3D Spheres Fill Levels) — two-tone fill spheres, studio auto-framed.",
+      "category": "presentation-slide",
+      "status": "ready",
+      "file": "fill-slide-03.json",
+      "renderer": "studio",
+      "prompt": "Fill Levels · Framed row + arrows (10/60/50)"
+    },
+    {
+      "id": "fill-slide-04",
+      "title": "Fill Levels · Hero 60%",
+      "thesisPoint": "Vision-authored lift of PDF chart slide (D0961 3D Spheres Fill Levels) — two-tone fill spheres, studio auto-framed.",
+      "category": "presentation-slide",
+      "status": "ready",
+      "file": "fill-slide-04.json",
+      "renderer": "studio",
+      "prompt": "Fill Levels · Hero 60%"
+    },
+    {
+      "id": "fill-slide-05",
+      "title": "Fill Levels · Hero 100% + legend",
+      "thesisPoint": "Vision-authored lift of PDF chart slide (D0961 3D Spheres Fill Levels) — two-tone fill spheres, studio auto-framed.",
+      "category": "presentation-slide",
+      "status": "ready",
+      "file": "fill-slide-05.json",
+      "renderer": "studio",
+      "prompt": "Fill Levels · Hero 100% + legend"
+    },
+    {
+      "id": "fill-slide-07",
+      "title": "Fill Levels · Row of 3 (50/100/80)",
+      "thesisPoint": "Vision-authored lift of PDF chart slide (D0961 3D Spheres Fill Levels) — two-tone fill spheres, studio auto-framed.",
+      "category": "presentation-slide",
+      "status": "ready",
+      "file": "fill-slide-07.json",
+      "renderer": "studio",
+      "prompt": "Fill Levels · Row of 3 (50/100/80)"
+    },
+    {
+      "id": "fill-slide-08",
+      "title": "Fill Levels · Cluster of 3 (60/50/80)",
+      "thesisPoint": "Vision-authored lift of PDF chart slide (D0961 3D Spheres Fill Levels) — two-tone fill spheres, studio auto-framed.",
+      "category": "presentation-slide",
+      "status": "ready",
+      "file": "fill-slide-08.json",
+      "renderer": "studio",
+      "prompt": "Fill Levels · Cluster of 3 (60/50/80)"
+    },
+    {
+      "id": "fill-slide-09",
+      "title": "Fill Levels · Row of 5 (10..90)",
+      "thesisPoint": "Vision-authored lift of PDF chart slide (D0961 3D Spheres Fill Levels) — two-tone fill spheres, studio auto-framed.",
+      "category": "presentation-slide",
+      "status": "ready",
+      "file": "fill-slide-09.json",
+      "renderer": "studio",
+      "prompt": "Fill Levels · Row of 5 (10..90)"
+    },
+    {
+      "id": "fill-slide-10",
+      "title": "Fill Levels · Grid of 6 (framed)",
+      "thesisPoint": "Vision-authored lift of PDF chart slide (D0961 3D Spheres Fill Levels) — two-tone fill spheres, studio auto-framed.",
+      "category": "presentation-slide",
+      "status": "ready",
+      "file": "fill-slide-10.json",
+      "renderer": "studio",
+      "prompt": "Fill Levels · Grid of 6 (framed)"
+    },
+    {
+      "id": "fill-slide-11",
+      "title": "Fill Levels · Hero 30% + list",
+      "thesisPoint": "Vision-authored lift of PDF chart slide (D0961 3D Spheres Fill Levels) — two-tone fill spheres, studio auto-framed.",
+      "category": "presentation-slide",
+      "status": "ready",
+      "file": "fill-slide-11.json",
+      "renderer": "studio",
+      "prompt": "Fill Levels · Hero 30% + list"
+    },
+    {
+      "id": "fill-slide-12",
+      "title": "Fill Levels · Row of 5 + captions",
+      "thesisPoint": "Vision-authored lift of PDF chart slide (D0961 3D Spheres Fill Levels) — two-tone fill spheres, studio auto-framed.",
+      "category": "presentation-slide",
+      "status": "ready",
+      "file": "fill-slide-12.json",
+      "renderer": "studio",
+      "prompt": "Fill Levels · Row of 5 + captions"
+    },
+    {
+      "id": "fill-slide-13",
+      "title": "Fill Levels · Hero 90% + list",
+      "thesisPoint": "Vision-authored lift of PDF chart slide (D0961 3D Spheres Fill Levels) — two-tone fill spheres, studio auto-framed.",
+      "category": "presentation-slide",
+      "status": "ready",
+      "file": "fill-slide-13.json",
+      "renderer": "studio",
+      "prompt": "Fill Levels · Hero 90% + list"
+    },
+    {
+      "id": "fill-slide-14",
+      "title": "Fill Levels · Bullet list of 4",
+      "thesisPoint": "Vision-authored lift of PDF chart slide (D0961 3D Spheres Fill Levels) — two-tone fill spheres, studio auto-framed.",
+      "category": "presentation-slide",
+      "status": "ready",
+      "file": "fill-slide-14.json",
+      "renderer": "studio",
+      "prompt": "Fill Levels · Bullet list of 4"
+    },
+    {
+      "id": "fill-slide-15",
+      "title": "Fill Levels · Hero 100% + 4 labels",
+      "thesisPoint": "Vision-authored lift of PDF chart slide (D0961 3D Spheres Fill Levels) — two-tone fill spheres, studio auto-framed.",
+      "category": "presentation-slide",
+      "status": "ready",
+      "file": "fill-slide-15.json",
+      "renderer": "studio",
+      "prompt": "Fill Levels · Hero 100% + 4 labels"
+    },
+    {
+      "id": "fill-slide-16",
+      "title": "Fill Levels · Vertical 3 (30/80/70)",
+      "thesisPoint": "Vision-authored lift of PDF chart slide (D0961 3D Spheres Fill Levels) — two-tone fill spheres, studio auto-framed.",
+      "category": "presentation-slide",
+      "status": "ready",
+      "file": "fill-slide-16.json",
+      "renderer": "studio",
+      "prompt": "Fill Levels · Vertical 3 (30/80/70)"
+    },
+    {
+      "id": "fill-slide-17",
+      "title": "Fill Levels · Two heroes (80/90)",
+      "thesisPoint": "Vision-authored lift of PDF chart slide (D0961 3D Spheres Fill Levels) — two-tone fill spheres, studio auto-framed.",
+      "category": "presentation-slide",
+      "status": "ready",
+      "file": "fill-slide-17.json",
+      "renderer": "studio",
+      "prompt": "Fill Levels · Two heroes (80/90)"
+    },
+    {
+      "id": "fill-slide-18",
+      "title": "Fill Levels · Progression grid 2×4",
+      "thesisPoint": "Vision-authored lift of PDF chart slide (D0961 3D Spheres Fill Levels) — two-tone fill spheres, studio auto-framed.",
+      "category": "presentation-slide",
+      "status": "ready",
+      "file": "fill-slide-18.json",
+      "renderer": "studio",
+      "prompt": "Fill Levels · Progression grid 2×4"
+    },
+    {
+      "id": "fill-slide-19",
+      "title": "Fill Levels · Row of 5 (20..100)",
+      "thesisPoint": "Vision-authored lift of PDF chart slide (D0961 3D Spheres Fill Levels) — two-tone fill spheres, studio auto-framed.",
+      "category": "presentation-slide",
+      "status": "ready",
+      "file": "fill-slide-19.json",
+      "renderer": "studio",
+      "prompt": "Fill Levels · Row of 5 (20..100)"
+    },
+    {
+      "id": "fill-slide-20",
+      "title": "Fill Levels · Grid 2×5",
+      "thesisPoint": "Vision-authored lift of PDF chart slide (D0961 3D Spheres Fill Levels) — two-tone fill spheres, studio auto-framed.",
+      "category": "presentation-slide",
+      "status": "ready",
+      "file": "fill-slide-20.json",
+      "renderer": "studio",
+      "prompt": "Fill Levels · Grid 2×5"
+    },
+    {
+      "id": "shape-gear-mechanism",
+      "title": "Gears · Meshing mechanism",
+      "thesisPoint": "Atlas shape showcase — PresentationLoad \"gear wheels\" category, quality material + composition, studio auto-framed.",
+      "category": "shape-showcase",
+      "status": "ready",
+      "file": "shape-gear-mechanism.json",
+      "renderer": "studio",
+      "prompt": "Gears · Meshing mechanism"
+    },
+    {
+      "id": "shape-gear-hero",
+      "title": "Gears · Single hero gear",
+      "thesisPoint": "Atlas shape showcase — PresentationLoad \"gear wheels\" category, quality material + composition, studio auto-framed.",
+      "category": "shape-showcase",
+      "status": "ready",
+      "file": "shape-gear-hero.json",
+      "renderer": "studio",
+      "prompt": "Gears · Single hero gear"
+    },
+    {
+      "id": "shape-arrows-cycle",
+      "title": "Arrows · Cycle (4 stage)",
+      "thesisPoint": "Atlas shape showcase — PresentationLoad \"arrows\" category, quality material + composition, studio auto-framed.",
+      "category": "shape-showcase",
+      "status": "ready",
+      "file": "shape-arrows-cycle.json",
+      "renderer": "studio",
+      "prompt": "Arrows · Cycle (4 stage)"
+    },
+    {
+      "id": "shape-arrows-row",
+      "title": "Arrows · Process row",
+      "thesisPoint": "Atlas shape showcase — PresentationLoad \"arrows\" category, quality material + composition, studio auto-framed.",
+      "category": "shape-showcase",
+      "status": "ready",
+      "file": "shape-arrows-row.json",
+      "renderer": "studio",
+      "prompt": "Arrows · Process row"
+    },
+    {
+      "id": "shape-cubes-row",
+      "title": "Cubes · Connected row",
+      "thesisPoint": "Atlas shape showcase — PresentationLoad \"cubes\" category, quality material + composition, studio auto-framed.",
+      "category": "shape-showcase",
+      "status": "ready",
+      "file": "shape-cubes-row.json",
+      "renderer": "studio",
+      "prompt": "Cubes · Connected row"
+    },
+    {
+      "id": "shape-cubes-grid",
+      "title": "Cubes · 3×3×3 grid",
+      "thesisPoint": "Atlas shape showcase — PresentationLoad \"cubes\" category, quality material + composition, studio auto-framed.",
+      "category": "shape-showcase",
+      "status": "ready",
+      "file": "shape-cubes-grid.json",
+      "renderer": "studio",
+      "prompt": "Cubes · 3×3×3 grid"
+    },
+    {
+      "id": "shape-pyramid-stepped",
+      "title": "Pyramids · Stepped 5-level",
+      "thesisPoint": "Atlas shape showcase — PresentationLoad \"pyramids\" category, quality material + composition, studio auto-framed.",
+      "category": "shape-showcase",
+      "status": "ready",
+      "file": "shape-pyramid-stepped.json",
+      "renderer": "studio",
+      "prompt": "Pyramids · Stepped 5-level"
+    },
+    {
+      "id": "shape-pyramid-smooth",
+      "title": "Pyramids · Smooth 4-level",
+      "thesisPoint": "Atlas shape showcase — PresentationLoad \"pyramids\" category, quality material + composition, studio auto-framed.",
+      "category": "shape-showcase",
+      "status": "ready",
+      "file": "shape-pyramid-smooth.json",
+      "renderer": "studio",
+      "prompt": "Pyramids · Smooth 4-level"
+    },
+    {
+      "id": "shape-puzzle-row",
+      "title": "Puzzles · Interlocking row of 4",
+      "thesisPoint": "Atlas shape showcase — PresentationLoad \"puzzles\" category, quality material + composition, studio auto-framed.",
+      "category": "shape-showcase",
+      "status": "ready",
+      "file": "shape-puzzle-row.json",
+      "renderer": "studio",
+      "prompt": "Puzzles · Interlocking row of 4"
+    },
+    {
+      "id": "shape-puzzle-pair",
+      "title": "Puzzles · Two-piece fit",
+      "thesisPoint": "Atlas shape showcase — PresentationLoad \"puzzles\" category, quality material + composition, studio auto-framed.",
+      "category": "shape-showcase",
+      "status": "ready",
+      "file": "shape-puzzle-pair.json",
+      "renderer": "studio",
+      "prompt": "Puzzles · Two-piece fit"
+    },
+    {
+      "id": "shape-circles-dial",
+      "title": "Circles · Segmented dial (6)",
+      "thesisPoint": "Atlas shape showcase — PresentationLoad \"circles\" category, quality material + composition, studio auto-framed.",
+      "category": "shape-showcase",
+      "status": "ready",
+      "file": "shape-circles-dial.json",
+      "renderer": "studio",
+      "prompt": "Circles · Segmented dial (6)"
+    },
+    {
+      "id": "shape-circles-frames",
+      "title": "Circles · Avatar frames (3)",
+      "thesisPoint": "Atlas shape showcase — PresentationLoad \"circles\" category, quality material + composition, studio auto-framed.",
+      "category": "shape-showcase",
+      "status": "ready",
+      "file": "shape-circles-frames.json",
+      "renderer": "studio",
+      "prompt": "Circles · Avatar frames (3)"
+    },
+    {
+      "id": "shape-circles-stack",
+      "title": "Circles · Tiered stack",
+      "thesisPoint": "Atlas shape showcase — PresentationLoad \"circles\" category, quality material + composition, studio auto-framed.",
+      "category": "shape-showcase",
+      "status": "ready",
+      "file": "shape-circles-stack.json",
+      "renderer": "studio",
+      "prompt": "Circles · Tiered stack"
     }
   ]
 }

--- a/sdf-js/examples/compositor/demo-lifts/shape-arrows-cycle.json
+++ b/sdf-js/examples/compositor/demo-lifts/shape-arrows-cycle.json
@@ -1,0 +1,66 @@
+{
+  "id": "shape-arrows-cycle",
+  "title": "Arrows · Cycle (4 stage)",
+  "prompt": "arrows: Arrows · Cycle (4 stage)",
+  "code2d": "// vision-authored showcase — PresentationLoad shape category \"arrows\".",
+  "sceneData": {
+    "v": 1,
+    "name": "Arrows · Cycle (4 stage)",
+    "source": {
+      "format": "vision-authored",
+      "prompt": "arrows shape showcase"
+    },
+    "subjects": [
+      {
+        "id": "s0",
+        "type": "circle-loop-3d",
+        "args": {
+          "segments": 4,
+          "radius": 0.95,
+          "tube": 0.09,
+          "headLength": 0.4,
+          "headRadius": 0.2
+        },
+        "transform": {
+          "translate": [0, 1, 0],
+          "rotate": [1.5707963267948966, 0, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.72,
+          "metal": 0.3,
+          "glow": 0
+        }
+      }
+    ],
+    "defaults": {
+      "camera": {
+        "yaw": 0.5,
+        "pitch": 0.3,
+        "distance": 10,
+        "focal": 1.5,
+        "targetX": 0,
+        "targetY": 1,
+        "targetZ": 0
+      },
+      "light": {
+        "azimuth": 0.6,
+        "altitude": 0.55,
+        "distance": 25,
+        "intensity": 1.2
+      },
+      "shadow": {
+        "enabled": true,
+        "mode": "darken",
+        "strength": 0.4
+      }
+    }
+  },
+  "meta": {
+    "generatedAt": "2026-06-21",
+    "model": "vision-authored",
+    "pattern": "arrows",
+    "costUSD": 0
+  }
+}

--- a/sdf-js/examples/compositor/demo-lifts/shape-arrows-row.json
+++ b/sdf-js/examples/compositor/demo-lifts/shape-arrows-row.json
@@ -1,0 +1,107 @@
+{
+  "id": "shape-arrows-row",
+  "title": "Arrows · Process row",
+  "prompt": "arrows: Arrows · Process row",
+  "code2d": "// vision-authored showcase — PresentationLoad shape category \"arrows\".",
+  "sceneData": {
+    "v": 1,
+    "name": "Arrows · Process row",
+    "source": {
+      "format": "vision-authored",
+      "prompt": "arrows shape showcase"
+    },
+    "subjects": [
+      {
+        "id": "s0",
+        "type": "arrow-3d",
+        "args": {
+          "length": 1.3,
+          "shaftWidth": 0.26,
+          "headLength": 0.5,
+          "headWidth": 0.66,
+          "depth": 0.3
+        },
+        "transform": {
+          "translate": [-1.5, 0.9, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.72,
+          "metal": 0.3,
+          "glow": 0
+        }
+      },
+      {
+        "id": "s1",
+        "type": "arrow-3d",
+        "args": {
+          "length": 1.3,
+          "shaftWidth": 0.26,
+          "headLength": 0.5,
+          "headWidth": 0.66,
+          "depth": 0.3
+        },
+        "transform": {
+          "translate": [0, 0.9, 0]
+        },
+        "material": {
+          "hue": 0.48,
+          "sat": 0.7,
+          "value": 0.7,
+          "metal": 0.25,
+          "glow": 0
+        }
+      },
+      {
+        "id": "s2",
+        "type": "arrow-3d",
+        "args": {
+          "length": 1.3,
+          "shaftWidth": 0.26,
+          "headLength": 0.5,
+          "headWidth": 0.66,
+          "depth": 0.3
+        },
+        "transform": {
+          "translate": [1.5, 0.9, 0]
+        },
+        "material": {
+          "hue": 0.07,
+          "sat": 0.88,
+          "value": 0.88,
+          "metal": 0.2,
+          "glow": 0
+        }
+      }
+    ],
+    "defaults": {
+      "camera": {
+        "yaw": 0.5,
+        "pitch": 0.3,
+        "distance": 10,
+        "focal": 1.5,
+        "targetX": 0,
+        "targetY": 0.9,
+        "targetZ": 0
+      },
+      "light": {
+        "azimuth": 0.6,
+        "altitude": 0.55,
+        "distance": 25,
+        "intensity": 1.2
+      },
+      "shadow": {
+        "enabled": true,
+        "mode": "darken",
+        "strength": 0.4
+      }
+    }
+  },
+  "meta": {
+    "generatedAt": "2026-06-21",
+    "model": "vision-authored",
+    "pattern": "arrows",
+    "costUSD": 0
+  }
+}

--- a/sdf-js/examples/compositor/demo-lifts/shape-circles-dial.json
+++ b/sdf-js/examples/compositor/demo-lifts/shape-circles-dial.json
@@ -1,0 +1,66 @@
+{
+  "id": "shape-circles-dial",
+  "title": "Circles · Segmented dial (6)",
+  "prompt": "circles: Circles · Segmented dial (6)",
+  "code2d": "// vision-authored showcase — PresentationLoad shape category \"circles\".",
+  "sceneData": {
+    "v": 1,
+    "name": "Circles · Segmented dial (6)",
+    "source": {
+      "format": "vision-authored",
+      "prompt": "circles shape showcase"
+    },
+    "subjects": [
+      {
+        "id": "s0",
+        "type": "circle-segmented-3d",
+        "args": {
+          "segments": 6,
+          "radius": 1,
+          "innerRatio": 0.5,
+          "thickness": 0.26,
+          "gapWidth": 0.14
+        },
+        "transform": {
+          "translate": [0, 1, 0],
+          "rotate": [1.5707963267948966, 0, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.72,
+          "metal": 0.3,
+          "glow": 0
+        }
+      }
+    ],
+    "defaults": {
+      "camera": {
+        "yaw": 0.5,
+        "pitch": 0.3,
+        "distance": 10,
+        "focal": 1.5,
+        "targetX": 0,
+        "targetY": 1,
+        "targetZ": 0
+      },
+      "light": {
+        "azimuth": 0.6,
+        "altitude": 0.55,
+        "distance": 25,
+        "intensity": 1.2
+      },
+      "shadow": {
+        "enabled": true,
+        "mode": "darken",
+        "strength": 0.4
+      }
+    }
+  },
+  "meta": {
+    "generatedAt": "2026-06-21",
+    "model": "vision-authored",
+    "pattern": "circles",
+    "costUSD": 0
+  }
+}

--- a/sdf-js/examples/compositor/demo-lifts/shape-circles-frames.json
+++ b/sdf-js/examples/compositor/demo-lifts/shape-circles-frames.json
@@ -1,0 +1,101 @@
+{
+  "id": "shape-circles-frames",
+  "title": "Circles · Avatar frames (3)",
+  "prompt": "circles: Circles · Avatar frames (3)",
+  "code2d": "// vision-authored showcase — PresentationLoad shape category \"circles\".",
+  "sceneData": {
+    "v": 1,
+    "name": "Circles · Avatar frames (3)",
+    "source": {
+      "format": "vision-authored",
+      "prompt": "circles shape showcase"
+    },
+    "subjects": [
+      {
+        "id": "s0",
+        "type": "circle-frame-3d",
+        "args": {
+          "radius": 0.62,
+          "frameWidth": 0.14,
+          "backDepth": 0.08
+        },
+        "transform": {
+          "translate": [-1.5, 1, 0]
+        },
+        "material": {
+          "hue": 0.6,
+          "sat": 0.04,
+          "value": 0.62,
+          "metal": 0.95,
+          "glow": 0
+        }
+      },
+      {
+        "id": "s1",
+        "type": "circle-frame-3d",
+        "args": {
+          "radius": 0.62,
+          "frameWidth": 0.14,
+          "backDepth": 0.08
+        },
+        "transform": {
+          "translate": [0, 1, 0]
+        },
+        "material": {
+          "hue": 0.13,
+          "sat": 0.85,
+          "value": 0.9,
+          "metal": 0.95,
+          "glow": 0
+        }
+      },
+      {
+        "id": "s2",
+        "type": "circle-frame-3d",
+        "args": {
+          "radius": 0.62,
+          "frameWidth": 0.14,
+          "backDepth": 0.08
+        },
+        "transform": {
+          "translate": [1.5, 1, 0]
+        },
+        "material": {
+          "hue": 0.6,
+          "sat": 0.04,
+          "value": 0.62,
+          "metal": 0.95,
+          "glow": 0
+        }
+      }
+    ],
+    "defaults": {
+      "camera": {
+        "yaw": 0.5,
+        "pitch": 0.3,
+        "distance": 10,
+        "focal": 1.5,
+        "targetX": 0,
+        "targetY": 1,
+        "targetZ": 0
+      },
+      "light": {
+        "azimuth": 0.6,
+        "altitude": 0.55,
+        "distance": 25,
+        "intensity": 1.2
+      },
+      "shadow": {
+        "enabled": true,
+        "mode": "darken",
+        "strength": 0.4
+      }
+    }
+  },
+  "meta": {
+    "generatedAt": "2026-06-21",
+    "model": "vision-authored",
+    "pattern": "circles",
+    "costUSD": 0
+  }
+}

--- a/sdf-js/examples/compositor/demo-lifts/shape-circles-stack.json
+++ b/sdf-js/examples/compositor/demo-lifts/shape-circles-stack.json
@@ -1,0 +1,65 @@
+{
+  "id": "shape-circles-stack",
+  "title": "Circles · Tiered stack",
+  "prompt": "circles: Circles · Tiered stack",
+  "code2d": "// vision-authored showcase — PresentationLoad shape category \"circles\".",
+  "sceneData": {
+    "v": 1,
+    "name": "Circles · Tiered stack",
+    "source": {
+      "format": "vision-authored",
+      "prompt": "circles shape showcase"
+    },
+    "subjects": [
+      {
+        "id": "s0",
+        "type": "circle-stack-3d",
+        "args": {
+          "count": 4,
+          "radius": 0.85,
+          "taper": 0.8,
+          "diskHeight": 0.2,
+          "gap": 0.1
+        },
+        "transform": {
+          "translate": [0, 0.5, 0]
+        },
+        "material": {
+          "hue": 0.48,
+          "sat": 0.7,
+          "value": 0.7,
+          "metal": 0.25,
+          "glow": 0
+        }
+      }
+    ],
+    "defaults": {
+      "camera": {
+        "yaw": 0.5,
+        "pitch": 0.3,
+        "distance": 10,
+        "focal": 1.5,
+        "targetX": 0,
+        "targetY": 0.5,
+        "targetZ": 0
+      },
+      "light": {
+        "azimuth": 0.6,
+        "altitude": 0.55,
+        "distance": 25,
+        "intensity": 1.2
+      },
+      "shadow": {
+        "enabled": true,
+        "mode": "darken",
+        "strength": 0.4
+      }
+    }
+  },
+  "meta": {
+    "generatedAt": "2026-06-21",
+    "model": "vision-authored",
+    "pattern": "circles",
+    "costUSD": 0
+  }
+}

--- a/sdf-js/examples/compositor/demo-lifts/shape-cubes-grid.json
+++ b/sdf-js/examples/compositor/demo-lifts/shape-cubes-grid.json
@@ -1,0 +1,64 @@
+{
+  "id": "shape-cubes-grid",
+  "title": "Cubes · 3×3×3 grid",
+  "prompt": "cubes: Cubes · 3×3×3 grid",
+  "code2d": "// vision-authored showcase — PresentationLoad shape category \"cubes\".",
+  "sceneData": {
+    "v": 1,
+    "name": "Cubes · 3×3×3 grid",
+    "source": {
+      "format": "vision-authored",
+      "prompt": "cubes shape showcase"
+    },
+    "subjects": [
+      {
+        "id": "s0",
+        "type": "cube-3d",
+        "args": {
+          "count": 27,
+          "arrangement": "grid3d",
+          "cubeSize": 0.42,
+          "spacing": 0.12
+        },
+        "transform": {
+          "translate": [0, 1, 0]
+        },
+        "material": {
+          "hue": 0.6,
+          "sat": 0.02,
+          "value": 0.82,
+          "metal": 0.98,
+          "glow": 0
+        }
+      }
+    ],
+    "defaults": {
+      "camera": {
+        "yaw": 0.5,
+        "pitch": 0.3,
+        "distance": 10,
+        "focal": 1.5,
+        "targetX": 0,
+        "targetY": 1,
+        "targetZ": 0
+      },
+      "light": {
+        "azimuth": 0.6,
+        "altitude": 0.55,
+        "distance": 25,
+        "intensity": 1.2
+      },
+      "shadow": {
+        "enabled": true,
+        "mode": "darken",
+        "strength": 0.4
+      }
+    }
+  },
+  "meta": {
+    "generatedAt": "2026-06-21",
+    "model": "vision-authored",
+    "pattern": "cubes",
+    "costUSD": 0
+  }
+}

--- a/sdf-js/examples/compositor/demo-lifts/shape-cubes-row.json
+++ b/sdf-js/examples/compositor/demo-lifts/shape-cubes-row.json
@@ -1,0 +1,65 @@
+{
+  "id": "shape-cubes-row",
+  "title": "Cubes · Connected row",
+  "prompt": "cubes: Cubes · Connected row",
+  "code2d": "// vision-authored showcase — PresentationLoad shape category \"cubes\".",
+  "sceneData": {
+    "v": 1,
+    "name": "Cubes · Connected row",
+    "source": {
+      "format": "vision-authored",
+      "prompt": "cubes shape showcase"
+    },
+    "subjects": [
+      {
+        "id": "s0",
+        "type": "cube-3d",
+        "args": {
+          "count": 4,
+          "arrangement": "row",
+          "cubeSize": 0.62,
+          "spacing": 0.5,
+          "connector": "pipe-through"
+        },
+        "transform": {
+          "translate": [0, 0.6, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.72,
+          "metal": 0.3,
+          "glow": 0
+        }
+      }
+    ],
+    "defaults": {
+      "camera": {
+        "yaw": 0.5,
+        "pitch": 0.3,
+        "distance": 10,
+        "focal": 1.5,
+        "targetX": 0,
+        "targetY": 0.6,
+        "targetZ": 0
+      },
+      "light": {
+        "azimuth": 0.6,
+        "altitude": 0.55,
+        "distance": 25,
+        "intensity": 1.2
+      },
+      "shadow": {
+        "enabled": true,
+        "mode": "darken",
+        "strength": 0.4
+      }
+    }
+  },
+  "meta": {
+    "generatedAt": "2026-06-21",
+    "model": "vision-authored",
+    "pattern": "cubes",
+    "costUSD": 0
+  }
+}

--- a/sdf-js/examples/compositor/demo-lifts/shape-gear-hero.json
+++ b/sdf-js/examples/compositor/demo-lifts/shape-gear-hero.json
@@ -1,0 +1,67 @@
+{
+  "id": "shape-gear-hero",
+  "title": "Gears · Single hero gear",
+  "prompt": "gear wheels: Gears · Single hero gear",
+  "code2d": "// vision-authored showcase — PresentationLoad shape category \"gear wheels\".",
+  "sceneData": {
+    "v": 1,
+    "name": "Gears · Single hero gear",
+    "source": {
+      "format": "vision-authored",
+      "prompt": "gear wheels shape showcase"
+    },
+    "subjects": [
+      {
+        "id": "s0",
+        "type": "gear-3d",
+        "args": {
+          "teeth": 18,
+          "radius": 1.1,
+          "thickness": 0.34,
+          "toothDepth": 0.2,
+          "toothWidth": 0.2,
+          "holeRadius": 0.4
+        },
+        "transform": {
+          "translate": [0, 1, 0],
+          "rotate": [1.5707963267948966, 0, 0]
+        },
+        "material": {
+          "hue": 0.6,
+          "sat": 0.02,
+          "value": 0.82,
+          "metal": 0.98,
+          "glow": 0
+        }
+      }
+    ],
+    "defaults": {
+      "camera": {
+        "yaw": 0.5,
+        "pitch": 0.3,
+        "distance": 10,
+        "focal": 1.5,
+        "targetX": 0,
+        "targetY": 1,
+        "targetZ": 0
+      },
+      "light": {
+        "azimuth": 0.6,
+        "altitude": 0.55,
+        "distance": 25,
+        "intensity": 1.2
+      },
+      "shadow": {
+        "enabled": true,
+        "mode": "darken",
+        "strength": 0.4
+      }
+    }
+  },
+  "meta": {
+    "generatedAt": "2026-06-21",
+    "model": "vision-authored",
+    "pattern": "gear wheels",
+    "costUSD": 0
+  }
+}

--- a/sdf-js/examples/compositor/demo-lifts/shape-gear-mechanism.json
+++ b/sdf-js/examples/compositor/demo-lifts/shape-gear-mechanism.json
@@ -1,0 +1,113 @@
+{
+  "id": "shape-gear-mechanism",
+  "title": "Gears · Meshing mechanism",
+  "prompt": "gear wheels: Gears · Meshing mechanism",
+  "code2d": "// vision-authored showcase — PresentationLoad shape category \"gear wheels\".",
+  "sceneData": {
+    "v": 1,
+    "name": "Gears · Meshing mechanism",
+    "source": {
+      "format": "vision-authored",
+      "prompt": "gear wheels shape showcase"
+    },
+    "subjects": [
+      {
+        "id": "s0",
+        "type": "gear-3d",
+        "args": {
+          "teeth": 16,
+          "radius": 0.95,
+          "thickness": 0.3,
+          "toothDepth": 0.18,
+          "toothWidth": 0.2,
+          "holeRadius": 0.32
+        },
+        "transform": {
+          "translate": [0, 1, 0],
+          "rotate": [1.5707963267948966, 0, 0]
+        },
+        "material": {
+          "hue": 0.6,
+          "sat": 0.04,
+          "value": 0.62,
+          "metal": 0.95,
+          "glow": 0
+        }
+      },
+      {
+        "id": "s1",
+        "type": "gear-3d",
+        "args": {
+          "teeth": 11,
+          "radius": 0.66,
+          "thickness": 0.3,
+          "toothDepth": 0.16,
+          "toothWidth": 0.18,
+          "holeRadius": 0.24
+        },
+        "transform": {
+          "translate": [1.5, 1.55, 0],
+          "rotate": [1.5707963267948966, 0, 0]
+        },
+        "material": {
+          "hue": 0.13,
+          "sat": 0.85,
+          "value": 0.9,
+          "metal": 0.95,
+          "glow": 0
+        }
+      },
+      {
+        "id": "s2",
+        "type": "gear-3d",
+        "args": {
+          "teeth": 9,
+          "radius": 0.55,
+          "thickness": 0.3,
+          "toothDepth": 0.15,
+          "toothWidth": 0.17,
+          "holeRadius": 0.2
+        },
+        "transform": {
+          "translate": [-1.2, 0.45, 0],
+          "rotate": [1.5707963267948966, 0, 0]
+        },
+        "material": {
+          "hue": 0.06,
+          "sat": 0.7,
+          "value": 0.62,
+          "metal": 0.9,
+          "glow": 0
+        }
+      }
+    ],
+    "defaults": {
+      "camera": {
+        "yaw": 0.5,
+        "pitch": 0.3,
+        "distance": 10,
+        "focal": 1.5,
+        "targetX": 0,
+        "targetY": 1,
+        "targetZ": 0
+      },
+      "light": {
+        "azimuth": 0.6,
+        "altitude": 0.55,
+        "distance": 25,
+        "intensity": 1.2
+      },
+      "shadow": {
+        "enabled": true,
+        "mode": "darken",
+        "strength": 0.4
+      }
+    }
+  },
+  "meta": {
+    "generatedAt": "2026-06-21",
+    "model": "vision-authored",
+    "pattern": "gear wheels",
+    "costUSD": 0
+  }
+}

--- a/sdf-js/examples/compositor/demo-lifts/shape-puzzle-pair.json
+++ b/sdf-js/examples/compositor/demo-lifts/shape-puzzle-pair.json
@@ -1,0 +1,82 @@
+{
+  "id": "shape-puzzle-pair",
+  "title": "Puzzles · Two-piece fit",
+  "prompt": "puzzles: Puzzles · Two-piece fit",
+  "code2d": "// vision-authored showcase — PresentationLoad shape category \"puzzles\".",
+  "sceneData": {
+    "v": 1,
+    "name": "Puzzles · Two-piece fit",
+    "source": {
+      "format": "vision-authored",
+      "prompt": "puzzles shape showcase"
+    },
+    "subjects": [
+      {
+        "id": "s0",
+        "type": "puzzle-piece-3d",
+        "args": {
+          "size": 1.3,
+          "depth": 0.36,
+          "knob": 0.3
+        },
+        "transform": {
+          "translate": [-0.65, 0.95, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.72,
+          "metal": 0.3,
+          "glow": 0
+        }
+      },
+      {
+        "id": "s1",
+        "type": "puzzle-piece-3d",
+        "args": {
+          "size": 1.3,
+          "depth": 0.36,
+          "knob": 0.3
+        },
+        "transform": {
+          "translate": [0.65, 0.95, 0]
+        },
+        "material": {
+          "hue": 0.13,
+          "sat": 0.85,
+          "value": 0.9,
+          "metal": 0.95,
+          "glow": 0
+        }
+      }
+    ],
+    "defaults": {
+      "camera": {
+        "yaw": 0.5,
+        "pitch": 0.3,
+        "distance": 10,
+        "focal": 1.5,
+        "targetX": 0,
+        "targetY": 0.95,
+        "targetZ": 0
+      },
+      "light": {
+        "azimuth": 0.6,
+        "altitude": 0.55,
+        "distance": 25,
+        "intensity": 1.2
+      },
+      "shadow": {
+        "enabled": true,
+        "mode": "darken",
+        "strength": 0.4
+      }
+    }
+  },
+  "meta": {
+    "generatedAt": "2026-06-21",
+    "model": "vision-authored",
+    "pattern": "puzzles",
+    "costUSD": 0
+  }
+}

--- a/sdf-js/examples/compositor/demo-lifts/shape-puzzle-row.json
+++ b/sdf-js/examples/compositor/demo-lifts/shape-puzzle-row.json
@@ -1,0 +1,120 @@
+{
+  "id": "shape-puzzle-row",
+  "title": "Puzzles · Interlocking row of 4",
+  "prompt": "puzzles: Puzzles · Interlocking row of 4",
+  "code2d": "// vision-authored showcase — PresentationLoad shape category \"puzzles\".",
+  "sceneData": {
+    "v": 1,
+    "name": "Puzzles · Interlocking row of 4",
+    "source": {
+      "format": "vision-authored",
+      "prompt": "puzzles shape showcase"
+    },
+    "subjects": [
+      {
+        "id": "s0",
+        "type": "puzzle-piece-3d",
+        "args": {
+          "size": 1,
+          "depth": 0.3,
+          "knob": 0.24
+        },
+        "transform": {
+          "translate": [-1.5, 0.9, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.72,
+          "metal": 0.3,
+          "glow": 0
+        }
+      },
+      {
+        "id": "s1",
+        "type": "puzzle-piece-3d",
+        "args": {
+          "size": 1,
+          "depth": 0.3,
+          "knob": 0.24
+        },
+        "transform": {
+          "translate": [-0.5, 0.9, 0]
+        },
+        "material": {
+          "hue": 0.07,
+          "sat": 0.88,
+          "value": 0.88,
+          "metal": 0.2,
+          "glow": 0
+        }
+      },
+      {
+        "id": "s2",
+        "type": "puzzle-piece-3d",
+        "args": {
+          "size": 1,
+          "depth": 0.3,
+          "knob": 0.24
+        },
+        "transform": {
+          "translate": [0.5, 0.9, 0]
+        },
+        "material": {
+          "hue": 0.38,
+          "sat": 0.72,
+          "value": 0.62,
+          "metal": 0.2,
+          "glow": 0
+        }
+      },
+      {
+        "id": "s3",
+        "type": "puzzle-piece-3d",
+        "args": {
+          "size": 1,
+          "depth": 0.3,
+          "knob": 0.24
+        },
+        "transform": {
+          "translate": [1.5, 0.9, 0]
+        },
+        "material": {
+          "hue": 0,
+          "sat": 0.78,
+          "value": 0.7,
+          "metal": 0.2,
+          "glow": 0
+        }
+      }
+    ],
+    "defaults": {
+      "camera": {
+        "yaw": 0.5,
+        "pitch": 0.3,
+        "distance": 10,
+        "focal": 1.5,
+        "targetX": 0,
+        "targetY": 0.9,
+        "targetZ": 0
+      },
+      "light": {
+        "azimuth": 0.6,
+        "altitude": 0.55,
+        "distance": 25,
+        "intensity": 1.2
+      },
+      "shadow": {
+        "enabled": true,
+        "mode": "darken",
+        "strength": 0.4
+      }
+    }
+  },
+  "meta": {
+    "generatedAt": "2026-06-21",
+    "model": "vision-authored",
+    "pattern": "puzzles",
+    "costUSD": 0
+  }
+}

--- a/sdf-js/examples/compositor/demo-lifts/shape-pyramid-smooth.json
+++ b/sdf-js/examples/compositor/demo-lifts/shape-pyramid-smooth.json
@@ -1,0 +1,66 @@
+{
+  "id": "shape-pyramid-smooth",
+  "title": "Pyramids · Smooth 4-level",
+  "prompt": "pyramids: Pyramids · Smooth 4-level",
+  "code2d": "// vision-authored showcase — PresentationLoad shape category \"pyramids\".",
+  "sceneData": {
+    "v": 1,
+    "name": "Pyramids · Smooth 4-level",
+    "source": {
+      "format": "vision-authored",
+      "prompt": "pyramids shape showcase"
+    },
+    "subjects": [
+      {
+        "id": "s0",
+        "type": "pyramid-3d",
+        "args": {
+          "levels": 4,
+          "baseWidth": 2,
+          "topWidth": 0.3,
+          "layerHeight": 0.4,
+          "gap": 0.04,
+          "depth": 0.6
+        },
+        "transform": {
+          "translate": [0, 0.1, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.72,
+          "metal": 0.3,
+          "glow": 0
+        }
+      }
+    ],
+    "defaults": {
+      "camera": {
+        "yaw": 0.5,
+        "pitch": 0.3,
+        "distance": 10,
+        "focal": 1.5,
+        "targetX": 0,
+        "targetY": 0.1,
+        "targetZ": 0
+      },
+      "light": {
+        "azimuth": 0.6,
+        "altitude": 0.55,
+        "distance": 25,
+        "intensity": 1.2
+      },
+      "shadow": {
+        "enabled": true,
+        "mode": "darken",
+        "strength": 0.4
+      }
+    }
+  },
+  "meta": {
+    "generatedAt": "2026-06-21",
+    "model": "vision-authored",
+    "pattern": "pyramids",
+    "costUSD": 0
+  }
+}

--- a/sdf-js/examples/compositor/demo-lifts/shape-pyramid-stepped.json
+++ b/sdf-js/examples/compositor/demo-lifts/shape-pyramid-stepped.json
@@ -1,0 +1,66 @@
+{
+  "id": "shape-pyramid-stepped",
+  "title": "Pyramids · Stepped 5-level",
+  "prompt": "pyramids: Pyramids · Stepped 5-level",
+  "code2d": "// vision-authored showcase — PresentationLoad shape category \"pyramids\".",
+  "sceneData": {
+    "v": 1,
+    "name": "Pyramids · Stepped 5-level",
+    "source": {
+      "format": "vision-authored",
+      "prompt": "pyramids shape showcase"
+    },
+    "subjects": [
+      {
+        "id": "s0",
+        "type": "pyramid-3d",
+        "args": {
+          "levels": 5,
+          "baseWidth": 2.2,
+          "topWidth": 0.4,
+          "layerHeight": 0.34,
+          "gap": 0.1,
+          "depth": 0.7
+        },
+        "transform": {
+          "translate": [0, 0.1, 0]
+        },
+        "material": {
+          "hue": 0.13,
+          "sat": 0.85,
+          "value": 0.9,
+          "metal": 0.95,
+          "glow": 0
+        }
+      }
+    ],
+    "defaults": {
+      "camera": {
+        "yaw": 0.5,
+        "pitch": 0.3,
+        "distance": 10,
+        "focal": 1.5,
+        "targetX": 0,
+        "targetY": 0.1,
+        "targetZ": 0
+      },
+      "light": {
+        "azimuth": 0.6,
+        "altitude": 0.55,
+        "distance": 25,
+        "intensity": 1.2
+      },
+      "shadow": {
+        "enabled": true,
+        "mode": "darken",
+        "strength": 0.4
+      }
+    }
+  },
+  "meta": {
+    "generatedAt": "2026-06-21",
+    "model": "vision-authored",
+    "pattern": "pyramids",
+    "costUSD": 0
+  }
+}

--- a/sdf-js/scripts/gen-fill-slides.mjs
+++ b/sdf-js/scripts/gen-fill-slides.mjs
@@ -1,0 +1,334 @@
+#!/usr/bin/env node
+// =============================================================================
+// gen-fill-slides.mjs — generate vision-authored 3D scenes for the
+// "D0961 3D Spheres Fill Levels" PDF deck (Atlas image→3D, scenario 2).
+// -----------------------------------------------------------------------------
+// Each fill sphere is rendered as a glossy TWO-TONE ball (studio glass is not
+// truly see-through), so we tile the sphere at the waterline:
+//   - liquid (bottom, y ≤ waterline): sphere-fill-3d cage:false  → blue
+//   - empty  (top,    y ≥ waterline): cut-sphere(r, r*(2f-1))    → porcelain
+// Fill fraction f → blue covers the bottom f of the ball, crisp waterline seam.
+//
+// Define each slide's sphere layout in SLIDES, run this to (re)write the demo
+// JSONs + register them in demo-lifts/index.json. Renderer: studio (auto-frame).
+//
+// Usage: node sdf-js/scripts/gen-fill-slides.mjs
+// =============================================================================
+
+import { readFileSync, writeFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const OUT_DIR = resolve(__dirname, '../examples/compositor/demo-lifts');
+
+const LIQUID = { hue: 0.58, sat: 0.85, value: 0.72, metal: 0.3, glow: 0 }; // vivid glossy azure fill
+const EMPTY = 'porcelain'; // clean white upper cap
+
+// ---- Per-slide sphere layouts (vision-authored from each PDF page) ----------
+// sphere = { x, y, z, r, f }  (f = fill fraction 0..1)
+// extras = optional array of raw subjects (arrows / rings) appended as-is.
+const SLIDES = {
+  'fill-slide-01': {
+    title: 'Fill Levels · Cover (20/40/80)',
+    pattern: 'kpi-hero',
+    prompt: 'Cover — three glass fill spheres at 20/40/80%, increasing in size.',
+    spheres: [
+      { x: -1.75, y: 0.9, z: 0, r: 0.46, f: 0.2 },
+      { x: -0.35, y: 0.9, z: 0, r: 0.64, f: 0.4 },
+      { x: 1.5, y: 0.9, z: 0, r: 0.92, f: 0.8 },
+    ],
+  },
+  'fill-slide-02': {
+    title: 'Fill Levels · Row of 4 (20/60/80/90)',
+    pattern: 'compare',
+    prompt: 'A row of four fill spheres at 20/60/80/90%.',
+    spheres: rowOf([0.2, 0.6, 0.8, 0.9], { r: 0.55, spacing: 0.5, y: 0.9 }),
+  },
+  'fill-slide-03': {
+    title: 'Fill Levels · Framed row + arrows (10/60/50)',
+    pattern: 'sequence',
+    prompt: 'Three framed fill spheres 10/60/50% connected left-to-right by arrows.',
+    spheres: rowOf([0.1, 0.6, 0.5], { r: 0.7, spacing: 1.0, y: 0.9 }),
+    extras: arrowsBetween(3, { r: 0.7, spacing: 1.0, y: 0.9 }),
+  },
+  'fill-slide-04': {
+    title: 'Fill Levels · Hero 60%',
+    pattern: 'kpi-hero',
+    prompt: 'A single large fill sphere at 60% with two callout text blocks.',
+    spheres: [{ x: 0, y: 1.0, z: 0, r: 1.05, f: 0.6 }],
+  },
+  'fill-slide-05': {
+    title: 'Fill Levels · Hero 100% + legend',
+    pattern: 'kpi-hero',
+    prompt: 'A single full (100%) fill sphere with a side legend.',
+    spheres: [{ x: 0, y: 1.0, z: 0, r: 1.05, f: 1.0 }],
+  },
+  'fill-slide-06': {
+    title: 'Fill Levels · Cluster of 5 (50/20/100/40/80)',
+    pattern: 'compare',
+    prompt: 'Five varied-size fill spheres clustered around a large 100% sphere.',
+    spheres: [
+      { x: 0, y: 0.95, z: 0, r: 0.95, f: 1.0 },
+      { x: -2.15, y: 0.7, z: 0.2, r: 0.6, f: 0.5 },
+      { x: -1.05, y: 1.35, z: -0.3, r: 0.42, f: 0.2 },
+      { x: 1.05, y: 1.35, z: -0.3, r: 0.42, f: 0.4 },
+      { x: 2.15, y: 0.7, z: 0.2, r: 0.6, f: 0.8 },
+    ],
+  },
+  'fill-slide-07': {
+    title: 'Fill Levels · Row of 3 (50/100/80)',
+    pattern: 'compare',
+    prompt: 'A row of three fill spheres 50/100/80%, the middle one largest.',
+    spheres: [
+      { x: -1.9, y: 0.85, z: 0, r: 0.62, f: 0.5 },
+      { x: 0, y: 1.0, z: 0, r: 0.85, f: 1.0 },
+      { x: 1.9, y: 0.85, z: 0, r: 0.62, f: 0.8 },
+    ],
+  },
+  'fill-slide-08': {
+    title: 'Fill Levels · Cluster of 3 (60/50/80)',
+    pattern: 'compare',
+    prompt: 'Three overlapping varied-size fill spheres 60/50/80%.',
+    spheres: [
+      { x: -1.35, y: 0.95, z: 0, r: 0.78, f: 0.6 },
+      { x: 0.1, y: 0.7, z: 0.25, r: 0.55, f: 0.5 },
+      { x: 1.4, y: 1.0, z: -0.1, r: 0.72, f: 0.8 },
+    ],
+  },
+  'fill-slide-09': {
+    title: 'Fill Levels · Row of 5 (10..90)',
+    pattern: 'compare',
+    prompt: 'A row of five small fill spheres rising 10/30/50/70/90%.',
+    spheres: rowOf([0.1, 0.3, 0.5, 0.7, 0.9], { r: 0.45, spacing: 0.35, y: 0.8 }),
+  },
+  'fill-slide-10': {
+    title: 'Fill Levels · Grid of 6 (framed)',
+    pattern: 'list',
+    prompt: 'A grid of six framed fill spheres at mixed levels.',
+    spheres: gridOf([0.55, 0.75, 0.6, 0.2, 0.4, 0.65], {
+      cols: 3,
+      r: 0.5,
+      gapX: 0.5,
+      gapY: 0.6,
+      y: 1.0,
+    }),
+  },
+  'fill-slide-11': {
+    title: 'Fill Levels · Hero 30% + list',
+    pattern: 'kpi-hero',
+    prompt: 'A single large fill sphere at 30% with a 4-item side list.',
+    spheres: [{ x: 0, y: 1.0, z: 0, r: 1.05, f: 0.3 }],
+  },
+  'fill-slide-12': {
+    title: 'Fill Levels · Row of 5 + captions',
+    pattern: 'compare',
+    prompt: 'A row of five fill spheres 20/40/60/50/80% over caption columns.',
+    spheres: rowOf([0.2, 0.4, 0.6, 0.5, 0.8], { r: 0.5, spacing: 0.4, y: 0.85 }),
+  },
+  'fill-slide-13': {
+    title: 'Fill Levels · Hero 90% + list',
+    pattern: 'kpi-hero',
+    prompt: 'A single large fill sphere at 90% with a side list.',
+    spheres: [{ x: 0, y: 1.0, z: 0, r: 1.05, f: 0.9 }],
+  },
+  'fill-slide-14': {
+    title: 'Fill Levels · Bullet list of 4',
+    pattern: 'list',
+    prompt: 'A vertical list of four items, each marked by a small fill sphere.',
+    spheres: columnOf([0.4, 0.6, 0.5, 0.7], { r: 0.34, gap: 0.45, x: -1.6, y: 0.9 }),
+  },
+  'fill-slide-15': {
+    title: 'Fill Levels · Hero 100% + 4 labels',
+    pattern: 'kpi-hero',
+    prompt: 'A single full fill sphere with four surrounding labels.',
+    spheres: [{ x: 0, y: 1.0, z: 0, r: 1.1, f: 1.0 }],
+  },
+  'fill-slide-16': {
+    title: 'Fill Levels · Vertical 3 (30/80/70)',
+    pattern: 'list',
+    prompt: 'Three fill spheres stacked vertically 30/80/70% with connector lines.',
+    spheres: columnOf([0.3, 0.8, 0.7], { r: 0.5, gap: 0.4, x: -1.8, y: 0.95 }),
+  },
+  'fill-slide-17': {
+    title: 'Fill Levels · Two heroes (80/90)',
+    pattern: 'compare',
+    prompt: 'Two large fill spheres 80% and 90% stacked with side text.',
+    spheres: [
+      { x: -1.4, y: 1.45, z: 0, r: 0.7, f: 0.8 },
+      { x: -1.4, y: -0.05, z: 0, r: 0.75, f: 0.9 },
+    ],
+  },
+  'fill-slide-18': {
+    title: 'Fill Levels · Progression grid 2×4',
+    pattern: 'sequence',
+    prompt: 'Two rows of four spheres showing a fill progression up to 100%.',
+    spheres: gridOf([0.15, 0.25, 0.35, 0.45, 0.6, 0.8, 0.9, 1.0], {
+      cols: 4,
+      r: 0.42,
+      gapX: 0.45,
+      gapY: 0.55,
+      y: 1.0,
+    }),
+  },
+  'fill-slide-19': {
+    title: 'Fill Levels · Row of 5 (20..100)',
+    pattern: 'sequence',
+    prompt: 'A clean row of five fill spheres rising 20/40/60/80/100%.',
+    spheres: rowOf([0.2, 0.4, 0.6, 0.8, 1.0], { r: 0.5, spacing: 0.4, y: 0.85 }),
+  },
+  'fill-slide-20': {
+    title: 'Fill Levels · Grid 2×5',
+    pattern: 'list',
+    prompt: 'Two rows of five fill spheres at mixed levels.',
+    spheres: gridOf([0.1, 0.3, 0.5, 0.7, 0.9, 0.2, 0.45, 0.65, 0.8, 1.0], {
+      cols: 5,
+      r: 0.4,
+      gapX: 0.35,
+      gapY: 0.5,
+      y: 0.95,
+    }),
+  },
+};
+
+// Helper: grid of fill spheres (row-major, centered both axes).
+function gridOf(levels, { cols = 3, r = 0.5, gapX = 0.4, gapY = 0.4, y = 0.9, z = 0 } = {}) {
+  const N = levels.length;
+  const rows = Math.ceil(N / cols);
+  const sx = 2 * r + gapX;
+  const sy = 2 * r + gapY;
+  const offX = ((cols - 1) / 2) * sx;
+  const offY = ((rows - 1) / 2) * sy;
+  return levels.map((f, i) => {
+    const c = i % cols;
+    const rw = Math.floor(i / cols);
+    return { x: c * sx - offX, y: y + offY - rw * sy, z, r, f };
+  });
+}
+
+// Helper: vertical column of fill spheres (top to bottom).
+function columnOf(levels, { r = 0.4, gap = 0.3, x = 0, y = 0.9, z = 0 } = {}) {
+  const N = levels.length;
+  const s = 2 * r + gap;
+  const off = ((N - 1) / 2) * s;
+  return levels.map((f, i) => ({ x, y: y + off - i * s, z, r, f }));
+}
+
+// Helper: evenly spaced row of fill spheres.
+function rowOf(levels, { r = 0.55, spacing = 0.5, y = 0.9, z = 0 } = {}) {
+  const N = levels.length;
+  const stride = 2 * r + spacing;
+  const off = ((N - 1) / 2) * stride;
+  return levels.map((f, i) => ({ x: i * stride - off, y, z, r, f }));
+}
+
+// Helper: right-pointing arrows in the gaps between N row spheres.
+function arrowsBetween(n, { r = 0.7, spacing = 1.0, y = 0.9, z = 0 } = {}) {
+  const stride = 2 * r + spacing;
+  const off = ((n - 1) / 2) * stride;
+  const out = [];
+  for (let i = 0; i < n - 1; i++) {
+    const x = i * stride - off + stride / 2;
+    out.push({
+      id: `arrow${i}`,
+      type: 'arrow-3d',
+      args: {
+        length: spacing * 0.9,
+        shaftWidth: 0.1,
+        headLength: 0.28,
+        headWidth: 0.34,
+        depth: 0.18,
+      },
+      transform: { translate: [x, y, z] },
+      material: 'silver',
+    });
+  }
+  return out;
+}
+
+// ---- Build one sphere → 1-2 subjects (liquid cap + empty cap) ----------------
+function sphereSubjects(s, idx) {
+  const subs = [];
+  const f = Math.max(0, Math.min(1, s.f));
+  // liquid (bottom cap) — sphere-fill-3d with no cage, liquid fills to radius
+  if (f > 0) {
+    subs.push({
+      id: `liq${idx}`,
+      type: 'sphere-fill-3d',
+      args: { levels: [f], radius: s.r, cage: false, fillScale: 1.0 },
+      transform: { translate: [s.x, s.y, s.z] },
+      material: LIQUID,
+    });
+  }
+  // empty (top cap) — cut-sphere keeps y ≥ waterline; skip when full
+  if (f < 1) {
+    subs.push({
+      id: `emp${idx}`,
+      type: 'cut-sphere',
+      args: { radius: s.r, h: s.r * (2 * f - 1) },
+      transform: { translate: [s.x, s.y, s.z] },
+      material: EMPTY,
+    });
+  }
+  return subs;
+}
+
+function buildScene(id, def) {
+  const subjects = [];
+  def.spheres.forEach((s, i) => subjects.push(...sphereSubjects(s, i)));
+  if (def.extras) subjects.push(...def.extras);
+  // camera target ~ mean sphere y; auto-frame overrides distance anyway
+  const ys = def.spheres.map((s) => s.y);
+  const ty = ys.reduce((a, b) => a + b, 0) / ys.length;
+  return {
+    id,
+    title: def.title,
+    prompt: `${def.pattern}: ${def.prompt}`,
+    code2d: `// vision-authored from PDF slide (D0961 3D Spheres Fill Levels).`,
+    sceneData: {
+      v: 1,
+      name: `${def.pattern}: ${def.title}`,
+      source: { format: 'vision-authored', prompt: def.prompt },
+      subjects,
+      defaults: {
+        camera: {
+          yaw: 0.5,
+          pitch: 0.28,
+          distance: 10,
+          focal: 1.5,
+          targetX: 0,
+          targetY: ty,
+          targetZ: 0,
+        },
+        light: { azimuth: 0.6, altitude: 0.55, distance: 25, intensity: 1.2 },
+        shadow: { enabled: true, mode: 'darken', strength: 0.4 },
+      },
+    },
+    meta: { generatedAt: '2026-06-21', model: 'vision-authored', pattern: def.pattern, costUSD: 0 },
+  };
+}
+
+// ---- Write demos + register in index.json -----------------------------------
+const indexPath = `${OUT_DIR}/index.json`;
+const index = JSON.parse(readFileSync(indexPath, 'utf8'));
+let wrote = 0;
+for (const [id, def] of Object.entries(SLIDES)) {
+  const entry = buildScene(id, def);
+  writeFileSync(`${OUT_DIR}/${id}.json`, JSON.stringify(entry, null, 2) + '\n');
+  wrote++;
+  if (!index.demos.some((d) => d.id === id)) {
+    index.demos.push({
+      id,
+      title: def.title,
+      thesisPoint:
+        'Vision-authored lift of PDF chart slide (D0961 3D Spheres Fill Levels) — two-tone fill spheres, studio auto-framed.',
+      category: 'presentation-slide',
+      status: 'ready',
+      file: `${id}.json`,
+      renderer: 'studio',
+      prompt: def.title,
+    });
+  }
+}
+writeFileSync(indexPath, JSON.stringify(index, null, 2) + '\n');
+console.log(`wrote ${wrote} fill-slide scenes; index now ${index.demos.length} demos`);

--- a/sdf-js/scripts/gen-shape-showcases.mjs
+++ b/sdf-js/scripts/gen-shape-showcases.mjs
@@ -1,0 +1,321 @@
+#!/usr/bin/env node
+// =============================================================================
+// gen-shape-showcases.mjs — quality 3D showcases across PresentationLoad shape
+// categories (Arrows / Circles / Cubes / Pyramids / Puzzles / Gear Wheels),
+// using Atlas atoms with category-appropriate materials + composition.
+// "质感 first": metallic gears, glossy arrows, layered pyramids, multi-color
+// puzzles, chrome rings. Studio auto-frames each scene.
+//
+// Usage: node sdf-js/scripts/gen-shape-showcases.mjs
+// =============================================================================
+
+import { readFileSync, writeFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const OUT_DIR = resolve(__dirname, '../examples/compositor/demo-lifts');
+const P2 = Math.PI / 2;
+
+// ---- material palette (inline HSV+metal for full control) -------------------
+const M = {
+  steel: { hue: 0.6, sat: 0.04, value: 0.62, metal: 0.95, glow: 0 },
+  chrome: { hue: 0.6, sat: 0.02, value: 0.82, metal: 0.98, glow: 0 },
+  gold: { hue: 0.13, sat: 0.85, value: 0.9, metal: 0.95, glow: 0 },
+  copper: { hue: 0.06, sat: 0.7, value: 0.62, metal: 0.9, glow: 0 },
+  azure: { hue: 0.58, sat: 0.85, value: 0.72, metal: 0.3, glow: 0 },
+  teal: { hue: 0.48, sat: 0.7, value: 0.7, metal: 0.25, glow: 0 },
+  orange: { hue: 0.07, sat: 0.88, value: 0.88, metal: 0.2, glow: 0 },
+  emerald: { hue: 0.38, sat: 0.72, value: 0.62, metal: 0.2, glow: 0 },
+  violet: { hue: 0.75, sat: 0.55, value: 0.64, metal: 0.2, glow: 0 },
+  crimson: { hue: 0.0, sat: 0.78, value: 0.7, metal: 0.2, glow: 0 },
+  white: 'porcelain',
+};
+
+const S = (type, args, translate, material, rotate) => ({
+  type,
+  args,
+  transform: rotate ? { translate, rotate } : { translate },
+  material,
+});
+
+// ---- scenes (category → composed subjects) ----------------------------------
+const SCENES = {
+  // ---------- GEAR WHEELS ----------
+  'shape-gear-mechanism': {
+    title: 'Gears · Meshing mechanism',
+    cat: 'gear wheels',
+    subjects: [
+      S(
+        'gear-3d',
+        {
+          teeth: 16,
+          radius: 0.95,
+          thickness: 0.3,
+          toothDepth: 0.18,
+          toothWidth: 0.2,
+          holeRadius: 0.32,
+        },
+        [0, 1.0, 0],
+        M.steel,
+        [P2, 0, 0],
+      ),
+      S(
+        'gear-3d',
+        {
+          teeth: 11,
+          radius: 0.66,
+          thickness: 0.3,
+          toothDepth: 0.16,
+          toothWidth: 0.18,
+          holeRadius: 0.24,
+        },
+        [1.5, 1.55, 0],
+        M.gold,
+        [P2, 0, 0],
+      ),
+      S(
+        'gear-3d',
+        {
+          teeth: 9,
+          radius: 0.55,
+          thickness: 0.3,
+          toothDepth: 0.15,
+          toothWidth: 0.17,
+          holeRadius: 0.2,
+        },
+        [-1.2, 0.45, 0],
+        M.copper,
+        [P2, 0, 0],
+      ),
+    ],
+  },
+  'shape-gear-hero': {
+    title: 'Gears · Single hero gear',
+    cat: 'gear wheels',
+    subjects: [
+      S(
+        'gear-3d',
+        {
+          teeth: 18,
+          radius: 1.1,
+          thickness: 0.34,
+          toothDepth: 0.2,
+          toothWidth: 0.2,
+          holeRadius: 0.4,
+        },
+        [0, 1.0, 0],
+        M.chrome,
+        [P2, 0, 0],
+      ),
+    ],
+  },
+  // ---------- ARROWS ----------
+  'shape-arrows-cycle': {
+    title: 'Arrows · Cycle (4 stage)',
+    cat: 'arrows',
+    subjects: [
+      S(
+        'circle-loop-3d',
+        { segments: 4, radius: 0.95, tube: 0.09, headLength: 0.4, headRadius: 0.2 },
+        [0, 1.0, 0],
+        M.azure,
+        [P2, 0, 0],
+      ),
+    ],
+  },
+  'shape-arrows-row': {
+    title: 'Arrows · Process row',
+    cat: 'arrows',
+    subjects: [
+      S(
+        'arrow-3d',
+        { length: 1.3, shaftWidth: 0.26, headLength: 0.5, headWidth: 0.66, depth: 0.3 },
+        [-1.5, 0.9, 0],
+        M.azure,
+      ),
+      S(
+        'arrow-3d',
+        { length: 1.3, shaftWidth: 0.26, headLength: 0.5, headWidth: 0.66, depth: 0.3 },
+        [0, 0.9, 0],
+        M.teal,
+      ),
+      S(
+        'arrow-3d',
+        { length: 1.3, shaftWidth: 0.26, headLength: 0.5, headWidth: 0.66, depth: 0.3 },
+        [1.5, 0.9, 0],
+        M.orange,
+      ),
+    ],
+  },
+  // ---------- CUBES ----------
+  'shape-cubes-row': {
+    title: 'Cubes · Connected row',
+    cat: 'cubes',
+    subjects: [
+      S(
+        'cube-3d',
+        { count: 4, arrangement: 'row', cubeSize: 0.62, spacing: 0.5, connector: 'pipe-through' },
+        [0, 0.6, 0],
+        M.azure,
+      ),
+    ],
+  },
+  'shape-cubes-grid': {
+    title: 'Cubes · 3×3×3 grid',
+    cat: 'cubes',
+    subjects: [
+      S(
+        'cube-3d',
+        { count: 27, arrangement: 'grid3d', cubeSize: 0.42, spacing: 0.12 },
+        [0, 1.0, 0],
+        M.chrome,
+      ),
+    ],
+  },
+  // ---------- PYRAMIDS ----------
+  'shape-pyramid-stepped': {
+    title: 'Pyramids · Stepped 5-level',
+    cat: 'pyramids',
+    subjects: [
+      S(
+        'pyramid-3d',
+        { levels: 5, baseWidth: 2.2, topWidth: 0.4, layerHeight: 0.34, gap: 0.1, depth: 0.7 },
+        [0, 0.1, 0],
+        M.gold,
+      ),
+    ],
+  },
+  'shape-pyramid-smooth': {
+    title: 'Pyramids · Smooth 4-level',
+    cat: 'pyramids',
+    subjects: [
+      S(
+        'pyramid-3d',
+        { levels: 4, baseWidth: 2.0, topWidth: 0.3, layerHeight: 0.4, gap: 0.04, depth: 0.6 },
+        [0, 0.1, 0],
+        M.azure,
+      ),
+    ],
+  },
+  // ---------- PUZZLES ----------
+  'shape-puzzle-row': {
+    title: 'Puzzles · Interlocking row of 4',
+    cat: 'puzzles',
+    subjects: [
+      S('puzzle-piece-3d', { size: 1.0, depth: 0.3, knob: 0.24 }, [-1.5, 0.9, 0], M.azure),
+      S('puzzle-piece-3d', { size: 1.0, depth: 0.3, knob: 0.24 }, [-0.5, 0.9, 0], M.orange),
+      S('puzzle-piece-3d', { size: 1.0, depth: 0.3, knob: 0.24 }, [0.5, 0.9, 0], M.emerald),
+      S('puzzle-piece-3d', { size: 1.0, depth: 0.3, knob: 0.24 }, [1.5, 0.9, 0], M.crimson),
+    ],
+  },
+  'shape-puzzle-pair': {
+    title: 'Puzzles · Two-piece fit',
+    cat: 'puzzles',
+    subjects: [
+      S('puzzle-piece-3d', { size: 1.3, depth: 0.36, knob: 0.3 }, [-0.65, 0.95, 0], M.azure),
+      S('puzzle-piece-3d', { size: 1.3, depth: 0.36, knob: 0.3 }, [0.65, 0.95, 0], M.gold),
+    ],
+  },
+  // ---------- CIRCLES ----------
+  'shape-circles-dial': {
+    title: 'Circles · Segmented dial (6)',
+    cat: 'circles',
+    subjects: [
+      S(
+        'circle-segmented-3d',
+        { segments: 6, radius: 1.0, innerRatio: 0.5, thickness: 0.26, gapWidth: 0.14 },
+        [0, 1.0, 0],
+        M.azure,
+        [P2, 0, 0],
+      ),
+    ],
+  },
+  'shape-circles-frames': {
+    title: 'Circles · Avatar frames (3)',
+    cat: 'circles',
+    subjects: [
+      S(
+        'circle-frame-3d',
+        { radius: 0.62, frameWidth: 0.14, backDepth: 0.08 },
+        [-1.5, 1.0, 0],
+        M.steel,
+      ),
+      S(
+        'circle-frame-3d',
+        { radius: 0.62, frameWidth: 0.14, backDepth: 0.08 },
+        [0, 1.0, 0],
+        M.gold,
+      ),
+      S(
+        'circle-frame-3d',
+        { radius: 0.62, frameWidth: 0.14, backDepth: 0.08 },
+        [1.5, 1.0, 0],
+        M.steel,
+      ),
+    ],
+  },
+  'shape-circles-stack': {
+    title: 'Circles · Tiered stack',
+    cat: 'circles',
+    subjects: [
+      S(
+        'circle-stack-3d',
+        { count: 4, radius: 0.85, taper: 0.8, diskHeight: 0.2, gap: 0.1 },
+        [0, 0.5, 0],
+        M.teal,
+      ),
+    ],
+  },
+};
+
+// ---- build + write + register -----------------------------------------------
+const indexPath = `${OUT_DIR}/index.json`;
+const index = JSON.parse(readFileSync(indexPath, 'utf8'));
+let wrote = 0;
+for (const [id, def] of Object.entries(SCENES)) {
+  const ys = def.subjects.map((s) => s.transform.translate[1]);
+  const ty = ys.reduce((a, b) => a + b, 0) / ys.length;
+  const entry = {
+    id,
+    title: def.title,
+    prompt: `${def.cat}: ${def.title}`,
+    code2d: `// vision-authored showcase — PresentationLoad shape category "${def.cat}".`,
+    sceneData: {
+      v: 1,
+      name: def.title,
+      source: { format: 'vision-authored', prompt: `${def.cat} shape showcase` },
+      subjects: def.subjects.map((s, i) => ({ id: `s${i}`, ...s })),
+      defaults: {
+        camera: {
+          yaw: 0.5,
+          pitch: 0.3,
+          distance: 10,
+          focal: 1.5,
+          targetX: 0,
+          targetY: ty,
+          targetZ: 0,
+        },
+        light: { azimuth: 0.6, altitude: 0.55, distance: 25, intensity: 1.2 },
+        shadow: { enabled: true, mode: 'darken', strength: 0.4 },
+      },
+    },
+    meta: { generatedAt: '2026-06-21', model: 'vision-authored', pattern: def.cat, costUSD: 0 },
+  };
+  writeFileSync(`${OUT_DIR}/${id}.json`, JSON.stringify(entry, null, 2) + '\n');
+  wrote++;
+  if (!index.demos.some((d) => d.id === id)) {
+    index.demos.push({
+      id,
+      title: def.title,
+      thesisPoint: `Atlas shape showcase — PresentationLoad "${def.cat}" category, quality material + composition, studio auto-framed.`,
+      category: 'shape-showcase',
+      status: 'ready',
+      file: `${id}.json`,
+      renderer: 'studio',
+      prompt: def.title,
+    });
+  }
+}
+writeFileSync(indexPath, JSON.stringify(index, null, 2) + '\n');
+console.log(`wrote ${wrote} shape showcases; index now ${index.demos.length} demos`);


### PR DESCRIPTION
## What

Two things, born from the "image → 3D" work (scenario 2: user already has visual slides):

### 1. Perf fix — instant studio scene entry (`compositor.js`)
Entering a studio scene felt much slower than Shadertoy. **Browser-measured root cause**: the W12 auto-framing bbox sweep — `bbox3FromSDF` at `radius:10 / res:56` = 57³ ≈ **185k synchronous `sdf.f()` evals on the main thread** — froze entry for **~95ms** (cubes-grid), scaling with subject count. The studio GPU render itself is only **~0.8ms** (as fast as Shadertoy); there is **no CPU renderer pass** — the "CPU-first then studio" feel was this 95ms stall before the first frame.

**Fix:**
- **Defer** the bbox + camera fit into `requestAnimationFrame` → the first studio frame paints immediately (~1ms); the fit runs next frame and re-renders. Entry is now GPU-instant.
- **Cheaper sweep**: search radius 10 → 6 (covers translated atoms; *finer* cells ~0.33 → better thin-atom capture), res 56 → 36 ≈ 50k evals (~25ms), now off the critical path. `iso 0.2` keeps thin atoms (rings / teeth / shafts) registered.
- Preempt guard so a newer scene aborts a stale deferred fit.

Verified: cubes-grid (was 95ms freeze) opens instantly + framed; arrows-cycle thin ring still auto-frames.

### 2. Image → 3D showcases (33 vision-authored scenes + 2 generators)
- **Fill Levels deck** (PresentationLoad D0961, 20 PDF slides → 20 scenes): every layout — cover / rows 3-5 / clusters / grids (6, 2×4, 2×5) / bullet list / hero+legend. Each fill sphere is a glossy **two-tone** ball (studio glass isn't see-through): blue liquid bottom (`sphere-fill-3d` cage off) + porcelain top cap (`cut-sphere`), tiled at the waterline. → `scripts/gen-fill-slides.mjs`
- **Shape-category showcases** (13) across the PresentationLoad Shapes catalog: **Gears** (metallic meshing) · **Arrows** (glossy cycle + process row) · **Cubes** (connected row + 3×3×3 grid) · **Pyramids** (stepped + smooth) · **Puzzles** (multi-color interlocking) · **Circles** (dial + frames + stack). Category-appropriate quality materials. → `scripts/gen-shape-showcases.mjs`

All 33 scenes **compile clean (E0/W0)** and are registered in `demo-lifts/index.json` (`renderer: "studio"`). Source PDFs/PPTX stay in gitignored `fixtures/`.

## Notes
- Scenes are vision-authored (Claude reads the slide/shape image and writes SceneData with the matching atoms) — validating the atom library end-to-end on real PresentationLoad layouts.
- Known one-time cost (not addressed, separate): first-ever studio entry compiles the WebGL shader (~tens of ms, once per session).

## Verification
- Browser perf re-measured (instant entry).
- 33/33 scenes compile clean; representative renders confirmed across every category + every fill-deck layout.
- Prettier + `node --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
