### PR TITLE
atoms-2d Phase 1c: column atom (closes charts/data family)

### DIFF
--- a/sdf-js/examples/atoms-2d-demo/index.html
+++ b/sdf-js/examples/atoms-2d-demo/index.html
@@ -88,6 +88,16 @@
       { title: 'Pie — Revenue by Segment',
         size: { w: 480, h: 320 },
         atom: { type: 'pie', args: { values: [4.2, 2.1, 1.5, 0.8], labels: ['Enterprise', 'Mid-market', 'SMB', 'Indie'], format: 'currency', title: 'Revenue $M by Segment', donutRatio: 0.4 } } },
+      // ---- Column chart samples (Phase 1c) ----
+      { title: 'Column — Quarterly Revenue',
+        size: { w: 540, h: 320 },
+        atom: { type: 'column', args: { values: [1.2, 1.8, 2.4, 3.1], labels: ['Q1', 'Q2', 'Q3', 'Q4'], format: 'currency', title: 'Quarterly Revenue ($M)' } } },
+      { title: 'Column — Monthly Signups',
+        size: { w: 540, h: 320 },
+        atom: { type: 'column', args: { values: [340, 420, 510, 580, 670, 820], labels: ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun'], format: 'number', title: 'Monthly Signups' } } },
+      { title: 'Column — Conversion by Channel',
+        size: { w: 540, h: 320 },
+        atom: { type: 'column', args: { values: [4.2, 8.7, 3.1, 12.5, 6.3], labels: ['Organic', 'Paid', 'Email', 'Referral', 'Social'], format: 'percent', title: 'Conversion Rate by Channel' } } },
     ];
 
     function rgbCss(rgb) { return `rgb(${rgb[0]},${rgb[1]},${rgb[2]})`; }

--- a/sdf-js/scripts/test-atoms-2d-framework.mjs
+++ b/sdf-js/scripts/test-atoms-2d-framework.mjs
@@ -432,7 +432,49 @@ console.log('\n--- pie atom ---');
   ok(!crashed, 'zero-sum values → no crash');
 }
 
-// Shared stub ctx factory (used by tests above + may be used in future atom tests)
+// ----- column atom (Phase 1c) -----
+console.log('\n--- column atom ---');
+{
+  const spec = await getAtomSpec('column');
+  ok(spec.type === 'column', 'column spec.type');
+  ok(spec.args.values.required && spec.args.labels.required, 'column requires values + labels');
+
+  const recorded = [];
+  const c = stubCtx(recorded);
+  await renderAtom(
+    c,
+    'column',
+    {
+      values: [1.2, 1.8, 2.4, 3.1],
+      labels: ['Q1', 'Q2', 'Q3', 'Q4'],
+      format: 'currency',
+      title: 'Quarterly',
+    },
+    'pseudo3d',
+    { x: 0, y: 0, w: 480, h: 280, palette: { bg: [255, 255, 255], silhouetteColor: [0, 0, 0] } },
+  );
+  ok(recorded.includes('Quarterly'), 'title rendered');
+  ok(recorded.includes('Q1') && recorded.includes('Q4'), 'X labels rendered');
+  ok(
+    recorded.includes('$1.2') && recorded.includes('$3.1'),
+    'values on top rendered (showValues default true)',
+  );
+
+  // showValues: false → no values drawn
+  recorded.length = 0;
+  await renderAtom(
+    c,
+    'column',
+    { values: [10, 20], labels: ['A', 'B'], showValues: false },
+    'pseudo3d',
+    { x: 0, y: 0, w: 200, h: 200, palette: { bg: [255, 255, 255], silhouetteColor: [0, 0, 0] } },
+  );
+  ok(recorded.includes('A') && recorded.includes('B'), 'labels still drawn');
+  ok(
+    !recorded.includes('10') && !recorded.includes('20'),
+    'values suppressed when showValues=false',
+  );
+}
 function stubCtx(recorded) {
   const c = {};
   const noop = () => {};

--- a/sdf-js/src/present/atoms-2d/charts/data/column.js
+++ b/sdf-js/src/present/atoms-2d/charts/data/column.js
@@ -1,0 +1,210 @@
+// =============================================================================
+// atoms-2d/charts/data/column.js — Vertical column chart
+// -----------------------------------------------------------------------------
+// 5th atom in 2D vector library (Phase 1c). Completes charts/data family.
+//
+// Sibling of `bar` atom: same data shape but COLUMNS (vertical bars) instead
+// of horizontal bars. Convention: column = time-series (X = ordered
+// categories, Y = value). bar = magnitude comparison (Y = categories, X =
+// value). Both are valid for "values + labels" data — choice is editorial.
+//
+// Args (identical to bar atom for LLM consistency):
+//   values  — number[] (raw, will be normalized via max)
+//   labels  — string[] (same length, X-axis category names under each column)
+//   format  — 'currency' | 'percent' | 'number' | function (value formatter)
+//   max     — optional explicit max for scaling
+//   title   — optional title above chart
+//   showValues — bool, draw value on top of each column (default true)
+//
+// Render: pseudo-3D (drawPseudo3D)
+//   - Title row (Inter 700) above
+//   - Y-axis baseline (faint horizontal line at bottom)
+//   - Each column: gradient + drop shadow + top iso edge
+//   - Column color from palette.colors[i % N] (or fallback)
+//   - X label under each column (Inter 500, centered)
+//   - Value above each column top (IBM Plex Mono 600, optional)
+//
+// Per [[atlas-sprint14-finance-preset-plan]] — atom #2 of 5 finance preset
+// (quarterly trajectory variant — bar but vertical).
+// =============================================================================
+
+import { rgbCss, rgbaCss } from '../../renderer.js';
+
+export const spec = {
+  type: 'column',
+  category: 'charts/data',
+  description:
+    'Vertical column chart. Sibling of bar atom (same args, rotated 90°). Best for time-series.',
+  args: {
+    values: { type: 'number[]', required: true, example: [1.2, 1.8, 2.4, 3.1] },
+    labels: { type: 'string[]', required: true, example: ['Q1', 'Q2', 'Q3', 'Q4'] },
+    format: {
+      type: "'currency'|'percent'|'number'|function",
+      default: 'number',
+      example: 'currency',
+    },
+    max: { type: 'number?', example: 4 },
+    title: { type: 'string?', example: 'Quarterly Revenue ($M)' },
+    showValues: { type: 'boolean?', default: true },
+  },
+};
+
+const PAD = 14;
+const TITLE_FRAC = 0.13;
+const X_LABEL_FRAC = 0.1;
+const VALUE_TOP_GAP = 6;
+
+export function drawPseudo3D(ctx, args, opts = {}) {
+  const x = opts.x ?? 0;
+  const y = opts.y ?? 0;
+  const w = opts.w ?? 480;
+  const h = opts.h ?? 280;
+  const palette = opts.palette || {};
+  const fg = palette.silhouetteColor || [30, 27, 30];
+  const colors = palette.colors || null;
+  const fallbackBar = palette.colors?.[0] || [60, 100, 200];
+
+  const values = Array.isArray(args.values) ? args.values : [];
+  const labels = Array.isArray(args.labels) ? args.labels : [];
+  const n = Math.min(values.length, labels.length);
+  if (n === 0) return;
+
+  const max = args.max ?? Math.max(...values, 0);
+  const format = args.format ?? 'number';
+  const title = args.title;
+  const showValues = args.showValues !== false; // default true
+
+  // ---- Title row ----
+  let plotTop = y + PAD;
+  if (title) {
+    const titleSize = Math.round(h * 0.07);
+    ctx.fillStyle = rgbCss(fg);
+    ctx.font = `700 ${titleSize}px Inter, system-ui, sans-serif`;
+    ctx.textAlign = 'left';
+    ctx.textBaseline = 'top';
+    ctx.fillText(title, x + PAD, y + PAD);
+    plotTop = y + h * TITLE_FRAC;
+  }
+
+  // ---- Plot dimensions ----
+  const xLabelH = h * X_LABEL_FRAC;
+  const valueLabelH = showValues ? h * 0.07 : 0;
+  const plotBottom = y + h - xLabelH - PAD;
+  const plotEffectiveTop = plotTop + valueLabelH + PAD;
+  const plotH = Math.max(40, plotBottom - plotEffectiveTop);
+  const plotLeft = x + PAD;
+  const plotRight = x + w - PAD;
+  const plotW = plotRight - plotLeft;
+
+  // ---- Faint baseline ----
+  ctx.save();
+  ctx.strokeStyle = rgbaCss(fg, 0.15);
+  ctx.lineWidth = 1;
+  ctx.beginPath();
+  ctx.moveTo(plotLeft, plotBottom);
+  ctx.lineTo(plotRight, plotBottom);
+  ctx.stroke();
+  ctx.restore();
+
+  // ---- Column geometry ----
+  const slotW = plotW / n;
+  const columnW = Math.min(60, slotW * 0.7);
+
+  // ---- Draw each column ----
+  const valueSize = Math.max(11, Math.round(h * 0.05));
+  const labelSize = Math.max(11, Math.round(h * 0.05));
+
+  for (let i = 0; i < n; i++) {
+    const v = values[i];
+    const cx = plotLeft + slotW * (i + 0.5);
+    const lengthFrac = max > 0 ? v / max : 0;
+    const colH = Math.max(2, plotH * lengthFrac);
+    const colTop = plotBottom - colH;
+    const colLeft = cx - columnW / 2;
+    const color = colors ? colors[i % colors.length] : fallbackBar;
+
+    // Column body — pseudo-3D
+    drawPseudoColumn(ctx, colLeft, colTop, columnW, colH, color);
+
+    // Value on top
+    if (showValues) {
+      ctx.fillStyle = rgbCss(fg);
+      ctx.font = `600 ${valueSize}px IBM Plex Mono, monospace`;
+      ctx.textAlign = 'center';
+      ctx.textBaseline = 'bottom';
+      ctx.fillText(formatValue(v, format), cx, colTop - VALUE_TOP_GAP);
+    }
+
+    // X label below
+    ctx.fillStyle = rgbaCss(fg, 0.85);
+    ctx.font = `500 ${labelSize}px Inter, system-ui, sans-serif`;
+    ctx.textAlign = 'center';
+    ctx.textBaseline = 'top';
+    ctx.fillText(String(labels[i]), cx, plotBottom + 6);
+  }
+}
+
+// ============================================================================
+// Private helpers
+// ============================================================================
+
+function drawPseudoColumn(ctx, x, y, w, h, color) {
+  if (w <= 0 || h <= 0) return;
+  const radius = Math.min(w / 2, 4);
+
+  // Shadow
+  ctx.save();
+  ctx.shadowColor = rgbaCss([0, 0, 0], 0.18);
+  ctx.shadowBlur = 6;
+  ctx.shadowOffsetY = 2;
+
+  // Gradient (left lighter, right darker for sidelit feel)
+  const gradient = ctx.createLinearGradient(x, 0, x + w, 0);
+  gradient.addColorStop(0, rgbaCss(lighten(color, 0.18), 1));
+  gradient.addColorStop(1, rgbCss(color));
+  ctx.fillStyle = gradient;
+
+  ctx.beginPath();
+  ctx.moveTo(x, y + radius);
+  ctx.quadraticCurveTo(x, y, x + radius, y);
+  ctx.lineTo(x + w - radius, y);
+  ctx.quadraticCurveTo(x + w, y, x + w, y + radius);
+  ctx.lineTo(x + w, y + h);
+  ctx.lineTo(x, y + h);
+  ctx.closePath();
+  ctx.fill();
+  ctx.restore();
+
+  // Top iso edge accent
+  ctx.save();
+  ctx.fillStyle = rgbaCss(lighten(color, 0.32), 0.7);
+  ctx.beginPath();
+  ctx.moveTo(x + radius, y);
+  ctx.lineTo(x + w - radius, y);
+  ctx.lineTo(x + w - radius, y + 2);
+  ctx.lineTo(x + radius, y + 2);
+  ctx.closePath();
+  ctx.fill();
+  ctx.restore();
+}
+
+function formatValue(v, format) {
+  if (typeof format === 'function') return format(v);
+  switch (format) {
+    case 'currency':
+      return `$${v}`;
+    case 'percent':
+      return `${v}%`;
+    case 'number':
+    default:
+      return String(v);
+  }
+}
+
+function lighten(rgb, amt) {
+  return [
+    Math.min(255, rgb[0] + (255 - rgb[0]) * amt),
+    Math.min(255, rgb[1] + (255 - rgb[1]) * amt),
+    Math.min(255, rgb[2] + (255 - rgb[2]) * amt),
+  ];
+}

--- a/sdf-js/src/present/atoms-2d/registry.js
+++ b/sdf-js/src/present/atoms-2d/registry.js
@@ -29,7 +29,8 @@ const ATOM_LOADERS = {
   bar: () => import('./charts/data/bar.js'),
   line: () => import('./charts/data/line.js'),
   pie: () => import('./charts/data/pie.js'),
-  // Future Phase 1: column
+  column: () => import('./charts/data/column.js'),
+  // Phase 1 (charts/data) complete: kpi-card / bar / line / pie / column
 
   // Charts / diagrams (Phase 2)
   // Charts / hierarchy (Phase 2)


### PR DESCRIPTION
## What ships

5th and final atom in `charts/data/` family. Vertical column chart.

Sibling of `bar` atom — same args, rotated 90°. Convention:
- `column` → time series (X = ordered categories, Y = value)
- `bar` → magnitude comparison (Y = categories, X = value)

## Phase 1 complete

| atom | PR |
|---|---|
| kpi-card | #52 |
| bar | #53 |
| line | #55 |
| pie | #55 |
| column | this |

= matches 3D atom inventory charts/data exactly (5 atoms).

## Demo: 3 new column samples

- Quarterly Revenue ($M, 4 columns)
- Monthly Signups (number, 6 columns)
- Conversion by Channel (percent, 5 columns)

## Branch chain

#52 → #53 → #55 → this. Merge in order.

## Test

- 7 new assertions → 53 total
- 81/81 npm test passing
- Browser visual verified — no console errors

## Next batch

Phase 2 — diagrams (flow / mindmap / org-chart / relationship / timeline / tree) + hierarchy (pyramid)

🤖 Generated with [Claude Code](https://claude.com/claude-code)