### PR TITLE
atoms-2d Phase 0 — framework + KPI hero pseudo-3D hello-world

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -149,6 +149,7 @@ const TESTS = [
   { category: 'present', file: 'sdf-js/scripts/test-branding-palettes.mjs' },
   { category: 'present', file: 'sdf-js/scripts/test-waypoint-tween.mjs' },
   { category: 'present', file: 'sdf-js/scripts/test-pipeline.mjs' },
+  { category: 'present', file: 'sdf-js/scripts/test-atoms-2d-framework.mjs' },
 ];
 
 // -----------------------------------------------------------------------------

--- a/sdf-js/examples/atoms-2d-demo/index.html
+++ b/sdf-js/examples/atoms-2d-demo/index.html
@@ -1,0 +1,125 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Atlas 2D Atom Library Demo</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;900&family=IBM+Plex+Mono:wght@400;500;700&display=swap" rel="stylesheet">
+  <style>
+    body { margin: 24px; font-family: 'Inter', system-ui; background: #fafafa; color: #1e1b1e; }
+    h1 { margin: 0 0 4px; font-size: 22px; }
+    h1 + p { margin: 0 0 24px; color: #666; font-size: 13px; }
+    .palette-bar { margin: 8px 0 24px; display: flex; flex-wrap: wrap; gap: 6px; align-items: center; font-size: 12px; }
+    .palette-bar .label { color: #666; margin-right: 6px; }
+    .palette-bar button { padding: 4px 10px; border: 1px solid #ccc; background: #fff; cursor: pointer; font: inherit; border-radius: 3px; }
+    .palette-bar button.active { background: #1e1b1e; color: #fff; border-color: #1e1b1e; }
+    .palette-swatch { display: inline-flex; gap: 1px; margin-left: 4px; vertical-align: middle; }
+    .palette-swatch span { width: 8px; height: 12px; display: inline-block; }
+    .grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(320px, 1fr)); gap: 24px; }
+    .sample { background: var(--bg, #fff); padding: 0; border-radius: 6px; border: 1px solid #e5e5e5; overflow: hidden; }
+    .sample h3 { margin: 0; padding: 10px 14px; font-size: 12px; font-weight: 600; background: #f5f5f5; border-bottom: 1px solid #e5e5e5; }
+    .sample canvas { display: block; width: 100%; height: auto; }
+    .meta { padding: 8px 14px; font-size: 11px; color: #666; border-top: 1px solid #e5e5e5; font-family: 'IBM Plex Mono', monospace; }
+  </style>
+</head>
+<body>
+  <h1>Atlas 2D Atom Library — Pseudo-3D Style Demo</h1>
+  <p>Phase 0 hello-world: <code>kpi-card</code> atom rendered in main-page Canvas2D (not iframe). Switch palette to see how branding affects each atom.</p>
+  <div id="palette-bar" class="palette-bar"></div>
+  <div id="grid" class="grid"></div>
+
+  <script type="module">
+    import { renderSceneDataToCanvas } from '/src/present/atoms-2d/renderer.js';
+    import { listAtomTypes } from '/src/present/atoms-2d/registry.js';
+    import { BRANDING_PALETTES, getPalette } from '/src/present/branding-palettes.js';
+
+    const FEATURED_PALETTES = [
+      'mono-light',
+      'chromotome:hilda01',
+      'chromotome:jung_bird',
+      'chromotome:kov_03',
+      'chromotome:rag-mysore',
+    ];
+
+    let currentPaletteId = 'mono-light';
+
+    // Demo cases — KPI card in different content shapes
+    const SAMPLES = [
+      { title: 'Hero Revenue + Trend Up',
+        atom: { type: 'kpi-card', args: { value: '$3.4M', label: 'Q3 Revenue', sublabel: 'vs Q2 2024', trend: 'up', trendValue: '+127%', icon: 'chart-bar' } } },
+      { title: 'User Growth',
+        atom: { type: 'kpi-card', args: { value: '12,450', label: 'Monthly Active Users', sublabel: '+1.2k from last month', trend: 'up', trendValue: '+10.6%', icon: 'users' } } },
+      { title: 'Churn Drop',
+        atom: { type: 'kpi-card', args: { value: '2.1%', label: 'Monthly Churn', sublabel: 'down from 3.4%', trend: 'down', trendValue: '-1.3pt', icon: 'arrow-down' } } },
+      { title: 'NPS Steady',
+        atom: { type: 'kpi-card', args: { value: '68', label: 'NPS Score', sublabel: 'unchanged QoQ', trend: 'neutral', trendValue: '0', icon: 'star' } } },
+      { title: 'Minimal (no trend, no icon)',
+        atom: { type: 'kpi-card', args: { value: '$10M', label: 'Total ARR' } } },
+      { title: 'Long Label',
+        atom: { type: 'kpi-card', args: { value: '94%', label: 'Customer Satisfaction Score', sublabel: 'Based on Q3 NPS survey, n=1,250', trend: 'up', trendValue: '+3pt', icon: 'heart' } } },
+    ];
+
+    function rgbCss(rgb) { return `rgb(${rgb[0]},${rgb[1]},${rgb[2]})`; }
+
+    function renderPaletteBar() {
+      const bar = document.getElementById('palette-bar');
+      bar.innerHTML = '<span class="label">Palette:</span>';
+      for (const id of FEATURED_PALETTES) {
+        const p = getPalette(id);
+        if (!p) continue;
+        const btn = document.createElement('button');
+        btn.textContent = p.label || id;
+        if (id === currentPaletteId) btn.classList.add('active');
+        const sw = document.createElement('span');
+        sw.className = 'palette-swatch';
+        sw.innerHTML += `<span style="background:${rgbCss(p.bg)}"></span>`;
+        for (const c of (p.colors || [p.silhouetteColor]).slice(0, 4)) {
+          sw.innerHTML += `<span style="background:${rgbCss(c)}"></span>`;
+        }
+        btn.appendChild(sw);
+        btn.addEventListener('click', () => { currentPaletteId = id; renderAll(); });
+        bar.appendChild(btn);
+      }
+    }
+
+    async function renderAll() {
+      renderPaletteBar();
+      const grid = document.getElementById('grid');
+      grid.innerHTML = '';
+      const palette = getPalette(currentPaletteId);
+      const sceneDataBg = rgbCss(palette.bg);
+
+      for (const sample of SAMPLES) {
+        const card = document.createElement('div');
+        card.className = 'sample';
+        card.style.setProperty('--bg', sceneDataBg);
+        card.innerHTML = `<h3>${sample.title}</h3>`;
+
+        const canvas = document.createElement('canvas');
+        canvas.width = 320;
+        canvas.height = 180;
+        card.appendChild(canvas);
+
+        const sceneData = {
+          subjects: [
+            { ...sample.atom, x: 20, y: 20, w: 280, h: 140, style: 'pseudo3d' },
+          ],
+        };
+        const result = await renderSceneDataToCanvas(canvas, sceneData, { palette });
+
+        const meta = document.createElement('div');
+        meta.className = 'meta';
+        meta.textContent = `rendered: ${result.rendered} / skipped: ${result.skipped} / errors: ${result.errors.length}`;
+        if (result.errors.length) meta.textContent += ' — ' + result.errors[0].error;
+        card.appendChild(meta);
+
+        grid.appendChild(card);
+      }
+    }
+
+    console.log('Loaded atoms:', listAtomTypes());
+    renderAll();
+  </script>
+</body>
+</html>

--- a/sdf-js/scripts/test-atoms-2d-framework.mjs
+++ b/sdf-js/scripts/test-atoms-2d-framework.mjs
@@ -1,0 +1,236 @@
+#!/usr/bin/env node
+// =============================================================================
+// test-atoms-2d-framework.mjs — smoke test for atoms-2d Phase 0 framework
+// -----------------------------------------------------------------------------
+// Node-side test. Verifies:
+//   1. Registry exports & dispatch
+//   2. KPI card spec is well-formed
+//   3. drawPseudo3D is callable with a stub ctx (records call sequence)
+//
+// Visual verify is in browser via /examples/atoms-2d-demo/.
+// =============================================================================
+
+import {
+  isAtom2DType,
+  listAtomTypes,
+  getAtomSpec,
+  renderAtom,
+} from '../src/present/atoms-2d/registry.js';
+
+let pass = 0,
+  fail = 0;
+function ok(cond, msg) {
+  if (cond) {
+    pass++;
+    console.log(`  ✓ ${msg}`);
+  } else {
+    fail++;
+    console.log(`  ✗ ${msg}`);
+  }
+}
+
+// ----- Registry -----
+console.log('--- registry ---');
+{
+  const types = listAtomTypes();
+  ok(Array.isArray(types), 'listAtomTypes returns array');
+  ok(types.includes('kpi-card'), `kpi-card registered (types: ${types.join(', ')})`);
+  ok(isAtom2DType('kpi-card'), 'isAtom2DType("kpi-card") true');
+  ok(!isAtom2DType('p5-sketch'), 'isAtom2DType("p5-sketch") false (not in registry)');
+  ok(!isAtom2DType('nonsense-foo'), 'isAtom2DType unknown type false');
+}
+
+// ----- KPI card spec -----
+console.log('\n--- kpi-card spec ---');
+{
+  const spec = await getAtomSpec('kpi-card');
+  ok(spec.type === 'kpi-card', 'spec.type matches');
+  ok(spec.category === 'charts/data', `spec.category = "${spec.category}"`);
+  ok(typeof spec.description === 'string', 'spec has description');
+  ok(spec.args && spec.args.value && spec.args.label, 'spec declares value + label args');
+  ok(spec.args.value.required === true, 'value is required');
+  ok(spec.args.trend && spec.args.trend.type.includes('?'), 'trend is optional');
+}
+
+// ----- drawPseudo3D smoke (stub ctx recording call sequence) -----
+console.log('\n--- drawPseudo3D smoke ---');
+{
+  const calls = [];
+  function makeStubCtx() {
+    const c = {
+      save: () => calls.push('save'),
+      restore: () => calls.push('restore'),
+      beginPath: () => calls.push('beginPath'),
+      closePath: () => calls.push('closePath'),
+      moveTo: (...a) => calls.push(['moveTo', ...a]),
+      lineTo: (...a) => calls.push(['lineTo', ...a]),
+      quadraticCurveTo: (...a) => calls.push(['quadraticCurveTo', ...a]),
+      arc: (...a) => calls.push(['arc', ...a]),
+      stroke: () => calls.push('stroke'),
+      fill: () => calls.push('fill'),
+      fillText: (...a) => calls.push(['fillText', ...a]),
+      measureText: () => ({ width: 24 }),
+      createLinearGradient: () => ({ addColorStop: () => {} }),
+      fillRect: (...a) => calls.push(['fillRect', ...a]),
+      set fillStyle(v) {
+        calls.push(['fillStyle=', v]);
+      },
+      set strokeStyle(v) {
+        calls.push(['strokeStyle=', v]);
+      },
+      set lineWidth(v) {
+        calls.push(['lineWidth=', v]);
+      },
+      set shadowColor(v) {
+        calls.push(['shadowColor=', v]);
+      },
+      set shadowBlur(v) {
+        calls.push(['shadowBlur=', v]);
+      },
+      set shadowOffsetY(v) {
+        calls.push(['shadowOffsetY=', v]);
+      },
+      set font(v) {
+        calls.push(['font=', v]);
+      },
+      set textAlign(v) {
+        calls.push(['textAlign=', v]);
+      },
+      set textBaseline(v) {
+        calls.push(['textBaseline=', v]);
+      },
+    };
+    return c;
+  }
+  const ctx = makeStubCtx();
+  await renderAtom(
+    ctx,
+    'kpi-card',
+    { value: '$3.4M', label: 'Q3 Revenue', trend: 'up', trendValue: '+127%', icon: 'chart-bar' },
+    'pseudo3d',
+    { x: 0, y: 0, w: 280, h: 160, palette: { bg: [247, 244, 224], silhouetteColor: [30, 27, 30] } },
+  );
+
+  ok(calls.length > 10, `drawPseudo3D made many ctx calls (${calls.length})`);
+  ok(
+    calls.some((c) => Array.isArray(c) && c[0] === 'fillText' && String(c[1]).includes('3.4')),
+    'value text "$3.4M" drawn',
+  );
+  ok(
+    calls.some(
+      (c) => Array.isArray(c) && c[0] === 'fillText' && String(c[1]).includes('Q3 Revenue'),
+    ),
+    'label text "Q3 Revenue" drawn',
+  );
+  ok(
+    calls.some((c) => Array.isArray(c) && c[0] === 'fillText' && String(c[1]).includes('127%')),
+    'trend value "+127%" drawn',
+  );
+  ok(
+    calls.some((c) => Array.isArray(c) && c[0] === 'fillText' && String(c[1]).includes('↑')),
+    'up arrow ↑ drawn',
+  );
+  ok(
+    calls.some((c) => Array.isArray(c) && c[0] === 'arc'),
+    'icon circle (stub) drawn',
+  );
+  ok(
+    calls.filter((c) => c === 'save').length === calls.filter((c) => c === 'restore').length,
+    `save/restore balanced (${calls.filter((c) => c === 'save').length} pairs)`,
+  );
+}
+
+// ----- Unknown style throws -----
+console.log('\n--- error paths ---');
+{
+  let threw = false;
+  try {
+    await renderAtom({}, 'kpi-card', {}, 'unknown-style');
+  } catch (e) {
+    threw = e.message.includes('style');
+  }
+  ok(threw, 'unknown style throws');
+
+  threw = false;
+  try {
+    await renderAtom({}, 'nonsense-atom-foo', {}, 'pseudo3d');
+  } catch (e) {
+    threw = e.message.includes('unknown atom type');
+  }
+  ok(threw, 'unknown atom type throws');
+
+  threw = false;
+  try {
+    await renderAtom({}, 'kpi-card', {}, 'flat');
+  } catch (e) {
+    threw = e.message.includes('does not implement');
+  }
+  ok(threw, 'unimplemented style (flat) throws clearly');
+}
+
+// ----- Trend variations: down + neutral -----
+console.log('\n--- trend variants ---');
+{
+  const ctx = (() => {
+    const c = {};
+    const noop = () => {};
+    for (const m of [
+      'save',
+      'restore',
+      'beginPath',
+      'closePath',
+      'moveTo',
+      'lineTo',
+      'quadraticCurveTo',
+      'arc',
+      'stroke',
+      'fill',
+      'fillRect',
+    ]) {
+      c[m] = noop;
+    }
+    c.measureText = () => ({ width: 12 });
+    c.createLinearGradient = () => ({ addColorStop: noop });
+    const recorded = [];
+    c.fillText = (t) => recorded.push(t);
+    Object.defineProperty(c, 'fillStyle', { set() {} });
+    Object.defineProperty(c, 'strokeStyle', { set() {} });
+    Object.defineProperty(c, 'lineWidth', { set() {} });
+    Object.defineProperty(c, 'shadowColor', { set() {} });
+    Object.defineProperty(c, 'shadowBlur', { set() {} });
+    Object.defineProperty(c, 'shadowOffsetY', { set() {} });
+    Object.defineProperty(c, 'font', { set() {} });
+    Object.defineProperty(c, 'textAlign', { set() {} });
+    Object.defineProperty(c, 'textBaseline', { set() {} });
+    c._recorded = recorded;
+    return c;
+  })();
+
+  await renderAtom(
+    ctx,
+    'kpi-card',
+    { value: '2.1%', label: 'Churn', trend: 'down', trendValue: '-1.3pt' },
+    'pseudo3d',
+    { palette: { bg: [255, 255, 255], silhouetteColor: [0, 0, 0] } },
+  );
+  ok(
+    ctx._recorded.some((t) => String(t).includes('↓')),
+    'down trend draws ↓',
+  );
+
+  ctx._recorded.length = 0;
+  await renderAtom(
+    ctx,
+    'kpi-card',
+    { value: '68', label: 'NPS', trend: 'neutral', trendValue: '0' },
+    'pseudo3d',
+    { palette: { bg: [255, 255, 255], silhouetteColor: [0, 0, 0] } },
+  );
+  ok(
+    ctx._recorded.some((t) => String(t).includes('→')),
+    'neutral trend draws →',
+  );
+}
+
+console.log(`\n=== Result: ${pass} passed, ${fail} failed ===`);
+process.exit(fail > 0 ? 1 : 0);

--- a/sdf-js/src/present/atoms-2d/README.md
+++ b/sdf-js/src/present/atoms-2d/README.md
@@ -1,0 +1,78 @@
+# Atlas 2D Atom Library
+
+Per [[atlas-2d-two-track-architecture-lock]] (2026-06-21 user LOCK):
+
+> 行业模板 + ICON 库用 **2D vector** 预先做好 (Atlas 团队写), 其他 LLM 解读文字走 **P5 路径** (LLM 自由生成).
+
+This directory is the **pre-authored 2D vector atom library**. Each atom is a semantic concept (e.g. `kpi-card`, `bar`, `waterfall`) with multiple render implementations:
+
+- **Pseudo-3D vector** (`drawPseudo3D`): gradient + drop shadow + isometric edge — PresentationLoad / think-cell style for professional business decks
+- **Flat vector** (`drawFlat`): solid color + outline — Napkin / Linear / modern style (TBD, after pseudo-3D batch ships)
+- **3D SDF** (`eval3D`): geometry for future Atlas 3D presentation mode (per [[atlas-present-spatial-narrative-thesis]])
+
+## Architecture
+
+```
+atoms-2d/
+├── registry.js       atom dispatch table + render API
+├── renderer.js       Canvas2D renderer (runs in main page, NOT iframe — trusted code)
+├── charts/
+│   ├── data/         kpi-card / bar / line / pie / column
+│   ├── diagrams/     flow / mindmap / org-chart / relationship / timeline / tree
+│   └── hierarchy/    pyramid
+├── shapes/           cube / sphere / diamond / gear / arrow + basic primitives
+├── icons/            24 icons upgraded from atlas-icon-library SVG paths to vector
+└── presentation/     cover
+```
+
+Each atom file follows this shape:
+
+```js
+export const spec = {
+  type: 'kpi-card',
+  category: 'charts/data',
+  args: {
+    value: { type: 'string|number', required: true },
+    label: { type: 'string', required: true },
+    trend: { type: 'up|down|neutral?', default: null },
+    // ...
+  },
+};
+
+export function drawPseudo3D(ctx, args, opts) {
+  // Canvas2D draw calls with gradient + shadow + isometric tricks
+}
+
+// Future: drawFlat, eval3D
+```
+
+## Why main-page Canvas2D (not iframe)?
+
+Per user 2026-06-21 sanity Q response: render path **(C)** chosen.
+
+- These atoms are **Atlas-authored**, not LLM-generated → no sandbox needed
+- Main-page render is **~10× faster** than iframe postMessage round-trip (10ms vs 100ms)
+- High-level escape hatch (manual edit / hover / inspect) is natively supported
+- iframe sandbox continues to wrap LLM-generated P5 sketches (security model unchanged)
+
+## How LLM invokes these atoms
+
+Lift prompt (v3.30+) routes content matching presets to atom types:
+
+```json
+{
+  "subjects": [
+    {
+      "type": "kpi-card",
+      "args": { "value": "$3.4M", "label": "Q3 Revenue", "trend": "up", "trendValue": "+127%" },
+      "style": "pseudo3d"
+    }
+  ]
+}
+```
+
+Pipeline detects atom type (not `p5-sketch`) and routes to atoms-2d renderer.
+
+## Style switching (per-deck or per-visual)
+
+Same atom type with different `style` arg renders differently. User can switch deck-level branding from "pseudo3d" to "flat" and all atoms re-render — same data, different visual identity.

--- a/sdf-js/src/present/atoms-2d/charts/data/kpi-card.js
+++ b/sdf-js/src/present/atoms-2d/charts/data/kpi-card.js
@@ -1,0 +1,212 @@
+// =============================================================================
+// atoms-2d/charts/data/kpi-card.js — KPI hero card atom
+// -----------------------------------------------------------------------------
+// First atom in the 2D vector library (Phase 0 hello-world).
+//
+// Semantic: a single rectangular tile carrying ONE big number + label +
+// optional trend indicator + optional icon. The bread-and-butter of any
+// dashboard, pitch deck, or quarterly report.
+//
+// Args (matches think-cell agenda block + PresentationLoad KPI tile):
+//   value         — primary number (e.g. "$3.4M", "127%", "1,250")
+//   label         — primary label (e.g. "Q3 Revenue")
+//   sublabel      — optional small caption (e.g. "vs Q2 2024")
+//   trend         — 'up' | 'down' | 'neutral' (arrow direction)
+//   trendValue    — optional delta (e.g. "+127%", "-12pt")
+//   icon          — optional atlas-icon name (e.g. 'chart-bar')
+//
+// Render strategies:
+//   drawPseudo3D — gradient bg + drop shadow + isometric edge + bold typo (this PR)
+//   drawFlat     — TBD (later batch)
+//   draw3D       — TBD (3D presentation mode, per atlas-present-spatial-narrative-thesis
+//                  Lock 4: card = floating 3D plate with text-3d glyphs)
+//
+// Per [[atlas-sprint14-finance-preset-plan]] Lock 4 + B answer (浮空板 + text-3d 字).
+// =============================================================================
+
+import { rgbCss, rgbaCss } from '../../renderer.js';
+
+export const spec = {
+  type: 'kpi-card',
+  category: 'charts/data',
+  description:
+    'Hero KPI tile — big number + label + optional trend + icon. Bread-and-butter of dashboards.',
+  args: {
+    value: { type: 'string|number', required: true, example: '$3.4M' },
+    label: { type: 'string', required: true, example: 'Q3 Revenue' },
+    sublabel: { type: 'string?', example: 'vs Q2 2024' },
+    trend: { type: "'up'|'down'|'neutral'?", example: 'up' },
+    trendValue: { type: 'string?', example: '+127%' },
+    icon: { type: 'string? (atlas-icon name)', example: 'chart-bar' },
+  },
+};
+
+/**
+ * Pseudo-3D KPI card render. PresentationLoad / think-cell aesthetic:
+ *   - Rounded rectangle with subtle linear gradient (top lighter, bottom darker)
+ *   - Drop shadow (offset Y + soft blur)
+ *   - Optional isometric edge accent on right side for depth
+ *   - Big hero number (Inter 700, scales to card height)
+ *   - Label below (Inter 500, smaller)
+ *   - Sublabel below (Inter 400, faded)
+ *   - Trend arrow + value in top-right corner (color-coded green/red/grey)
+ *   - Icon in top-left (if specified) drawn from atlas-icon-library
+ *
+ * @param {CanvasRenderingContext2D} ctx
+ * @param {object} args — see spec.args
+ * @param {object} opts — { x, y, w, h, palette }
+ */
+export function drawPseudo3D(ctx, args, opts = {}) {
+  const x = opts.x ?? 0;
+  const y = opts.y ?? 0;
+  const w = opts.w ?? 280;
+  const h = opts.h ?? 160;
+  const palette = opts.palette || {};
+  const fg = palette.silhouetteColor || [30, 27, 30];
+  const bg = palette.bg || [247, 244, 224];
+  const accent = palette.colors?.[0] || [60, 100, 200];
+
+  // ---- Drop shadow ----
+  ctx.save();
+  ctx.shadowColor = rgbaCss([0, 0, 0], 0.18);
+  ctx.shadowBlur = 14;
+  ctx.shadowOffsetY = 6;
+
+  // ---- Rounded gradient body ----
+  const cardRadius = Math.min(w, h) * 0.06;
+  const gradient = ctx.createLinearGradient(x, y, x, y + h);
+  gradient.addColorStop(0, rgbaCss(lighten(fg, 0.08), 1));
+  gradient.addColorStop(1, rgbCss(fg));
+  ctx.fillStyle = gradient;
+  roundedRectPath(ctx, x, y, w, h, cardRadius);
+  ctx.fill();
+  ctx.restore(); // drop shadow off
+
+  // ---- Isometric edge accent (right side) ----
+  // Tiny parallelogram on the right gives "block" 3D feel
+  const edgeDepth = Math.max(4, w * 0.012);
+  ctx.save();
+  ctx.fillStyle = rgbaCss(darken(fg, 0.15), 0.9);
+  ctx.beginPath();
+  ctx.moveTo(x + w, y + cardRadius);
+  ctx.lineTo(x + w + edgeDepth, y + cardRadius + edgeDepth);
+  ctx.lineTo(x + w + edgeDepth, y + h);
+  ctx.lineTo(x + w, y + h - cardRadius);
+  ctx.closePath();
+  ctx.fill();
+  ctx.restore();
+
+  // ---- Trend pill (top-right) ----
+  if (args.trend && args.trendValue) {
+    drawTrendPill(ctx, args.trend, args.trendValue, x + w - 12, y + 12, palette);
+  }
+
+  // ---- Icon (top-left) ----
+  if (args.icon) {
+    drawIconStub(ctx, args.icon, x + 18, y + 22, 22, rgbCss(bg));
+  }
+
+  // ---- Hero value (centered) ----
+  ctx.fillStyle = rgbCss(bg);
+  ctx.textAlign = 'left';
+  ctx.textBaseline = 'alphabetic';
+  const valueSize = Math.round(h * 0.34);
+  ctx.font = `900 ${valueSize}px Inter, system-ui, sans-serif`;
+  const valueY = y + h * 0.55;
+  ctx.fillText(String(args.value ?? ''), x + 18, valueY);
+
+  // ---- Label (below value) ----
+  ctx.fillStyle = rgbaCss(bg, 0.85);
+  ctx.font = `600 ${Math.round(h * 0.11)}px Inter, system-ui, sans-serif`;
+  ctx.fillText(String(args.label ?? ''), x + 18, valueY + Math.round(h * 0.17));
+
+  // ---- Sublabel (below label) ----
+  if (args.sublabel) {
+    ctx.fillStyle = rgbaCss(bg, 0.55);
+    ctx.font = `400 ${Math.round(h * 0.085)}px Inter, system-ui, sans-serif`;
+    ctx.fillText(String(args.sublabel), x + 18, valueY + Math.round(h * 0.28));
+  }
+}
+
+// ============================================================================
+// Private helpers (file-local). Kept simple — not factored to a shared
+// "pseudo3d-toolkit" yet, do that when 2nd+3rd atom share these.
+// ============================================================================
+
+function roundedRectPath(ctx, x, y, w, h, r) {
+  ctx.beginPath();
+  ctx.moveTo(x + r, y);
+  ctx.lineTo(x + w - r, y);
+  ctx.quadraticCurveTo(x + w, y, x + w, y + r);
+  ctx.lineTo(x + w, y + h - r);
+  ctx.quadraticCurveTo(x + w, y + h, x + w - r, y + h);
+  ctx.lineTo(x + r, y + h);
+  ctx.quadraticCurveTo(x, y + h, x, y + h - r);
+  ctx.lineTo(x, y + r);
+  ctx.quadraticCurveTo(x, y, x + r, y);
+  ctx.closePath();
+}
+
+function drawTrendPill(ctx, trend, value, rightX, topY, palette) {
+  const text = String(value);
+  ctx.font = '700 12px Inter, system-ui, sans-serif';
+  const textW = ctx.measureText(text).width;
+  const pillW = textW + 28;
+  const pillH = 22;
+  const left = rightX - pillW;
+
+  // pill colors by trend semantics
+  let pillColor;
+  let arrowChar;
+  if (trend === 'up') {
+    pillColor = [40, 160, 100];
+    arrowChar = '↑';
+  } else if (trend === 'down') {
+    pillColor = [200, 80, 80];
+    arrowChar = '↓';
+  } else {
+    pillColor = [150, 150, 150];
+    arrowChar = '→';
+  }
+
+  ctx.fillStyle = rgbaCss(pillColor, 0.95);
+  roundedRectPath(ctx, left, topY, pillW, pillH, pillH / 2);
+  ctx.fill();
+
+  ctx.fillStyle = 'rgba(255,255,255,1)';
+  ctx.textAlign = 'left';
+  ctx.textBaseline = 'middle';
+  ctx.font = '700 13px Inter, system-ui, sans-serif';
+  ctx.fillText(arrowChar, left + 8, topY + pillH / 2);
+  ctx.font = '700 12px Inter, system-ui, sans-serif';
+  ctx.fillText(text, left + 20, topY + pillH / 2 + 1);
+}
+
+// Lightweight icon stub — Phase 0 placeholder before atoms-2d/icons/ Phase
+// 4 ships. Draws a simple circle outline so the layout space is occupied.
+// When Phase 4 lands, replace with renderAtom(ctx, args.icon, ..., 'pseudo3d').
+function drawIconStub(ctx, name, cx, cy, size, color) {
+  ctx.save();
+  ctx.strokeStyle = color;
+  ctx.lineWidth = 1.8;
+  ctx.beginPath();
+  ctx.arc(cx, cy, size / 2, 0, Math.PI * 2);
+  ctx.stroke();
+  ctx.restore();
+}
+
+function lighten(rgb, amt) {
+  return [
+    Math.min(255, rgb[0] + (255 - rgb[0]) * amt),
+    Math.min(255, rgb[1] + (255 - rgb[1]) * amt),
+    Math.min(255, rgb[2] + (255 - rgb[2]) * amt),
+  ];
+}
+
+function darken(rgb, amt) {
+  return [
+    Math.max(0, rgb[0] * (1 - amt)),
+    Math.max(0, rgb[1] * (1 - amt)),
+    Math.max(0, rgb[2] * (1 - amt)),
+  ];
+}

--- a/sdf-js/src/present/atoms-2d/registry.js
+++ b/sdf-js/src/present/atoms-2d/registry.js
@@ -1,0 +1,113 @@
+// =============================================================================
+// atoms-2d/registry.js — Atlas 2D atom registry + render API
+// -----------------------------------------------------------------------------
+// Maps atom `type` string → import path. Loaded on demand (dynamic import)
+// to keep initial bundle small.
+//
+// API:
+//   isAtom2DType(type)              — quick check before dispatching
+//   getAtomSpec(type)               — async load and return atom's spec object
+//   renderAtom(ctx, type, args, style, opts)  — render atom to Canvas2D context
+//
+// Per [[atlas-2d-two-track-architecture-lock]] — these atoms are Atlas-
+// authored, rendered in main page Canvas2D (NOT iframe), shared name across
+// pseudo3d / flat / 3D-SDF render strategies.
+//
+// Style options:
+//   - 'pseudo3d'  (Phase 0+, this batch)
+//   - 'flat'      (future, after pseudo3d batch merged)
+//   - '3d'        (future, when present mode adds true 3D path)
+// =============================================================================
+
+// Static registry. Keys are atom types (also LLM-emit'd in SceneData.subjects[].type).
+// Values are dynamic import functions to keep startup light.
+//
+// Add new atoms by extending this map.
+const ATOM_LOADERS = {
+  // Charts / data
+  'kpi-card': () => import('./charts/data/kpi-card.js'),
+  // Future Phase 1: bar / line / pie / column
+
+  // Charts / diagrams (Phase 2)
+  // Charts / hierarchy (Phase 2)
+  // Shapes (Phase 3)
+  // Icons (Phase 4)
+  // Presentation (Phase 4)
+};
+
+/**
+ * Quick membership check. Use to route SceneData.subjects[].type before
+ * deciding p5-sketch vs atom-2d render path.
+ */
+export function isAtom2DType(type) {
+  return Object.prototype.hasOwnProperty.call(ATOM_LOADERS, type);
+}
+
+/**
+ * Returns the array of known atom type strings. For dev/debug and prompt
+ * generation tooling.
+ */
+export function listAtomTypes() {
+  return Object.keys(ATOM_LOADERS);
+}
+
+// Module cache so we don't dynamic-import the same atom twice.
+const MODULE_CACHE = new Map();
+
+async function loadAtomModule(type) {
+  if (MODULE_CACHE.has(type)) return MODULE_CACHE.get(type);
+  const loader = ATOM_LOADERS[type];
+  if (!loader) throw new Error(`atoms-2d: unknown atom type "${type}"`);
+  const mod = await loader();
+  MODULE_CACHE.set(type, mod);
+  return mod;
+}
+
+/**
+ * Get the atom's static spec (args schema, category, etc) without rendering.
+ * Used by prompt-generation tooling and the atom-browser sidebar (future Q4).
+ */
+export async function getAtomSpec(type) {
+  const mod = await loadAtomModule(type);
+  return mod.spec;
+}
+
+/**
+ * Render an atom to a Canvas2D context.
+ *
+ * @param {CanvasRenderingContext2D} ctx
+ * @param {string} type — atom type (must be in registry)
+ * @param {object} args — atom-specific args (matches spec.args schema)
+ * @param {'pseudo3d'|'flat'|'3d'} style — render strategy
+ * @param {object} [opts]
+ * @param {number} [opts.x=0]
+ * @param {number} [opts.y=0]
+ * @param {number} [opts.w]
+ * @param {number} [opts.h]
+ * @param {object} [opts.palette] — branding palette { bg, silhouetteColor, colors? }
+ *
+ * @returns {Promise<void>}
+ *
+ * Throws if type is unknown OR if the atom doesn't implement requested style.
+ */
+export async function renderAtom(ctx, type, args, style = 'pseudo3d', opts = {}) {
+  const mod = await loadAtomModule(type);
+  let drawFn;
+  switch (style) {
+    case 'pseudo3d':
+      drawFn = mod.drawPseudo3D;
+      break;
+    case 'flat':
+      drawFn = mod.drawFlat;
+      break;
+    case '3d':
+      drawFn = mod.draw3D;
+      break;
+    default:
+      throw new Error(`atoms-2d: unknown style "${style}"`);
+  }
+  if (typeof drawFn !== 'function') {
+    throw new Error(`atoms-2d: atom "${type}" does not implement style "${style}" yet`);
+  }
+  return drawFn(ctx, args, opts);
+}

--- a/sdf-js/src/present/atoms-2d/renderer.js
+++ b/sdf-js/src/present/atoms-2d/renderer.js
@@ -1,0 +1,114 @@
+// =============================================================================
+// atoms-2d/renderer.js — high-level "render SceneData into Canvas2D" wrapper
+// -----------------------------------------------------------------------------
+// Consumes a SceneData object whose `subjects[]` are 2D atoms (NOT p5-sketch)
+// and renders to a target canvas. Bridges between SceneData spec emitted by
+// LLM lift and the per-atom render functions in registry.js.
+//
+// Per [[atlas-2d-two-track-architecture-lock]]: this renderer runs in MAIN
+// PAGE (no iframe), receives Atlas-authored atoms, fast Canvas2D path.
+//
+// API:
+//   renderSceneDataToCanvas(canvas, sceneData, opts) — render all subjects
+//   create2DAtomCanvas(width, height) — convenience factory for offscreen render
+//
+// Returns the dataUrl (PNG) when called with `opts.exportPng = true`.
+// =============================================================================
+
+import { renderAtom, isAtom2DType } from './registry.js';
+
+const DEFAULT_PALETTE = {
+  bg: [247, 244, 224],
+  silhouetteColor: [30, 27, 30],
+};
+
+/**
+ * Render a SceneData of 2D atoms onto a canvas.
+ *
+ * @param {HTMLCanvasElement} canvas
+ * @param {object} sceneData — { subjects: [{ type, args, style?, x?, y?, w?, h? }, ...] }
+ * @param {object} [opts]
+ * @param {object} [opts.palette]   — overrides per-subject palette
+ * @param {string} [opts.style]     — overrides per-subject style (deck-level lock)
+ * @param {boolean} [opts.clear=true] — clear canvas before rendering
+ *
+ * @returns {Promise<{rendered: number, skipped: number, errors: Array}>}
+ */
+export async function renderSceneDataToCanvas(canvas, sceneData, opts = {}) {
+  const ctx = canvas.getContext('2d');
+  if (!ctx) throw new Error('atoms-2d/renderer: canvas has no 2D context');
+
+  const palette = opts.palette || DEFAULT_PALETTE;
+  const deckStyle = opts.style;
+
+  // Fill background
+  if (opts.clear !== false) {
+    ctx.fillStyle = rgbCss(palette.bg);
+    ctx.fillRect(0, 0, canvas.width, canvas.height);
+  }
+
+  const subjects = Array.isArray(sceneData?.subjects) ? sceneData.subjects : [];
+  let rendered = 0;
+  let skipped = 0;
+  const errors = [];
+
+  for (let i = 0; i < subjects.length; i++) {
+    const s = subjects[i];
+    if (!s || typeof s.type !== 'string') {
+      skipped++;
+      continue;
+    }
+    if (!isAtom2DType(s.type)) {
+      // Not a 2D atom — caller should route to p5-sketch path
+      skipped++;
+      continue;
+    }
+    const args = s.args || {};
+    const style = deckStyle || s.style || 'pseudo3d';
+    const subjectOpts = {
+      x: s.x ?? 0,
+      y: s.y ?? 0,
+      w: s.w ?? canvas.width,
+      h: s.h ?? canvas.height,
+      palette,
+    };
+    try {
+      ctx.save();
+      await renderAtom(ctx, s.type, args, style, subjectOpts);
+      ctx.restore();
+      rendered++;
+    } catch (e) {
+      ctx.restore(); // ensure no leaked transform state
+      errors.push({ index: i, type: s.type, error: e.message });
+    }
+  }
+
+  return { rendered, skipped, errors };
+}
+
+/**
+ * Convenience: create an offscreen canvas at the given size.
+ * Useful for previews / PNG export.
+ */
+export function create2DAtomCanvas(width = 600, height = 360) {
+  const canvas = document.createElement('canvas');
+  canvas.width = width;
+  canvas.height = height;
+  return canvas;
+}
+
+/**
+ * Convert [r,g,b] to CSS rgb() string. Helper exported for atom files.
+ */
+export function rgbCss(rgb) {
+  if (!rgb) return 'rgb(0,0,0)';
+  return `rgb(${rgb[0] | 0},${rgb[1] | 0},${rgb[2] | 0})`;
+}
+
+/**
+ * Like rgbCss but with alpha. atom 0 < a <= 1.
+ */
+export function rgbaCss(rgb, a = 1) {
+  if (!rgb) return `rgba(0,0,0,${a})`;
+  return `rgba(${rgb[0] | 0},${rgb[1] | 0},${rgb[2] | 0},${a})`;
+}


### PR DESCRIPTION
## Goal

Per 2026-06-21 user LOCK (path **a**): build full 2D vector library (pseudo-3D + flat) before Sprint 14 finance preset. This is PR **1 of ~10** in the pseudo-3D batch.

## What ships

**Framework** (`sdf-js/src/present/atoms-2d/`):
- `README.md` — architecture overview, conventions
- `registry.js` — atom dispatch (isAtom2DType / getAtomSpec / renderAtom)
- `renderer.js` — SceneData → Canvas2D wrapper (main-page, not iframe)

**First atom** (`charts/data/kpi-card.js`):
- drawPseudo3D — gradient + drop shadow + isometric edge + Inter typography + color-coded trend pill + icon stub
- spec with full args schema (value / label / sublabel / trend / trendValue / icon)
- Flat + 3D implementations deferred to later batches

**Demo** (`sdf-js/examples/atoms-2d-demo/index.html`):
- 6 KPI samples + palette switcher
- Live verify of palette + content shape variants

**Test** (`sdf-js/scripts/test-atoms-2d-framework.mjs`):
- 23 assertions covering registry / spec / drawPseudo3D calls / error paths / trend variants

## Architecture decisions (per user sanity answers 2026-06-21)

| Question | Decision |
|---|---|
| Render path | **(C) main-page Canvas2D** — atoms are Atlas-authored = trusted, ~10× faster than iframe |
| Atom naming | **shared** — `kpi-card` semantic + style param (pseudo3d / flat / 3d) |
| Style batch order | **pseudo-3D first**, then flat after user merges |

## Test plan

- [x] `npm test` — 81/81 ✓
- [x] Framework smoke test — 23/23 ✓
- [x] Visual verify in browser (palette swap + 6 content shapes)
- [ ] User merges this PR + remaining 9 PRs in pseudo-3D batch before flat style work begins

## Next PRs (queued)

- PR B: charts/data/bar
- PR C: charts/data/line + pie + column
- PR D-E: diagrams (flow, mindmap, org-chart, relationship, timeline, tree)
- PR F: shapes (cube, sphere, diamond, gear, arrow basics)
- PR G-H: icons (24 from atlas-icon-library refactored to vector pseudo-3D)
- PR I: Sprint 14 finance preset assembly + L3 verify

🤖 Generated with [Claude Code](https://claude.com/claude-code)