### PR TITLE
atoms-2d Phase 2b: tree-diagram + org-chart atoms

### DIFF
--- a/sdf-js/examples/atoms-2d-demo/index.html
+++ b/sdf-js/examples/atoms-2d-demo/index.html
@@ -108,6 +108,14 @@
       { title: 'Flow — Vertical Decision',
         size: { w: 320, h: 540 },
         atom: { type: 'flow-chart', args: { steps: ['Request', 'Auth check', 'Rate limit', 'Process', 'Response'], orientation: 'vertical', title: 'Request Pipeline' } } },
+      // ---- Tree diagram (Phase 2b) ----
+      { title: 'Tree — Product Categories',
+        size: { w: 720, h: 360 },
+        atom: { type: 'tree-diagram', args: { title: 'Product Categories', root: { label: 'Software', children: [{ label: 'Enterprise', children: [{ label: 'CRM' }, { label: 'ERP' }] }, { label: 'Consumer', children: [{ label: 'Mobile' }, { label: 'Web' }, { label: 'Desktop' }] }, { label: 'Developer' }] } } } },
+      // ---- Org chart (Phase 2b) ----
+      { title: 'Org — Executive Team',
+        size: { w: 720, h: 380 },
+        atom: { type: 'org-chart', args: { title: 'Executive Team', root: { name: 'Sarah Chen', title: 'CEO', children: [{ name: 'Mike Park', title: 'CTO', children: [{ name: 'Alex Wu', title: 'Eng Manager' }, { name: 'Jamie Lee', title: 'Sr Engineer' }] }, { name: 'Lisa Wang', title: 'CMO', children: [{ name: 'Tom Chen', title: 'Brand Lead' }] }, { name: 'David Liu', title: 'CFO' }] } } } },
     ];
 
     function rgbCss(rgb) { return `rgb(${rgb[0]},${rgb[1]},${rgb[2]})`; }

--- a/sdf-js/scripts/test-atoms-2d-framework.mjs
+++ b/sdf-js/scripts/test-atoms-2d-framework.mjs
@@ -531,6 +531,89 @@ console.log('\n--- flow-chart atom ---');
   ok(!crashed, 'empty steps no crash');
 }
 
+// ----- tree-diagram + org-chart (Phase 2b) -----
+console.log('\n--- tree-diagram atom ---');
+{
+  const spec = await getAtomSpec('tree-diagram');
+  ok(spec.type === 'tree-diagram', 'tree-diagram spec.type');
+  ok(spec.args.root.required, 'root required');
+
+  const recorded = [];
+  const c = stubCtx(recorded);
+  await renderAtom(
+    c,
+    'tree-diagram',
+    {
+      title: 'Org Tree',
+      root: {
+        label: 'Product',
+        children: [
+          { label: 'Engineering', children: [{ label: 'Backend' }, { label: 'Frontend' }] },
+          { label: 'Design' },
+        ],
+      },
+    },
+    'pseudo3d',
+    { x: 0, y: 0, w: 600, h: 400, palette: { bg: [255, 255, 255], silhouetteColor: [0, 0, 0] } },
+  );
+  ok(recorded.includes('Org Tree'), 'title rendered');
+  ok(recorded.includes('Product'), 'root label rendered');
+  ok(recorded.includes('Engineering') && recorded.includes('Backend'), 'nested labels rendered');
+
+  // Empty root no crash
+  recorded.length = 0;
+  let crashed = false;
+  try {
+    await renderAtom(c, 'tree-diagram', { root: null }, 'pseudo3d', {
+      w: 200,
+      h: 200,
+      palette: { bg: [255, 255, 255], silhouetteColor: [0, 0, 0] },
+    });
+  } catch (e) {
+    crashed = true;
+  }
+  ok(!crashed, 'null root no crash');
+
+  // Single root no children
+  recorded.length = 0;
+  await renderAtom(c, 'tree-diagram', { root: { label: 'Lonely' } }, 'pseudo3d', {
+    w: 200,
+    h: 200,
+    palette: { bg: [255, 255, 255], silhouetteColor: [0, 0, 0] },
+  });
+  ok(recorded.includes('Lonely'), 'single-node tree renders');
+}
+
+console.log('\n--- org-chart atom ---');
+{
+  const spec = await getAtomSpec('org-chart');
+  ok(spec.type === 'org-chart', 'org-chart spec.type');
+  ok(spec.args.root.required, 'root required');
+
+  const recorded = [];
+  const c = stubCtx(recorded);
+  await renderAtom(
+    c,
+    'org-chart',
+    {
+      title: 'Executive Team',
+      root: {
+        name: 'Sarah Chen',
+        title: 'CEO',
+        children: [
+          { name: 'Mike Park', title: 'CTO' },
+          { name: 'Lisa Wang', title: 'CMO' },
+        ],
+      },
+    },
+    'pseudo3d',
+    { x: 0, y: 0, w: 600, h: 400, palette: { bg: [255, 255, 255], silhouetteColor: [0, 0, 0] } },
+  );
+  ok(recorded.includes('Executive Team'), 'title rendered');
+  ok(recorded.includes('Sarah Chen') && recorded.includes('CEO'), 'root name + title rendered');
+  ok(recorded.includes('Mike Park') && recorded.includes('CTO'), 'child name + title rendered');
+}
+
 function stubCtx(recorded) {
   const c = {};
   const noop = () => {};
@@ -542,6 +625,7 @@ function stubCtx(recorded) {
     'moveTo',
     'lineTo',
     'quadraticCurveTo',
+    'bezierCurveTo',
     'arc',
     'stroke',
     'fill',

--- a/sdf-js/src/present/atoms-2d/charts/diagrams/_tree-layout.js
+++ b/sdf-js/src/present/atoms-2d/charts/diagrams/_tree-layout.js
@@ -1,0 +1,83 @@
+// =============================================================================
+// _tree-layout.js — shared layout kernel for tree-diagram + org-chart atoms
+// -----------------------------------------------------------------------------
+// Both atoms render a top-down hierarchical tree. Layout is the same; the
+// node + connector styles differ. This module computes layout positions;
+// each atom owns its own draw logic for the visual style.
+//
+// Layout algorithm: Reingold-Tilford-inspired tidy tree.
+//   - Leaf x-positions assigned in left-to-right traversal order
+//   - Parent x = average of children x
+//   - Y = depth * levelHeight
+//
+// Input: nested object { label, children?: [{ label, ... }] }
+// Output: flat array of { node, x, y, depth, parentX, parentY, nodeWidth, levelHeight }
+// =============================================================================
+
+/**
+ * Compute tree layout positions for a nested tree, including parent x/y refs.
+ *
+ * @param {object} root — { label: string, children?: array, ...arbitrary node fields }
+ * @param {object} opts
+ * @param {number} opts.x — left edge of layout area
+ * @param {number} opts.y — top edge of layout area
+ * @param {number} opts.w — total width
+ * @param {number} opts.h — total height
+ * @param {number} [opts.minNodeWidth=80] — minimum node width to enforce
+ * @param {number} [opts.maxNodeWidth=180] — max node width cap
+ *
+ * @returns {Array<{node, x, y, depth, parentX, parentY, nodeWidth, levelHeight}>}
+ *   — flat list, each entry positioned absolutely. parentX/Y are null for root.
+ */
+export function computeTreeLayout(root, opts) {
+  if (!root || typeof root !== 'object') return [];
+  const { x = 0, y = 0, w = 600, h = 400, minNodeWidth = 80, maxNodeWidth = 180 } = opts || {};
+  const minLeafGap = 12;
+
+  const flat = [];
+  let leafCursor = 0;
+
+  function walk(node, depth, parentEntry) {
+    const entry = { node, depth, parent: parentEntry || null, x: 0, y: 0, children: [] };
+    flat.push(entry);
+    if (parentEntry) parentEntry.children.push(entry);
+
+    const kids = Array.isArray(node.children) ? node.children : [];
+    if (kids.length === 0) {
+      entry.x = leafCursor++;
+    } else {
+      for (const k of kids) walk(k, depth + 1, entry);
+      entry.x = entry.children.reduce((a, c) => a + c.x, 0) / entry.children.length;
+    }
+  }
+
+  walk(root, 0, null);
+  if (flat.length === 0) return [];
+
+  const minX = Math.min(...flat.map((e) => e.x));
+  const maxX = Math.max(...flat.map((e) => e.x));
+  const xRange = maxX - minX || 1;
+  const nLeaves = leafCursor || 1;
+  const availPerLeaf = w / nLeaves;
+  const nodeW = Math.max(minNodeWidth, Math.min(maxNodeWidth, availPerLeaf - minLeafGap));
+  const maxDepth = Math.max(...flat.map((e) => e.depth));
+  const levelHeight = maxDepth > 0 ? h / (maxDepth + 1) : h;
+
+  // Compute abs positions
+  for (const e of flat) {
+    const normX = (e.x - minX) / xRange;
+    e.absX = x + nodeW / 2 + normX * (w - nodeW);
+    e.absY = y + e.depth * levelHeight + levelHeight / 2;
+  }
+
+  return flat.map((e) => ({
+    node: e.node,
+    depth: e.depth,
+    x: e.absX,
+    y: e.absY,
+    parentX: e.parent ? e.parent.absX : null,
+    parentY: e.parent ? e.parent.absY : null,
+    nodeWidth: nodeW,
+    levelHeight,
+  }));
+}

--- a/sdf-js/src/present/atoms-2d/charts/diagrams/org-chart.js
+++ b/sdf-js/src/present/atoms-2d/charts/diagrams/org-chart.js
@@ -1,0 +1,209 @@
+// =============================================================================
+// atoms-2d/charts/diagrams/org-chart.js — Organizational hierarchy
+// -----------------------------------------------------------------------------
+// 8th atom in 2D vector library (Phase 2b).
+//
+// Semantic: top-down org chart with named boxes connected by orthogonal
+// (elbow) lines. Sibling of tree-diagram but specifically for organizations:
+// boxier nodes, name + title sublabel, orthogonal connectors (not curved).
+//
+// Args:
+//   root  — nested object { name, title?, sublabel?, children?: [{ name, title?, ... }] }
+//   title — optional chart title
+//   accent — optional accent color override (rgb tuple)
+//
+// Render: pseudo-3D
+//   - Each node: rectangular card with gradient + drop shadow
+//   - Name (Inter 700) top + title (Inter 500 faded) below
+//   - Orthogonal "elbow" connectors (90° corners, not curved)
+//   - Root node has accent fill
+//
+// Per [[atlas-sprint14-finance-preset-plan]] — diagram family.
+// =============================================================================
+
+import { rgbCss, rgbaCss } from '../../renderer.js';
+import { computeTreeLayout } from './_tree-layout.js';
+
+export const spec = {
+  type: 'org-chart',
+  category: 'charts/diagrams',
+  description:
+    'Organizational hierarchy chart. Rectangular boxes with name + title, orthogonal connectors.',
+  args: {
+    root: {
+      type: 'object { name, title?, sublabel?, children?: [...] }',
+      required: true,
+      example: {
+        name: 'Sarah Chen',
+        title: 'CEO',
+        children: [
+          {
+            name: 'Mike Park',
+            title: 'CTO',
+            children: [{ name: 'Alex Wu', title: 'Eng Manager' }],
+          },
+          { name: 'Lisa Wang', title: 'CMO' },
+          { name: 'David Liu', title: 'CFO' },
+        ],
+      },
+    },
+    title: { type: 'string?', example: 'Executive Team' },
+  },
+};
+
+const PAD = 14;
+const TITLE_FRAC = 0.1;
+const NODE_HEIGHT = 56;
+
+export function drawPseudo3D(ctx, args, opts = {}) {
+  const x = opts.x ?? 0;
+  const y = opts.y ?? 0;
+  const w = opts.w ?? 600;
+  const h = opts.h ?? 400;
+  const palette = opts.palette || {};
+  const fg = palette.silhouetteColor || [30, 27, 30];
+  const bg = palette.bg || [247, 244, 224];
+  const accent = palette.colors?.[0] || [60, 100, 200];
+
+  const root = args.root;
+  const title = args.title;
+  if (!root || typeof root !== 'object') return;
+
+  let layoutTop = y + PAD;
+  if (title) {
+    const titleSize = Math.round(h * 0.07);
+    ctx.fillStyle = rgbCss(fg);
+    ctx.font = `700 ${titleSize}px Inter, system-ui, sans-serif`;
+    ctx.textAlign = 'left';
+    ctx.textBaseline = 'top';
+    ctx.fillText(title, x + PAD, y + PAD);
+    layoutTop = y + h * TITLE_FRAC + PAD;
+  }
+
+  const layout = computeTreeLayout(root, {
+    x: x + PAD,
+    y: layoutTop,
+    w: w - PAD * 2,
+    h: y + h - layoutTop - PAD,
+    minNodeWidth: 110,
+    maxNodeWidth: 160,
+  });
+  if (layout.length === 0) return;
+
+  // Connectors first
+  for (const entry of layout) {
+    if (entry.parentX == null) continue;
+    drawOrthogonalConnector(
+      ctx,
+      entry.parentX,
+      entry.parentY + NODE_HEIGHT / 2,
+      entry.x,
+      entry.y - NODE_HEIGHT / 2,
+      fg,
+    );
+  }
+
+  // Nodes
+  for (const entry of layout) {
+    const isRoot = entry.depth === 0;
+    drawNode(ctx, entry.x, entry.y, entry.nodeWidth, NODE_HEIGHT, entry.node, isRoot, {
+      fg,
+      bg,
+      accent,
+    });
+  }
+}
+
+function drawOrthogonalConnector(ctx, x0, y0, x1, y1, color) {
+  ctx.save();
+  ctx.strokeStyle = rgbaCss(color, 0.35);
+  ctx.lineWidth = 1.4;
+  ctx.lineCap = 'butt';
+  ctx.lineJoin = 'miter';
+  const midY = (y0 + y1) / 2;
+  ctx.beginPath();
+  ctx.moveTo(x0, y0);
+  ctx.lineTo(x0, midY);
+  ctx.lineTo(x1, midY);
+  ctx.lineTo(x1, y1);
+  ctx.stroke();
+  ctx.restore();
+}
+
+function drawNode(ctx, cx, cy, w, h, nodeData, isRoot, colorCtx) {
+  const { fg, bg, accent } = colorCtx;
+  const nx = cx - w / 2;
+  const ny = cy - h / 2;
+  const radius = 6;
+
+  ctx.save();
+  ctx.shadowColor = rgbaCss([0, 0, 0], 0.18);
+  ctx.shadowBlur = 8;
+  ctx.shadowOffsetY = 3;
+
+  const gradient = ctx.createLinearGradient(nx, ny, nx, ny + h);
+  if (isRoot) {
+    gradient.addColorStop(0, rgbCss(lighten(accent, 0.12)));
+    gradient.addColorStop(1, rgbCss(accent));
+  } else {
+    gradient.addColorStop(0, rgbCss(bg));
+    gradient.addColorStop(1, rgbCss(darken(bg, 0.05)));
+  }
+  ctx.fillStyle = gradient;
+  roundedRectPath(ctx, nx, ny, w, h, radius);
+  ctx.fill();
+  ctx.restore();
+
+  // Border for non-root
+  if (!isRoot) {
+    ctx.strokeStyle = rgbaCss(fg, 0.2);
+    ctx.lineWidth = 1;
+    roundedRectPath(ctx, nx, ny, w, h, radius);
+    ctx.stroke();
+  }
+
+  // Name (top)
+  const name = nodeData.name ?? nodeData.label ?? '';
+  ctx.fillStyle = isRoot ? rgbCss(bg) : rgbCss(fg);
+  ctx.font = `700 ${Math.min(14, h * 0.25)}px Inter, system-ui, sans-serif`;
+  ctx.textAlign = 'center';
+  ctx.textBaseline = 'middle';
+  ctx.fillText(String(name), cx, ny + h * 0.36);
+
+  // Title (below)
+  if (nodeData.title) {
+    ctx.fillStyle = isRoot ? rgbaCss(bg, 0.78) : rgbaCss(fg, 0.6);
+    ctx.font = `500 ${Math.min(11, h * 0.2)}px Inter, system-ui, sans-serif`;
+    ctx.fillText(String(nodeData.title), cx, ny + h * 0.66);
+  }
+}
+
+function roundedRectPath(ctx, x, y, w, h, r) {
+  ctx.beginPath();
+  ctx.moveTo(x + r, y);
+  ctx.lineTo(x + w - r, y);
+  ctx.quadraticCurveTo(x + w, y, x + w, y + r);
+  ctx.lineTo(x + w, y + h - r);
+  ctx.quadraticCurveTo(x + w, y + h, x + w - r, y + h);
+  ctx.lineTo(x + r, y + h);
+  ctx.quadraticCurveTo(x, y + h, x, y + h - r);
+  ctx.lineTo(x, y + r);
+  ctx.quadraticCurveTo(x, y, x + r, y);
+  ctx.closePath();
+}
+
+function lighten(rgb, amt) {
+  return [
+    Math.min(255, rgb[0] + (255 - rgb[0]) * amt),
+    Math.min(255, rgb[1] + (255 - rgb[1]) * amt),
+    Math.min(255, rgb[2] + (255 - rgb[2]) * amt),
+  ];
+}
+
+function darken(rgb, amt) {
+  return [
+    Math.max(0, rgb[0] * (1 - amt)),
+    Math.max(0, rgb[1] * (1 - amt)),
+    Math.max(0, rgb[2] * (1 - amt)),
+  ];
+}

--- a/sdf-js/src/present/atoms-2d/charts/diagrams/tree-diagram.js
+++ b/sdf-js/src/present/atoms-2d/charts/diagrams/tree-diagram.js
@@ -1,0 +1,194 @@
+// =============================================================================
+// atoms-2d/charts/diagrams/tree-diagram.js — Generic hierarchical tree
+// -----------------------------------------------------------------------------
+// 7th atom in 2D vector library (Phase 2b).
+//
+// Semantic: top-down hierarchical tree with rounded card nodes connected by
+// curved lines. Use for: decision trees, category taxonomies, file systems,
+// feature decompositions.
+//
+// (org-chart is sibling atom with same data shape but boxier style + name/title.)
+//
+// Args:
+//   root  — nested object { label, children?: [{ label, children?, ... }] }
+//   title — optional chart title
+//
+// Render: pseudo-3D (drawPseudo3D)
+//   - Each node: rounded card with gradient + drop shadow (same pattern as
+//     kpi-card / flow-chart node)
+//   - Connector: bezier curve from parent bottom to child top
+//   - Root node: emphasized with accent color fill
+//
+// Per [[atlas-sprint14-finance-preset-plan]] — diagram family.
+// =============================================================================
+
+import { rgbCss, rgbaCss } from '../../renderer.js';
+import { computeTreeLayout } from './_tree-layout.js';
+
+export const spec = {
+  type: 'tree-diagram',
+  category: 'charts/diagrams',
+  description: 'Generic hierarchical tree (decision tree / taxonomy / decomposition).',
+  args: {
+    root: {
+      type: 'object { label, children?: [...] }',
+      required: true,
+      example: {
+        label: 'Product',
+        children: [
+          { label: 'Engineering', children: [{ label: 'Backend' }, { label: 'Frontend' }] },
+          { label: 'Design' },
+          { label: 'Marketing' },
+        ],
+      },
+    },
+    title: { type: 'string?', example: 'Org Tree' },
+  },
+};
+
+const PAD = 14;
+const TITLE_FRAC = 0.1;
+const NODE_HEIGHT = 36;
+
+export function drawPseudo3D(ctx, args, opts = {}) {
+  const x = opts.x ?? 0;
+  const y = opts.y ?? 0;
+  const w = opts.w ?? 600;
+  const h = opts.h ?? 400;
+  const palette = opts.palette || {};
+  const fg = palette.silhouetteColor || [30, 27, 30];
+  const bg = palette.bg || [247, 244, 224];
+  const accent = palette.colors?.[0] || [60, 100, 200];
+
+  const root = args.root;
+  const title = args.title;
+  if (!root || typeof root !== 'object') return;
+
+  let layoutTop = y + PAD;
+  if (title) {
+    const titleSize = Math.round(h * 0.07);
+    ctx.fillStyle = rgbCss(fg);
+    ctx.font = `700 ${titleSize}px Inter, system-ui, sans-serif`;
+    ctx.textAlign = 'left';
+    ctx.textBaseline = 'top';
+    ctx.fillText(title, x + PAD, y + PAD);
+    layoutTop = y + h * TITLE_FRAC + PAD;
+  }
+
+  const layout = computeTreeLayout(root, {
+    x: x + PAD,
+    y: layoutTop,
+    w: w - PAD * 2,
+    h: y + h - layoutTop - PAD,
+    minNodeWidth: 80,
+    maxNodeWidth: 140,
+  });
+  if (layout.length === 0) return;
+
+  // ---- Draw connectors first (so they sit under nodes) ----
+  for (const entry of layout) {
+    if (entry.parentX == null) continue;
+    drawConnector(
+      ctx,
+      entry.parentX,
+      entry.parentY + NODE_HEIGHT / 2,
+      entry.x,
+      entry.y - NODE_HEIGHT / 2,
+      accent,
+    );
+  }
+
+  // ---- Draw nodes ----
+  for (const entry of layout) {
+    const isRoot = entry.depth === 0;
+    drawNode(ctx, entry.x, entry.y, entry.nodeWidth, NODE_HEIGHT, entry.node.label, isRoot, {
+      fg,
+      bg,
+      accent,
+    });
+  }
+}
+
+function drawConnector(ctx, x0, y0, x1, y1, color) {
+  ctx.save();
+  ctx.strokeStyle = rgbaCss(color, 0.55);
+  ctx.lineWidth = 1.6;
+  ctx.lineCap = 'round';
+  ctx.beginPath();
+  ctx.moveTo(x0, y0);
+  // Smooth S-curve: control points midway with vertical bias
+  const midY = (y0 + y1) / 2;
+  ctx.bezierCurveTo(x0, midY, x1, midY, x1, y1);
+  ctx.stroke();
+  ctx.restore();
+}
+
+function drawNode(ctx, cx, cy, w, h, label, isRoot, colorCtx) {
+  const { fg, bg, accent } = colorCtx;
+  const nx = cx - w / 2;
+  const ny = cy - h / 2;
+  const radius = h / 2; // pill-shaped
+
+  ctx.save();
+  ctx.shadowColor = rgbaCss([0, 0, 0], 0.15);
+  ctx.shadowBlur = 6;
+  ctx.shadowOffsetY = 2;
+
+  const gradient = ctx.createLinearGradient(nx, ny, nx, ny + h);
+  if (isRoot) {
+    gradient.addColorStop(0, rgbCss(lighten(accent, 0.12)));
+    gradient.addColorStop(1, rgbCss(accent));
+  } else {
+    gradient.addColorStop(0, rgbCss(bg));
+    gradient.addColorStop(1, rgbCss(darken(bg, 0.06)));
+  }
+  ctx.fillStyle = gradient;
+  roundedRectPath(ctx, nx, ny, w, h, radius);
+  ctx.fill();
+  ctx.restore();
+
+  // Border for non-root (light separator from bg)
+  if (!isRoot) {
+    ctx.strokeStyle = rgbaCss(fg, 0.18);
+    ctx.lineWidth = 1;
+    roundedRectPath(ctx, nx, ny, w, h, radius);
+    ctx.stroke();
+  }
+
+  // Label
+  ctx.fillStyle = isRoot ? rgbCss(bg) : rgbCss(fg);
+  ctx.font = `${isRoot ? 700 : 500} ${Math.min(13, h * 0.4)}px Inter, system-ui, sans-serif`;
+  ctx.textAlign = 'center';
+  ctx.textBaseline = 'middle';
+  ctx.fillText(String(label), cx, cy + 1);
+}
+
+function roundedRectPath(ctx, x, y, w, h, r) {
+  ctx.beginPath();
+  ctx.moveTo(x + r, y);
+  ctx.lineTo(x + w - r, y);
+  ctx.quadraticCurveTo(x + w, y, x + w, y + r);
+  ctx.lineTo(x + w, y + h - r);
+  ctx.quadraticCurveTo(x + w, y + h, x + w - r, y + h);
+  ctx.lineTo(x + r, y + h);
+  ctx.quadraticCurveTo(x, y + h, x, y + h - r);
+  ctx.lineTo(x, y + r);
+  ctx.quadraticCurveTo(x, y, x + r, y);
+  ctx.closePath();
+}
+
+function lighten(rgb, amt) {
+  return [
+    Math.min(255, rgb[0] + (255 - rgb[0]) * amt),
+    Math.min(255, rgb[1] + (255 - rgb[1]) * amt),
+    Math.min(255, rgb[2] + (255 - rgb[2]) * amt),
+  ];
+}
+
+function darken(rgb, amt) {
+  return [
+    Math.max(0, rgb[0] * (1 - amt)),
+    Math.max(0, rgb[1] * (1 - amt)),
+    Math.max(0, rgb[2] * (1 - amt)),
+  ];
+}

--- a/sdf-js/src/present/atoms-2d/registry.js
+++ b/sdf-js/src/present/atoms-2d/registry.js
@@ -34,6 +34,8 @@ const ATOM_LOADERS = {
 
   // Charts / diagrams (Phase 2)
   'flow-chart': () => import('./charts/diagrams/flow-chart.js'),
+  'tree-diagram': () => import('./charts/diagrams/tree-diagram.js'),
+  'org-chart': () => import('./charts/diagrams/org-chart.js'),
 
   // Charts / diagrams (Phase 2)
   // Charts / hierarchy (Phase 2)


### PR DESCRIPTION
## What ships

Atoms 7 + 8 in 2D vector library. Both top-down hierarchy diagrams.

**Shared `_tree-layout.js`**: Reingold-Tilford tidy-tree positioning kernel. Returns flat array of `{node, x, y, parentX, parentY, ...}` so each atom's draw layer only deals with rendering, not layout.

**tree-diagram**: pill-shaped nodes + curved bezier connectors. Use for decision trees / taxonomies / decompositions.

**org-chart**: rectangular cards + orthogonal "elbow" connectors. Each node: name (Inter 700) + title (Inter 500). McKinsey deck aesthetic.

## Demo

- Tree: Software → 3 categories → 5 leaves (Enterprise/Consumer/Developer)
- Org: Sarah Chen CEO → 3 reports → 3 grand-reports (8 total nodes)

## Branch chain

#52 → #53 → #55 → #56 → #57 → this. Merge in order.

## Test

- 12 new assertions → 74 total
- Edge cases: null root no crash, single-node tree renders
- Browser visual verified

## Next PRs

- Phase 2c: mindmap + relationship + timeline + pyramid
- Phase 3: shapes basic
- Phase 4: icons + cover
- Phase 5: Sprint 14 finance preset

🤖 Generated with [Claude Code](https://claude.com/claude-code)