### PR TITLE
Complete 3D shape-product coverage — 10 more pixel-align recreations

### DIFF
--- a/sdf-js/examples/compositor/demo-lifts/index.json
+++ b/sdf-js/examples/compositor/demo-lifts/index.json
@@ -928,6 +928,106 @@
       "file": "product-arrow.json",
       "renderer": "studio",
       "prompt": "Arrow Toolbox · Rising arrow"
+    },
+    {
+      "id": "product-gearwheels",
+      "title": "Gear Wheels 3D · Meshing (grey + blue)",
+      "thesisPoint": "Pixel-align recreation of PresentationLoad \"gear wheels\" product cover — Atlas atoms + dark studio.",
+      "category": "product-pixel-align",
+      "status": "ready",
+      "file": "product-gearwheels.json",
+      "renderer": "studio",
+      "prompt": "Gear Wheels 3D · Meshing (grey + blue)"
+    },
+    {
+      "id": "product-chrome-spheres",
+      "title": "Chrome Spheres · Receding row",
+      "thesisPoint": "Pixel-align recreation of PresentationLoad \"spheres\" product cover — Atlas atoms + dark studio.",
+      "category": "product-pixel-align",
+      "status": "ready",
+      "file": "product-chrome-spheres.json",
+      "renderer": "studio",
+      "prompt": "Chrome Spheres · Receding row"
+    },
+    {
+      "id": "product-spheres",
+      "title": "3D Spheres · Colour cluster",
+      "thesisPoint": "Pixel-align recreation of PresentationLoad \"spheres\" product cover — Atlas atoms + dark studio.",
+      "category": "product-pixel-align",
+      "status": "ready",
+      "file": "product-spheres.json",
+      "renderer": "studio",
+      "prompt": "3D Spheres · Colour cluster"
+    },
+    {
+      "id": "product-spheres-network",
+      "title": "3D Spheres · Network",
+      "thesisPoint": "Pixel-align recreation of PresentationLoad \"spheres\" product cover — Atlas atoms + dark studio.",
+      "category": "product-pixel-align",
+      "status": "ready",
+      "file": "product-spheres-network.json",
+      "renderer": "studio",
+      "prompt": "3D Spheres · Network"
+    },
+    {
+      "id": "product-spheres-tree",
+      "title": "3D Spheres · Tree structure",
+      "thesisPoint": "Pixel-align recreation of PresentationLoad \"spheres\" product cover — Atlas atoms + dark studio.",
+      "category": "product-pixel-align",
+      "status": "ready",
+      "file": "product-spheres-tree.json",
+      "renderer": "studio",
+      "prompt": "3D Spheres · Tree structure"
+    },
+    {
+      "id": "product-circles-segmented",
+      "title": "3D Circles · Segmented ring",
+      "thesisPoint": "Pixel-align recreation of PresentationLoad \"circles\" product cover — Atlas atoms + dark studio.",
+      "category": "product-pixel-align",
+      "status": "ready",
+      "file": "product-circles-segmented.json",
+      "renderer": "studio",
+      "prompt": "3D Circles · Segmented ring"
+    },
+    {
+      "id": "product-circle-shapes",
+      "title": "3D Circle Shapes · Layered stack",
+      "thesisPoint": "Pixel-align recreation of PresentationLoad \"circles\" product cover — Atlas atoms + dark studio.",
+      "category": "product-pixel-align",
+      "status": "ready",
+      "file": "product-circle-shapes.json",
+      "renderer": "studio",
+      "prompt": "3D Circle Shapes · Layered stack"
+    },
+    {
+      "id": "product-cubes-segmented",
+      "title": "3D Cubes · Segmented",
+      "thesisPoint": "Pixel-align recreation of PresentationLoad \"cubes\" product cover — Atlas atoms + dark studio.",
+      "category": "product-pixel-align",
+      "status": "ready",
+      "file": "product-cubes-segmented.json",
+      "renderer": "studio",
+      "prompt": "3D Cubes · Segmented"
+    },
+    {
+      "id": "product-puzzle-toolbox",
+      "title": "Puzzle Toolbox 3D · Row of 5",
+      "thesisPoint": "Pixel-align recreation of PresentationLoad \"puzzles\" product cover — Atlas atoms + dark studio.",
+      "category": "product-pixel-align",
+      "status": "ready",
+      "file": "product-puzzle-toolbox.json",
+      "renderer": "studio",
+      "prompt": "Puzzle Toolbox 3D · Row of 5"
+    },
+    {
+      "id": "product-circle-looping",
+      "title": "Circle Charts · Looping cycle",
+      "thesisPoint": "Pixel-align recreation of PresentationLoad \"circles\" product cover — Atlas atoms + dark studio.",
+      "category": "product-pixel-align",
+      "status": "ready",
+      "file": "product-circle-looping.json",
+      "renderer": "studio",
+      "prompt": "Circle Charts · Looping cycle"
     }
   ]
 }

--- a/sdf-js/examples/compositor/demo-lifts/product-chrome-spheres.json
+++ b/sdf-js/examples/compositor/demo-lifts/product-chrome-spheres.json
@@ -1,0 +1,147 @@
+{
+  "id": "product-chrome-spheres",
+  "title": "Chrome Spheres · Receding row",
+  "prompt": "spheres: Chrome Spheres · Receding row",
+  "code2d": "// vision-authored pixel-align of a PresentationLoad product cover (\"spheres\").",
+  "sceneData": {
+    "v": 1,
+    "name": "Chrome Spheres · Receding row",
+    "source": {
+      "format": "vision-authored",
+      "prompt": "spheres product cover pixel-align"
+    },
+    "subjects": [
+      {
+        "id": "s0",
+        "type": "sphere",
+        "args": {
+          "radius": 0.68
+        },
+        "transform": {
+          "translate": [1.3, 0.75, 0.5]
+        },
+        "material": {
+          "hue": 0.3,
+          "sat": 0.75,
+          "value": 0.6,
+          "metal": 0.25,
+          "glow": 0
+        }
+      },
+      {
+        "id": "s1",
+        "type": "sphere",
+        "args": {
+          "radius": 0.54
+        },
+        "transform": {
+          "translate": [0.3, 0.85, 0]
+        },
+        "material": {
+          "hue": 0.6,
+          "sat": 0.02,
+          "value": 0.85,
+          "metal": 0.98,
+          "glow": 0
+        }
+      },
+      {
+        "id": "s2",
+        "type": "sphere",
+        "args": {
+          "radius": 0.44
+        },
+        "transform": {
+          "translate": [-0.5, 0.92, -0.4]
+        },
+        "material": {
+          "hue": 0.6,
+          "sat": 0.02,
+          "value": 0.85,
+          "metal": 0.98,
+          "glow": 0
+        }
+      },
+      {
+        "id": "s3",
+        "type": "sphere",
+        "args": {
+          "radius": 0.35
+        },
+        "transform": {
+          "translate": [-1.1, 1, -0.8]
+        },
+        "material": {
+          "hue": 0.6,
+          "sat": 0.02,
+          "value": 0.85,
+          "metal": 0.98,
+          "glow": 0
+        }
+      },
+      {
+        "id": "s4",
+        "type": "sphere",
+        "args": {
+          "radius": 0.28
+        },
+        "transform": {
+          "translate": [-1.6, 1.05, -1.1]
+        },
+        "material": {
+          "hue": 0.6,
+          "sat": 0.02,
+          "value": 0.85,
+          "metal": 0.98,
+          "glow": 0
+        }
+      },
+      {
+        "id": "s5",
+        "type": "sphere",
+        "args": {
+          "radius": 0.22
+        },
+        "transform": {
+          "translate": [-2, 1.1, -1.4]
+        },
+        "material": {
+          "hue": 0.6,
+          "sat": 0.02,
+          "value": 0.85,
+          "metal": 0.98,
+          "glow": 0
+        }
+      }
+    ],
+    "defaults": {
+      "camera": {
+        "yaw": 0.5,
+        "pitch": 0.3,
+        "distance": 10,
+        "focal": 1.5,
+        "targetX": 0,
+        "targetY": 0.945,
+        "targetZ": 0
+      },
+      "light": {
+        "azimuth": 0.6,
+        "altitude": 0.55,
+        "distance": 25,
+        "intensity": 1.2
+      },
+      "shadow": {
+        "enabled": true,
+        "mode": "darken",
+        "strength": 0.4
+      },
+      "studioBg": "dark"
+    }
+  },
+  "meta": {
+    "generatedAt": "2026-06-21",
+    "model": "vision-authored",
+    "pattern": "spheres",
+    "costUSD": 0
+  }
+}

--- a/sdf-js/examples/compositor/demo-lifts/product-circle-looping.json
+++ b/sdf-js/examples/compositor/demo-lifts/product-circle-looping.json
@@ -1,0 +1,67 @@
+{
+  "id": "product-circle-looping",
+  "title": "Circle Charts · Looping cycle",
+  "prompt": "circles: Circle Charts · Looping cycle",
+  "code2d": "// vision-authored pixel-align of a PresentationLoad product cover (\"circles\").",
+  "sceneData": {
+    "v": 1,
+    "name": "Circle Charts · Looping cycle",
+    "source": {
+      "format": "vision-authored",
+      "prompt": "circles product cover pixel-align"
+    },
+    "subjects": [
+      {
+        "id": "s0",
+        "type": "circle-loop-3d",
+        "args": {
+          "segments": 5,
+          "radius": 1,
+          "tube": 0.08,
+          "headLength": 0.36,
+          "headRadius": 0.18
+        },
+        "transform": {
+          "translate": [0, 1, 0],
+          "rotate": [1.5707963267948966, 0, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.75,
+          "metal": 0.35,
+          "glow": 0
+        }
+      }
+    ],
+    "defaults": {
+      "camera": {
+        "yaw": 0.5,
+        "pitch": 0.3,
+        "distance": 10,
+        "focal": 1.5,
+        "targetX": 0,
+        "targetY": 1,
+        "targetZ": 0
+      },
+      "light": {
+        "azimuth": 0.6,
+        "altitude": 0.55,
+        "distance": 25,
+        "intensity": 1.2
+      },
+      "shadow": {
+        "enabled": true,
+        "mode": "darken",
+        "strength": 0.4
+      },
+      "studioBg": "dark"
+    }
+  },
+  "meta": {
+    "generatedAt": "2026-06-21",
+    "model": "vision-authored",
+    "pattern": "circles",
+    "costUSD": 0
+  }
+}

--- a/sdf-js/examples/compositor/demo-lifts/product-circle-shapes.json
+++ b/sdf-js/examples/compositor/demo-lifts/product-circle-shapes.json
@@ -1,0 +1,66 @@
+{
+  "id": "product-circle-shapes",
+  "title": "3D Circle Shapes · Layered stack",
+  "prompt": "circles: 3D Circle Shapes · Layered stack",
+  "code2d": "// vision-authored pixel-align of a PresentationLoad product cover (\"circles\").",
+  "sceneData": {
+    "v": 1,
+    "name": "3D Circle Shapes · Layered stack",
+    "source": {
+      "format": "vision-authored",
+      "prompt": "circles product cover pixel-align"
+    },
+    "subjects": [
+      {
+        "id": "s0",
+        "type": "circle-stack-3d",
+        "args": {
+          "count": 5,
+          "radius": 0.95,
+          "taper": 0.82,
+          "diskHeight": 0.18,
+          "gap": 0.12
+        },
+        "transform": {
+          "translate": [0, 0.6, 0]
+        },
+        "material": {
+          "hue": 0.5,
+          "sat": 0.72,
+          "value": 0.7,
+          "metal": 0.3,
+          "glow": 0
+        }
+      }
+    ],
+    "defaults": {
+      "camera": {
+        "yaw": 0.5,
+        "pitch": 0.3,
+        "distance": 10,
+        "focal": 1.5,
+        "targetX": 0,
+        "targetY": 0.6,
+        "targetZ": 0
+      },
+      "light": {
+        "azimuth": 0.6,
+        "altitude": 0.55,
+        "distance": 25,
+        "intensity": 1.2
+      },
+      "shadow": {
+        "enabled": true,
+        "mode": "darken",
+        "strength": 0.4
+      },
+      "studioBg": "dark"
+    }
+  },
+  "meta": {
+    "generatedAt": "2026-06-21",
+    "model": "vision-authored",
+    "pattern": "circles",
+    "costUSD": 0
+  }
+}

--- a/sdf-js/examples/compositor/demo-lifts/product-circles-segmented.json
+++ b/sdf-js/examples/compositor/demo-lifts/product-circles-segmented.json
@@ -1,0 +1,67 @@
+{
+  "id": "product-circles-segmented",
+  "title": "3D Circles · Segmented ring",
+  "prompt": "circles: 3D Circles · Segmented ring",
+  "code2d": "// vision-authored pixel-align of a PresentationLoad product cover (\"circles\").",
+  "sceneData": {
+    "v": 1,
+    "name": "3D Circles · Segmented ring",
+    "source": {
+      "format": "vision-authored",
+      "prompt": "circles product cover pixel-align"
+    },
+    "subjects": [
+      {
+        "id": "s0",
+        "type": "circle-segmented-3d",
+        "args": {
+          "segments": 6,
+          "radius": 1.05,
+          "innerRatio": 0.5,
+          "thickness": 0.28,
+          "gapWidth": 0.14
+        },
+        "transform": {
+          "translate": [0, 1, 0],
+          "rotate": [1.5707963267948966, 0, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.75,
+          "metal": 0.35,
+          "glow": 0
+        }
+      }
+    ],
+    "defaults": {
+      "camera": {
+        "yaw": 0.5,
+        "pitch": 0.3,
+        "distance": 10,
+        "focal": 1.5,
+        "targetX": 0,
+        "targetY": 1,
+        "targetZ": 0
+      },
+      "light": {
+        "azimuth": 0.6,
+        "altitude": 0.55,
+        "distance": 25,
+        "intensity": 1.2
+      },
+      "shadow": {
+        "enabled": true,
+        "mode": "darken",
+        "strength": 0.4
+      },
+      "studioBg": "dark"
+    }
+  },
+  "meta": {
+    "generatedAt": "2026-06-21",
+    "model": "vision-authored",
+    "pattern": "circles",
+    "costUSD": 0
+  }
+}

--- a/sdf-js/examples/compositor/demo-lifts/product-cubes-segmented.json
+++ b/sdf-js/examples/compositor/demo-lifts/product-cubes-segmented.json
@@ -1,0 +1,65 @@
+{
+  "id": "product-cubes-segmented",
+  "title": "3D Cubes · Segmented",
+  "prompt": "cubes: 3D Cubes · Segmented",
+  "code2d": "// vision-authored pixel-align of a PresentationLoad product cover (\"cubes\").",
+  "sceneData": {
+    "v": 1,
+    "name": "3D Cubes · Segmented",
+    "source": {
+      "format": "vision-authored",
+      "prompt": "cubes product cover pixel-align"
+    },
+    "subjects": [
+      {
+        "id": "s0",
+        "type": "cube-segmented-3d",
+        "args": {
+          "segments": 5,
+          "size": 1.6,
+          "gap": 0.12,
+          "axis": "x"
+        },
+        "transform": {
+          "translate": [0, 0.9, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.75,
+          "metal": 0.35,
+          "glow": 0
+        }
+      }
+    ],
+    "defaults": {
+      "camera": {
+        "yaw": 0.5,
+        "pitch": 0.3,
+        "distance": 10,
+        "focal": 1.5,
+        "targetX": 0,
+        "targetY": 0.9,
+        "targetZ": 0
+      },
+      "light": {
+        "azimuth": 0.6,
+        "altitude": 0.55,
+        "distance": 25,
+        "intensity": 1.2
+      },
+      "shadow": {
+        "enabled": true,
+        "mode": "darken",
+        "strength": 0.4
+      },
+      "studioBg": "dark"
+    }
+  },
+  "meta": {
+    "generatedAt": "2026-06-21",
+    "model": "vision-authored",
+    "pattern": "cubes",
+    "costUSD": 0
+  }
+}

--- a/sdf-js/examples/compositor/demo-lifts/product-gearwheels.json
+++ b/sdf-js/examples/compositor/demo-lifts/product-gearwheels.json
@@ -1,0 +1,114 @@
+{
+  "id": "product-gearwheels",
+  "title": "Gear Wheels 3D · Meshing (grey + blue)",
+  "prompt": "gear wheels: Gear Wheels 3D · Meshing (grey + blue)",
+  "code2d": "// vision-authored pixel-align of a PresentationLoad product cover (\"gear wheels\").",
+  "sceneData": {
+    "v": 1,
+    "name": "Gear Wheels 3D · Meshing (grey + blue)",
+    "source": {
+      "format": "vision-authored",
+      "prompt": "gear wheels product cover pixel-align"
+    },
+    "subjects": [
+      {
+        "id": "s0",
+        "type": "gear-3d",
+        "args": {
+          "teeth": 16,
+          "radius": 0.95,
+          "thickness": 0.3,
+          "toothDepth": 0.18,
+          "toothWidth": 0.2,
+          "holeRadius": 0.32
+        },
+        "transform": {
+          "translate": [0, 1, 0],
+          "rotate": [1.5707963267948966, 0, 0]
+        },
+        "material": {
+          "hue": 0.6,
+          "sat": 0.04,
+          "value": 0.46,
+          "metal": 0.5,
+          "glow": 0
+        }
+      },
+      {
+        "id": "s1",
+        "type": "gear-3d",
+        "args": {
+          "teeth": 11,
+          "radius": 0.66,
+          "thickness": 0.3,
+          "toothDepth": 0.16,
+          "toothWidth": 0.18,
+          "holeRadius": 0.24
+        },
+        "transform": {
+          "translate": [1.5, 1.55, 0],
+          "rotate": [1.5707963267948966, 0, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.75,
+          "metal": 0.35,
+          "glow": 0
+        }
+      },
+      {
+        "id": "s2",
+        "type": "gear-3d",
+        "args": {
+          "teeth": 9,
+          "radius": 0.55,
+          "thickness": 0.3,
+          "toothDepth": 0.15,
+          "toothWidth": 0.17,
+          "holeRadius": 0.2
+        },
+        "transform": {
+          "translate": [-1.2, 0.45, 0],
+          "rotate": [1.5707963267948966, 0, 0]
+        },
+        "material": {
+          "hue": 0.6,
+          "sat": 0.04,
+          "value": 0.46,
+          "metal": 0.5,
+          "glow": 0
+        }
+      }
+    ],
+    "defaults": {
+      "camera": {
+        "yaw": 0.5,
+        "pitch": 0.3,
+        "distance": 10,
+        "focal": 1.5,
+        "targetX": 0,
+        "targetY": 1,
+        "targetZ": 0
+      },
+      "light": {
+        "azimuth": 0.6,
+        "altitude": 0.55,
+        "distance": 25,
+        "intensity": 1.2
+      },
+      "shadow": {
+        "enabled": true,
+        "mode": "darken",
+        "strength": 0.4
+      },
+      "studioBg": "dark"
+    }
+  },
+  "meta": {
+    "generatedAt": "2026-06-21",
+    "model": "vision-authored",
+    "pattern": "gear wheels",
+    "costUSD": 0
+  }
+}

--- a/sdf-js/examples/compositor/demo-lifts/product-puzzle-toolbox.json
+++ b/sdf-js/examples/compositor/demo-lifts/product-puzzle-toolbox.json
@@ -1,0 +1,140 @@
+{
+  "id": "product-puzzle-toolbox",
+  "title": "Puzzle Toolbox 3D · Row of 5",
+  "prompt": "puzzles: Puzzle Toolbox 3D · Row of 5",
+  "code2d": "// vision-authored pixel-align of a PresentationLoad product cover (\"puzzles\").",
+  "sceneData": {
+    "v": 1,
+    "name": "Puzzle Toolbox 3D · Row of 5",
+    "source": {
+      "format": "vision-authored",
+      "prompt": "puzzles product cover pixel-align"
+    },
+    "subjects": [
+      {
+        "id": "s0",
+        "type": "puzzle-piece-3d",
+        "args": {
+          "size": 1,
+          "depth": 0.3,
+          "knob": 0.24
+        },
+        "transform": {
+          "translate": [-2, 0.8, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.75,
+          "metal": 0.35,
+          "glow": 0
+        }
+      },
+      {
+        "id": "s1",
+        "type": "puzzle-piece-3d",
+        "args": {
+          "size": 1,
+          "depth": 0.3,
+          "knob": 0.24
+        },
+        "transform": {
+          "translate": [-1, 0.8, 0]
+        },
+        "material": {
+          "hue": 0.07,
+          "sat": 0.88,
+          "value": 0.85,
+          "metal": 0.25,
+          "glow": 0
+        }
+      },
+      {
+        "id": "s2",
+        "type": "puzzle-piece-3d",
+        "args": {
+          "size": 1,
+          "depth": 0.3,
+          "knob": 0.24
+        },
+        "transform": {
+          "translate": [0, 0.8, 0]
+        },
+        "material": {
+          "hue": 0.4,
+          "sat": 0.72,
+          "value": 0.6,
+          "metal": 0.25,
+          "glow": 0
+        }
+      },
+      {
+        "id": "s3",
+        "type": "puzzle-piece-3d",
+        "args": {
+          "size": 1,
+          "depth": 0.3,
+          "knob": 0.24
+        },
+        "transform": {
+          "translate": [1, 0.8, 0]
+        },
+        "material": {
+          "hue": 0.98,
+          "sat": 0.78,
+          "value": 0.62,
+          "metal": 0.25,
+          "glow": 0
+        }
+      },
+      {
+        "id": "s4",
+        "type": "puzzle-piece-3d",
+        "args": {
+          "size": 1,
+          "depth": 0.3,
+          "knob": 0.24
+        },
+        "transform": {
+          "translate": [2, 0.8, 0]
+        },
+        "material": {
+          "hue": 0.13,
+          "sat": 0.85,
+          "value": 0.9,
+          "metal": 0.9,
+          "glow": 0
+        }
+      }
+    ],
+    "defaults": {
+      "camera": {
+        "yaw": 0.5,
+        "pitch": 0.3,
+        "distance": 10,
+        "focal": 1.5,
+        "targetX": 0,
+        "targetY": 0.8,
+        "targetZ": 0
+      },
+      "light": {
+        "azimuth": 0.6,
+        "altitude": 0.55,
+        "distance": 25,
+        "intensity": 1.2
+      },
+      "shadow": {
+        "enabled": true,
+        "mode": "darken",
+        "strength": 0.4
+      },
+      "studioBg": "dark"
+    }
+  },
+  "meta": {
+    "generatedAt": "2026-06-21",
+    "model": "vision-authored",
+    "pattern": "puzzles",
+    "costUSD": 0
+  }
+}

--- a/sdf-js/examples/compositor/demo-lifts/product-spheres-network.json
+++ b/sdf-js/examples/compositor/demo-lifts/product-spheres-network.json
@@ -1,0 +1,66 @@
+{
+  "id": "product-spheres-network",
+  "title": "3D Spheres · Network",
+  "prompt": "spheres: 3D Spheres · Network",
+  "code2d": "// vision-authored pixel-align of a PresentationLoad product cover (\"spheres\").",
+  "sceneData": {
+    "v": 1,
+    "name": "3D Spheres · Network",
+    "source": {
+      "format": "vision-authored",
+      "prompt": "spheres product cover pixel-align"
+    },
+    "subjects": [
+      {
+        "id": "s0",
+        "type": "sphere-network-3d",
+        "args": {
+          "count": 6,
+          "hubRadius": 0.45,
+          "satelliteRadius": 0.26,
+          "radius": 1.5,
+          "linkThickness": 0.05
+        },
+        "transform": {
+          "translate": [0, 1.3, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.75,
+          "metal": 0.35,
+          "glow": 0
+        }
+      }
+    ],
+    "defaults": {
+      "camera": {
+        "yaw": 0.5,
+        "pitch": 0.3,
+        "distance": 10,
+        "focal": 1.5,
+        "targetX": 0,
+        "targetY": 1.3,
+        "targetZ": 0
+      },
+      "light": {
+        "azimuth": 0.6,
+        "altitude": 0.55,
+        "distance": 25,
+        "intensity": 1.2
+      },
+      "shadow": {
+        "enabled": true,
+        "mode": "darken",
+        "strength": 0.4
+      },
+      "studioBg": "dark"
+    }
+  },
+  "meta": {
+    "generatedAt": "2026-06-21",
+    "model": "vision-authored",
+    "pattern": "spheres",
+    "costUSD": 0
+  }
+}

--- a/sdf-js/examples/compositor/demo-lifts/product-spheres-tree.json
+++ b/sdf-js/examples/compositor/demo-lifts/product-spheres-tree.json
@@ -1,0 +1,66 @@
+{
+  "id": "product-spheres-tree",
+  "title": "3D Spheres · Tree structure",
+  "prompt": "spheres: 3D Spheres · Tree structure",
+  "code2d": "// vision-authored pixel-align of a PresentationLoad product cover (\"spheres\").",
+  "sceneData": {
+    "v": 1,
+    "name": "3D Spheres · Tree structure",
+    "source": {
+      "format": "vision-authored",
+      "prompt": "spheres product cover pixel-align"
+    },
+    "subjects": [
+      {
+        "id": "s0",
+        "type": "sphere-tree-3d",
+        "args": {
+          "levels": 3,
+          "branching": 2,
+          "rootRadius": 0.4,
+          "levelHeight": 1,
+          "spread": 3
+        },
+        "transform": {
+          "translate": [0, 1.6, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.75,
+          "metal": 0.35,
+          "glow": 0
+        }
+      }
+    ],
+    "defaults": {
+      "camera": {
+        "yaw": 0.5,
+        "pitch": 0.3,
+        "distance": 10,
+        "focal": 1.5,
+        "targetX": 0,
+        "targetY": 1.6,
+        "targetZ": 0
+      },
+      "light": {
+        "azimuth": 0.6,
+        "altitude": 0.55,
+        "distance": 25,
+        "intensity": 1.2
+      },
+      "shadow": {
+        "enabled": true,
+        "mode": "darken",
+        "strength": 0.4
+      },
+      "studioBg": "dark"
+    }
+  },
+  "meta": {
+    "generatedAt": "2026-06-21",
+    "model": "vision-authored",
+    "pattern": "spheres",
+    "costUSD": 0
+  }
+}

--- a/sdf-js/examples/compositor/demo-lifts/product-spheres.json
+++ b/sdf-js/examples/compositor/demo-lifts/product-spheres.json
@@ -1,0 +1,130 @@
+{
+  "id": "product-spheres",
+  "title": "3D Spheres · Colour cluster",
+  "prompt": "spheres: 3D Spheres · Colour cluster",
+  "code2d": "// vision-authored pixel-align of a PresentationLoad product cover (\"spheres\").",
+  "sceneData": {
+    "v": 1,
+    "name": "3D Spheres · Colour cluster",
+    "source": {
+      "format": "vision-authored",
+      "prompt": "spheres product cover pixel-align"
+    },
+    "subjects": [
+      {
+        "id": "s0",
+        "type": "sphere",
+        "args": {
+          "radius": 0.85
+        },
+        "transform": {
+          "translate": [0, 1, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.75,
+          "metal": 0.35,
+          "glow": 0
+        }
+      },
+      {
+        "id": "s1",
+        "type": "sphere",
+        "args": {
+          "radius": 0.6
+        },
+        "transform": {
+          "translate": [-1.5, 0.78, 0.2]
+        },
+        "material": {
+          "hue": 0.3,
+          "sat": 0.75,
+          "value": 0.6,
+          "metal": 0.25,
+          "glow": 0
+        }
+      },
+      {
+        "id": "s2",
+        "type": "sphere",
+        "args": {
+          "radius": 0.55
+        },
+        "transform": {
+          "translate": [1.4, 0.82, -0.1]
+        },
+        "material": {
+          "hue": 0.07,
+          "sat": 0.88,
+          "value": 0.85,
+          "metal": 0.25,
+          "glow": 0
+        }
+      },
+      {
+        "id": "s3",
+        "type": "sphere",
+        "args": {
+          "radius": 0.42
+        },
+        "transform": {
+          "translate": [0.6, 1.5, -0.3]
+        },
+        "material": {
+          "hue": 0.6,
+          "sat": 0.04,
+          "value": 0.46,
+          "metal": 0.5,
+          "glow": 0
+        }
+      },
+      {
+        "id": "s4",
+        "type": "sphere",
+        "args": {
+          "radius": 0.4
+        },
+        "transform": {
+          "translate": [-0.8, 1.45, -0.2]
+        },
+        "material": {
+          "hue": 0.5,
+          "sat": 0.72,
+          "value": 0.7,
+          "metal": 0.3,
+          "glow": 0
+        }
+      }
+    ],
+    "defaults": {
+      "camera": {
+        "yaw": 0.5,
+        "pitch": 0.3,
+        "distance": 10,
+        "focal": 1.5,
+        "targetX": 0,
+        "targetY": 1.1099999999999999,
+        "targetZ": 0
+      },
+      "light": {
+        "azimuth": 0.6,
+        "altitude": 0.55,
+        "distance": 25,
+        "intensity": 1.2
+      },
+      "shadow": {
+        "enabled": true,
+        "mode": "darken",
+        "strength": 0.4
+      },
+      "studioBg": "dark"
+    }
+  },
+  "meta": {
+    "generatedAt": "2026-06-21",
+    "model": "vision-authored",
+    "pattern": "spheres",
+    "costUSD": 0
+  }
+}

--- a/sdf-js/scripts/gen-product-pixel.mjs
+++ b/sdf-js/scripts/gen-product-pixel.mjs
@@ -33,6 +33,7 @@ const M = {
   emerald: { hue: 0.4, sat: 0.72, value: 0.6, metal: 0.25, glow: 0 },
   crimson: { hue: 0.98, sat: 0.78, value: 0.62, metal: 0.25, glow: 0 },
   gold: { hue: 0.13, sat: 0.85, value: 0.9, metal: 0.9, glow: 0 },
+  chrome: { hue: 0.6, sat: 0.02, value: 0.85, metal: 0.98, glow: 0 },
 };
 
 const P2 = Math.PI / 2;
@@ -192,6 +193,154 @@ const SCENES = {
         [0.2, 1.2, 0.2],
         M.blue,
         [0, 0, 0.52],
+      ),
+    ],
+  },
+  // ---- Round 2: remaining 3D shape products (2026-06-21) ----
+  'product-gearwheels': {
+    title: 'Gear Wheels 3D · Meshing (grey + blue)',
+    cat: 'gear wheels',
+    subjects: [
+      S(
+        'gear-3d',
+        {
+          teeth: 16,
+          radius: 0.95,
+          thickness: 0.3,
+          toothDepth: 0.18,
+          toothWidth: 0.2,
+          holeRadius: 0.32,
+        },
+        [0, 1.0, 0],
+        M.grey,
+        [P2, 0, 0],
+      ),
+      S(
+        'gear-3d',
+        {
+          teeth: 11,
+          radius: 0.66,
+          thickness: 0.3,
+          toothDepth: 0.16,
+          toothWidth: 0.18,
+          holeRadius: 0.24,
+        },
+        [1.5, 1.55, 0],
+        M.blue,
+        [P2, 0, 0],
+      ),
+      S(
+        'gear-3d',
+        {
+          teeth: 9,
+          radius: 0.55,
+          thickness: 0.3,
+          toothDepth: 0.15,
+          toothWidth: 0.17,
+          holeRadius: 0.2,
+        },
+        [-1.2, 0.45, 0],
+        M.grey,
+        [P2, 0, 0],
+      ),
+    ],
+  },
+  'product-chrome-spheres': {
+    title: 'Chrome Spheres · Receding row',
+    cat: 'spheres',
+    subjects: [
+      S('sphere', { radius: 0.68 }, [1.3, 0.75, 0.5], M.green),
+      S('sphere', { radius: 0.54 }, [0.3, 0.85, 0.0], M.chrome),
+      S('sphere', { radius: 0.44 }, [-0.5, 0.92, -0.4], M.chrome),
+      S('sphere', { radius: 0.35 }, [-1.1, 1.0, -0.8], M.chrome),
+      S('sphere', { radius: 0.28 }, [-1.6, 1.05, -1.1], M.chrome),
+      S('sphere', { radius: 0.22 }, [-2.0, 1.1, -1.4], M.chrome),
+    ],
+  },
+  'product-spheres': {
+    title: '3D Spheres · Colour cluster',
+    cat: 'spheres',
+    subjects: [
+      S('sphere', { radius: 0.85 }, [0, 1.0, 0], M.blue),
+      S('sphere', { radius: 0.6 }, [-1.5, 0.78, 0.2], M.green),
+      S('sphere', { radius: 0.55 }, [1.4, 0.82, -0.1], M.orange),
+      S('sphere', { radius: 0.42 }, [0.6, 1.5, -0.3], M.grey),
+      S('sphere', { radius: 0.4 }, [-0.8, 1.45, -0.2], M.teal),
+    ],
+  },
+  'product-spheres-network': {
+    title: '3D Spheres · Network',
+    cat: 'spheres',
+    subjects: [
+      S(
+        'sphere-network-3d',
+        { count: 6, hubRadius: 0.45, satelliteRadius: 0.26, radius: 1.5, linkThickness: 0.05 },
+        [0, 1.3, 0],
+        M.blue,
+      ),
+    ],
+  },
+  'product-spheres-tree': {
+    title: '3D Spheres · Tree structure',
+    cat: 'spheres',
+    subjects: [
+      S(
+        'sphere-tree-3d',
+        { levels: 3, branching: 2, rootRadius: 0.4, levelHeight: 1.0, spread: 3.0 },
+        [0, 1.6, 0],
+        M.blue,
+      ),
+    ],
+  },
+  'product-circles-segmented': {
+    title: '3D Circles · Segmented ring',
+    cat: 'circles',
+    subjects: [
+      S(
+        'circle-segmented-3d',
+        { segments: 6, radius: 1.05, innerRatio: 0.5, thickness: 0.28, gapWidth: 0.14 },
+        [0, 1.0, 0],
+        M.blue,
+        [P2, 0, 0],
+      ),
+    ],
+  },
+  'product-circle-shapes': {
+    title: '3D Circle Shapes · Layered stack',
+    cat: 'circles',
+    subjects: [
+      S(
+        'circle-stack-3d',
+        { count: 5, radius: 0.95, taper: 0.82, diskHeight: 0.18, gap: 0.12 },
+        [0, 0.6, 0],
+        M.teal,
+      ),
+    ],
+  },
+  'product-cubes-segmented': {
+    title: '3D Cubes · Segmented',
+    cat: 'cubes',
+    subjects: [
+      S('cube-segmented-3d', { segments: 5, size: 1.6, gap: 0.12, axis: 'x' }, [0, 0.9, 0], M.blue),
+    ],
+  },
+  'product-puzzle-toolbox': {
+    title: 'Puzzle Toolbox 3D · Row of 5',
+    cat: 'puzzles',
+    subjects: ['blue', 'orange', 'emerald', 'crimson', 'gold'].map((c, i) =>
+      S('puzzle-piece-3d', { size: 1.0, depth: 0.3, knob: 0.24 }, [(i - 2) * 1.0, 0.8, 0], M[c]),
+    ),
+  },
+  'product-circle-looping': {
+    title: 'Circle Charts · Looping cycle',
+    cat: 'circles',
+    subjects: [
+      S(
+        'circle-loop-3d',
+        { segments: 5, radius: 1.0, tube: 0.08, headLength: 0.36, headRadius: 0.18 },
+        [0, 1.0, 0],
+        M.blue,
+        [P2, 0, 0],
       ),
     ],
   },


### PR DESCRIPTION
## What

Swept the PresentationLoad **/powerpoint-shapes/** listing for every **3D (not 2D)** product and added the ones still missing a dedicated cover recreation — completing 3D-product coverage. Atlas atoms + dark dramatic studio. Extends `gen-product-pixel.mjs` (7 → **17 scenes**).

| new scene | source product |
| --- | --- |
| `product-gearwheels` | Gear Wheels 3D — grey meshing gears + 1 blue accent |
| `product-chrome-spheres` | 3D Chrome Spheres — receding chrome spheres + green front |
| `product-spheres` | 3D Spheres — glossy colour cluster |
| `product-spheres-network` | 3D Spheres Network — hub + satellites + links |
| `product-spheres-tree` | 3D Spheres Tree Structures — branching sphere tree |
| `product-circles-segmented` | 3D Circles Segmented — segmented ring/dial |
| `product-circle-shapes` | 3D Circle Shapes — layered disc stack |
| `product-cubes-segmented` | 3D Cubes Segmented — sliced cube slabs |
| `product-puzzle-toolbox` | Puzzle Toolbox 3D — 5 interlocking colour pieces |
| `product-circle-looping` | Circle Charts Looping — cycle loop arrows |

Already covered by the prior PR (#63): diamond / cubes-flow / cubes-semicircle / spheres-sliced / cubes-shapes / puzzle / arrow + the 20 fill-levels.

**2D products skipped** per the "3D only" scope: Puzzle-Toolbox 2D, Gearwheels 2D, Arrow-Toolbox 2D, Circle Image Infographics, Puzzle Globe (background).

## Verification
- All 10 **compile clean (E0/W0)**; registered (`renderer:"studio"`, `studioBg:"dark"`).
- **Real-browser GPU** verified the higher-risk ones (chrome material; gears; sphere network/tree; segmented cube; puzzle row; circle stack) — 0 shader errors. The remaining single-atom scenes are byte-identical to already-verified showcases.
- Prettier + `node --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
