### PR TITLE
Pixel-fidelity: fill-deck colors/labels + 7 product-cover recreations (dark studio)

### DIFF
--- a/sdf-js/examples/compositor/demo-lifts/fill-slide-01.json
+++ b/sdf-js/examples/compositor/demo-lifts/fill-slide-01.json
@@ -1,14 +1,14 @@
 {
   "id": "fill-slide-01",
   "title": "Fill Levels · Cover (20/40/80)",
-  "prompt": "kpi-hero: Cover — three glass fill spheres at 20/40/80%, increasing in size.",
+  "prompt": "kpi-hero: Cover — three overlapping glass fill spheres 20% green / 40% red / 80% blue, increasing in size, dark glassy domes.",
   "code2d": "// vision-authored from PDF slide (D0961 3D Spheres Fill Levels).",
   "sceneData": {
     "v": 1,
     "name": "kpi-hero: Fill Levels · Cover (20/40/80)",
     "source": {
       "format": "vision-authored",
-      "prompt": "Cover — three glass fill spheres at 20/40/80%, increasing in size."
+      "prompt": "Cover — three overlapping glass fill spheres 20% green / 40% red / 80% blue, increasing in size, dark glassy domes."
     },
     "subjects": [
       {
@@ -16,18 +16,18 @@
         "type": "sphere-fill-3d",
         "args": {
           "levels": [0.2],
-          "radius": 0.46,
+          "radius": 0.5,
           "cage": false,
           "fillScale": 1
         },
         "transform": {
-          "translate": [-1.75, 0.9, 0]
+          "translate": [-2.05, 1, -0.6]
         },
         "material": {
-          "hue": 0.58,
-          "sat": 0.85,
-          "value": 0.72,
-          "metal": 0.3,
+          "hue": 0.28,
+          "sat": 0.78,
+          "value": 0.62,
+          "metal": 0.2,
           "glow": 0
         }
       },
@@ -35,31 +35,57 @@
         "id": "emp0",
         "type": "cut-sphere",
         "args": {
-          "radius": 0.46,
-          "h": -0.276
+          "radius": 0.5,
+          "h": -0.3
         },
         "transform": {
-          "translate": [-1.75, 0.9, 0]
+          "translate": [-2.05, 1, -0.6]
         },
-        "material": "porcelain"
+        "material": {
+          "hue": 0.6,
+          "sat": 0.28,
+          "value": 0.07,
+          "metal": 0.55,
+          "glow": 0
+        }
+      },
+      {
+        "id": "lab0",
+        "type": "text-3d-pipe",
+        "args": {
+          "text": "20%",
+          "height": 0.275,
+          "pipeRadius": 0.05,
+          "align": "center"
+        },
+        "transform": {
+          "translate": [-2.05, 0.8025, -1.2000000000000002]
+        },
+        "material": {
+          "hue": 0,
+          "sat": 0,
+          "value": 1,
+          "metal": 0,
+          "glow": 0.25
+        }
       },
       {
         "id": "liq1",
         "type": "sphere-fill-3d",
         "args": {
           "levels": [0.4],
-          "radius": 0.64,
+          "radius": 0.7,
           "cage": false,
           "fillScale": 1
         },
         "transform": {
-          "translate": [-0.35, 0.9, 0]
+          "translate": [-0.95, 0.95, -0.2]
         },
         "material": {
-          "hue": 0.58,
-          "sat": 0.85,
-          "value": 0.72,
-          "metal": 0.3,
+          "hue": 0,
+          "sat": 0.82,
+          "value": 0.62,
+          "metal": 0.2,
           "glow": 0
         }
       },
@@ -67,25 +93,51 @@
         "id": "emp1",
         "type": "cut-sphere",
         "args": {
-          "radius": 0.64,
-          "h": -0.12799999999999997
+          "radius": 0.7,
+          "h": -0.13999999999999996
         },
         "transform": {
-          "translate": [-0.35, 0.9, 0]
+          "translate": [-0.95, 0.95, -0.2]
         },
-        "material": "porcelain"
+        "material": {
+          "hue": 0.6,
+          "sat": 0.28,
+          "value": 0.07,
+          "metal": 0.55,
+          "glow": 0
+        }
+      },
+      {
+        "id": "lab1",
+        "type": "text-3d-pipe",
+        "args": {
+          "text": "40%",
+          "height": 0.385,
+          "pipeRadius": 0.05,
+          "align": "center"
+        },
+        "transform": {
+          "translate": [-0.95, 0.6735, -0.9999999999999999]
+        },
+        "material": {
+          "hue": 0,
+          "sat": 0,
+          "value": 1,
+          "metal": 0,
+          "glow": 0.25
+        }
       },
       {
         "id": "liq2",
         "type": "sphere-fill-3d",
         "args": {
           "levels": [0.8],
-          "radius": 0.92,
+          "radius": 1,
           "cage": false,
           "fillScale": 1
         },
         "transform": {
-          "translate": [1.5, 0.9, 0]
+          "translate": [0.75, 0.9, 0.35]
         },
         "material": {
           "hue": 0.58,
@@ -99,13 +151,39 @@
         "id": "emp2",
         "type": "cut-sphere",
         "args": {
-          "radius": 0.92,
-          "h": 0.5520000000000002
+          "radius": 1,
+          "h": 0.6000000000000001
         },
         "transform": {
-          "translate": [1.5, 0.9, 0]
+          "translate": [0.75, 0.9, 0.35]
         },
-        "material": "porcelain"
+        "material": {
+          "hue": 0.6,
+          "sat": 0.28,
+          "value": 0.07,
+          "metal": 0.55,
+          "glow": 0
+        }
+      },
+      {
+        "id": "lab2",
+        "type": "text-3d-pipe",
+        "args": {
+          "text": "80%",
+          "height": 0.5,
+          "pipeRadius": 0.05,
+          "align": "center"
+        },
+        "transform": {
+          "translate": [0.75, 0.53, -0.75]
+        },
+        "material": {
+          "hue": 0,
+          "sat": 0,
+          "value": 1,
+          "metal": 0,
+          "glow": 0.25
+        }
       }
     ],
     "defaults": {
@@ -115,7 +193,7 @@
         "distance": 10,
         "focal": 1.5,
         "targetX": 0,
-        "targetY": 0.9,
+        "targetY": 0.9500000000000001,
         "targetZ": 0
       },
       "light": {

--- a/sdf-js/examples/compositor/demo-lifts/fill-slide-02.json
+++ b/sdf-js/examples/compositor/demo-lifts/fill-slide-02.json
@@ -44,6 +44,26 @@
         "material": "porcelain"
       },
       {
+        "id": "lab0",
+        "type": "text-3d-pipe",
+        "args": {
+          "text": "20%",
+          "height": 0.30250000000000005,
+          "pipeRadius": 0.05,
+          "align": "center"
+        },
+        "transform": {
+          "translate": [-2.4000000000000004, 0.68275, -0.65]
+        },
+        "material": {
+          "hue": 0,
+          "sat": 0,
+          "value": 1,
+          "metal": 0,
+          "glow": 0.25
+        }
+      },
+      {
         "id": "liq1",
         "type": "sphere-fill-3d",
         "args": {
@@ -74,6 +94,26 @@
           "translate": [-0.8000000000000003, 0.9, 0]
         },
         "material": "porcelain"
+      },
+      {
+        "id": "lab1",
+        "type": "text-3d-pipe",
+        "args": {
+          "text": "60%",
+          "height": 0.30250000000000005,
+          "pipeRadius": 0.05,
+          "align": "center"
+        },
+        "transform": {
+          "translate": [-0.8000000000000003, 0.68275, -0.65]
+        },
+        "material": {
+          "hue": 0,
+          "sat": 0,
+          "value": 1,
+          "metal": 0,
+          "glow": 0.25
+        }
       },
       {
         "id": "liq2",
@@ -108,6 +148,26 @@
         "material": "porcelain"
       },
       {
+        "id": "lab2",
+        "type": "text-3d-pipe",
+        "args": {
+          "text": "80%",
+          "height": 0.30250000000000005,
+          "pipeRadius": 0.05,
+          "align": "center"
+        },
+        "transform": {
+          "translate": [0.7999999999999998, 0.68275, -0.65]
+        },
+        "material": {
+          "hue": 0,
+          "sat": 0,
+          "value": 1,
+          "metal": 0,
+          "glow": 0.25
+        }
+      },
+      {
         "id": "liq3",
         "type": "sphere-fill-3d",
         "args": {
@@ -138,6 +198,26 @@
           "translate": [2.4000000000000004, 0.9, 0]
         },
         "material": "porcelain"
+      },
+      {
+        "id": "lab3",
+        "type": "text-3d-pipe",
+        "args": {
+          "text": "90%",
+          "height": 0.30250000000000005,
+          "pipeRadius": 0.05,
+          "align": "center"
+        },
+        "transform": {
+          "translate": [2.4000000000000004, 0.68275, -0.65]
+        },
+        "material": {
+          "hue": 0,
+          "sat": 0,
+          "value": 1,
+          "metal": 0,
+          "glow": 0.25
+        }
       }
     ],
     "defaults": {

--- a/sdf-js/examples/compositor/demo-lifts/fill-slide-06.json
+++ b/sdf-js/examples/compositor/demo-lifts/fill-slide-06.json
@@ -32,6 +32,26 @@
         }
       },
       {
+        "id": "lab0",
+        "type": "text-3d-pipe",
+        "args": {
+          "text": "100%",
+          "height": 0.5,
+          "pipeRadius": 0.05,
+          "align": "center"
+        },
+        "transform": {
+          "translate": [0, 0.586, -1.05]
+        },
+        "material": {
+          "hue": 0,
+          "sat": 0,
+          "value": 1,
+          "metal": 0,
+          "glow": 0.25
+        }
+      },
+      {
         "id": "liq1",
         "type": "sphere-fill-3d",
         "args": {
@@ -62,6 +82,26 @@
           "translate": [-2.15, 0.7, 0.2]
         },
         "material": "porcelain"
+      },
+      {
+        "id": "lab1",
+        "type": "text-3d-pipe",
+        "args": {
+          "text": "50%",
+          "height": 0.33,
+          "pipeRadius": 0.05,
+          "align": "center"
+        },
+        "transform": {
+          "translate": [-2.15, 0.4629999999999999, -0.5]
+        },
+        "material": {
+          "hue": 0,
+          "sat": 0,
+          "value": 1,
+          "metal": 0,
+          "glow": 0.25
+        }
       },
       {
         "id": "liq2",
@@ -96,6 +136,26 @@
         "material": "porcelain"
       },
       {
+        "id": "lab2",
+        "type": "text-3d-pipe",
+        "args": {
+          "text": "20%",
+          "height": 0.26,
+          "pipeRadius": 0.05,
+          "align": "center"
+        },
+        "transform": {
+          "translate": [-1.05, 1.1696000000000002, -0.82]
+        },
+        "material": {
+          "hue": 0,
+          "sat": 0,
+          "value": 1,
+          "metal": 0,
+          "glow": 0.25
+        }
+      },
+      {
         "id": "liq3",
         "type": "sphere-fill-3d",
         "args": {
@@ -128,6 +188,26 @@
         "material": "porcelain"
       },
       {
+        "id": "lab3",
+        "type": "text-3d-pipe",
+        "args": {
+          "text": "40%",
+          "height": 0.26,
+          "pipeRadius": 0.05,
+          "align": "center"
+        },
+        "transform": {
+          "translate": [1.05, 1.1696000000000002, -0.82]
+        },
+        "material": {
+          "hue": 0,
+          "sat": 0,
+          "value": 1,
+          "metal": 0,
+          "glow": 0.25
+        }
+      },
+      {
         "id": "liq4",
         "type": "sphere-fill-3d",
         "args": {
@@ -158,6 +238,26 @@
           "translate": [2.15, 0.7, 0.2]
         },
         "material": "porcelain"
+      },
+      {
+        "id": "lab4",
+        "type": "text-3d-pipe",
+        "args": {
+          "text": "80%",
+          "height": 0.33,
+          "pipeRadius": 0.05,
+          "align": "center"
+        },
+        "transform": {
+          "translate": [2.15, 0.4629999999999999, -0.5]
+        },
+        "material": {
+          "hue": 0,
+          "sat": 0,
+          "value": 1,
+          "metal": 0,
+          "glow": 0.25
+        }
       }
     ],
     "defaults": {

--- a/sdf-js/examples/compositor/demo-lifts/index.json
+++ b/sdf-js/examples/compositor/demo-lifts/index.json
@@ -858,6 +858,76 @@
       "file": "shape-circles-stack.json",
       "renderer": "studio",
       "prompt": "Circles · Tiered stack"
+    },
+    {
+      "id": "product-diamond",
+      "title": "Diamond Charts · 3 gems",
+      "thesisPoint": "Pixel-align recreation of PresentationLoad \"diamonds\" product cover — Atlas atoms + dark studio.",
+      "category": "product-pixel-align",
+      "status": "ready",
+      "file": "product-diamond.json",
+      "renderer": "studio",
+      "prompt": "Diamond Charts · 3 gems"
+    },
+    {
+      "id": "product-cubes-flow",
+      "title": "Cubes Flow · Process row",
+      "thesisPoint": "Pixel-align recreation of PresentationLoad \"cubes\" product cover — Atlas atoms + dark studio.",
+      "category": "product-pixel-align",
+      "status": "ready",
+      "file": "product-cubes-flow.json",
+      "renderer": "studio",
+      "prompt": "Cubes Flow · Process row"
+    },
+    {
+      "id": "product-cubes-arc",
+      "title": "Cubes Semi-Circle · Arc of 7",
+      "thesisPoint": "Pixel-align recreation of PresentationLoad \"cubes\" product cover — Atlas atoms + dark studio.",
+      "category": "product-pixel-align",
+      "status": "ready",
+      "file": "product-cubes-arc.json",
+      "renderer": "studio",
+      "prompt": "Cubes Semi-Circle · Arc of 7"
+    },
+    {
+      "id": "product-spheres-sliced",
+      "title": "Spheres Sliced · Nested cross-section",
+      "thesisPoint": "Pixel-align recreation of PresentationLoad \"spheres\" product cover — Atlas atoms + dark studio.",
+      "category": "product-pixel-align",
+      "status": "ready",
+      "file": "product-spheres-sliced.json",
+      "renderer": "studio",
+      "prompt": "Spheres Sliced · Nested cross-section"
+    },
+    {
+      "id": "product-cubes-grid",
+      "title": "Cubes Shapes · 3×3×3 + accents",
+      "thesisPoint": "Pixel-align recreation of PresentationLoad \"cubes\" product cover — Atlas atoms + dark studio.",
+      "category": "product-pixel-align",
+      "status": "ready",
+      "file": "product-cubes-grid.json",
+      "renderer": "studio",
+      "prompt": "Cubes Shapes · 3×3×3 + accents"
+    },
+    {
+      "id": "product-puzzle",
+      "title": "Puzzle 3D · Interlocking + lifted",
+      "thesisPoint": "Pixel-align recreation of PresentationLoad \"puzzles\" product cover — Atlas atoms + dark studio.",
+      "category": "product-pixel-align",
+      "status": "ready",
+      "file": "product-puzzle.json",
+      "renderer": "studio",
+      "prompt": "Puzzle 3D · Interlocking + lifted"
+    },
+    {
+      "id": "product-arrow",
+      "title": "Arrow Toolbox · Rising arrow",
+      "thesisPoint": "Pixel-align recreation of PresentationLoad \"arrows\" product cover — Atlas atoms + dark studio.",
+      "category": "product-pixel-align",
+      "status": "ready",
+      "file": "product-arrow.json",
+      "renderer": "studio",
+      "prompt": "Arrow Toolbox · Rising arrow"
     }
   ]
 }

--- a/sdf-js/examples/compositor/demo-lifts/product-arrow.json
+++ b/sdf-js/examples/compositor/demo-lifts/product-arrow.json
@@ -1,0 +1,111 @@
+{
+  "id": "product-arrow",
+  "title": "Arrow Toolbox · Rising arrow",
+  "prompt": "arrows: Arrow Toolbox · Rising arrow",
+  "code2d": "// vision-authored pixel-align of a PresentationLoad product cover (\"arrows\").",
+  "sceneData": {
+    "v": 1,
+    "name": "Arrow Toolbox · Rising arrow",
+    "source": {
+      "format": "vision-authored",
+      "prompt": "arrows product cover pixel-align"
+    },
+    "subjects": [
+      {
+        "id": "s0",
+        "type": "arrow-3d",
+        "args": {
+          "length": 1.1,
+          "shaftWidth": 0.22,
+          "headLength": 0.5,
+          "headWidth": 0.7,
+          "depth": 0.3
+        },
+        "transform": {
+          "translate": [-0.7, 0.5, -0.5],
+          "rotate": [0, 0, 0.5]
+        },
+        "material": {
+          "hue": 0.6,
+          "sat": 0.04,
+          "value": 0.46,
+          "metal": 0.5,
+          "glow": 0
+        }
+      },
+      {
+        "id": "s1",
+        "type": "arrow-3d",
+        "args": {
+          "length": 1.5,
+          "shaftWidth": 0.3,
+          "headLength": 0.6,
+          "headWidth": 0.95,
+          "depth": 0.34
+        },
+        "transform": {
+          "translate": [-0.3, 0.8, -0.2],
+          "rotate": [0, 0, 0.5]
+        },
+        "material": {
+          "hue": 0.6,
+          "sat": 0.06,
+          "value": 0.26,
+          "metal": 0.4,
+          "glow": 0
+        }
+      },
+      {
+        "id": "s2",
+        "type": "arrow-3d",
+        "args": {
+          "length": 2.4,
+          "shaftWidth": 0.42,
+          "headLength": 0.95,
+          "headWidth": 1.3,
+          "depth": 0.42
+        },
+        "transform": {
+          "translate": [0.2, 1.2, 0.2],
+          "rotate": [0, 0, 0.52]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.75,
+          "metal": 0.35,
+          "glow": 0
+        }
+      }
+    ],
+    "defaults": {
+      "camera": {
+        "yaw": 0.5,
+        "pitch": 0.3,
+        "distance": 10,
+        "focal": 1.5,
+        "targetX": 0,
+        "targetY": 0.8333333333333334,
+        "targetZ": 0
+      },
+      "light": {
+        "azimuth": 0.6,
+        "altitude": 0.55,
+        "distance": 25,
+        "intensity": 1.2
+      },
+      "shadow": {
+        "enabled": true,
+        "mode": "darken",
+        "strength": 0.4
+      },
+      "studioBg": "dark"
+    }
+  },
+  "meta": {
+    "generatedAt": "2026-06-21",
+    "model": "vision-authored",
+    "pattern": "arrows",
+    "costUSD": 0
+  }
+}

--- a/sdf-js/examples/compositor/demo-lifts/product-cubes-arc.json
+++ b/sdf-js/examples/compositor/demo-lifts/product-cubes-arc.json
@@ -1,0 +1,178 @@
+{
+  "id": "product-cubes-arc",
+  "title": "Cubes Semi-Circle · Arc of 7",
+  "prompt": "cubes: Cubes Semi-Circle · Arc of 7",
+  "code2d": "// vision-authored pixel-align of a PresentationLoad product cover (\"cubes\").",
+  "sceneData": {
+    "v": 1,
+    "name": "Cubes Semi-Circle · Arc of 7",
+    "source": {
+      "format": "vision-authored",
+      "prompt": "cubes product cover pixel-align"
+    },
+    "subjects": [
+      {
+        "id": "s0",
+        "type": "cube-3d",
+        "args": {
+          "count": 1,
+          "cubeSize": 0.5
+        },
+        "transform": {
+          "translate": [2.1384859175429782, 0.45, 0.07331352882524078],
+          "rotate": [0, 0.37699111843077515, 0]
+        },
+        "material": {
+          "hue": 0.6,
+          "sat": 0.04,
+          "value": 0.46,
+          "metal": 0.5,
+          "glow": 0
+        }
+      },
+      {
+        "id": "s1",
+        "type": "cube-3d",
+        "args": {
+          "count": 1,
+          "cubeSize": 0.5
+        },
+        "transform": {
+          "translate": [1.6432871631554475, 0.45, -0.6892256831807404],
+          "rotate": [0, 0.7749261878854823, 0]
+        },
+        "material": {
+          "hue": 0.6,
+          "sat": 0.04,
+          "value": 0.46,
+          "metal": 0.5,
+          "glow": 0
+        }
+      },
+      {
+        "id": "s2",
+        "type": "cube-3d",
+        "args": {
+          "count": 1,
+          "cubeSize": 0.5
+        },
+        "transform": {
+          "translate": [0.8912858488398371, 0.45, -1.2002852486535511],
+          "rotate": [0, 1.1728612573401893, 0]
+        },
+        "material": {
+          "hue": 0.6,
+          "sat": 0.04,
+          "value": 0.46,
+          "metal": 0.5,
+          "glow": 0
+        }
+      },
+      {
+        "id": "s3",
+        "type": "cube-3d",
+        "args": {
+          "count": 1,
+          "cubeSize": 0.5
+        },
+        "transform": {
+          "translate": [1.408343819019456e-16, 0.45, -1.38],
+          "rotate": [0, 1.5707963267948966, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.75,
+          "metal": 0.35,
+          "glow": 0
+        }
+      },
+      {
+        "id": "s4",
+        "type": "cube-3d",
+        "args": {
+          "count": 1,
+          "cubeSize": 0.5
+        },
+        "transform": {
+          "translate": [-0.8912858488398359, 0.45, -1.2002852486535516],
+          "rotate": [0, 1.9687313962496034, 0]
+        },
+        "material": {
+          "hue": 0.6,
+          "sat": 0.04,
+          "value": 0.46,
+          "metal": 0.5,
+          "glow": 0
+        }
+      },
+      {
+        "id": "s5",
+        "type": "cube-3d",
+        "args": {
+          "count": 1,
+          "cubeSize": 0.5
+        },
+        "transform": {
+          "translate": [-1.6432871631554478, 0.45, -0.6892256831807402],
+          "rotate": [0, 2.366666465704311, 0]
+        },
+        "material": {
+          "hue": 0.6,
+          "sat": 0.04,
+          "value": 0.46,
+          "metal": 0.5,
+          "glow": 0
+        }
+      },
+      {
+        "id": "s6",
+        "type": "cube-3d",
+        "args": {
+          "count": 1,
+          "cubeSize": 0.5
+        },
+        "transform": {
+          "translate": [-2.138485917542978, 0.45, 0.07331352882524023],
+          "rotate": [0, 2.764601535159018, 0]
+        },
+        "material": {
+          "hue": 0.6,
+          "sat": 0.04,
+          "value": 0.46,
+          "metal": 0.5,
+          "glow": 0
+        }
+      }
+    ],
+    "defaults": {
+      "camera": {
+        "yaw": 0.5,
+        "pitch": 0.3,
+        "distance": 10,
+        "focal": 1.5,
+        "targetX": 0,
+        "targetY": 0.45000000000000007,
+        "targetZ": 0
+      },
+      "light": {
+        "azimuth": 0.6,
+        "altitude": 0.55,
+        "distance": 25,
+        "intensity": 1.2
+      },
+      "shadow": {
+        "enabled": true,
+        "mode": "darken",
+        "strength": 0.4
+      },
+      "studioBg": "dark"
+    }
+  },
+  "meta": {
+    "generatedAt": "2026-06-21",
+    "model": "vision-authored",
+    "pattern": "cubes",
+    "costUSD": 0
+  }
+}

--- a/sdf-js/examples/compositor/demo-lifts/product-cubes-flow.json
+++ b/sdf-js/examples/compositor/demo-lifts/product-cubes-flow.json
@@ -1,0 +1,180 @@
+{
+  "id": "product-cubes-flow",
+  "title": "Cubes Flow · Process row",
+  "prompt": "cubes: Cubes Flow · Process row",
+  "code2d": "// vision-authored pixel-align of a PresentationLoad product cover (\"cubes\").",
+  "sceneData": {
+    "v": 1,
+    "name": "Cubes Flow · Process row",
+    "source": {
+      "format": "vision-authored",
+      "prompt": "cubes product cover pixel-align"
+    },
+    "subjects": [
+      {
+        "id": "s0",
+        "type": "cube-3d",
+        "args": {
+          "count": 1,
+          "cubeSize": 0.62
+        },
+        "transform": {
+          "translate": [-2.4, 0.6, 0]
+        },
+        "material": {
+          "hue": 0.5,
+          "sat": 0.72,
+          "value": 0.7,
+          "metal": 0.3,
+          "glow": 0
+        }
+      },
+      {
+        "id": "s1",
+        "type": "cube-3d",
+        "args": {
+          "count": 1,
+          "cubeSize": 0.62
+        },
+        "transform": {
+          "translate": [-0.8, 0.6, 0]
+        },
+        "material": {
+          "hue": 0.5,
+          "sat": 0.72,
+          "value": 0.7,
+          "metal": 0.3,
+          "glow": 0
+        }
+      },
+      {
+        "id": "s2",
+        "type": "cube-3d",
+        "args": {
+          "count": 1,
+          "cubeSize": 0.62
+        },
+        "transform": {
+          "translate": [0.8, 0.6, 0]
+        },
+        "material": {
+          "hue": 0.5,
+          "sat": 0.72,
+          "value": 0.7,
+          "metal": 0.3,
+          "glow": 0
+        }
+      },
+      {
+        "id": "s3",
+        "type": "cube-3d",
+        "args": {
+          "count": 1,
+          "cubeSize": 0.62
+        },
+        "transform": {
+          "translate": [2.4, 0.6, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.75,
+          "metal": 0.35,
+          "glow": 0
+        }
+      },
+      {
+        "id": "s4",
+        "type": "arrow-3d",
+        "args": {
+          "length": 0.7,
+          "shaftWidth": 0.14,
+          "headLength": 0.3,
+          "headWidth": 0.4,
+          "depth": 0.2
+        },
+        "transform": {
+          "translate": [-1.6, 0.6, 0]
+        },
+        "material": {
+          "hue": 0.07,
+          "sat": 0.88,
+          "value": 0.85,
+          "metal": 0.25,
+          "glow": 0
+        }
+      },
+      {
+        "id": "s5",
+        "type": "arrow-3d",
+        "args": {
+          "length": 0.7,
+          "shaftWidth": 0.14,
+          "headLength": 0.3,
+          "headWidth": 0.4,
+          "depth": 0.2
+        },
+        "transform": {
+          "translate": [0, 0.6, 0]
+        },
+        "material": {
+          "hue": 0.07,
+          "sat": 0.88,
+          "value": 0.85,
+          "metal": 0.25,
+          "glow": 0
+        }
+      },
+      {
+        "id": "s6",
+        "type": "arrow-3d",
+        "args": {
+          "length": 0.7,
+          "shaftWidth": 0.14,
+          "headLength": 0.3,
+          "headWidth": 0.4,
+          "depth": 0.2
+        },
+        "transform": {
+          "translate": [1.6, 0.6, 0]
+        },
+        "material": {
+          "hue": 0.07,
+          "sat": 0.88,
+          "value": 0.85,
+          "metal": 0.25,
+          "glow": 0
+        }
+      }
+    ],
+    "defaults": {
+      "camera": {
+        "yaw": 0.5,
+        "pitch": 0.3,
+        "distance": 10,
+        "focal": 1.5,
+        "targetX": 0,
+        "targetY": 0.6,
+        "targetZ": 0
+      },
+      "light": {
+        "azimuth": 0.6,
+        "altitude": 0.55,
+        "distance": 25,
+        "intensity": 1.2
+      },
+      "shadow": {
+        "enabled": true,
+        "mode": "darken",
+        "strength": 0.4
+      },
+      "studioBg": "dark"
+    }
+  },
+  "meta": {
+    "generatedAt": "2026-06-21",
+    "model": "vision-authored",
+    "pattern": "cubes",
+    "costUSD": 0
+  }
+}

--- a/sdf-js/examples/compositor/demo-lifts/product-cubes-grid.json
+++ b/sdf-js/examples/compositor/demo-lifts/product-cubes-grid.json
@@ -1,0 +1,119 @@
+{
+  "id": "product-cubes-grid",
+  "title": "Cubes Shapes · 3×3×3 + accents",
+  "prompt": "cubes: Cubes Shapes · 3×3×3 + accents",
+  "code2d": "// vision-authored pixel-align of a PresentationLoad product cover (\"cubes\").",
+  "sceneData": {
+    "v": 1,
+    "name": "Cubes Shapes · 3×3×3 + accents",
+    "source": {
+      "format": "vision-authored",
+      "prompt": "cubes product cover pixel-align"
+    },
+    "subjects": [
+      {
+        "id": "s0",
+        "type": "cube-3d",
+        "args": {
+          "count": 27,
+          "arrangement": "grid3d",
+          "cubeSize": 0.42,
+          "spacing": 0.14
+        },
+        "transform": {
+          "translate": [0, 1.1, 0]
+        },
+        "material": {
+          "hue": 0.6,
+          "sat": 0.06,
+          "value": 0.26,
+          "metal": 0.4,
+          "glow": 0
+        }
+      },
+      {
+        "id": "s1",
+        "type": "cube-3d",
+        "args": {
+          "count": 1,
+          "cubeSize": 0.42
+        },
+        "transform": {
+          "translate": [0.56, 1.66, 0.56]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.75,
+          "metal": 0.35,
+          "glow": 0
+        }
+      },
+      {
+        "id": "s2",
+        "type": "cube-3d",
+        "args": {
+          "count": 1,
+          "cubeSize": 0.42
+        },
+        "transform": {
+          "translate": [-0.56, 0.54, 0.56]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.75,
+          "metal": 0.35,
+          "glow": 0
+        }
+      },
+      {
+        "id": "s3",
+        "type": "cube-3d",
+        "args": {
+          "count": 1,
+          "cubeSize": 0.42
+        },
+        "transform": {
+          "translate": [0.56, 1.1, -0.56]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.75,
+          "metal": 0.35,
+          "glow": 0
+        }
+      }
+    ],
+    "defaults": {
+      "camera": {
+        "yaw": 0.5,
+        "pitch": 0.3,
+        "distance": 10,
+        "focal": 1.5,
+        "targetX": 0,
+        "targetY": 1.1,
+        "targetZ": 0
+      },
+      "light": {
+        "azimuth": 0.6,
+        "altitude": 0.55,
+        "distance": 25,
+        "intensity": 1.2
+      },
+      "shadow": {
+        "enabled": true,
+        "mode": "darken",
+        "strength": 0.4
+      },
+      "studioBg": "dark"
+    }
+  },
+  "meta": {
+    "generatedAt": "2026-06-21",
+    "model": "vision-authored",
+    "pattern": "cubes",
+    "costUSD": 0
+  }
+}

--- a/sdf-js/examples/compositor/demo-lifts/product-diamond.json
+++ b/sdf-js/examples/compositor/demo-lifts/product-diamond.json
@@ -1,0 +1,105 @@
+{
+  "id": "product-diamond",
+  "title": "Diamond Charts · 3 gems",
+  "prompt": "diamonds: Diamond Charts · 3 gems",
+  "code2d": "// vision-authored pixel-align of a PresentationLoad product cover (\"diamonds\").",
+  "sceneData": {
+    "v": 1,
+    "name": "Diamond Charts · 3 gems",
+    "source": {
+      "format": "vision-authored",
+      "prompt": "diamonds product cover pixel-align"
+    },
+    "subjects": [
+      {
+        "id": "s0",
+        "type": "diamond-3d",
+        "args": {
+          "width": 0.9,
+          "crownHeight": 0.32,
+          "pavilionHeight": 0.82,
+          "tableRatio": 0.45
+        },
+        "transform": {
+          "translate": [-1.75, 1.05, -0.5]
+        },
+        "material": {
+          "hue": 0.3,
+          "sat": 0.75,
+          "value": 0.6,
+          "metal": 0.25,
+          "glow": 0
+        }
+      },
+      {
+        "id": "s1",
+        "type": "diamond-3d",
+        "args": {
+          "width": 1.2,
+          "crownHeight": 0.42,
+          "pavilionHeight": 1.05,
+          "tableRatio": 0.45
+        },
+        "transform": {
+          "translate": [-0.5, 0.95, -0.1]
+        },
+        "material": {
+          "hue": 0,
+          "sat": 0.8,
+          "value": 0.62,
+          "metal": 0.25,
+          "glow": 0
+        }
+      },
+      {
+        "id": "s2",
+        "type": "diamond-3d",
+        "args": {
+          "width": 1.6,
+          "crownHeight": 0.55,
+          "pavilionHeight": 1.35,
+          "tableRatio": 0.45
+        },
+        "transform": {
+          "translate": [1.2, 1, 0.35]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.75,
+          "metal": 0.35,
+          "glow": 0
+        }
+      }
+    ],
+    "defaults": {
+      "camera": {
+        "yaw": 0.5,
+        "pitch": 0.3,
+        "distance": 10,
+        "focal": 1.5,
+        "targetX": 0,
+        "targetY": 1,
+        "targetZ": 0
+      },
+      "light": {
+        "azimuth": 0.6,
+        "altitude": 0.55,
+        "distance": 25,
+        "intensity": 1.2
+      },
+      "shadow": {
+        "enabled": true,
+        "mode": "darken",
+        "strength": 0.4
+      },
+      "studioBg": "dark"
+    }
+  },
+  "meta": {
+    "generatedAt": "2026-06-21",
+    "model": "vision-authored",
+    "pattern": "diamonds",
+    "costUSD": 0
+  }
+}

--- a/sdf-js/examples/compositor/demo-lifts/product-puzzle.json
+++ b/sdf-js/examples/compositor/demo-lifts/product-puzzle.json
@@ -1,0 +1,121 @@
+{
+  "id": "product-puzzle",
+  "title": "Puzzle 3D · Interlocking + lifted",
+  "prompt": "puzzles: Puzzle 3D · Interlocking + lifted",
+  "code2d": "// vision-authored pixel-align of a PresentationLoad product cover (\"puzzles\").",
+  "sceneData": {
+    "v": 1,
+    "name": "Puzzle 3D · Interlocking + lifted",
+    "source": {
+      "format": "vision-authored",
+      "prompt": "puzzles product cover pixel-align"
+    },
+    "subjects": [
+      {
+        "id": "s0",
+        "type": "puzzle-piece-3d",
+        "args": {
+          "size": 1,
+          "depth": 0.32,
+          "knob": 0.24
+        },
+        "transform": {
+          "translate": [-1.5, 0.7, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.75,
+          "metal": 0.35,
+          "glow": 0
+        }
+      },
+      {
+        "id": "s1",
+        "type": "puzzle-piece-3d",
+        "args": {
+          "size": 1,
+          "depth": 0.32,
+          "knob": 0.24
+        },
+        "transform": {
+          "translate": [-0.5, 0.7, 0]
+        },
+        "material": {
+          "hue": 0.07,
+          "sat": 0.88,
+          "value": 0.85,
+          "metal": 0.25,
+          "glow": 0
+        }
+      },
+      {
+        "id": "s2",
+        "type": "puzzle-piece-3d",
+        "args": {
+          "size": 1,
+          "depth": 0.32,
+          "knob": 0.24
+        },
+        "transform": {
+          "translate": [0.5, 0.7, 0]
+        },
+        "material": {
+          "hue": 0.4,
+          "sat": 0.72,
+          "value": 0.6,
+          "metal": 0.25,
+          "glow": 0
+        }
+      },
+      {
+        "id": "s3",
+        "type": "puzzle-piece-3d",
+        "args": {
+          "size": 1,
+          "depth": 0.32,
+          "knob": 0.24
+        },
+        "transform": {
+          "translate": [1.5, 1.55, 0.15]
+        },
+        "material": {
+          "hue": 0.13,
+          "sat": 0.85,
+          "value": 0.9,
+          "metal": 0.9,
+          "glow": 0
+        }
+      }
+    ],
+    "defaults": {
+      "camera": {
+        "yaw": 0.5,
+        "pitch": 0.3,
+        "distance": 10,
+        "focal": 1.5,
+        "targetX": 0,
+        "targetY": 0.9124999999999999,
+        "targetZ": 0
+      },
+      "light": {
+        "azimuth": 0.6,
+        "altitude": 0.55,
+        "distance": 25,
+        "intensity": 1.2
+      },
+      "shadow": {
+        "enabled": true,
+        "mode": "darken",
+        "strength": 0.4
+      },
+      "studioBg": "dark"
+    }
+  },
+  "meta": {
+    "generatedAt": "2026-06-21",
+    "model": "vision-authored",
+    "pattern": "puzzles",
+    "costUSD": 0
+  }
+}

--- a/sdf-js/examples/compositor/demo-lifts/product-spheres-sliced.json
+++ b/sdf-js/examples/compositor/demo-lifts/product-spheres-sliced.json
@@ -1,0 +1,95 @@
+{
+  "id": "product-spheres-sliced",
+  "title": "Spheres Sliced · Nested cross-section",
+  "prompt": "spheres: Spheres Sliced · Nested cross-section",
+  "code2d": "// vision-authored pixel-align of a PresentationLoad product cover (\"spheres\").",
+  "sceneData": {
+    "v": 1,
+    "name": "Spheres Sliced · Nested cross-section",
+    "source": {
+      "format": "vision-authored",
+      "prompt": "spheres product cover pixel-align"
+    },
+    "subjects": [
+      {
+        "id": "slice-outer",
+        "type": "difference",
+        "material": {
+          "hue": 0.6,
+          "sat": 0.06,
+          "value": 0.26,
+          "metal": 0.4,
+          "glow": 0
+        },
+        "transform": {
+          "translate": [0, 1.1, 0]
+        },
+        "children": [
+          {
+            "id": "so",
+            "type": "sphere",
+            "args": {
+              "radius": 1.3
+            }
+          },
+          {
+            "id": "wedge0",
+            "type": "box",
+            "args": {
+              "size": [3, 6, 3]
+            },
+            "transform": {
+              "translate": [-1.5, 0, -1.5]
+            }
+          }
+        ]
+      },
+      {
+        "id": "s1",
+        "type": "sphere",
+        "args": {
+          "radius": 0.92
+        },
+        "transform": {
+          "translate": [0, 1.1, 0]
+        },
+        "material": {
+          "hue": 0.57,
+          "sat": 0.9,
+          "value": 0.98,
+          "metal": 0.3,
+          "glow": 0.35
+        }
+      }
+    ],
+    "defaults": {
+      "camera": {
+        "yaw": 0.5,
+        "pitch": 0.3,
+        "distance": 10,
+        "focal": 1.5,
+        "targetX": 0,
+        "targetY": 1.1,
+        "targetZ": 0
+      },
+      "light": {
+        "azimuth": 0.6,
+        "altitude": 0.55,
+        "distance": 25,
+        "intensity": 1.2
+      },
+      "shadow": {
+        "enabled": true,
+        "mode": "darken",
+        "strength": 0.4
+      },
+      "studioBg": "dark"
+    }
+  },
+  "meta": {
+    "generatedAt": "2026-06-21",
+    "model": "vision-authored",
+    "pattern": "spheres",
+    "costUSD": 0
+  }
+}

--- a/sdf-js/scripts/gen-fill-slides.mjs
+++ b/sdf-js/scripts/gen-fill-slides.mjs
@@ -23,7 +23,16 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const OUT_DIR = resolve(__dirname, '../examples/compositor/demo-lifts');
 
 const LIQUID = { hue: 0.58, sat: 0.85, value: 0.72, metal: 0.3, glow: 0 }; // vivid glossy azure fill
-const EMPTY = 'porcelain'; // clean white upper cap
+const EMPTY = 'porcelain'; // clean white upper cap (default)
+
+// Optional per-sphere overrides (sphere.c = liquid color, sphere.top = top cap):
+const C = {
+  green: { hue: 0.28, sat: 0.78, value: 0.62, metal: 0.2, glow: 0 },
+  red: { hue: 0.0, sat: 0.82, value: 0.62, metal: 0.2, glow: 0 },
+  blue: { hue: 0.58, sat: 0.85, value: 0.72, metal: 0.3, glow: 0 },
+};
+const GLASS_DARK = { hue: 0.6, sat: 0.28, value: 0.07, metal: 0.55, glow: 0 }; // dark glassy dome
+const LABEL = { hue: 0, sat: 0, value: 1.0, metal: 0, glow: 0.25 }; // bright white % label (slight glow → legible on any bg)
 
 // ---- Per-slide sphere layouts (vision-authored from each PDF page) ----------
 // sphere = { x, y, z, r, f }  (f = fill fraction 0..1)
@@ -32,18 +41,24 @@ const SLIDES = {
   'fill-slide-01': {
     title: 'Fill Levels · Cover (20/40/80)',
     pattern: 'kpi-hero',
-    prompt: 'Cover — three glass fill spheres at 20/40/80%, increasing in size.',
+    prompt:
+      'Cover — three overlapping glass fill spheres 20% green / 40% red / 80% blue, increasing in size, dark glassy domes.',
+    // Overlapping cluster receding back-left → front-right; coloured liquid +
+    // dark glass dome (matches the dark cover); blue 80% is biggest + front.
     spheres: [
-      { x: -1.75, y: 0.9, z: 0, r: 0.46, f: 0.2 },
-      { x: -0.35, y: 0.9, z: 0, r: 0.64, f: 0.4 },
-      { x: 1.5, y: 0.9, z: 0, r: 0.92, f: 0.8 },
+      { x: -2.05, y: 1.0, z: -0.6, r: 0.5, f: 0.2, c: C.green, top: GLASS_DARK, label: '20%' },
+      { x: -0.95, y: 0.95, z: -0.2, r: 0.7, f: 0.4, c: C.red, top: GLASS_DARK, label: '40%' },
+      { x: 0.75, y: 0.9, z: 0.35, r: 1.0, f: 0.8, c: C.blue, top: GLASS_DARK, label: '80%' },
     ],
   },
   'fill-slide-02': {
     title: 'Fill Levels · Row of 4 (20/60/80/90)',
     pattern: 'compare',
     prompt: 'A row of four fill spheres at 20/60/80/90%.',
-    spheres: rowOf([0.2, 0.6, 0.8, 0.9], { r: 0.55, spacing: 0.5, y: 0.9 }),
+    spheres: rowOf([0.2, 0.6, 0.8, 0.9], { r: 0.55, spacing: 0.5, y: 0.9 }).map((s, i) => ({
+      ...s,
+      label: ['20%', '60%', '80%', '90%'][i],
+    })),
   },
   'fill-slide-03': {
     title: 'Fill Levels · Framed row + arrows (10/60/50)',
@@ -69,11 +84,11 @@ const SLIDES = {
     pattern: 'compare',
     prompt: 'Five varied-size fill spheres clustered around a large 100% sphere.',
     spheres: [
-      { x: 0, y: 0.95, z: 0, r: 0.95, f: 1.0 },
-      { x: -2.15, y: 0.7, z: 0.2, r: 0.6, f: 0.5 },
-      { x: -1.05, y: 1.35, z: -0.3, r: 0.42, f: 0.2 },
-      { x: 1.05, y: 1.35, z: -0.3, r: 0.42, f: 0.4 },
-      { x: 2.15, y: 0.7, z: 0.2, r: 0.6, f: 0.8 },
+      { x: 0, y: 0.95, z: 0, r: 0.95, f: 1.0, label: '100%' },
+      { x: -2.15, y: 0.7, z: 0.2, r: 0.6, f: 0.5, label: '50%' },
+      { x: -1.05, y: 1.35, z: -0.3, r: 0.42, f: 0.2, label: '20%' },
+      { x: 1.05, y: 1.35, z: -0.3, r: 0.42, f: 0.4, label: '40%' },
+      { x: 2.15, y: 0.7, z: 0.2, r: 0.6, f: 0.8, label: '80%' },
     ],
   },
   'fill-slide-07': {
@@ -257,7 +272,7 @@ function sphereSubjects(s, idx) {
       type: 'sphere-fill-3d',
       args: { levels: [f], radius: s.r, cage: false, fillScale: 1.0 },
       transform: { translate: [s.x, s.y, s.z] },
-      material: LIQUID,
+      material: s.c || LIQUID, // per-sphere liquid color override
     });
   }
   // empty (top cap) — cut-sphere keeps y ≥ waterline; skip when full
@@ -267,7 +282,23 @@ function sphereSubjects(s, idx) {
       type: 'cut-sphere',
       args: { radius: s.r, h: s.r * (2 * f - 1) },
       transform: { translate: [s.x, s.y, s.z] },
-      material: EMPTY,
+      material: s.top || EMPTY, // per-sphere top-cap override (e.g. dark glass)
+    });
+  }
+  // optional % label — text-3d-pipe floating just in front of the sphere,
+  // centred horizontally, sitting on the lower (filled) half like the source.
+  if (s.label) {
+    const h = Math.max(0.26, Math.min(0.5, s.r * 0.55));
+    // The studio auto-frame camera sits at −z looking toward +z, so the label
+    // goes on the camera-facing (−z) side, rotated 180° about Y to face it.
+    subs.push({
+      id: `lab${idx}`,
+      type: 'text-3d-pipe',
+      args: { text: s.label, height: h, pipeRadius: 0.05, align: 'center' },
+      transform: {
+        translate: [s.x, s.y - h * 0.5 - s.r * 0.12, s.z - s.r - 0.1],
+      },
+      material: LABEL,
     });
   }
   return subs;

--- a/sdf-js/scripts/gen-product-pixel.mjs
+++ b/sdf-js/scripts/gen-product-pixel.mjs
@@ -1,0 +1,250 @@
+#!/usr/bin/env node
+// =============================================================================
+// gen-product-pixel.mjs — pixel-aligned 3D recreations of 7 PresentationLoad
+// product covers (user-selected 2026-06-21). Each scene targets that deck's
+// hero look with Atlas atoms + the dark dramatic studio mode.
+//   1 diamond-charts      → diamond-3d ×3 (green/red/blue, increasing size)
+//   2 3d-cubes-flow       → cube row + arrow connectors (process)
+//   3 3d-cubes-semicircle → cubes along a semicircle arc (+ accent)
+//   4 3d-spheres-sliced   → nested spheres with a quadrant wedge removed
+//   5 3d-cubes-shapes     → 3×3×3 grid (dark) + blue accent cubes
+//   6 3d-puzzle           → interlocking colour pieces + one lifted
+//   7 arrow-toolbox-3d    → big blue rising arrow + grey supporting arrows
+//
+// Usage: node sdf-js/scripts/gen-product-pixel.mjs
+// =============================================================================
+
+import { readFileSync, writeFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const OUT_DIR = resolve(__dirname, '../examples/compositor/demo-lifts');
+
+const M = {
+  grey: { hue: 0.6, sat: 0.04, value: 0.46, metal: 0.5, glow: 0 },
+  darkgrey: { hue: 0.6, sat: 0.06, value: 0.26, metal: 0.4, glow: 0 },
+  blue: { hue: 0.58, sat: 0.85, value: 0.75, metal: 0.35, glow: 0 },
+  blueBright: { hue: 0.57, sat: 0.9, value: 0.98, metal: 0.3, glow: 0.35 },
+  teal: { hue: 0.5, sat: 0.72, value: 0.7, metal: 0.3, glow: 0 },
+  green: { hue: 0.3, sat: 0.75, value: 0.6, metal: 0.25, glow: 0 },
+  red: { hue: 0.0, sat: 0.8, value: 0.62, metal: 0.25, glow: 0 },
+  orange: { hue: 0.07, sat: 0.88, value: 0.85, metal: 0.25, glow: 0 },
+  emerald: { hue: 0.4, sat: 0.72, value: 0.6, metal: 0.25, glow: 0 },
+  crimson: { hue: 0.98, sat: 0.78, value: 0.62, metal: 0.25, glow: 0 },
+  gold: { hue: 0.13, sat: 0.85, value: 0.9, metal: 0.9, glow: 0 },
+};
+
+const P2 = Math.PI / 2;
+const S = (type, args, translate, material, rotate) => ({
+  type,
+  args,
+  transform: rotate ? { translate, rotate } : { translate },
+  material,
+});
+
+// Sliced shell: difference(sphere(r), wedge box that removes the −x,−z quadrant
+// facing the camera) → reveals the cross-section / nested layers.
+// "Sliced sphere": an outer dark shell with a camera-facing quadrant removed
+// (difference with a box), revealing a smaller BRIGHT-BLUE inner sphere also
+// quadrant-cut → the notch reads as a cross-section / divided sphere. Two high-
+// contrast shells (skip mid-greys that would occlude the blue). Wedge removes
+// the −x,−z quadrant (toward the camera at −x,−z).
+function slicedSphere(center) {
+  const wedge = (i) => ({
+    id: `wedge${i}`,
+    type: 'box',
+    args: { size: [3, 6, 3] },
+    transform: { translate: [-1.5, 0, -1.5] },
+  });
+  return [
+    {
+      id: 'slice-outer',
+      type: 'difference',
+      material: M.darkgrey,
+      transform: { translate: center },
+      children: [{ id: 'so', type: 'sphere', args: { radius: 1.3 } }, wedge(0)],
+    },
+    // inner = FULL blue sphere (uncut) so the outer's notch reveals its curved
+    // surface as a glowing blue core (coplanar cuts would z-fight to grey).
+    S('sphere', { radius: 0.92 }, center, M.blueBright),
+  ];
+}
+
+// Cubes along a semicircle arc in the XZ plane.
+function cubeArc(n, { R = 2.2, y = 0.45, size = 0.5, accent = -1 } = {}) {
+  const out = [];
+  for (let i = 0; i < n; i++) {
+    const a = Math.PI * (0.12 + 0.76 * (i / (n - 1))); // 0.12π .. 0.88π
+    out.push(
+      S(
+        'cube-3d',
+        { count: 1, cubeSize: size },
+        [R * Math.cos(a), y, -R * Math.sin(a) + R * 0.4],
+        i === accent ? M.blue : M.grey,
+        [0, a, 0],
+      ),
+    );
+  }
+  return out;
+}
+
+const SCENES = {
+  'product-diamond': {
+    title: 'Diamond Charts · 3 gems',
+    cat: 'diamonds',
+    subjects: [
+      S(
+        'diamond-3d',
+        { width: 0.9, crownHeight: 0.32, pavilionHeight: 0.82, tableRatio: 0.45 },
+        [-1.75, 1.05, -0.5],
+        M.green,
+      ),
+      S(
+        'diamond-3d',
+        { width: 1.2, crownHeight: 0.42, pavilionHeight: 1.05, tableRatio: 0.45 },
+        [-0.5, 0.95, -0.1],
+        M.red,
+      ),
+      S(
+        'diamond-3d',
+        { width: 1.6, crownHeight: 0.55, pavilionHeight: 1.35, tableRatio: 0.45 },
+        [1.2, 1.0, 0.35],
+        M.blue,
+      ),
+    ],
+  },
+  'product-cubes-flow': {
+    title: 'Cubes Flow · Process row',
+    cat: 'cubes',
+    subjects: [
+      ...[-2.4, -0.8, 0.8, 2.4].map((x, i) =>
+        S('cube-3d', { count: 1, cubeSize: 0.62 }, [x, 0.6, 0], i === 3 ? M.blue : M.teal),
+      ),
+      ...[-1.6, 0, 1.6].map((x) =>
+        S(
+          'arrow-3d',
+          { length: 0.7, shaftWidth: 0.14, headLength: 0.3, headWidth: 0.4, depth: 0.2 },
+          [x, 0.6, 0],
+          M.orange,
+        ),
+      ),
+    ],
+  },
+  'product-cubes-arc': {
+    title: 'Cubes Semi-Circle · Arc of 7',
+    cat: 'cubes',
+    subjects: cubeArc(7, { R: 2.3, y: 0.45, size: 0.5, accent: 3 }),
+  },
+  'product-spheres-sliced': {
+    title: 'Spheres Sliced · Nested cross-section',
+    cat: 'spheres',
+    subjects: slicedSphere([0, 1.1, 0]),
+  },
+  'product-cubes-grid': {
+    title: 'Cubes Shapes · 3×3×3 + accents',
+    cat: 'cubes',
+    subjects: [
+      S(
+        'cube-3d',
+        { count: 27, arrangement: 'grid3d', cubeSize: 0.42, spacing: 0.14 },
+        [0, 1.1, 0],
+        M.darkgrey,
+      ),
+      // blue accent cubes occupying a few grid cells (stride = 0.42 + 0.14 = 0.56)
+      S('cube-3d', { count: 1, cubeSize: 0.42 }, [0.56, 1.66, 0.56], M.blue),
+      S('cube-3d', { count: 1, cubeSize: 0.42 }, [-0.56, 0.54, 0.56], M.blue),
+      S('cube-3d', { count: 1, cubeSize: 0.42 }, [0.56, 1.1, -0.56], M.blue),
+    ],
+  },
+  'product-puzzle': {
+    title: 'Puzzle 3D · Interlocking + lifted',
+    cat: 'puzzles',
+    subjects: [
+      S('puzzle-piece-3d', { size: 1.0, depth: 0.32, knob: 0.24 }, [-1.5, 0.7, 0], M.blue),
+      S('puzzle-piece-3d', { size: 1.0, depth: 0.32, knob: 0.24 }, [-0.5, 0.7, 0], M.orange),
+      S('puzzle-piece-3d', { size: 1.0, depth: 0.32, knob: 0.24 }, [0.5, 0.7, 0], M.emerald),
+      // the 4th piece lifted up out of its slot (solution / missing-piece motif)
+      S('puzzle-piece-3d', { size: 1.0, depth: 0.32, knob: 0.24 }, [1.5, 1.55, 0.15], M.gold),
+    ],
+  },
+  'product-arrow': {
+    title: 'Arrow Toolbox · Rising arrow',
+    cat: 'arrows',
+    subjects: [
+      S(
+        'arrow-3d',
+        { length: 1.1, shaftWidth: 0.22, headLength: 0.5, headWidth: 0.7, depth: 0.3 },
+        [-0.7, 0.5, -0.5],
+        M.grey,
+        [0, 0, 0.5],
+      ),
+      S(
+        'arrow-3d',
+        { length: 1.5, shaftWidth: 0.3, headLength: 0.6, headWidth: 0.95, depth: 0.34 },
+        [-0.3, 0.8, -0.2],
+        M.darkgrey,
+        [0, 0, 0.5],
+      ),
+      S(
+        'arrow-3d',
+        { length: 2.4, shaftWidth: 0.42, headLength: 0.95, headWidth: 1.3, depth: 0.42 },
+        [0.2, 1.2, 0.2],
+        M.blue,
+        [0, 0, 0.52],
+      ),
+    ],
+  },
+};
+
+// ---- build + write + register -----------------------------------------------
+const indexPath = `${OUT_DIR}/index.json`;
+const index = JSON.parse(readFileSync(indexPath, 'utf8'));
+let wrote = 0;
+for (const [id, def] of Object.entries(SCENES)) {
+  const ys = def.subjects.map((s) => s.transform.translate[1]);
+  const ty = ys.reduce((a, b) => a + b, 0) / ys.length;
+  const entry = {
+    id,
+    title: def.title,
+    prompt: `${def.cat}: ${def.title}`,
+    code2d: `// vision-authored pixel-align of a PresentationLoad product cover ("${def.cat}").`,
+    sceneData: {
+      v: 1,
+      name: def.title,
+      source: { format: 'vision-authored', prompt: `${def.cat} product cover pixel-align` },
+      subjects: def.subjects.map((s, i) => ({ id: `s${i}`, ...s })),
+      defaults: {
+        camera: {
+          yaw: 0.5,
+          pitch: 0.3,
+          distance: 10,
+          focal: 1.5,
+          targetX: 0,
+          targetY: ty,
+          targetZ: 0,
+        },
+        light: { azimuth: 0.6, altitude: 0.55, distance: 25, intensity: 1.2 },
+        shadow: { enabled: true, mode: 'darken', strength: 0.4 },
+        studioBg: 'dark',
+      },
+    },
+    meta: { generatedAt: '2026-06-21', model: 'vision-authored', pattern: def.cat, costUSD: 0 },
+  };
+  writeFileSync(`${OUT_DIR}/${id}.json`, JSON.stringify(entry, null, 2) + '\n');
+  wrote++;
+  if (!index.demos.some((d) => d.id === id)) {
+    index.demos.push({
+      id,
+      title: def.title,
+      thesisPoint: `Pixel-align recreation of PresentationLoad "${def.cat}" product cover — Atlas atoms + dark studio.`,
+      category: 'product-pixel-align',
+      status: 'ready',
+      file: `${id}.json`,
+      renderer: 'studio',
+      prompt: def.title,
+    });
+  }
+}
+writeFileSync(indexPath, JSON.stringify(index, null, 2) + '\n');
+console.log(`wrote ${wrote} product scenes; index now ${index.demos.length} demos`);


### PR DESCRIPTION
## What

Pixel-fidelity pass on the image→3D recreations, plus 7 new product-cover recreations — all in the **dark dramatic studio** look (`studioBg:"dark"`, shipped #54).

### 1. Fill Levels deck — pixel pass (`gen-fill-slides.mjs`)
- **Cover**: 20% green / 40% red / 80% blue (categorical colors), overlapping increasing-size cluster, **dark glassy domes** (cut-sphere top in dark glass) — matches the dark source cover, not uniform blue.
- **% labels**: optional per-sphere `label` → `text-3d-pipe`, on the camera-facing side, sitting on the filled lower half. Cover (20/40/80), row-of-4 (20/60/80/90), cluster-of-5 (100/50/20/40/80) now carry their numbers. (Label gotcha: camera is at −z, so the label goes on the −z side with **no** Y-rotation — rotating mirrors the glyphs.)
- Generator gains per-sphere `c` (liquid color) + `top` (cap material) overrides + a label builder.

### 2. Seven PresentationLoad product covers → 3D (`gen-product-pixel.mjs`)
| scene | source | build |
| --- | --- | --- |
| `product-diamond` | Diamond Charts | 3 gems green/red/blue, increasing size (`diamond-3d`) |
| `product-cubes-flow` | 3D Cubes Flow | teal cube row + orange arrow connectors |
| `product-cubes-arc` | Cubes Semi-Circle | 7 cubes on a semicircle (+ blue accent) |
| `product-spheres-sliced` | 3D Spheres Sliced | dark shell with a camera-facing quadrant removed (`difference` w/ box) revealing a glowing blue core |
| `product-cubes-grid` | 3D cubes-shapes | 3×3×3 dark grid + blue accent cubes |
| `product-puzzle` | Puzzle 3D | interlocking color pieces + one lifted |
| `product-arrow` | Arrow Toolbox 3D | big blue rising arrow + grey supports |

## Verification
- All scenes **compile clean (E0/W0)**; registered in `demo-lifts/index.json` (`renderer:"studio"`, `studioBg:"dark"`).
- **Real-browser GPU verified each** — 0 shader errors. Cover reads green/red/blue with upright labels; sliced sphere reveals the blue core; gems / cube grid+accents / flow arrows / semicircle / puzzle+lifted / rising arrows all render correctly. Subject-level boolean (`type:"difference"` + children) used for the sliced sphere (children need globally-unique ids).
- Prettier + `node --check` clean.

Source PDFs/PPTX + the `fixtures/pdf-render.html` pdfjs harness stay out of the repo (gitignored / local).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
