### PR TITLE
atoms-2d Phase 1b: line + pie atoms (pseudo-3D)

### DIFF
--- a/sdf-js/examples/atoms-2d-demo/index.html
+++ b/sdf-js/examples/atoms-2d-demo/index.html
@@ -68,6 +68,26 @@
       { title: 'Bar — Survey Response',
         size: { w: 540, h: 280 },
         atom: { type: 'bar', args: { values: [62, 48, 35, 22, 18, 12], labels: ['Pricing', 'UX', 'Speed', 'Docs', 'Mobile', 'API'], format: 'number', title: 'Top Pain Points (% mentions)' } } },
+      // ---- Line chart samples (Phase 1b) ----
+      { title: 'Line — Revenue Trajectory',
+        size: { w: 540, h: 300 },
+        atom: { type: 'line', args: { values: [1.2, 1.8, 2.4, 3.1], labels: ['Q1', 'Q2', 'Q3', 'Q4'], format: 'currency', title: 'Quarterly Revenue ($M)', showValues: true } } },
+      { title: 'Line — With Annotation',
+        size: { w: 540, h: 300 },
+        atom: { type: 'line', args: { values: [120, 142, 168, 240, 285, 310], labels: ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun'], format: 'number', title: 'MAU (thousands)', annotations: [{ index: 3, text: '↑ feature launch' }] } } },
+      { title: 'Line — Steady Growth',
+        size: { w: 540, h: 280 },
+        atom: { type: 'line', args: { values: [85, 88, 92, 94, 96, 95, 97], labels: ['W1', 'W2', 'W3', 'W4', 'W5', 'W6', 'W7'], format: 'percent', title: 'Weekly Retention' } } },
+      // ---- Pie chart samples (Phase 1b) ----
+      { title: 'Pie — Solid Cloud Share',
+        size: { w: 480, h: 320 },
+        atom: { type: 'pie', args: { values: [32, 23, 11, 8, 26], labels: ['AWS', 'Azure', 'GCP', 'Alibaba', 'Others'], format: 'percent', title: 'Cloud Market Share' } } },
+      { title: 'Pie — Donut + Center Label',
+        size: { w: 480, h: 320 },
+        atom: { type: 'pie', args: { values: [45, 25, 15, 10, 5], labels: ['Eng', 'Sales', 'Marketing', 'Support', 'Other'], format: 'percent', title: 'Headcount Split', donutRatio: 0.55, centerLabel: '120' } } },
+      { title: 'Pie — Revenue by Segment',
+        size: { w: 480, h: 320 },
+        atom: { type: 'pie', args: { values: [4.2, 2.1, 1.5, 0.8], labels: ['Enterprise', 'Mid-market', 'SMB', 'Indie'], format: 'currency', title: 'Revenue $M by Segment', donutRatio: 0.4 } } },
     ];
 
     function rgbCss(rgb) { return `rgb(${rgb[0]},${rgb[1]},${rgb[2]})`; }

--- a/sdf-js/scripts/test-atoms-2d-framework.mjs
+++ b/sdf-js/scripts/test-atoms-2d-framework.mjs
@@ -321,5 +321,157 @@ console.log('\n--- bar atom ---');
   );
 }
 
+// ----- line atom (Phase 1b) -----
+console.log('\n--- line atom ---');
+{
+  const spec = await getAtomSpec('line');
+  ok(spec.type === 'line', 'line spec.type');
+  ok(spec.args.annotations.type.includes('index'), 'annotations spec describes shape');
+
+  const recorded = [];
+  const c = stubCtx(recorded);
+  await renderAtom(
+    c,
+    'line',
+    {
+      values: [1.2, 1.8, 2.4, 3.1],
+      labels: ['Q1', 'Q2', 'Q3', 'Q4'],
+      format: 'currency',
+      title: 'Revenue Trajectory',
+      annotations: [{ index: 2, text: '↑ launch' }],
+      showValues: true,
+    },
+    'pseudo3d',
+    { x: 0, y: 0, w: 480, h: 280, palette: { bg: [255, 255, 255], silhouetteColor: [0, 0, 0] } },
+  );
+  ok(recorded.includes('Revenue Trajectory'), 'title rendered');
+  ok(recorded.includes('Q1') && recorded.includes('Q4'), 'x labels rendered');
+  ok(
+    recorded.includes('$1.2') && recorded.includes('$3.1'),
+    'value labels rendered (showValues=true)',
+  );
+  ok(
+    recorded.some((t) => String(t).includes('launch')),
+    'annotation text rendered',
+  );
+
+  // n < 2 = no-op
+  recorded.length = 0;
+  let crashed = false;
+  try {
+    await renderAtom(c, 'line', { values: [1], labels: ['only'] }, 'pseudo3d', {
+      w: 100,
+      h: 100,
+      palette: { bg: [255, 255, 255], silhouetteColor: [0, 0, 0] },
+    });
+  } catch (e) {
+    crashed = true;
+  }
+  ok(!crashed, 'n=1 no crash (silently no-op)');
+}
+
+// ----- pie atom (Phase 1b) -----
+console.log('\n--- pie atom ---');
+{
+  const spec = await getAtomSpec('pie');
+  ok(spec.type === 'pie', 'pie spec.type');
+  ok(spec.args.donutRatio.default === 0, 'donutRatio defaults to 0 (solid pie)');
+
+  const recorded = [];
+  const c = stubCtx(recorded);
+  await renderAtom(
+    c,
+    'pie',
+    {
+      values: [32, 23, 11, 8, 26],
+      labels: ['AWS', 'Azure', 'GCP', 'Alibaba', 'Others'],
+      format: 'percent',
+      title: 'Cloud Market Share',
+    },
+    'pseudo3d',
+    { x: 0, y: 0, w: 400, h: 300, palette: { bg: [255, 255, 255], silhouetteColor: [0, 0, 0] } },
+  );
+  ok(recorded.includes('Cloud Market Share'), 'title rendered');
+  ok(
+    recorded.some((t) => String(t).includes('AWS') && String(t).includes('32')),
+    'AWS label + 32% rendered',
+  );
+  ok(
+    recorded.some((t) => String(t).includes('Alibaba') && String(t).includes('8')),
+    'Alibaba label + 8% rendered',
+  );
+
+  // Donut mode + center label
+  recorded.length = 0;
+  await renderAtom(
+    c,
+    'pie',
+    {
+      values: [45, 25, 15, 10, 5],
+      labels: ['A', 'B', 'C', 'D', 'E'],
+      donutRatio: 0.55,
+      centerLabel: '120',
+    },
+    'pseudo3d',
+    { x: 0, y: 0, w: 400, h: 300, palette: { bg: [255, 255, 255], silhouetteColor: [0, 0, 0] } },
+  );
+  ok(recorded.includes('120'), 'donut center label drawn');
+
+  // Zero sum no crash
+  recorded.length = 0;
+  let crashed = false;
+  try {
+    await renderAtom(c, 'pie', { values: [0, 0, 0], labels: ['a', 'b', 'c'] }, 'pseudo3d', {
+      w: 100,
+      h: 100,
+      palette: { bg: [255, 255, 255], silhouetteColor: [0, 0, 0] },
+    });
+  } catch (e) {
+    crashed = true;
+  }
+  ok(!crashed, 'zero-sum values → no crash');
+}
+
+// Shared stub ctx factory (used by tests above + may be used in future atom tests)
+function stubCtx(recorded) {
+  const c = {};
+  const noop = () => {};
+  for (const m of [
+    'save',
+    'restore',
+    'beginPath',
+    'closePath',
+    'moveTo',
+    'lineTo',
+    'quadraticCurveTo',
+    'arc',
+    'stroke',
+    'fill',
+    'fillRect',
+  ]) {
+    c[m] = noop;
+  }
+  c.measureText = (t) => ({ width: String(t).length * 7 });
+  c.createLinearGradient = () => ({ addColorStop: noop });
+  c.createRadialGradient = () => ({ addColorStop: noop });
+  c.fillText = (t) => recorded.push(t);
+  for (const p of [
+    'fillStyle',
+    'strokeStyle',
+    'lineWidth',
+    'lineCap',
+    'lineJoin',
+    'shadowColor',
+    'shadowBlur',
+    'shadowOffsetY',
+    'font',
+    'textAlign',
+    'textBaseline',
+  ]) {
+    Object.defineProperty(c, p, { set() {} });
+  }
+  return c;
+}
+
 console.log(`\n=== Result: ${pass} passed, ${fail} failed ===`);
 process.exit(fail > 0 ? 1 : 0);

--- a/sdf-js/src/present/atoms-2d/charts/data/line.js
+++ b/sdf-js/src/present/atoms-2d/charts/data/line.js
@@ -1,0 +1,227 @@
+// =============================================================================
+// atoms-2d/charts/data/line.js — Line chart with annotations
+// -----------------------------------------------------------------------------
+// 3rd atom in 2D vector library (Phase 1b).
+//
+// Semantic: time-series or sequential trend showing change over points.
+// Each point connected by a line; optional data point markers; optional
+// per-point annotation labels (e.g. "→ launch", "← peak").
+//
+// Args:
+//   values        — number[] (Y values, in plot order)
+//   labels        — string[] (X labels under each point)
+//   format        — 'currency' | 'percent' | 'number' (Y-axis value formatter)
+//   title         — optional title above chart
+//   annotations   — array of { index, text } — point-specific callouts
+//   showPoints    — bool, draw dot markers (default true)
+//   showValues    — bool, draw Y value above each point (default false)
+//
+// Render: pseudo-3D (drawPseudo3D)
+//   - Faint baseline grid (3 horizontal lines)
+//   - Connected line with subtle drop shadow + thick stroke
+//   - Filled area gradient under line (fades to bg)
+//   - Point markers (circles with shadow + gradient — same pseudo-3D treatment)
+//   - X labels under each point (Inter 500)
+//   - Annotations as small callouts pointing to specific points
+//
+// Per [[atlas-sprint14-finance-preset-plan]] atom #5 of 5 finance preset
+// (line trend with annotations).
+// =============================================================================
+
+import { rgbCss, rgbaCss } from '../../renderer.js';
+
+export const spec = {
+  type: 'line',
+  category: 'charts/data',
+  description:
+    'Line/trend chart showing sequence of values. Optional dot markers, value labels, and point-specific annotations.',
+  args: {
+    values: { type: 'number[]', required: true, example: [1.2, 1.8, 2.4, 3.1] },
+    labels: { type: 'string[]', required: true, example: ['Q1', 'Q2', 'Q3', 'Q4'] },
+    format: {
+      type: "'currency'|'percent'|'number'",
+      default: 'number',
+      example: 'currency',
+    },
+    title: { type: 'string?', example: 'Revenue Trajectory ($M)' },
+    annotations: {
+      type: '{ index: number, text: string }[]?',
+      example: [{ index: 2, text: '↑ product launch' }],
+    },
+    showPoints: { type: 'boolean?', default: true },
+    showValues: { type: 'boolean?', default: false },
+  },
+};
+
+const TITLE_FRAC = 0.14;
+const X_LABEL_FRAC = 0.1;
+const ANNOTATION_FRAC = 0.16;
+const PAD = 14;
+
+export function drawPseudo3D(ctx, args, opts = {}) {
+  const x = opts.x ?? 0;
+  const y = opts.y ?? 0;
+  const w = opts.w ?? 480;
+  const h = opts.h ?? 280;
+  const palette = opts.palette || {};
+  const fg = palette.silhouetteColor || [30, 27, 30];
+  const bg = palette.bg || [247, 244, 224];
+  const lineColor = palette.colors?.[0] || [60, 100, 200];
+
+  const values = Array.isArray(args.values) ? args.values : [];
+  const labels = Array.isArray(args.labels) ? args.labels : [];
+  const n = Math.min(values.length, labels.length);
+  if (n < 2) return;
+
+  const format = args.format || 'number';
+  const title = args.title;
+  const annotations = Array.isArray(args.annotations) ? args.annotations : [];
+  const showPoints = args.showPoints !== false;
+  const showValues = args.showValues === true;
+  const hasAnn = annotations.length > 0;
+
+  // ---- Title ----
+  let chartTop = y + PAD;
+  if (title) {
+    const titleSize = Math.round(h * 0.07);
+    ctx.fillStyle = rgbCss(fg);
+    ctx.font = `700 ${titleSize}px Inter, system-ui, sans-serif`;
+    ctx.textAlign = 'left';
+    ctx.textBaseline = 'top';
+    ctx.fillText(title, x + PAD, y + PAD);
+    chartTop = y + h * TITLE_FRAC;
+  }
+
+  // ---- Plot area ----
+  const xLabelH = h * X_LABEL_FRAC;
+  const annH = hasAnn ? h * ANNOTATION_FRAC : 0;
+  const plotBottom = y + h - xLabelH - PAD;
+  const plotTop = chartTop + annH + PAD;
+  const plotLeft = x + PAD;
+  const plotRight = x + w - PAD;
+  const plotW = plotRight - plotLeft;
+  const plotH = Math.max(40, plotBottom - plotTop);
+
+  const minV = Math.min(...values);
+  const maxV = Math.max(...values, minV + 1);
+  const range = maxV - minV || 1;
+
+  // ---- Faint baseline grid (3 horizontal lines) ----
+  ctx.save();
+  ctx.strokeStyle = rgbaCss(fg, 0.08);
+  ctx.lineWidth = 1;
+  for (let i = 0; i <= 3; i++) {
+    const gy = plotTop + (plotH * i) / 3;
+    ctx.beginPath();
+    ctx.moveTo(plotLeft, gy);
+    ctx.lineTo(plotRight, gy);
+    ctx.stroke();
+  }
+  ctx.restore();
+
+  // ---- Compute point positions ----
+  const points = [];
+  for (let i = 0; i < n; i++) {
+    const xp = plotLeft + (plotW * i) / (n - 1);
+    const yp = plotBottom - (plotH * (values[i] - minV)) / range;
+    points.push({ x: xp, y: yp, value: values[i], label: labels[i] });
+  }
+
+  // ---- Area fill (gradient under line) ----
+  const areaGradient = ctx.createLinearGradient(0, plotTop, 0, plotBottom);
+  areaGradient.addColorStop(0, rgbaCss(lineColor, 0.35));
+  areaGradient.addColorStop(1, rgbaCss(lineColor, 0.02));
+  ctx.fillStyle = areaGradient;
+  ctx.beginPath();
+  ctx.moveTo(points[0].x, plotBottom);
+  for (const p of points) ctx.lineTo(p.x, p.y);
+  ctx.lineTo(points[n - 1].x, plotBottom);
+  ctx.closePath();
+  ctx.fill();
+
+  // ---- Connect line (with drop shadow) ----
+  ctx.save();
+  ctx.shadowColor = rgbaCss([0, 0, 0], 0.18);
+  ctx.shadowBlur = 6;
+  ctx.shadowOffsetY = 3;
+  ctx.strokeStyle = rgbCss(lineColor);
+  ctx.lineWidth = 3;
+  ctx.lineCap = 'round';
+  ctx.lineJoin = 'round';
+  ctx.beginPath();
+  ctx.moveTo(points[0].x, points[0].y);
+  for (let i = 1; i < n; i++) ctx.lineTo(points[i].x, points[i].y);
+  ctx.stroke();
+  ctx.restore();
+
+  // ---- Point markers ----
+  if (showPoints) {
+    for (const p of points) {
+      ctx.save();
+      ctx.shadowColor = rgbaCss([0, 0, 0], 0.2);
+      ctx.shadowBlur = 4;
+      ctx.shadowOffsetY = 2;
+      ctx.fillStyle = rgbCss(bg);
+      ctx.beginPath();
+      ctx.arc(p.x, p.y, 5, 0, Math.PI * 2);
+      ctx.fill();
+      ctx.restore();
+      ctx.fillStyle = rgbCss(lineColor);
+      ctx.beginPath();
+      ctx.arc(p.x, p.y, 3, 0, Math.PI * 2);
+      ctx.fill();
+    }
+  }
+
+  // ---- Value labels (optional) ----
+  if (showValues) {
+    ctx.font = `600 ${Math.round(h * 0.05)}px IBM Plex Mono, monospace`;
+    ctx.fillStyle = rgbCss(fg);
+    ctx.textAlign = 'center';
+    ctx.textBaseline = 'bottom';
+    for (const p of points) {
+      ctx.fillText(formatValue(p.value, format), p.x, p.y - 9);
+    }
+  }
+
+  // ---- X labels (under each point) ----
+  ctx.font = `500 ${Math.round(h * 0.05)}px Inter, system-ui, sans-serif`;
+  ctx.fillStyle = rgbaCss(fg, 0.75);
+  ctx.textAlign = 'center';
+  ctx.textBaseline = 'top';
+  for (const p of points) {
+    ctx.fillText(String(p.label), p.x, plotBottom + 6);
+  }
+
+  // ---- Annotations (callouts pointing to specific points) ----
+  if (hasAnn) {
+    ctx.font = `600 ${Math.round(h * 0.045)}px Inter, system-ui, sans-serif`;
+    ctx.fillStyle = rgbCss(lineColor);
+    ctx.textAlign = 'center';
+    ctx.textBaseline = 'bottom';
+    for (const ann of annotations) {
+      if (typeof ann.index !== 'number' || ann.index < 0 || ann.index >= n) continue;
+      const p = points[ann.index];
+      const ay = chartTop + annH * 0.45;
+      // Draw connector line from text to point
+      ctx.strokeStyle = rgbaCss(lineColor, 0.4);
+      ctx.lineWidth = 1;
+      ctx.beginPath();
+      ctx.moveTo(p.x, ay + 4);
+      ctx.lineTo(p.x, p.y - 8);
+      ctx.stroke();
+      ctx.fillText(String(ann.text), p.x, ay);
+    }
+  }
+}
+
+function formatValue(v, format) {
+  switch (format) {
+    case 'currency':
+      return `$${v}`;
+    case 'percent':
+      return `${v}%`;
+    default:
+      return String(v);
+  }
+}

--- a/sdf-js/src/present/atoms-2d/charts/data/pie.js
+++ b/sdf-js/src/present/atoms-2d/charts/data/pie.js
@@ -1,0 +1,245 @@
+// =============================================================================
+// atoms-2d/charts/data/pie.js — Pie / Donut chart
+// -----------------------------------------------------------------------------
+// 4th atom in 2D vector library (Phase 1b).
+//
+// Semantic: share of N segments out of 100%. Each segment proportional to
+// its value. Most common chart type for "X out of Y" composition.
+//
+// Args:
+//   values         — number[] (raw, will be normalized to 100%)
+//   labels         — string[] (same length, segment names)
+//   format         — 'percent' | 'currency' | 'number' (label suffix format)
+//   title          — optional title above chart
+//   donutRatio     — 0..0.95 — inner hole radius / outer radius (default 0)
+//                    0 = solid pie, 0.5 = donut, 0.7 = thin ring
+//   centerLabel    — optional text in donut center (e.g. "Total $100M")
+//
+// Render: pseudo-3D (drawPseudo3D)
+//   - Outer slices with radial gradient + drop shadow
+//   - Slice color from palette.colors[i % N]
+//   - Labels outside each slice with leader line (only labels for ≥4% segments)
+//   - Small segments grouped or labeled inline
+//   - Center label (donut mode) — bold Inter
+//
+// Per [[atlas-sprint14-finance-preset-plan]] atom #4 of 5 finance preset
+// (market share donut/pie).
+// =============================================================================
+
+import { rgbCss, rgbaCss } from '../../renderer.js';
+
+export const spec = {
+  type: 'pie',
+  category: 'charts/data',
+  description: 'Pie or donut chart for share/composition. Each slice proportional to value.',
+  args: {
+    values: { type: 'number[]', required: true, example: [32, 23, 11, 8, 26] },
+    labels: {
+      type: 'string[]',
+      required: true,
+      example: ['AWS', 'Azure', 'GCP', 'Alibaba', 'Others'],
+    },
+    format: { type: "'percent'|'currency'|'number'", default: 'percent', example: 'percent' },
+    title: { type: 'string?', example: 'Cloud Market Share' },
+    donutRatio: { type: 'number (0..0.95)', default: 0, example: 0.55 },
+    centerLabel: { type: 'string?', example: '100%' },
+  },
+};
+
+const PAD = 14;
+const TITLE_FRAC = 0.12;
+const SMALL_SEGMENT_THRESHOLD = 0.04; // segments < 4% don't get external label
+
+export function drawPseudo3D(ctx, args, opts = {}) {
+  const x = opts.x ?? 0;
+  const y = opts.y ?? 0;
+  const w = opts.w ?? 400;
+  const h = opts.h ?? 300;
+  const palette = opts.palette || {};
+  const fg = palette.silhouetteColor || [30, 27, 30];
+  const bg = palette.bg || [247, 244, 224];
+  const colors = palette.colors || null;
+  const fallbackColors = [
+    [60, 100, 200],
+    [200, 100, 60],
+    [60, 180, 100],
+    [180, 60, 180],
+    [200, 180, 60],
+    [120, 120, 120],
+  ];
+
+  const values = Array.isArray(args.values) ? args.values : [];
+  const labels = Array.isArray(args.labels) ? args.labels : [];
+  const n = Math.min(values.length, labels.length);
+  if (n === 0) return;
+
+  const format = args.format || 'percent';
+  const title = args.title;
+  const donutRatio = Math.max(0, Math.min(0.95, args.donutRatio || 0));
+  const centerLabel = args.centerLabel;
+
+  const sum = values.slice(0, n).reduce((a, b) => a + b, 0);
+  if (sum <= 0) return;
+
+  // ---- Title ----
+  let plotTop = y + PAD;
+  if (title) {
+    const titleSize = Math.round(h * 0.07);
+    ctx.fillStyle = rgbCss(fg);
+    ctx.font = `700 ${titleSize}px Inter, system-ui, sans-serif`;
+    ctx.textAlign = 'left';
+    ctx.textBaseline = 'top';
+    ctx.fillText(title, x + PAD, y + PAD);
+    plotTop = y + h * TITLE_FRAC;
+  }
+
+  // ---- Plot dimensions ----
+  // Need room for external labels — reserve ~20% horizontal padding for them
+  const labelRoom = w * 0.22;
+  const plotArea = {
+    cx: x + w / 2,
+    cy: plotTop + (y + h - plotTop) / 2,
+  };
+  const radius = Math.min(w - labelRoom * 2, y + h - plotTop) / 2 - PAD;
+  const innerRadius = radius * donutRatio;
+
+  // ---- Compute slice angles ----
+  const slices = [];
+  let currentAngle = -Math.PI / 2; // start at 12 o'clock
+  for (let i = 0; i < n; i++) {
+    const v = values[i];
+    const fraction = v / sum;
+    const startAngle = currentAngle;
+    const endAngle = currentAngle + fraction * Math.PI * 2;
+    const midAngle = (startAngle + endAngle) / 2;
+    const color = colors ? colors[i % colors.length] : fallbackColors[i % fallbackColors.length];
+    slices.push({
+      label: labels[i],
+      value: v,
+      fraction,
+      startAngle,
+      endAngle,
+      midAngle,
+      color,
+    });
+    currentAngle = endAngle;
+  }
+
+  // ---- Draw drop shadow for entire pie group ----
+  ctx.save();
+  ctx.shadowColor = rgbaCss([0, 0, 0], 0.22);
+  ctx.shadowBlur = 12;
+  ctx.shadowOffsetY = 4;
+  ctx.fillStyle = rgbCss(fg);
+  ctx.beginPath();
+  ctx.arc(plotArea.cx, plotArea.cy, radius, 0, Math.PI * 2);
+  ctx.fill();
+  ctx.restore();
+
+  // ---- Draw each slice with radial gradient ----
+  for (const s of slices) {
+    ctx.save();
+    // Per-slice gradient: lighter at outer edge, slightly darker toward center
+    const grad = ctx.createRadialGradient(
+      plotArea.cx,
+      plotArea.cy,
+      innerRadius || 4,
+      plotArea.cx,
+      plotArea.cy,
+      radius,
+    );
+    grad.addColorStop(0, rgbCss(darken(s.color, 0.12)));
+    grad.addColorStop(1, rgbCss(lighten(s.color, 0.06)));
+    ctx.fillStyle = grad;
+
+    ctx.beginPath();
+    ctx.moveTo(plotArea.cx, plotArea.cy);
+    ctx.arc(plotArea.cx, plotArea.cy, radius, s.startAngle, s.endAngle);
+    ctx.closePath();
+    ctx.fill();
+    ctx.restore();
+
+    // Slice separator (thin white line for visual crispness)
+    ctx.save();
+    ctx.strokeStyle = rgbCss(bg);
+    ctx.lineWidth = 2;
+    ctx.beginPath();
+    ctx.moveTo(plotArea.cx, plotArea.cy);
+    ctx.lineTo(
+      plotArea.cx + Math.cos(s.endAngle) * radius,
+      plotArea.cy + Math.sin(s.endAngle) * radius,
+    );
+    ctx.stroke();
+    ctx.restore();
+  }
+
+  // ---- Donut hole ----
+  if (donutRatio > 0) {
+    ctx.fillStyle = rgbCss(bg);
+    ctx.beginPath();
+    ctx.arc(plotArea.cx, plotArea.cy, innerRadius, 0, Math.PI * 2);
+    ctx.fill();
+
+    if (centerLabel) {
+      ctx.fillStyle = rgbCss(fg);
+      ctx.font = `700 ${Math.round(innerRadius * 0.35)}px Inter, system-ui, sans-serif`;
+      ctx.textAlign = 'center';
+      ctx.textBaseline = 'middle';
+      ctx.fillText(String(centerLabel), plotArea.cx, plotArea.cy);
+    }
+  }
+
+  // ---- External labels with leader lines ----
+  ctx.font = `500 ${Math.round(h * 0.05)}px Inter, system-ui, sans-serif`;
+  ctx.fillStyle = rgbCss(fg);
+  for (const s of slices) {
+    if (s.fraction < SMALL_SEGMENT_THRESHOLD) continue; // skip too-small slices
+
+    const labelText = `${s.label}  ${formatValue(s.value, s.fraction, format)}`;
+    const labelDist = radius + 14;
+    const tipX = plotArea.cx + Math.cos(s.midAngle) * radius;
+    const tipY = plotArea.cy + Math.sin(s.midAngle) * radius;
+    const labelX = plotArea.cx + Math.cos(s.midAngle) * labelDist;
+    const labelY = plotArea.cy + Math.sin(s.midAngle) * labelDist;
+    const onRight = Math.cos(s.midAngle) > 0;
+
+    // Leader line
+    ctx.strokeStyle = rgbaCss(fg, 0.4);
+    ctx.lineWidth = 1;
+    ctx.beginPath();
+    ctx.moveTo(tipX, tipY);
+    ctx.lineTo(labelX, labelY);
+    ctx.stroke();
+
+    ctx.textAlign = onRight ? 'left' : 'right';
+    ctx.textBaseline = 'middle';
+    ctx.fillText(labelText, labelX + (onRight ? 4 : -4), labelY);
+  }
+}
+
+function formatValue(rawValue, fraction, format) {
+  switch (format) {
+    case 'percent':
+      return `${Math.round(fraction * 1000) / 10}%`;
+    case 'currency':
+      return `$${rawValue}`;
+    default:
+      return String(rawValue);
+  }
+}
+
+function lighten(rgb, amt) {
+  return [
+    Math.min(255, rgb[0] + (255 - rgb[0]) * amt),
+    Math.min(255, rgb[1] + (255 - rgb[1]) * amt),
+    Math.min(255, rgb[2] + (255 - rgb[2]) * amt),
+  ];
+}
+
+function darken(rgb, amt) {
+  return [
+    Math.max(0, rgb[0] * (1 - amt)),
+    Math.max(0, rgb[1] * (1 - amt)),
+    Math.max(0, rgb[2] * (1 - amt)),
+  ];
+}

--- a/sdf-js/src/present/atoms-2d/registry.js
+++ b/sdf-js/src/present/atoms-2d/registry.js
@@ -27,7 +27,9 @@ const ATOM_LOADERS = {
   // Charts / data
   'kpi-card': () => import('./charts/data/kpi-card.js'),
   bar: () => import('./charts/data/bar.js'),
-  // Future Phase 1: line / pie / column
+  line: () => import('./charts/data/line.js'),
+  pie: () => import('./charts/data/pie.js'),
+  // Future Phase 1: column
 
   // Charts / diagrams (Phase 2)
   // Charts / hierarchy (Phase 2)


### PR DESCRIPTION
## What ships

Atoms 3 + 4 in 2D vector library (line + pie/donut). Both pseudo-3D style.

**LINE atom** (`charts/data/line.js`):
- Time series with optional dot markers, value labels, annotations
- Area fill gradient under line
- Annotation callouts with leader lines pointing to specific points

**PIE atom** (`charts/data/pie.js`):
- Solid pie OR donut (donutRatio 0-0.95)
- External labels with leader lines
- Donut center label (e.g. "Total: $100M")
- Per-slice radial gradient for pseudo-3D feel

## Demo: 6 new samples

- Line × 3: Quarterly Revenue / MAU with annotation / Weekly Retention
- Pie × 3: Solid Cloud Share / Donut Headcount Split / Revenue by Segment

## Branch chain

Builds on PR #53 (bar) → PR #52 (framework). Merge #52 → #53 → this.

## Test

- 14 new assertions → 46 total
- Edge cases: n<2 no crash, zero-sum no crash, donut + center label
- 81/81 npm test passing
- Browser visual verified — no console errors

## Next PR

Phase 1c — column + area atoms (5th chart family)

🤖 Generated with [Claude Code](https://claude.com/claude-code)