### PR TITLE
chore: gitignore local screens/ directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ node_modules/
 # repo so the browser demo runs without the original file.
 sdf-js/fixtures/*.pdf
 sdf-js/fixtures/*.pptx
+
+# Local atom screenshots (not committed, regenerable via atoms-2d-demo)
+screens/


### PR DESCRIPTION
Small chore to prevent accidental commit of locally-generated atom screenshots. User keeps them locally for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)