### PR TITLE
Charts & Diagrams category coverage — 23 dark covers + gauge-3d atom

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -131,6 +131,7 @@ const TESTS = [
   { category: 'diagram', file: 'sdf-js/scripts/test-waterfall-3d.mjs' },
   { category: 'diagram', file: 'sdf-js/scripts/test-scatter-3d.mjs' },
   { category: 'diagram', file: 'sdf-js/scripts/test-gantt-3d.mjs' },
+  { category: 'diagram', file: 'sdf-js/scripts/test-gauge-3d.mjs' },
 
   // Sprint 5 Wave C: fishbone / traffic-light / radial-spoke + puzzle-piece.
   { category: 'diagram', file: 'sdf-js/scripts/test-fishbone-3d.mjs' },

--- a/sdf-js/examples/compositor/demo-lifts/chart-7s.json
+++ b/sdf-js/examples/compositor/demo-lifts/chart-7s.json
@@ -1,0 +1,63 @@
+{
+  "id": "chart-7s",
+  "title": "7-S Model",
+  "prompt": "diagrams: 7-S Model",
+  "code2d": "// vision-authored chart-product cover (PresentationLoad Charts & Diagrams).",
+  "sceneData": {
+    "v": 1,
+    "name": "7-S Model",
+    "source": {
+      "format": "vision-authored",
+      "prompt": "diagrams chart product"
+    },
+    "subjects": [
+      {
+        "id": "s0",
+        "type": "relationship-graph-3d",
+        "args": {
+          "count": 7,
+          "radius": 1.4
+        },
+        "transform": {
+          "translate": [0, 1.2, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.75,
+          "metal": 0.3,
+          "glow": 0
+        }
+      }
+    ],
+    "defaults": {
+      "camera": {
+        "yaw": 0.5,
+        "pitch": 0.3,
+        "distance": 10,
+        "focal": 1.5,
+        "targetX": 0,
+        "targetY": 1.2,
+        "targetZ": 0
+      },
+      "light": {
+        "azimuth": 0.6,
+        "altitude": 0.55,
+        "distance": 25,
+        "intensity": 1.2
+      },
+      "shadow": {
+        "enabled": true,
+        "mode": "darken",
+        "strength": 0.4
+      },
+      "studioBg": "dark"
+    }
+  },
+  "meta": {
+    "generatedAt": "2026-06-21",
+    "model": "vision-authored",
+    "pattern": "diagrams",
+    "costUSD": 0
+  }
+}

--- a/sdf-js/examples/compositor/demo-lifts/chart-bcg-matrix.json
+++ b/sdf-js/examples/compositor/demo-lifts/chart-bcg-matrix.json
@@ -1,0 +1,65 @@
+{
+  "id": "chart-bcg-matrix",
+  "title": "BCG Matrix (2×2)",
+  "prompt": "matrix: BCG Matrix (2×2)",
+  "code2d": "// vision-authored chart-product cover (PresentationLoad Charts & Diagrams).",
+  "sceneData": {
+    "v": 1,
+    "name": "BCG Matrix (2×2)",
+    "source": {
+      "format": "vision-authored",
+      "prompt": "matrix chart product"
+    },
+    "subjects": [
+      {
+        "id": "s0",
+        "type": "matrix-grid-3d",
+        "args": {
+          "rows": 2,
+          "cols": 2,
+          "cardW": 0.95,
+          "cardH": 0.75
+        },
+        "transform": {
+          "translate": [0, 0.95, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.75,
+          "metal": 0.3,
+          "glow": 0
+        }
+      }
+    ],
+    "defaults": {
+      "camera": {
+        "yaw": 0.5,
+        "pitch": 0.3,
+        "distance": 10,
+        "focal": 1.5,
+        "targetX": 0,
+        "targetY": 0.95,
+        "targetZ": 0
+      },
+      "light": {
+        "azimuth": 0.6,
+        "altitude": 0.55,
+        "distance": 25,
+        "intensity": 1.2
+      },
+      "shadow": {
+        "enabled": true,
+        "mode": "darken",
+        "strength": 0.4
+      },
+      "studioBg": "dark"
+    }
+  },
+  "meta": {
+    "generatedAt": "2026-06-21",
+    "model": "vision-authored",
+    "pattern": "matrix",
+    "costUSD": 0
+  }
+}

--- a/sdf-js/examples/compositor/demo-lifts/chart-break-even.json
+++ b/sdf-js/examples/compositor/demo-lifts/chart-break-even.json
@@ -1,0 +1,132 @@
+{
+  "id": "chart-break-even",
+  "title": "Break-Even Analysis",
+  "prompt": "data: Break-Even Analysis",
+  "code2d": "// vision-authored chart-product cover (PresentationLoad Charts & Diagrams).",
+  "sceneData": {
+    "v": 1,
+    "name": "Break-Even Analysis",
+    "source": {
+      "format": "vision-authored",
+      "prompt": "data chart product"
+    },
+    "subjects": [
+      {
+        "id": "s0",
+        "type": "box",
+        "args": {
+          "size": [3, 0.05, 0.05]
+        },
+        "transform": {
+          "translate": [0, 0.2, 0]
+        },
+        "material": {
+          "hue": 0.6,
+          "sat": 0.05,
+          "value": 0.4,
+          "metal": 0.5,
+          "glow": 0
+        }
+      },
+      {
+        "id": "s1",
+        "type": "box",
+        "args": {
+          "size": [0.05, 2, 0.05]
+        },
+        "transform": {
+          "translate": [-1.5, 1.2, 0]
+        },
+        "material": {
+          "hue": 0.6,
+          "sat": 0.05,
+          "value": 0.4,
+          "metal": 0.5,
+          "glow": 0
+        }
+      },
+      {
+        "id": "s2",
+        "type": "box",
+        "args": {
+          "size": [3.2, 0.08, 0.12]
+        },
+        "transform": {
+          "translate": [0, 1.15, 0],
+          "rotate": [0, 0, 0.5]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.75,
+          "metal": 0.3,
+          "glow": 0
+        }
+      },
+      {
+        "id": "s3",
+        "type": "box",
+        "args": {
+          "size": [3.2, 0.08, 0.12]
+        },
+        "transform": {
+          "translate": [0, 1.15, 0.04],
+          "rotate": [0, 0, -0.5]
+        },
+        "material": {
+          "hue": 0.07,
+          "sat": 0.88,
+          "value": 0.85,
+          "metal": 0.25,
+          "glow": 0
+        }
+      },
+      {
+        "id": "s4",
+        "type": "sphere",
+        "args": {
+          "radius": 0.16
+        },
+        "transform": {
+          "translate": [0, 1.15, 0.12]
+        },
+        "material": {
+          "hue": 0.33,
+          "sat": 0.8,
+          "value": 0.62,
+          "metal": 0.2,
+          "glow": 0.1
+        }
+      }
+    ],
+    "defaults": {
+      "camera": {
+        "yaw": 0.5,
+        "pitch": 0.3,
+        "distance": 10,
+        "focal": 1.5,
+        "targetX": 0,
+        "targetY": 0.97,
+        "targetZ": 0
+      },
+      "light": {
+        "azimuth": 0.6,
+        "altitude": 0.55,
+        "distance": 25,
+        "intensity": 1.2
+      },
+      "shadow": {
+        "enabled": true,
+        "mode": "darken",
+        "strength": 0.4
+      },
+      "studioBg": "dark"
+    }
+  },
+  "meta": {
+    "generatedAt": "2026-06-21",
+    "model": "vision-authored",
+    "pattern": "data",
+    "costUSD": 0
+  }
+}

--- a/sdf-js/examples/compositor/demo-lifts/chart-cockpit.json
+++ b/sdf-js/examples/compositor/demo-lifts/chart-cockpit.json
@@ -1,0 +1,105 @@
+{
+  "id": "chart-cockpit",
+  "title": "Cockpit Dashboard · gauges",
+  "prompt": "data: Cockpit Dashboard · gauges",
+  "code2d": "// vision-authored chart-product cover (PresentationLoad Charts & Diagrams).",
+  "sceneData": {
+    "v": 1,
+    "name": "Cockpit Dashboard · gauges",
+    "source": {
+      "format": "vision-authored",
+      "prompt": "data chart product"
+    },
+    "subjects": [
+      {
+        "id": "s0",
+        "type": "gauge-3d",
+        "args": {
+          "value": 0.45,
+          "radius": 0.7,
+          "tube": 0.08,
+          "needleLen": 0.6
+        },
+        "transform": {
+          "translate": [-1.9, 1, 0]
+        },
+        "material": {
+          "hue": 0.5,
+          "sat": 0.72,
+          "value": 0.7,
+          "metal": 0.28,
+          "glow": 0
+        }
+      },
+      {
+        "id": "s1",
+        "type": "gauge-3d",
+        "args": {
+          "value": 0.7,
+          "radius": 0.7,
+          "tube": 0.08,
+          "needleLen": 0.6
+        },
+        "transform": {
+          "translate": [0, 1, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.75,
+          "metal": 0.3,
+          "glow": 0
+        }
+      },
+      {
+        "id": "s2",
+        "type": "gauge-3d",
+        "args": {
+          "value": 0.92,
+          "radius": 0.7,
+          "tube": 0.08,
+          "needleLen": 0.6
+        },
+        "transform": {
+          "translate": [1.9, 1, 0]
+        },
+        "material": {
+          "hue": 0.33,
+          "sat": 0.8,
+          "value": 0.62,
+          "metal": 0.2,
+          "glow": 0.1
+        }
+      }
+    ],
+    "defaults": {
+      "camera": {
+        "yaw": 0.5,
+        "pitch": 0.3,
+        "distance": 10,
+        "focal": 1.5,
+        "targetX": 0,
+        "targetY": 1,
+        "targetZ": 0
+      },
+      "light": {
+        "azimuth": 0.6,
+        "altitude": 0.55,
+        "distance": 25,
+        "intensity": 1.2
+      },
+      "shadow": {
+        "enabled": true,
+        "mode": "darken",
+        "strength": 0.4
+      },
+      "studioBg": "dark"
+    }
+  },
+  "meta": {
+    "generatedAt": "2026-06-21",
+    "model": "vision-authored",
+    "pattern": "data",
+    "costUSD": 0
+  }
+}

--- a/sdf-js/examples/compositor/demo-lifts/chart-data-bars.json
+++ b/sdf-js/examples/compositor/demo-lifts/chart-data-bars.json
@@ -1,0 +1,64 @@
+{
+  "id": "chart-data-bars",
+  "title": "Data Driven · 3D Bars",
+  "prompt": "data: Data Driven · 3D Bars",
+  "code2d": "// vision-authored chart-product cover (PresentationLoad Charts & Diagrams).",
+  "sceneData": {
+    "v": 1,
+    "name": "Data Driven · 3D Bars",
+    "source": {
+      "format": "vision-authored",
+      "prompt": "data chart product"
+    },
+    "subjects": [
+      {
+        "id": "s0",
+        "type": "bar-3d",
+        "args": {
+          "values": [0.4, 0.7, 1, 0.55, 0.85],
+          "barWidth": 0.45,
+          "gap": 0.18
+        },
+        "transform": {
+          "translate": [0, 0.1, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.75,
+          "metal": 0.3,
+          "glow": 0
+        }
+      }
+    ],
+    "defaults": {
+      "camera": {
+        "yaw": 0.5,
+        "pitch": 0.3,
+        "distance": 10,
+        "focal": 1.5,
+        "targetX": 0,
+        "targetY": 0.1,
+        "targetZ": 0
+      },
+      "light": {
+        "azimuth": 0.6,
+        "altitude": 0.55,
+        "distance": 25,
+        "intensity": 1.2
+      },
+      "shadow": {
+        "enabled": true,
+        "mode": "darken",
+        "strength": 0.4
+      },
+      "studioBg": "dark"
+    }
+  },
+  "meta": {
+    "generatedAt": "2026-06-21",
+    "model": "vision-authored",
+    "pattern": "data",
+    "costUSD": 0
+  }
+}

--- a/sdf-js/examples/compositor/demo-lifts/chart-data-columns.json
+++ b/sdf-js/examples/compositor/demo-lifts/chart-data-columns.json
@@ -1,0 +1,64 @@
+{
+  "id": "chart-data-columns",
+  "title": "Data Driven · Columns",
+  "prompt": "data: Data Driven · Columns",
+  "code2d": "// vision-authored chart-product cover (PresentationLoad Charts & Diagrams).",
+  "sceneData": {
+    "v": 1,
+    "name": "Data Driven · Columns",
+    "source": {
+      "format": "vision-authored",
+      "prompt": "data chart product"
+    },
+    "subjects": [
+      {
+        "id": "s0",
+        "type": "column-3d",
+        "args": {
+          "values": [0.4, 0.6, 0.85, 0.5, 0.75],
+          "barWidth": 0.36,
+          "gap": 0.16
+        },
+        "transform": {
+          "translate": [0, 0.9, 0]
+        },
+        "material": {
+          "hue": 0.5,
+          "sat": 0.72,
+          "value": 0.7,
+          "metal": 0.28,
+          "glow": 0
+        }
+      }
+    ],
+    "defaults": {
+      "camera": {
+        "yaw": 0.5,
+        "pitch": 0.3,
+        "distance": 10,
+        "focal": 1.5,
+        "targetX": 0,
+        "targetY": 0.9,
+        "targetZ": 0
+      },
+      "light": {
+        "azimuth": 0.6,
+        "altitude": 0.55,
+        "distance": 25,
+        "intensity": 1.2
+      },
+      "shadow": {
+        "enabled": true,
+        "mode": "darken",
+        "strength": 0.4
+      },
+      "studioBg": "dark"
+    }
+  },
+  "meta": {
+    "generatedAt": "2026-06-21",
+    "model": "vision-authored",
+    "pattern": "data",
+    "costUSD": 0
+  }
+}

--- a/sdf-js/examples/compositor/demo-lifts/chart-fishbone.json
+++ b/sdf-js/examples/compositor/demo-lifts/chart-fishbone.json
@@ -1,0 +1,62 @@
+{
+  "id": "chart-fishbone",
+  "title": "Fishbone / Ishikawa",
+  "prompt": "diagrams: Fishbone / Ishikawa",
+  "code2d": "// vision-authored chart-product cover (PresentationLoad Charts & Diagrams).",
+  "sceneData": {
+    "v": 1,
+    "name": "Fishbone / Ishikawa",
+    "source": {
+      "format": "vision-authored",
+      "prompt": "diagrams chart product"
+    },
+    "subjects": [
+      {
+        "id": "s0",
+        "type": "fishbone-3d",
+        "args": {
+          "ribs": 6
+        },
+        "transform": {
+          "translate": [0, 0.9, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.75,
+          "metal": 0.3,
+          "glow": 0
+        }
+      }
+    ],
+    "defaults": {
+      "camera": {
+        "yaw": 0.5,
+        "pitch": 0.3,
+        "distance": 10,
+        "focal": 1.5,
+        "targetX": 0,
+        "targetY": 0.9,
+        "targetZ": 0
+      },
+      "light": {
+        "azimuth": 0.6,
+        "altitude": 0.55,
+        "distance": 25,
+        "intensity": 1.2
+      },
+      "shadow": {
+        "enabled": true,
+        "mode": "darken",
+        "strength": 0.4
+      },
+      "studioBg": "dark"
+    }
+  },
+  "meta": {
+    "generatedAt": "2026-06-21",
+    "model": "vision-authored",
+    "pattern": "diagrams",
+    "costUSD": 0
+  }
+}

--- a/sdf-js/examples/compositor/demo-lifts/chart-gantt.json
+++ b/sdf-js/examples/compositor/demo-lifts/chart-gantt.json
@@ -1,0 +1,62 @@
+{
+  "id": "chart-gantt",
+  "title": "Gantt Chart",
+  "prompt": "data: Gantt Chart",
+  "code2d": "// vision-authored chart-product cover (PresentationLoad Charts & Diagrams).",
+  "sceneData": {
+    "v": 1,
+    "name": "Gantt Chart",
+    "source": {
+      "format": "vision-authored",
+      "prompt": "data chart product"
+    },
+    "subjects": [
+      {
+        "id": "s0",
+        "type": "gantt-3d",
+        "args": {
+          "tasks": 5
+        },
+        "transform": {
+          "translate": [0, 0.9, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.75,
+          "metal": 0.3,
+          "glow": 0
+        }
+      }
+    ],
+    "defaults": {
+      "camera": {
+        "yaw": 0.5,
+        "pitch": 0.3,
+        "distance": 10,
+        "focal": 1.5,
+        "targetX": 0,
+        "targetY": 0.9,
+        "targetZ": 0
+      },
+      "light": {
+        "azimuth": 0.6,
+        "altitude": 0.55,
+        "distance": 25,
+        "intensity": 1.2
+      },
+      "shadow": {
+        "enabled": true,
+        "mode": "darken",
+        "strength": 0.4
+      },
+      "studioBg": "dark"
+    }
+  },
+  "meta": {
+    "generatedAt": "2026-06-21",
+    "model": "vision-authored",
+    "pattern": "data",
+    "costUSD": 0
+  }
+}

--- a/sdf-js/examples/compositor/demo-lifts/chart-gauge.json
+++ b/sdf-js/examples/compositor/demo-lifts/chart-gauge.json
@@ -1,0 +1,62 @@
+{
+  "id": "chart-gauge",
+  "title": "KPI Gauge",
+  "prompt": "data: KPI Gauge",
+  "code2d": "// vision-authored chart-product cover (PresentationLoad Charts & Diagrams).",
+  "sceneData": {
+    "v": 1,
+    "name": "KPI Gauge",
+    "source": {
+      "format": "vision-authored",
+      "prompt": "data chart product"
+    },
+    "subjects": [
+      {
+        "id": "s0",
+        "type": "gauge-3d",
+        "args": {
+          "value": 0.72
+        },
+        "transform": {
+          "translate": [0, 1, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.75,
+          "metal": 0.3,
+          "glow": 0
+        }
+      }
+    ],
+    "defaults": {
+      "camera": {
+        "yaw": 0.5,
+        "pitch": 0.3,
+        "distance": 10,
+        "focal": 1.5,
+        "targetX": 0,
+        "targetY": 1,
+        "targetZ": 0
+      },
+      "light": {
+        "azimuth": 0.6,
+        "altitude": 0.55,
+        "distance": 25,
+        "intensity": 1.2
+      },
+      "shadow": {
+        "enabled": true,
+        "mode": "darken",
+        "strength": 0.4
+      },
+      "studioBg": "dark"
+    }
+  },
+  "meta": {
+    "generatedAt": "2026-06-21",
+    "model": "vision-authored",
+    "pattern": "data",
+    "costUSD": 0
+  }
+}

--- a/sdf-js/examples/compositor/demo-lifts/chart-layers.json
+++ b/sdf-js/examples/compositor/demo-lifts/chart-layers.json
@@ -1,0 +1,64 @@
+{
+  "id": "chart-layers",
+  "title": "3D Layers Parallel",
+  "prompt": "layers: 3D Layers Parallel",
+  "code2d": "// vision-authored chart-product cover (PresentationLoad Charts & Diagrams).",
+  "sceneData": {
+    "v": 1,
+    "name": "3D Layers Parallel",
+    "source": {
+      "format": "vision-authored",
+      "prompt": "layers chart product"
+    },
+    "subjects": [
+      {
+        "id": "s0",
+        "type": "layer-stack-3d",
+        "args": {
+          "layers": 5,
+          "layerW": 2,
+          "layerD": 1.3
+        },
+        "transform": {
+          "translate": [0, 0.8, 0]
+        },
+        "material": {
+          "hue": 0.5,
+          "sat": 0.72,
+          "value": 0.7,
+          "metal": 0.28,
+          "glow": 0
+        }
+      }
+    ],
+    "defaults": {
+      "camera": {
+        "yaw": 0.5,
+        "pitch": 0.3,
+        "distance": 10,
+        "focal": 1.5,
+        "targetX": 0,
+        "targetY": 0.8,
+        "targetZ": 0
+      },
+      "light": {
+        "azimuth": 0.6,
+        "altitude": 0.55,
+        "distance": 25,
+        "intensity": 1.2
+      },
+      "shadow": {
+        "enabled": true,
+        "mode": "darken",
+        "strength": 0.4
+      },
+      "studioBg": "dark"
+    }
+  },
+  "meta": {
+    "generatedAt": "2026-06-21",
+    "model": "vision-authored",
+    "pattern": "layers",
+    "costUSD": 0
+  }
+}

--- a/sdf-js/examples/compositor/demo-lifts/chart-line.json
+++ b/sdf-js/examples/compositor/demo-lifts/chart-line.json
@@ -1,0 +1,63 @@
+{
+  "id": "chart-line",
+  "title": "Line / Trend Chart",
+  "prompt": "data: Line / Trend Chart",
+  "code2d": "// vision-authored chart-product cover (PresentationLoad Charts & Diagrams).",
+  "sceneData": {
+    "v": 1,
+    "name": "Line / Trend Chart",
+    "source": {
+      "format": "vision-authored",
+      "prompt": "data chart product"
+    },
+    "subjects": [
+      {
+        "id": "s0",
+        "type": "line-3d",
+        "args": {
+          "values": [0.3, 0.5, 0.45, 0.7, 0.6, 0.9],
+          "pointSpacing": 0.6
+        },
+        "transform": {
+          "translate": [0, 0.1, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.75,
+          "metal": 0.3,
+          "glow": 0
+        }
+      }
+    ],
+    "defaults": {
+      "camera": {
+        "yaw": 0.5,
+        "pitch": 0.3,
+        "distance": 10,
+        "focal": 1.5,
+        "targetX": 0,
+        "targetY": 0.1,
+        "targetZ": 0
+      },
+      "light": {
+        "azimuth": 0.6,
+        "altitude": 0.55,
+        "distance": 25,
+        "intensity": 1.2
+      },
+      "shadow": {
+        "enabled": true,
+        "mode": "darken",
+        "strength": 0.4
+      },
+      "studioBg": "dark"
+    }
+  },
+  "meta": {
+    "generatedAt": "2026-06-21",
+    "model": "vision-authored",
+    "pattern": "data",
+    "costUSD": 0
+  }
+}

--- a/sdf-js/examples/compositor/demo-lifts/chart-list.json
+++ b/sdf-js/examples/compositor/demo-lifts/chart-list.json
@@ -1,0 +1,62 @@
+{
+  "id": "chart-list",
+  "title": "List Templates",
+  "prompt": "lists: List Templates",
+  "code2d": "// vision-authored chart-product cover (PresentationLoad Charts & Diagrams).",
+  "sceneData": {
+    "v": 1,
+    "name": "List Templates",
+    "source": {
+      "format": "vision-authored",
+      "prompt": "lists chart product"
+    },
+    "subjects": [
+      {
+        "id": "s0",
+        "type": "bullet-list-3d",
+        "args": {
+          "items": 5
+        },
+        "transform": {
+          "translate": [0, 1.1, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.75,
+          "metal": 0.3,
+          "glow": 0
+        }
+      }
+    ],
+    "defaults": {
+      "camera": {
+        "yaw": 0.5,
+        "pitch": 0.3,
+        "distance": 10,
+        "focal": 1.5,
+        "targetX": 0,
+        "targetY": 1.1,
+        "targetZ": 0
+      },
+      "light": {
+        "azimuth": 0.6,
+        "altitude": 0.55,
+        "distance": 25,
+        "intensity": 1.2
+      },
+      "shadow": {
+        "enabled": true,
+        "mode": "darken",
+        "strength": 0.4
+      },
+      "studioBg": "dark"
+    }
+  },
+  "meta": {
+    "generatedAt": "2026-06-21",
+    "model": "vision-authored",
+    "pattern": "lists",
+    "costUSD": 0
+  }
+}

--- a/sdf-js/examples/compositor/demo-lifts/chart-multiple-arrows.json
+++ b/sdf-js/examples/compositor/demo-lifts/chart-multiple-arrows.json
@@ -1,0 +1,133 @@
+{
+  "id": "chart-multiple-arrows",
+  "title": "Multiple Arrows",
+  "prompt": "arrows: Multiple Arrows",
+  "code2d": "// vision-authored chart-product cover (PresentationLoad Charts & Diagrams).",
+  "sceneData": {
+    "v": 1,
+    "name": "Multiple Arrows",
+    "source": {
+      "format": "vision-authored",
+      "prompt": "arrows chart product"
+    },
+    "subjects": [
+      {
+        "id": "s0",
+        "type": "arrow-3d",
+        "args": {
+          "length": 1.1,
+          "shaftWidth": 0.22,
+          "headLength": 0.45,
+          "headWidth": 0.6,
+          "depth": 0.28
+        },
+        "transform": {
+          "translate": [0.95, 1, 0],
+          "rotate": [0, 0, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.75,
+          "metal": 0.3,
+          "glow": 0
+        }
+      },
+      {
+        "id": "s1",
+        "type": "arrow-3d",
+        "args": {
+          "length": 1.1,
+          "shaftWidth": 0.22,
+          "headLength": 0.45,
+          "headWidth": 0.6,
+          "depth": 0.28
+        },
+        "transform": {
+          "translate": [0, 1.95, 0],
+          "rotate": [0, 0, 1.5707963267948966]
+        },
+        "material": {
+          "hue": 0.5,
+          "sat": 0.72,
+          "value": 0.7,
+          "metal": 0.28,
+          "glow": 0
+        }
+      },
+      {
+        "id": "s2",
+        "type": "arrow-3d",
+        "args": {
+          "length": 1.1,
+          "shaftWidth": 0.22,
+          "headLength": 0.45,
+          "headWidth": 0.6,
+          "depth": 0.28
+        },
+        "transform": {
+          "translate": [-0.95, 1, 0],
+          "rotate": [0, 0, 3.141592653589793]
+        },
+        "material": {
+          "hue": 0.07,
+          "sat": 0.88,
+          "value": 0.85,
+          "metal": 0.25,
+          "glow": 0
+        }
+      },
+      {
+        "id": "s3",
+        "type": "arrow-3d",
+        "args": {
+          "length": 1.1,
+          "shaftWidth": 0.22,
+          "headLength": 0.45,
+          "headWidth": 0.6,
+          "depth": 0.28
+        },
+        "transform": {
+          "translate": [0, 0.05, 0],
+          "rotate": [0, 0, -1.5707963267948966]
+        },
+        "material": {
+          "hue": 0.33,
+          "sat": 0.8,
+          "value": 0.62,
+          "metal": 0.2,
+          "glow": 0.1
+        }
+      }
+    ],
+    "defaults": {
+      "camera": {
+        "yaw": 0.5,
+        "pitch": 0.3,
+        "distance": 10,
+        "focal": 1.5,
+        "targetX": 0,
+        "targetY": 1,
+        "targetZ": 0
+      },
+      "light": {
+        "azimuth": 0.6,
+        "altitude": 0.55,
+        "distance": 25,
+        "intensity": 1.2
+      },
+      "shadow": {
+        "enabled": true,
+        "mode": "darken",
+        "strength": 0.4
+      },
+      "studioBg": "dark"
+    }
+  },
+  "meta": {
+    "generatedAt": "2026-06-21",
+    "model": "vision-authored",
+    "pattern": "arrows",
+    "costUSD": 0
+  }
+}

--- a/sdf-js/examples/compositor/demo-lifts/chart-nine-field.json
+++ b/sdf-js/examples/compositor/demo-lifts/chart-nine-field.json
@@ -1,0 +1,65 @@
+{
+  "id": "chart-nine-field",
+  "title": "Nine-Field Matrix (3×3)",
+  "prompt": "matrix: Nine-Field Matrix (3×3)",
+  "code2d": "// vision-authored chart-product cover (PresentationLoad Charts & Diagrams).",
+  "sceneData": {
+    "v": 1,
+    "name": "Nine-Field Matrix (3×3)",
+    "source": {
+      "format": "vision-authored",
+      "prompt": "matrix chart product"
+    },
+    "subjects": [
+      {
+        "id": "s0",
+        "type": "matrix-grid-3d",
+        "args": {
+          "rows": 3,
+          "cols": 3,
+          "cardW": 0.7,
+          "cardH": 0.6
+        },
+        "transform": {
+          "translate": [0, 1.05, 0]
+        },
+        "material": {
+          "hue": 0.5,
+          "sat": 0.72,
+          "value": 0.7,
+          "metal": 0.28,
+          "glow": 0
+        }
+      }
+    ],
+    "defaults": {
+      "camera": {
+        "yaw": 0.5,
+        "pitch": 0.3,
+        "distance": 10,
+        "focal": 1.5,
+        "targetX": 0,
+        "targetY": 1.05,
+        "targetZ": 0
+      },
+      "light": {
+        "azimuth": 0.6,
+        "altitude": 0.55,
+        "distance": 25,
+        "intensity": 1.2
+      },
+      "shadow": {
+        "enabled": true,
+        "mode": "darken",
+        "strength": 0.4
+      },
+      "studioBg": "dark"
+    }
+  },
+  "meta": {
+    "generatedAt": "2026-06-21",
+    "model": "vision-authored",
+    "pattern": "matrix",
+    "costUSD": 0
+  }
+}

--- a/sdf-js/examples/compositor/demo-lifts/chart-org.json
+++ b/sdf-js/examples/compositor/demo-lifts/chart-org.json
@@ -1,0 +1,63 @@
+{
+  "id": "chart-org",
+  "title": "Org Chart 3D",
+  "prompt": "hierarchy: Org Chart 3D",
+  "code2d": "// vision-authored chart-product cover (PresentationLoad Charts & Diagrams).",
+  "sceneData": {
+    "v": 1,
+    "name": "Org Chart 3D",
+    "source": {
+      "format": "vision-authored",
+      "prompt": "hierarchy chart product"
+    },
+    "subjects": [
+      {
+        "id": "s0",
+        "type": "org-chart-3d",
+        "args": {
+          "levels": 3,
+          "branching": 2
+        },
+        "transform": {
+          "translate": [0, 1.1, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.75,
+          "metal": 0.3,
+          "glow": 0
+        }
+      }
+    ],
+    "defaults": {
+      "camera": {
+        "yaw": 0.5,
+        "pitch": 0.3,
+        "distance": 10,
+        "focal": 1.5,
+        "targetX": 0,
+        "targetY": 1.1,
+        "targetZ": 0
+      },
+      "light": {
+        "azimuth": 0.6,
+        "altitude": 0.55,
+        "distance": 25,
+        "intensity": 1.2
+      },
+      "shadow": {
+        "enabled": true,
+        "mode": "darken",
+        "strength": 0.4
+      },
+      "studioBg": "dark"
+    }
+  },
+  "meta": {
+    "generatedAt": "2026-06-21",
+    "model": "vision-authored",
+    "pattern": "hierarchy",
+    "costUSD": 0
+  }
+}

--- a/sdf-js/examples/compositor/demo-lifts/chart-pie.json
+++ b/sdf-js/examples/compositor/demo-lifts/chart-pie.json
@@ -1,0 +1,66 @@
+{
+  "id": "chart-pie",
+  "title": "Pie / Donut Chart",
+  "prompt": "data: Pie / Donut Chart",
+  "code2d": "// vision-authored chart-product cover (PresentationLoad Charts & Diagrams).",
+  "sceneData": {
+    "v": 1,
+    "name": "Pie / Donut Chart",
+    "source": {
+      "format": "vision-authored",
+      "prompt": "data chart product"
+    },
+    "subjects": [
+      {
+        "id": "s0",
+        "type": "pie-3d",
+        "args": {
+          "values": [0.32, 0.24, 0.2, 0.14, 0.1],
+          "outerRadius": 1.1,
+          "innerRadius": 0.4,
+          "thickness": 0.4
+        },
+        "transform": {
+          "translate": [0, 0.8, 0],
+          "rotate": [1.5707963267948966, 0, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.75,
+          "metal": 0.3,
+          "glow": 0
+        }
+      }
+    ],
+    "defaults": {
+      "camera": {
+        "yaw": 0.5,
+        "pitch": 0.3,
+        "distance": 10,
+        "focal": 1.5,
+        "targetX": 0,
+        "targetY": 0.8,
+        "targetZ": 0
+      },
+      "light": {
+        "azimuth": 0.6,
+        "altitude": 0.55,
+        "distance": 25,
+        "intensity": 1.2
+      },
+      "shadow": {
+        "enabled": true,
+        "mode": "darken",
+        "strength": 0.4
+      },
+      "studioBg": "dark"
+    }
+  },
+  "meta": {
+    "generatedAt": "2026-06-21",
+    "model": "vision-authored",
+    "pattern": "data",
+    "costUSD": 0
+  }
+}

--- a/sdf-js/examples/compositor/demo-lifts/chart-radial.json
+++ b/sdf-js/examples/compositor/demo-lifts/chart-radial.json
@@ -1,0 +1,62 @@
+{
+  "id": "chart-radial",
+  "title": "Radial Diagram",
+  "prompt": "diagrams: Radial Diagram",
+  "code2d": "// vision-authored chart-product cover (PresentationLoad Charts & Diagrams).",
+  "sceneData": {
+    "v": 1,
+    "name": "Radial Diagram",
+    "source": {
+      "format": "vision-authored",
+      "prompt": "diagrams chart product"
+    },
+    "subjects": [
+      {
+        "id": "s0",
+        "type": "radial-spoke-3d",
+        "args": {
+          "spokes": 8
+        },
+        "transform": {
+          "translate": [0, 1.2, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.75,
+          "metal": 0.3,
+          "glow": 0
+        }
+      }
+    ],
+    "defaults": {
+      "camera": {
+        "yaw": 0.5,
+        "pitch": 0.3,
+        "distance": 10,
+        "focal": 1.5,
+        "targetX": 0,
+        "targetY": 1.2,
+        "targetZ": 0
+      },
+      "light": {
+        "azimuth": 0.6,
+        "altitude": 0.55,
+        "distance": 25,
+        "intensity": 1.2
+      },
+      "shadow": {
+        "enabled": true,
+        "mode": "darken",
+        "strength": 0.4
+      },
+      "studioBg": "dark"
+    }
+  },
+  "meta": {
+    "generatedAt": "2026-06-21",
+    "model": "vision-authored",
+    "pattern": "diagrams",
+    "costUSD": 0
+  }
+}

--- a/sdf-js/examples/compositor/demo-lifts/chart-scatter.json
+++ b/sdf-js/examples/compositor/demo-lifts/chart-scatter.json
@@ -1,0 +1,63 @@
+{
+  "id": "chart-scatter",
+  "title": "Scatter Plot",
+  "prompt": "data: Scatter Plot",
+  "code2d": "// vision-authored chart-product cover (PresentationLoad Charts & Diagrams).",
+  "sceneData": {
+    "v": 1,
+    "name": "Scatter Plot",
+    "source": {
+      "format": "vision-authored",
+      "prompt": "data chart product"
+    },
+    "subjects": [
+      {
+        "id": "s0",
+        "type": "scatter-3d",
+        "args": {
+          "count": 16,
+          "spread": 1.5
+        },
+        "transform": {
+          "translate": [0, 1.5, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.75,
+          "metal": 0.3,
+          "glow": 0
+        }
+      }
+    ],
+    "defaults": {
+      "camera": {
+        "yaw": 0.5,
+        "pitch": 0.3,
+        "distance": 10,
+        "focal": 1.5,
+        "targetX": 0,
+        "targetY": 1.5,
+        "targetZ": 0
+      },
+      "light": {
+        "azimuth": 0.6,
+        "altitude": 0.55,
+        "distance": 25,
+        "intensity": 1.2
+      },
+      "shadow": {
+        "enabled": true,
+        "mode": "darken",
+        "strength": 0.4
+      },
+      "studioBg": "dark"
+    }
+  },
+  "meta": {
+    "generatedAt": "2026-06-21",
+    "model": "vision-authored",
+    "pattern": "data",
+    "costUSD": 0
+  }
+}

--- a/sdf-js/examples/compositor/demo-lifts/chart-timeline.json
+++ b/sdf-js/examples/compositor/demo-lifts/chart-timeline.json
@@ -1,0 +1,62 @@
+{
+  "id": "chart-timeline",
+  "title": "Project Timeline",
+  "prompt": "timelines: Project Timeline",
+  "code2d": "// vision-authored chart-product cover (PresentationLoad Charts & Diagrams).",
+  "sceneData": {
+    "v": 1,
+    "name": "Project Timeline",
+    "source": {
+      "format": "vision-authored",
+      "prompt": "timelines chart product"
+    },
+    "subjects": [
+      {
+        "id": "s0",
+        "type": "timeline-3d",
+        "args": {
+          "count": 5
+        },
+        "transform": {
+          "translate": [0, 0.9, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.75,
+          "metal": 0.3,
+          "glow": 0
+        }
+      }
+    ],
+    "defaults": {
+      "camera": {
+        "yaw": 0.5,
+        "pitch": 0.3,
+        "distance": 10,
+        "focal": 1.5,
+        "targetX": 0,
+        "targetY": 0.9,
+        "targetZ": 0
+      },
+      "light": {
+        "azimuth": 0.6,
+        "altitude": 0.55,
+        "distance": 25,
+        "intensity": 1.2
+      },
+      "shadow": {
+        "enabled": true,
+        "mode": "darken",
+        "strength": 0.4
+      },
+      "studioBg": "dark"
+    }
+  },
+  "meta": {
+    "generatedAt": "2026-06-21",
+    "model": "vision-authored",
+    "pattern": "timelines",
+    "costUSD": 0
+  }
+}

--- a/sdf-js/examples/compositor/demo-lifts/chart-traffic-light.json
+++ b/sdf-js/examples/compositor/demo-lifts/chart-traffic-light.json
@@ -1,0 +1,113 @@
+{
+  "id": "chart-traffic-light",
+  "title": "Traffic Light Chart",
+  "prompt": "data: Traffic Light Chart",
+  "code2d": "// vision-authored chart-product cover (PresentationLoad Charts & Diagrams).",
+  "sceneData": {
+    "v": 1,
+    "name": "Traffic Light Chart",
+    "source": {
+      "format": "vision-authored",
+      "prompt": "data chart product"
+    },
+    "subjects": [
+      {
+        "id": "s0",
+        "type": "box",
+        "args": {
+          "size": [0.7, 1.7, 0.35]
+        },
+        "transform": {
+          "translate": [0, 1, 0]
+        },
+        "material": {
+          "hue": 0.6,
+          "sat": 0.05,
+          "value": 0.4,
+          "metal": 0.5,
+          "glow": 0
+        }
+      },
+      {
+        "id": "s1",
+        "type": "sphere",
+        "args": {
+          "radius": 0.22
+        },
+        "transform": {
+          "translate": [0, 1.5, -0.18]
+        },
+        "material": {
+          "hue": 0,
+          "sat": 0.82,
+          "value": 0.62,
+          "metal": 0.2,
+          "glow": 0.1
+        }
+      },
+      {
+        "id": "s2",
+        "type": "sphere",
+        "args": {
+          "radius": 0.22
+        },
+        "transform": {
+          "translate": [0, 1, -0.18]
+        },
+        "material": {
+          "hue": 0.11,
+          "sat": 0.9,
+          "value": 0.85,
+          "metal": 0.2,
+          "glow": 0.1
+        }
+      },
+      {
+        "id": "s3",
+        "type": "sphere",
+        "args": {
+          "radius": 0.22
+        },
+        "transform": {
+          "translate": [0, 0.5, -0.18]
+        },
+        "material": {
+          "hue": 0.33,
+          "sat": 0.8,
+          "value": 0.62,
+          "metal": 0.2,
+          "glow": 0.1
+        }
+      }
+    ],
+    "defaults": {
+      "camera": {
+        "yaw": 0.5,
+        "pitch": 0.3,
+        "distance": 10,
+        "focal": 1.5,
+        "targetX": 0,
+        "targetY": 1,
+        "targetZ": 0
+      },
+      "light": {
+        "azimuth": 0.6,
+        "altitude": 0.55,
+        "distance": 25,
+        "intensity": 1.2
+      },
+      "shadow": {
+        "enabled": true,
+        "mode": "darken",
+        "strength": 0.4
+      },
+      "studioBg": "dark"
+    }
+  },
+  "meta": {
+    "generatedAt": "2026-06-21",
+    "model": "vision-authored",
+    "pattern": "data",
+    "costUSD": 0
+  }
+}

--- a/sdf-js/examples/compositor/demo-lifts/chart-tree.json
+++ b/sdf-js/examples/compositor/demo-lifts/chart-tree.json
@@ -1,0 +1,63 @@
+{
+  "id": "chart-tree",
+  "title": "Tree Diagram",
+  "prompt": "diagrams: Tree Diagram",
+  "code2d": "// vision-authored chart-product cover (PresentationLoad Charts & Diagrams).",
+  "sceneData": {
+    "v": 1,
+    "name": "Tree Diagram",
+    "source": {
+      "format": "vision-authored",
+      "prompt": "diagrams chart product"
+    },
+    "subjects": [
+      {
+        "id": "s0",
+        "type": "tree-diagram-3d",
+        "args": {
+          "levels": 3,
+          "branching": 2
+        },
+        "transform": {
+          "translate": [0, 0.9, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.75,
+          "metal": 0.3,
+          "glow": 0
+        }
+      }
+    ],
+    "defaults": {
+      "camera": {
+        "yaw": 0.5,
+        "pitch": 0.3,
+        "distance": 10,
+        "focal": 1.5,
+        "targetX": 0,
+        "targetY": 0.9,
+        "targetZ": 0
+      },
+      "light": {
+        "azimuth": 0.6,
+        "altitude": 0.55,
+        "distance": 25,
+        "intensity": 1.2
+      },
+      "shadow": {
+        "enabled": true,
+        "mode": "darken",
+        "strength": 0.4
+      },
+      "studioBg": "dark"
+    }
+  },
+  "meta": {
+    "generatedAt": "2026-06-21",
+    "model": "vision-authored",
+    "pattern": "diagrams",
+    "costUSD": 0
+  }
+}

--- a/sdf-js/examples/compositor/demo-lifts/chart-venn.json
+++ b/sdf-js/examples/compositor/demo-lifts/chart-venn.json
@@ -1,0 +1,62 @@
+{
+  "id": "chart-venn",
+  "title": "Venn Diagram",
+  "prompt": "diagrams: Venn Diagram",
+  "code2d": "// vision-authored chart-product cover (PresentationLoad Charts & Diagrams).",
+  "sceneData": {
+    "v": 1,
+    "name": "Venn Diagram",
+    "source": {
+      "format": "vision-authored",
+      "prompt": "diagrams chart product"
+    },
+    "subjects": [
+      {
+        "id": "s0",
+        "type": "venn-3d",
+        "args": {
+          "sets": 3
+        },
+        "transform": {
+          "translate": [0, 1.1, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.75,
+          "metal": 0.3,
+          "glow": 0
+        }
+      }
+    ],
+    "defaults": {
+      "camera": {
+        "yaw": 0.5,
+        "pitch": 0.3,
+        "distance": 10,
+        "focal": 1.5,
+        "targetX": 0,
+        "targetY": 1.1,
+        "targetZ": 0
+      },
+      "light": {
+        "azimuth": 0.6,
+        "altitude": 0.55,
+        "distance": 25,
+        "intensity": 1.2
+      },
+      "shadow": {
+        "enabled": true,
+        "mode": "darken",
+        "strength": 0.4
+      },
+      "studioBg": "dark"
+    }
+  },
+  "meta": {
+    "generatedAt": "2026-06-21",
+    "model": "vision-authored",
+    "pattern": "diagrams",
+    "costUSD": 0
+  }
+}

--- a/sdf-js/examples/compositor/demo-lifts/chart-waterfall.json
+++ b/sdf-js/examples/compositor/demo-lifts/chart-waterfall.json
@@ -1,0 +1,62 @@
+{
+  "id": "chart-waterfall",
+  "title": "Waterfall Diagram",
+  "prompt": "data: Waterfall Diagram",
+  "code2d": "// vision-authored chart-product cover (PresentationLoad Charts & Diagrams).",
+  "sceneData": {
+    "v": 1,
+    "name": "Waterfall Diagram",
+    "source": {
+      "format": "vision-authored",
+      "prompt": "data chart product"
+    },
+    "subjects": [
+      {
+        "id": "s0",
+        "type": "waterfall-3d",
+        "args": {
+          "count": 6
+        },
+        "transform": {
+          "translate": [0, 0.1, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.75,
+          "metal": 0.3,
+          "glow": 0
+        }
+      }
+    ],
+    "defaults": {
+      "camera": {
+        "yaw": 0.5,
+        "pitch": 0.3,
+        "distance": 10,
+        "focal": 1.5,
+        "targetX": 0,
+        "targetY": 0.1,
+        "targetZ": 0
+      },
+      "light": {
+        "azimuth": 0.6,
+        "altitude": 0.55,
+        "distance": 25,
+        "intensity": 1.2
+      },
+      "shadow": {
+        "enabled": true,
+        "mode": "darken",
+        "strength": 0.4
+      },
+      "studioBg": "dark"
+    }
+  },
+  "meta": {
+    "generatedAt": "2026-06-21",
+    "model": "vision-authored",
+    "pattern": "data",
+    "costUSD": 0
+  }
+}

--- a/sdf-js/examples/compositor/demo-lifts/index.json
+++ b/sdf-js/examples/compositor/demo-lifts/index.json
@@ -1028,6 +1028,236 @@
       "file": "product-circle-looping.json",
       "renderer": "studio",
       "prompt": "Circle Charts · Looping cycle"
+    },
+    {
+      "id": "chart-data-bars",
+      "title": "Data Driven · 3D Bars",
+      "thesisPoint": "Charts & Diagrams category cover — Atlas chart atom + dark studio.",
+      "category": "chart-product",
+      "status": "ready",
+      "file": "chart-data-bars.json",
+      "renderer": "studio",
+      "prompt": "Data Driven · 3D Bars"
+    },
+    {
+      "id": "chart-data-columns",
+      "title": "Data Driven · Columns",
+      "thesisPoint": "Charts & Diagrams category cover — Atlas chart atom + dark studio.",
+      "category": "chart-product",
+      "status": "ready",
+      "file": "chart-data-columns.json",
+      "renderer": "studio",
+      "prompt": "Data Driven · Columns"
+    },
+    {
+      "id": "chart-pie",
+      "title": "Pie / Donut Chart",
+      "thesisPoint": "Charts & Diagrams category cover — Atlas chart atom + dark studio.",
+      "category": "chart-product",
+      "status": "ready",
+      "file": "chart-pie.json",
+      "renderer": "studio",
+      "prompt": "Pie / Donut Chart"
+    },
+    {
+      "id": "chart-line",
+      "title": "Line / Trend Chart",
+      "thesisPoint": "Charts & Diagrams category cover — Atlas chart atom + dark studio.",
+      "category": "chart-product",
+      "status": "ready",
+      "file": "chart-line.json",
+      "renderer": "studio",
+      "prompt": "Line / Trend Chart"
+    },
+    {
+      "id": "chart-bcg-matrix",
+      "title": "BCG Matrix (2×2)",
+      "thesisPoint": "Charts & Diagrams category cover — Atlas chart atom + dark studio.",
+      "category": "chart-product",
+      "status": "ready",
+      "file": "chart-bcg-matrix.json",
+      "renderer": "studio",
+      "prompt": "BCG Matrix (2×2)"
+    },
+    {
+      "id": "chart-nine-field",
+      "title": "Nine-Field Matrix (3×3)",
+      "thesisPoint": "Charts & Diagrams category cover — Atlas chart atom + dark studio.",
+      "category": "chart-product",
+      "status": "ready",
+      "file": "chart-nine-field.json",
+      "renderer": "studio",
+      "prompt": "Nine-Field Matrix (3×3)"
+    },
+    {
+      "id": "chart-fishbone",
+      "title": "Fishbone / Ishikawa",
+      "thesisPoint": "Charts & Diagrams category cover — Atlas chart atom + dark studio.",
+      "category": "chart-product",
+      "status": "ready",
+      "file": "chart-fishbone.json",
+      "renderer": "studio",
+      "prompt": "Fishbone / Ishikawa"
+    },
+    {
+      "id": "chart-radial",
+      "title": "Radial Diagram",
+      "thesisPoint": "Charts & Diagrams category cover — Atlas chart atom + dark studio.",
+      "category": "chart-product",
+      "status": "ready",
+      "file": "chart-radial.json",
+      "renderer": "studio",
+      "prompt": "Radial Diagram"
+    },
+    {
+      "id": "chart-scatter",
+      "title": "Scatter Plot",
+      "thesisPoint": "Charts & Diagrams category cover — Atlas chart atom + dark studio.",
+      "category": "chart-product",
+      "status": "ready",
+      "file": "chart-scatter.json",
+      "renderer": "studio",
+      "prompt": "Scatter Plot"
+    },
+    {
+      "id": "chart-waterfall",
+      "title": "Waterfall Diagram",
+      "thesisPoint": "Charts & Diagrams category cover — Atlas chart atom + dark studio.",
+      "category": "chart-product",
+      "status": "ready",
+      "file": "chart-waterfall.json",
+      "renderer": "studio",
+      "prompt": "Waterfall Diagram"
+    },
+    {
+      "id": "chart-gantt",
+      "title": "Gantt Chart",
+      "thesisPoint": "Charts & Diagrams category cover — Atlas chart atom + dark studio.",
+      "category": "chart-product",
+      "status": "ready",
+      "file": "chart-gantt.json",
+      "renderer": "studio",
+      "prompt": "Gantt Chart"
+    },
+    {
+      "id": "chart-venn",
+      "title": "Venn Diagram",
+      "thesisPoint": "Charts & Diagrams category cover — Atlas chart atom + dark studio.",
+      "category": "chart-product",
+      "status": "ready",
+      "file": "chart-venn.json",
+      "renderer": "studio",
+      "prompt": "Venn Diagram"
+    },
+    {
+      "id": "chart-tree",
+      "title": "Tree Diagram",
+      "thesisPoint": "Charts & Diagrams category cover — Atlas chart atom + dark studio.",
+      "category": "chart-product",
+      "status": "ready",
+      "file": "chart-tree.json",
+      "renderer": "studio",
+      "prompt": "Tree Diagram"
+    },
+    {
+      "id": "chart-timeline",
+      "title": "Project Timeline",
+      "thesisPoint": "Charts & Diagrams category cover — Atlas chart atom + dark studio.",
+      "category": "chart-product",
+      "status": "ready",
+      "file": "chart-timeline.json",
+      "renderer": "studio",
+      "prompt": "Project Timeline"
+    },
+    {
+      "id": "chart-org",
+      "title": "Org Chart 3D",
+      "thesisPoint": "Charts & Diagrams category cover — Atlas chart atom + dark studio.",
+      "category": "chart-product",
+      "status": "ready",
+      "file": "chart-org.json",
+      "renderer": "studio",
+      "prompt": "Org Chart 3D"
+    },
+    {
+      "id": "chart-layers",
+      "title": "3D Layers Parallel",
+      "thesisPoint": "Charts & Diagrams category cover — Atlas chart atom + dark studio.",
+      "category": "chart-product",
+      "status": "ready",
+      "file": "chart-layers.json",
+      "renderer": "studio",
+      "prompt": "3D Layers Parallel"
+    },
+    {
+      "id": "chart-list",
+      "title": "List Templates",
+      "thesisPoint": "Charts & Diagrams category cover — Atlas chart atom + dark studio.",
+      "category": "chart-product",
+      "status": "ready",
+      "file": "chart-list.json",
+      "renderer": "studio",
+      "prompt": "List Templates"
+    },
+    {
+      "id": "chart-7s",
+      "title": "7-S Model",
+      "thesisPoint": "Charts & Diagrams category cover — Atlas chart atom + dark studio.",
+      "category": "chart-product",
+      "status": "ready",
+      "file": "chart-7s.json",
+      "renderer": "studio",
+      "prompt": "7-S Model"
+    },
+    {
+      "id": "chart-gauge",
+      "title": "KPI Gauge",
+      "thesisPoint": "Charts & Diagrams category cover — Atlas chart atom + dark studio.",
+      "category": "chart-product",
+      "status": "ready",
+      "file": "chart-gauge.json",
+      "renderer": "studio",
+      "prompt": "KPI Gauge"
+    },
+    {
+      "id": "chart-traffic-light",
+      "title": "Traffic Light Chart",
+      "thesisPoint": "Charts & Diagrams category cover — Atlas chart atom + dark studio.",
+      "category": "chart-product",
+      "status": "ready",
+      "file": "chart-traffic-light.json",
+      "renderer": "studio",
+      "prompt": "Traffic Light Chart"
+    },
+    {
+      "id": "chart-cockpit",
+      "title": "Cockpit Dashboard · gauges",
+      "thesisPoint": "Charts & Diagrams category cover — Atlas chart atom + dark studio.",
+      "category": "chart-product",
+      "status": "ready",
+      "file": "chart-cockpit.json",
+      "renderer": "studio",
+      "prompt": "Cockpit Dashboard · gauges"
+    },
+    {
+      "id": "chart-multiple-arrows",
+      "title": "Multiple Arrows",
+      "thesisPoint": "Charts & Diagrams category cover — Atlas chart atom + dark studio.",
+      "category": "chart-product",
+      "status": "ready",
+      "file": "chart-multiple-arrows.json",
+      "renderer": "studio",
+      "prompt": "Multiple Arrows"
+    },
+    {
+      "id": "chart-break-even",
+      "title": "Break-Even Analysis",
+      "thesisPoint": "Charts & Diagrams category cover — Atlas chart atom + dark studio.",
+      "category": "chart-product",
+      "status": "ready",
+      "file": "chart-break-even.json",
+      "renderer": "studio",
+      "prompt": "Break-Even Analysis"
     }
   ]
 }

--- a/sdf-js/examples/compositor/demo-lifts/index.json
+++ b/sdf-js/examples/compositor/demo-lifts/index.json
@@ -928,6 +928,106 @@
       "file": "product-arrow.json",
       "renderer": "studio",
       "prompt": "Arrow Toolbox · Rising arrow"
+    },
+    {
+      "id": "product-gearwheels",
+      "title": "Gear Wheels 3D · Meshing (grey + blue)",
+      "thesisPoint": "Pixel-align recreation of PresentationLoad \"gear wheels\" product cover — Atlas atoms + dark studio.",
+      "category": "product-pixel-align",
+      "status": "ready",
+      "file": "product-gearwheels.json",
+      "renderer": "studio",
+      "prompt": "Gear Wheels 3D · Meshing (grey + blue)"
+    },
+    {
+      "id": "product-chrome-spheres",
+      "title": "Chrome Spheres · Receding row",
+      "thesisPoint": "Pixel-align recreation of PresentationLoad \"spheres\" product cover — Atlas atoms + dark studio.",
+      "category": "product-pixel-align",
+      "status": "ready",
+      "file": "product-chrome-spheres.json",
+      "renderer": "studio",
+      "prompt": "Chrome Spheres · Receding row"
+    },
+    {
+      "id": "product-spheres",
+      "title": "3D Spheres · Colour cluster",
+      "thesisPoint": "Pixel-align recreation of PresentationLoad \"spheres\" product cover — Atlas atoms + dark studio.",
+      "category": "product-pixel-align",
+      "status": "ready",
+      "file": "product-spheres.json",
+      "renderer": "studio",
+      "prompt": "3D Spheres · Colour cluster"
+    },
+    {
+      "id": "product-spheres-network",
+      "title": "3D Spheres · Network",
+      "thesisPoint": "Pixel-align recreation of PresentationLoad \"spheres\" product cover — Atlas atoms + dark studio.",
+      "category": "product-pixel-align",
+      "status": "ready",
+      "file": "product-spheres-network.json",
+      "renderer": "studio",
+      "prompt": "3D Spheres · Network"
+    },
+    {
+      "id": "product-spheres-tree",
+      "title": "3D Spheres · Tree structure",
+      "thesisPoint": "Pixel-align recreation of PresentationLoad \"spheres\" product cover — Atlas atoms + dark studio.",
+      "category": "product-pixel-align",
+      "status": "ready",
+      "file": "product-spheres-tree.json",
+      "renderer": "studio",
+      "prompt": "3D Spheres · Tree structure"
+    },
+    {
+      "id": "product-circles-segmented",
+      "title": "3D Circles · Segmented ring",
+      "thesisPoint": "Pixel-align recreation of PresentationLoad \"circles\" product cover — Atlas atoms + dark studio.",
+      "category": "product-pixel-align",
+      "status": "ready",
+      "file": "product-circles-segmented.json",
+      "renderer": "studio",
+      "prompt": "3D Circles · Segmented ring"
+    },
+    {
+      "id": "product-circle-shapes",
+      "title": "3D Circle Shapes · Layered stack",
+      "thesisPoint": "Pixel-align recreation of PresentationLoad \"circles\" product cover — Atlas atoms + dark studio.",
+      "category": "product-pixel-align",
+      "status": "ready",
+      "file": "product-circle-shapes.json",
+      "renderer": "studio",
+      "prompt": "3D Circle Shapes · Layered stack"
+    },
+    {
+      "id": "product-cubes-segmented",
+      "title": "3D Cubes · Segmented",
+      "thesisPoint": "Pixel-align recreation of PresentationLoad \"cubes\" product cover — Atlas atoms + dark studio.",
+      "category": "product-pixel-align",
+      "status": "ready",
+      "file": "product-cubes-segmented.json",
+      "renderer": "studio",
+      "prompt": "3D Cubes · Segmented"
+    },
+    {
+      "id": "product-puzzle-toolbox",
+      "title": "Puzzle Toolbox 3D · Row of 5",
+      "thesisPoint": "Pixel-align recreation of PresentationLoad \"puzzles\" product cover — Atlas atoms + dark studio.",
+      "category": "product-pixel-align",
+      "status": "ready",
+      "file": "product-puzzle-toolbox.json",
+      "renderer": "studio",
+      "prompt": "Puzzle Toolbox 3D · Row of 5"
+    },
+    {
+      "id": "product-circle-looping",
+      "title": "Circle Charts · Looping cycle",
+      "thesisPoint": "Pixel-align recreation of PresentationLoad \"circles\" product cover — Atlas atoms + dark studio.",
+      "category": "product-pixel-align",
+      "status": "ready",
+      "file": "product-circle-looping.json",
+      "renderer": "studio",
+      "prompt": "Circle Charts · Looping cycle"
     }
   ]
 }

--- a/sdf-js/examples/compositor/demo-lifts/product-chrome-spheres.json
+++ b/sdf-js/examples/compositor/demo-lifts/product-chrome-spheres.json
@@ -1,0 +1,147 @@
+{
+  "id": "product-chrome-spheres",
+  "title": "Chrome Spheres · Receding row",
+  "prompt": "spheres: Chrome Spheres · Receding row",
+  "code2d": "// vision-authored pixel-align of a PresentationLoad product cover (\"spheres\").",
+  "sceneData": {
+    "v": 1,
+    "name": "Chrome Spheres · Receding row",
+    "source": {
+      "format": "vision-authored",
+      "prompt": "spheres product cover pixel-align"
+    },
+    "subjects": [
+      {
+        "id": "s0",
+        "type": "sphere",
+        "args": {
+          "radius": 0.68
+        },
+        "transform": {
+          "translate": [1.3, 0.75, 0.5]
+        },
+        "material": {
+          "hue": 0.3,
+          "sat": 0.75,
+          "value": 0.6,
+          "metal": 0.25,
+          "glow": 0
+        }
+      },
+      {
+        "id": "s1",
+        "type": "sphere",
+        "args": {
+          "radius": 0.54
+        },
+        "transform": {
+          "translate": [0.3, 0.85, 0]
+        },
+        "material": {
+          "hue": 0.6,
+          "sat": 0.02,
+          "value": 0.85,
+          "metal": 0.98,
+          "glow": 0
+        }
+      },
+      {
+        "id": "s2",
+        "type": "sphere",
+        "args": {
+          "radius": 0.44
+        },
+        "transform": {
+          "translate": [-0.5, 0.92, -0.4]
+        },
+        "material": {
+          "hue": 0.6,
+          "sat": 0.02,
+          "value": 0.85,
+          "metal": 0.98,
+          "glow": 0
+        }
+      },
+      {
+        "id": "s3",
+        "type": "sphere",
+        "args": {
+          "radius": 0.35
+        },
+        "transform": {
+          "translate": [-1.1, 1, -0.8]
+        },
+        "material": {
+          "hue": 0.6,
+          "sat": 0.02,
+          "value": 0.85,
+          "metal": 0.98,
+          "glow": 0
+        }
+      },
+      {
+        "id": "s4",
+        "type": "sphere",
+        "args": {
+          "radius": 0.28
+        },
+        "transform": {
+          "translate": [-1.6, 1.05, -1.1]
+        },
+        "material": {
+          "hue": 0.6,
+          "sat": 0.02,
+          "value": 0.85,
+          "metal": 0.98,
+          "glow": 0
+        }
+      },
+      {
+        "id": "s5",
+        "type": "sphere",
+        "args": {
+          "radius": 0.22
+        },
+        "transform": {
+          "translate": [-2, 1.1, -1.4]
+        },
+        "material": {
+          "hue": 0.6,
+          "sat": 0.02,
+          "value": 0.85,
+          "metal": 0.98,
+          "glow": 0
+        }
+      }
+    ],
+    "defaults": {
+      "camera": {
+        "yaw": 0.5,
+        "pitch": 0.3,
+        "distance": 10,
+        "focal": 1.5,
+        "targetX": 0,
+        "targetY": 0.945,
+        "targetZ": 0
+      },
+      "light": {
+        "azimuth": 0.6,
+        "altitude": 0.55,
+        "distance": 25,
+        "intensity": 1.2
+      },
+      "shadow": {
+        "enabled": true,
+        "mode": "darken",
+        "strength": 0.4
+      },
+      "studioBg": "dark"
+    }
+  },
+  "meta": {
+    "generatedAt": "2026-06-21",
+    "model": "vision-authored",
+    "pattern": "spheres",
+    "costUSD": 0
+  }
+}

--- a/sdf-js/examples/compositor/demo-lifts/product-circle-looping.json
+++ b/sdf-js/examples/compositor/demo-lifts/product-circle-looping.json
@@ -1,0 +1,67 @@
+{
+  "id": "product-circle-looping",
+  "title": "Circle Charts · Looping cycle",
+  "prompt": "circles: Circle Charts · Looping cycle",
+  "code2d": "// vision-authored pixel-align of a PresentationLoad product cover (\"circles\").",
+  "sceneData": {
+    "v": 1,
+    "name": "Circle Charts · Looping cycle",
+    "source": {
+      "format": "vision-authored",
+      "prompt": "circles product cover pixel-align"
+    },
+    "subjects": [
+      {
+        "id": "s0",
+        "type": "circle-loop-3d",
+        "args": {
+          "segments": 5,
+          "radius": 1,
+          "tube": 0.08,
+          "headLength": 0.36,
+          "headRadius": 0.18
+        },
+        "transform": {
+          "translate": [0, 1, 0],
+          "rotate": [1.5707963267948966, 0, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.75,
+          "metal": 0.35,
+          "glow": 0
+        }
+      }
+    ],
+    "defaults": {
+      "camera": {
+        "yaw": 0.5,
+        "pitch": 0.3,
+        "distance": 10,
+        "focal": 1.5,
+        "targetX": 0,
+        "targetY": 1,
+        "targetZ": 0
+      },
+      "light": {
+        "azimuth": 0.6,
+        "altitude": 0.55,
+        "distance": 25,
+        "intensity": 1.2
+      },
+      "shadow": {
+        "enabled": true,
+        "mode": "darken",
+        "strength": 0.4
+      },
+      "studioBg": "dark"
+    }
+  },
+  "meta": {
+    "generatedAt": "2026-06-21",
+    "model": "vision-authored",
+    "pattern": "circles",
+    "costUSD": 0
+  }
+}

--- a/sdf-js/examples/compositor/demo-lifts/product-circle-shapes.json
+++ b/sdf-js/examples/compositor/demo-lifts/product-circle-shapes.json
@@ -1,0 +1,66 @@
+{
+  "id": "product-circle-shapes",
+  "title": "3D Circle Shapes · Layered stack",
+  "prompt": "circles: 3D Circle Shapes · Layered stack",
+  "code2d": "// vision-authored pixel-align of a PresentationLoad product cover (\"circles\").",
+  "sceneData": {
+    "v": 1,
+    "name": "3D Circle Shapes · Layered stack",
+    "source": {
+      "format": "vision-authored",
+      "prompt": "circles product cover pixel-align"
+    },
+    "subjects": [
+      {
+        "id": "s0",
+        "type": "circle-stack-3d",
+        "args": {
+          "count": 5,
+          "radius": 0.95,
+          "taper": 0.82,
+          "diskHeight": 0.18,
+          "gap": 0.12
+        },
+        "transform": {
+          "translate": [0, 0.6, 0]
+        },
+        "material": {
+          "hue": 0.5,
+          "sat": 0.72,
+          "value": 0.7,
+          "metal": 0.3,
+          "glow": 0
+        }
+      }
+    ],
+    "defaults": {
+      "camera": {
+        "yaw": 0.5,
+        "pitch": 0.3,
+        "distance": 10,
+        "focal": 1.5,
+        "targetX": 0,
+        "targetY": 0.6,
+        "targetZ": 0
+      },
+      "light": {
+        "azimuth": 0.6,
+        "altitude": 0.55,
+        "distance": 25,
+        "intensity": 1.2
+      },
+      "shadow": {
+        "enabled": true,
+        "mode": "darken",
+        "strength": 0.4
+      },
+      "studioBg": "dark"
+    }
+  },
+  "meta": {
+    "generatedAt": "2026-06-21",
+    "model": "vision-authored",
+    "pattern": "circles",
+    "costUSD": 0
+  }
+}

--- a/sdf-js/examples/compositor/demo-lifts/product-circles-segmented.json
+++ b/sdf-js/examples/compositor/demo-lifts/product-circles-segmented.json
@@ -1,0 +1,67 @@
+{
+  "id": "product-circles-segmented",
+  "title": "3D Circles · Segmented ring",
+  "prompt": "circles: 3D Circles · Segmented ring",
+  "code2d": "// vision-authored pixel-align of a PresentationLoad product cover (\"circles\").",
+  "sceneData": {
+    "v": 1,
+    "name": "3D Circles · Segmented ring",
+    "source": {
+      "format": "vision-authored",
+      "prompt": "circles product cover pixel-align"
+    },
+    "subjects": [
+      {
+        "id": "s0",
+        "type": "circle-segmented-3d",
+        "args": {
+          "segments": 6,
+          "radius": 1.05,
+          "innerRatio": 0.5,
+          "thickness": 0.28,
+          "gapWidth": 0.14
+        },
+        "transform": {
+          "translate": [0, 1, 0],
+          "rotate": [1.5707963267948966, 0, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.75,
+          "metal": 0.35,
+          "glow": 0
+        }
+      }
+    ],
+    "defaults": {
+      "camera": {
+        "yaw": 0.5,
+        "pitch": 0.3,
+        "distance": 10,
+        "focal": 1.5,
+        "targetX": 0,
+        "targetY": 1,
+        "targetZ": 0
+      },
+      "light": {
+        "azimuth": 0.6,
+        "altitude": 0.55,
+        "distance": 25,
+        "intensity": 1.2
+      },
+      "shadow": {
+        "enabled": true,
+        "mode": "darken",
+        "strength": 0.4
+      },
+      "studioBg": "dark"
+    }
+  },
+  "meta": {
+    "generatedAt": "2026-06-21",
+    "model": "vision-authored",
+    "pattern": "circles",
+    "costUSD": 0
+  }
+}

--- a/sdf-js/examples/compositor/demo-lifts/product-cubes-segmented.json
+++ b/sdf-js/examples/compositor/demo-lifts/product-cubes-segmented.json
@@ -1,0 +1,65 @@
+{
+  "id": "product-cubes-segmented",
+  "title": "3D Cubes · Segmented",
+  "prompt": "cubes: 3D Cubes · Segmented",
+  "code2d": "// vision-authored pixel-align of a PresentationLoad product cover (\"cubes\").",
+  "sceneData": {
+    "v": 1,
+    "name": "3D Cubes · Segmented",
+    "source": {
+      "format": "vision-authored",
+      "prompt": "cubes product cover pixel-align"
+    },
+    "subjects": [
+      {
+        "id": "s0",
+        "type": "cube-segmented-3d",
+        "args": {
+          "segments": 5,
+          "size": 1.6,
+          "gap": 0.12,
+          "axis": "x"
+        },
+        "transform": {
+          "translate": [0, 0.9, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.75,
+          "metal": 0.35,
+          "glow": 0
+        }
+      }
+    ],
+    "defaults": {
+      "camera": {
+        "yaw": 0.5,
+        "pitch": 0.3,
+        "distance": 10,
+        "focal": 1.5,
+        "targetX": 0,
+        "targetY": 0.9,
+        "targetZ": 0
+      },
+      "light": {
+        "azimuth": 0.6,
+        "altitude": 0.55,
+        "distance": 25,
+        "intensity": 1.2
+      },
+      "shadow": {
+        "enabled": true,
+        "mode": "darken",
+        "strength": 0.4
+      },
+      "studioBg": "dark"
+    }
+  },
+  "meta": {
+    "generatedAt": "2026-06-21",
+    "model": "vision-authored",
+    "pattern": "cubes",
+    "costUSD": 0
+  }
+}

--- a/sdf-js/examples/compositor/demo-lifts/product-gearwheels.json
+++ b/sdf-js/examples/compositor/demo-lifts/product-gearwheels.json
@@ -1,0 +1,114 @@
+{
+  "id": "product-gearwheels",
+  "title": "Gear Wheels 3D · Meshing (grey + blue)",
+  "prompt": "gear wheels: Gear Wheels 3D · Meshing (grey + blue)",
+  "code2d": "// vision-authored pixel-align of a PresentationLoad product cover (\"gear wheels\").",
+  "sceneData": {
+    "v": 1,
+    "name": "Gear Wheels 3D · Meshing (grey + blue)",
+    "source": {
+      "format": "vision-authored",
+      "prompt": "gear wheels product cover pixel-align"
+    },
+    "subjects": [
+      {
+        "id": "s0",
+        "type": "gear-3d",
+        "args": {
+          "teeth": 16,
+          "radius": 0.95,
+          "thickness": 0.3,
+          "toothDepth": 0.18,
+          "toothWidth": 0.2,
+          "holeRadius": 0.32
+        },
+        "transform": {
+          "translate": [0, 1, 0],
+          "rotate": [1.5707963267948966, 0, 0]
+        },
+        "material": {
+          "hue": 0.6,
+          "sat": 0.04,
+          "value": 0.46,
+          "metal": 0.5,
+          "glow": 0
+        }
+      },
+      {
+        "id": "s1",
+        "type": "gear-3d",
+        "args": {
+          "teeth": 11,
+          "radius": 0.66,
+          "thickness": 0.3,
+          "toothDepth": 0.16,
+          "toothWidth": 0.18,
+          "holeRadius": 0.24
+        },
+        "transform": {
+          "translate": [1.5, 1.55, 0],
+          "rotate": [1.5707963267948966, 0, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.75,
+          "metal": 0.35,
+          "glow": 0
+        }
+      },
+      {
+        "id": "s2",
+        "type": "gear-3d",
+        "args": {
+          "teeth": 9,
+          "radius": 0.55,
+          "thickness": 0.3,
+          "toothDepth": 0.15,
+          "toothWidth": 0.17,
+          "holeRadius": 0.2
+        },
+        "transform": {
+          "translate": [-1.2, 0.45, 0],
+          "rotate": [1.5707963267948966, 0, 0]
+        },
+        "material": {
+          "hue": 0.6,
+          "sat": 0.04,
+          "value": 0.46,
+          "metal": 0.5,
+          "glow": 0
+        }
+      }
+    ],
+    "defaults": {
+      "camera": {
+        "yaw": 0.5,
+        "pitch": 0.3,
+        "distance": 10,
+        "focal": 1.5,
+        "targetX": 0,
+        "targetY": 1,
+        "targetZ": 0
+      },
+      "light": {
+        "azimuth": 0.6,
+        "altitude": 0.55,
+        "distance": 25,
+        "intensity": 1.2
+      },
+      "shadow": {
+        "enabled": true,
+        "mode": "darken",
+        "strength": 0.4
+      },
+      "studioBg": "dark"
+    }
+  },
+  "meta": {
+    "generatedAt": "2026-06-21",
+    "model": "vision-authored",
+    "pattern": "gear wheels",
+    "costUSD": 0
+  }
+}

--- a/sdf-js/examples/compositor/demo-lifts/product-puzzle-toolbox.json
+++ b/sdf-js/examples/compositor/demo-lifts/product-puzzle-toolbox.json
@@ -1,0 +1,140 @@
+{
+  "id": "product-puzzle-toolbox",
+  "title": "Puzzle Toolbox 3D · Row of 5",
+  "prompt": "puzzles: Puzzle Toolbox 3D · Row of 5",
+  "code2d": "// vision-authored pixel-align of a PresentationLoad product cover (\"puzzles\").",
+  "sceneData": {
+    "v": 1,
+    "name": "Puzzle Toolbox 3D · Row of 5",
+    "source": {
+      "format": "vision-authored",
+      "prompt": "puzzles product cover pixel-align"
+    },
+    "subjects": [
+      {
+        "id": "s0",
+        "type": "puzzle-piece-3d",
+        "args": {
+          "size": 1,
+          "depth": 0.3,
+          "knob": 0.24
+        },
+        "transform": {
+          "translate": [-2, 0.8, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.75,
+          "metal": 0.35,
+          "glow": 0
+        }
+      },
+      {
+        "id": "s1",
+        "type": "puzzle-piece-3d",
+        "args": {
+          "size": 1,
+          "depth": 0.3,
+          "knob": 0.24
+        },
+        "transform": {
+          "translate": [-1, 0.8, 0]
+        },
+        "material": {
+          "hue": 0.07,
+          "sat": 0.88,
+          "value": 0.85,
+          "metal": 0.25,
+          "glow": 0
+        }
+      },
+      {
+        "id": "s2",
+        "type": "puzzle-piece-3d",
+        "args": {
+          "size": 1,
+          "depth": 0.3,
+          "knob": 0.24
+        },
+        "transform": {
+          "translate": [0, 0.8, 0]
+        },
+        "material": {
+          "hue": 0.4,
+          "sat": 0.72,
+          "value": 0.6,
+          "metal": 0.25,
+          "glow": 0
+        }
+      },
+      {
+        "id": "s3",
+        "type": "puzzle-piece-3d",
+        "args": {
+          "size": 1,
+          "depth": 0.3,
+          "knob": 0.24
+        },
+        "transform": {
+          "translate": [1, 0.8, 0]
+        },
+        "material": {
+          "hue": 0.98,
+          "sat": 0.78,
+          "value": 0.62,
+          "metal": 0.25,
+          "glow": 0
+        }
+      },
+      {
+        "id": "s4",
+        "type": "puzzle-piece-3d",
+        "args": {
+          "size": 1,
+          "depth": 0.3,
+          "knob": 0.24
+        },
+        "transform": {
+          "translate": [2, 0.8, 0]
+        },
+        "material": {
+          "hue": 0.13,
+          "sat": 0.85,
+          "value": 0.9,
+          "metal": 0.9,
+          "glow": 0
+        }
+      }
+    ],
+    "defaults": {
+      "camera": {
+        "yaw": 0.5,
+        "pitch": 0.3,
+        "distance": 10,
+        "focal": 1.5,
+        "targetX": 0,
+        "targetY": 0.8,
+        "targetZ": 0
+      },
+      "light": {
+        "azimuth": 0.6,
+        "altitude": 0.55,
+        "distance": 25,
+        "intensity": 1.2
+      },
+      "shadow": {
+        "enabled": true,
+        "mode": "darken",
+        "strength": 0.4
+      },
+      "studioBg": "dark"
+    }
+  },
+  "meta": {
+    "generatedAt": "2026-06-21",
+    "model": "vision-authored",
+    "pattern": "puzzles",
+    "costUSD": 0
+  }
+}

--- a/sdf-js/examples/compositor/demo-lifts/product-spheres-network.json
+++ b/sdf-js/examples/compositor/demo-lifts/product-spheres-network.json
@@ -1,0 +1,66 @@
+{
+  "id": "product-spheres-network",
+  "title": "3D Spheres · Network",
+  "prompt": "spheres: 3D Spheres · Network",
+  "code2d": "// vision-authored pixel-align of a PresentationLoad product cover (\"spheres\").",
+  "sceneData": {
+    "v": 1,
+    "name": "3D Spheres · Network",
+    "source": {
+      "format": "vision-authored",
+      "prompt": "spheres product cover pixel-align"
+    },
+    "subjects": [
+      {
+        "id": "s0",
+        "type": "sphere-network-3d",
+        "args": {
+          "count": 6,
+          "hubRadius": 0.45,
+          "satelliteRadius": 0.26,
+          "radius": 1.5,
+          "linkThickness": 0.05
+        },
+        "transform": {
+          "translate": [0, 1.3, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.75,
+          "metal": 0.35,
+          "glow": 0
+        }
+      }
+    ],
+    "defaults": {
+      "camera": {
+        "yaw": 0.5,
+        "pitch": 0.3,
+        "distance": 10,
+        "focal": 1.5,
+        "targetX": 0,
+        "targetY": 1.3,
+        "targetZ": 0
+      },
+      "light": {
+        "azimuth": 0.6,
+        "altitude": 0.55,
+        "distance": 25,
+        "intensity": 1.2
+      },
+      "shadow": {
+        "enabled": true,
+        "mode": "darken",
+        "strength": 0.4
+      },
+      "studioBg": "dark"
+    }
+  },
+  "meta": {
+    "generatedAt": "2026-06-21",
+    "model": "vision-authored",
+    "pattern": "spheres",
+    "costUSD": 0
+  }
+}

--- a/sdf-js/examples/compositor/demo-lifts/product-spheres-tree.json
+++ b/sdf-js/examples/compositor/demo-lifts/product-spheres-tree.json
@@ -1,0 +1,66 @@
+{
+  "id": "product-spheres-tree",
+  "title": "3D Spheres · Tree structure",
+  "prompt": "spheres: 3D Spheres · Tree structure",
+  "code2d": "// vision-authored pixel-align of a PresentationLoad product cover (\"spheres\").",
+  "sceneData": {
+    "v": 1,
+    "name": "3D Spheres · Tree structure",
+    "source": {
+      "format": "vision-authored",
+      "prompt": "spheres product cover pixel-align"
+    },
+    "subjects": [
+      {
+        "id": "s0",
+        "type": "sphere-tree-3d",
+        "args": {
+          "levels": 3,
+          "branching": 2,
+          "rootRadius": 0.4,
+          "levelHeight": 1,
+          "spread": 3
+        },
+        "transform": {
+          "translate": [0, 1.6, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.75,
+          "metal": 0.35,
+          "glow": 0
+        }
+      }
+    ],
+    "defaults": {
+      "camera": {
+        "yaw": 0.5,
+        "pitch": 0.3,
+        "distance": 10,
+        "focal": 1.5,
+        "targetX": 0,
+        "targetY": 1.6,
+        "targetZ": 0
+      },
+      "light": {
+        "azimuth": 0.6,
+        "altitude": 0.55,
+        "distance": 25,
+        "intensity": 1.2
+      },
+      "shadow": {
+        "enabled": true,
+        "mode": "darken",
+        "strength": 0.4
+      },
+      "studioBg": "dark"
+    }
+  },
+  "meta": {
+    "generatedAt": "2026-06-21",
+    "model": "vision-authored",
+    "pattern": "spheres",
+    "costUSD": 0
+  }
+}

--- a/sdf-js/examples/compositor/demo-lifts/product-spheres.json
+++ b/sdf-js/examples/compositor/demo-lifts/product-spheres.json
@@ -1,0 +1,130 @@
+{
+  "id": "product-spheres",
+  "title": "3D Spheres · Colour cluster",
+  "prompt": "spheres: 3D Spheres · Colour cluster",
+  "code2d": "// vision-authored pixel-align of a PresentationLoad product cover (\"spheres\").",
+  "sceneData": {
+    "v": 1,
+    "name": "3D Spheres · Colour cluster",
+    "source": {
+      "format": "vision-authored",
+      "prompt": "spheres product cover pixel-align"
+    },
+    "subjects": [
+      {
+        "id": "s0",
+        "type": "sphere",
+        "args": {
+          "radius": 0.85
+        },
+        "transform": {
+          "translate": [0, 1, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.75,
+          "metal": 0.35,
+          "glow": 0
+        }
+      },
+      {
+        "id": "s1",
+        "type": "sphere",
+        "args": {
+          "radius": 0.6
+        },
+        "transform": {
+          "translate": [-1.5, 0.78, 0.2]
+        },
+        "material": {
+          "hue": 0.3,
+          "sat": 0.75,
+          "value": 0.6,
+          "metal": 0.25,
+          "glow": 0
+        }
+      },
+      {
+        "id": "s2",
+        "type": "sphere",
+        "args": {
+          "radius": 0.55
+        },
+        "transform": {
+          "translate": [1.4, 0.82, -0.1]
+        },
+        "material": {
+          "hue": 0.07,
+          "sat": 0.88,
+          "value": 0.85,
+          "metal": 0.25,
+          "glow": 0
+        }
+      },
+      {
+        "id": "s3",
+        "type": "sphere",
+        "args": {
+          "radius": 0.42
+        },
+        "transform": {
+          "translate": [0.6, 1.5, -0.3]
+        },
+        "material": {
+          "hue": 0.6,
+          "sat": 0.04,
+          "value": 0.46,
+          "metal": 0.5,
+          "glow": 0
+        }
+      },
+      {
+        "id": "s4",
+        "type": "sphere",
+        "args": {
+          "radius": 0.4
+        },
+        "transform": {
+          "translate": [-0.8, 1.45, -0.2]
+        },
+        "material": {
+          "hue": 0.5,
+          "sat": 0.72,
+          "value": 0.7,
+          "metal": 0.3,
+          "glow": 0
+        }
+      }
+    ],
+    "defaults": {
+      "camera": {
+        "yaw": 0.5,
+        "pitch": 0.3,
+        "distance": 10,
+        "focal": 1.5,
+        "targetX": 0,
+        "targetY": 1.1099999999999999,
+        "targetZ": 0
+      },
+      "light": {
+        "azimuth": 0.6,
+        "altitude": 0.55,
+        "distance": 25,
+        "intensity": 1.2
+      },
+      "shadow": {
+        "enabled": true,
+        "mode": "darken",
+        "strength": 0.4
+      },
+      "studioBg": "dark"
+    }
+  },
+  "meta": {
+    "generatedAt": "2026-06-21",
+    "model": "vision-authored",
+    "pattern": "spheres",
+    "costUSD": 0
+  }
+}

--- a/sdf-js/scripts/gen-chart-products.mjs
+++ b/sdf-js/scripts/gen-chart-products.mjs
@@ -1,0 +1,303 @@
+#!/usr/bin/env node
+// =============================================================================
+// gen-chart-products.mjs — dark dramatic product covers for the PresentationLoad
+// "Charts & Diagrams" category. Nearly every product maps to an existing Atlas
+// chart atom; this sweeps the category like the shapes one. Plus the new
+// gauge-3d atom (cockpit) + a few multi-subject compositions.
+//
+// Usage: node sdf-js/scripts/gen-chart-products.mjs
+// =============================================================================
+
+import { readFileSync, writeFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const OUT_DIR = resolve(__dirname, '../examples/compositor/demo-lifts');
+const P2 = Math.PI / 2;
+
+const M = {
+  grey: { hue: 0.6, sat: 0.05, value: 0.4, metal: 0.5, glow: 0 },
+  blue: { hue: 0.58, sat: 0.85, value: 0.75, metal: 0.3, glow: 0 },
+  teal: { hue: 0.5, sat: 0.72, value: 0.7, metal: 0.28, glow: 0 },
+  green: { hue: 0.33, sat: 0.8, value: 0.62, metal: 0.2, glow: 0.1 },
+  red: { hue: 0.0, sat: 0.82, value: 0.62, metal: 0.2, glow: 0.1 },
+  amber: { hue: 0.11, sat: 0.9, value: 0.85, metal: 0.2, glow: 0.1 },
+  orange: { hue: 0.07, sat: 0.88, value: 0.85, metal: 0.25, glow: 0 },
+  gold: { hue: 0.13, sat: 0.85, value: 0.9, metal: 0.9, glow: 0 },
+};
+
+const S = (type, args, translate, material, rotate) => ({
+  type,
+  args,
+  transform: rotate ? { translate, rotate } : { translate },
+  material,
+});
+
+const SCENES = {
+  // ---- direct single-atom maps ----
+  'chart-data-bars': {
+    title: 'Data Driven · 3D Bars',
+    cat: 'data',
+    subjects: [
+      S(
+        'bar-3d',
+        { values: [0.4, 0.7, 1.0, 0.55, 0.85], barWidth: 0.45, gap: 0.18 },
+        [0, 0.1, 0],
+        M.blue,
+      ),
+    ],
+  },
+  'chart-data-columns': {
+    title: 'Data Driven · Columns',
+    cat: 'data',
+    subjects: [
+      S(
+        'column-3d',
+        { values: [0.4, 0.6, 0.85, 0.5, 0.75], barWidth: 0.36, gap: 0.16 },
+        [0, 0.9, 0],
+        M.teal,
+      ),
+    ],
+  },
+  'chart-pie': {
+    title: 'Pie / Donut Chart',
+    cat: 'data',
+    subjects: [
+      S(
+        'pie-3d',
+        {
+          values: [0.32, 0.24, 0.2, 0.14, 0.1],
+          outerRadius: 1.1,
+          innerRadius: 0.4,
+          thickness: 0.4,
+        },
+        [0, 0.8, 0],
+        M.blue,
+        [P2, 0, 0],
+      ),
+    ],
+  },
+  'chart-line': {
+    title: 'Line / Trend Chart',
+    cat: 'data',
+    subjects: [
+      S(
+        'line-3d',
+        { values: [0.3, 0.5, 0.45, 0.7, 0.6, 0.9], pointSpacing: 0.6 },
+        [0, 0.1, 0],
+        M.blue,
+      ),
+    ],
+  },
+  'chart-bcg-matrix': {
+    title: 'BCG Matrix (2×2)',
+    cat: 'matrix',
+    subjects: [
+      S('matrix-grid-3d', { rows: 2, cols: 2, cardW: 0.95, cardH: 0.75 }, [0, 0.95, 0], M.blue),
+    ],
+  },
+  'chart-nine-field': {
+    title: 'Nine-Field Matrix (3×3)',
+    cat: 'matrix',
+    subjects: [
+      S('matrix-grid-3d', { rows: 3, cols: 3, cardW: 0.7, cardH: 0.6 }, [0, 1.05, 0], M.teal),
+    ],
+  },
+  'chart-fishbone': {
+    title: 'Fishbone / Ishikawa',
+    cat: 'diagrams',
+    subjects: [S('fishbone-3d', { ribs: 6 }, [0, 0.9, 0], M.blue)],
+  },
+  'chart-radial': {
+    title: 'Radial Diagram',
+    cat: 'diagrams',
+    subjects: [S('radial-spoke-3d', { spokes: 8 }, [0, 1.2, 0], M.blue)],
+  },
+  'chart-scatter': {
+    title: 'Scatter Plot',
+    cat: 'data',
+    subjects: [S('scatter-3d', { count: 16, spread: 1.5 }, [0, 1.5, 0], M.blue)],
+  },
+  'chart-waterfall': {
+    title: 'Waterfall Diagram',
+    cat: 'data',
+    subjects: [S('waterfall-3d', { count: 6 }, [0, 0.1, 0], M.blue)],
+  },
+  'chart-gantt': {
+    title: 'Gantt Chart',
+    cat: 'data',
+    subjects: [S('gantt-3d', { tasks: 5 }, [0, 0.9, 0], M.blue)],
+  },
+  'chart-venn': {
+    title: 'Venn Diagram',
+    cat: 'diagrams',
+    subjects: [S('venn-3d', { sets: 3 }, [0, 1.1, 0], M.blue)],
+  },
+  'chart-tree': {
+    title: 'Tree Diagram',
+    cat: 'diagrams',
+    subjects: [S('tree-diagram-3d', { levels: 3, branching: 2 }, [0, 0.9, 0], M.blue)],
+  },
+  'chart-timeline': {
+    title: 'Project Timeline',
+    cat: 'timelines',
+    subjects: [S('timeline-3d', { count: 5 }, [0, 0.9, 0], M.blue)],
+  },
+  'chart-org': {
+    title: 'Org Chart 3D',
+    cat: 'hierarchy',
+    subjects: [S('org-chart-3d', { levels: 3, branching: 2 }, [0, 1.1, 0], M.blue)],
+  },
+  'chart-layers': {
+    title: '3D Layers Parallel',
+    cat: 'layers',
+    subjects: [S('layer-stack-3d', { layers: 5, layerW: 2.0, layerD: 1.3 }, [0, 0.8, 0], M.teal)],
+  },
+  'chart-list': {
+    title: 'List Templates',
+    cat: 'lists',
+    subjects: [S('bullet-list-3d', { items: 5 }, [0, 1.1, 0], M.blue)],
+  },
+  'chart-7s': {
+    title: '7-S Model',
+    cat: 'diagrams',
+    subjects: [S('relationship-graph-3d', { count: 7, radius: 1.4 }, [0, 1.2, 0], M.blue)],
+  },
+  'chart-gauge': {
+    title: 'KPI Gauge',
+    cat: 'data',
+    subjects: [S('gauge-3d', { value: 0.72 }, [0, 1.0, 0], M.blue)],
+  },
+
+  // ---- multi-subject compositions ----
+  'chart-traffic-light': {
+    title: 'Traffic Light Chart',
+    cat: 'data',
+    subjects: [
+      S('box', { size: [0.7, 1.7, 0.35] }, [0, 1.0, 0], M.grey),
+      S('sphere', { radius: 0.22 }, [0, 1.5, -0.18], M.red),
+      S('sphere', { radius: 0.22 }, [0, 1.0, -0.18], M.amber),
+      S('sphere', { radius: 0.22 }, [0, 0.5, -0.18], M.green),
+    ],
+  },
+  'chart-cockpit': {
+    title: 'Cockpit Dashboard · gauges',
+    cat: 'data',
+    subjects: [
+      S(
+        'gauge-3d',
+        { value: 0.45, radius: 0.7, tube: 0.08, needleLen: 0.6 },
+        [-1.9, 1.0, 0],
+        M.teal,
+      ),
+      S('gauge-3d', { value: 0.7, radius: 0.7, tube: 0.08, needleLen: 0.6 }, [0, 1.0, 0], M.blue),
+      S(
+        'gauge-3d',
+        { value: 0.92, radius: 0.7, tube: 0.08, needleLen: 0.6 },
+        [1.9, 1.0, 0],
+        M.green,
+      ),
+    ],
+  },
+  'chart-multiple-arrows': {
+    title: 'Multiple Arrows',
+    cat: 'arrows',
+    subjects: [
+      S(
+        'arrow-3d',
+        { length: 1.1, shaftWidth: 0.22, headLength: 0.45, headWidth: 0.6, depth: 0.28 },
+        [0.95, 1.0, 0],
+        M.blue,
+        [0, 0, 0],
+      ),
+      S(
+        'arrow-3d',
+        { length: 1.1, shaftWidth: 0.22, headLength: 0.45, headWidth: 0.6, depth: 0.28 },
+        [0, 1.95, 0],
+        M.teal,
+        [0, 0, P2],
+      ),
+      S(
+        'arrow-3d',
+        { length: 1.1, shaftWidth: 0.22, headLength: 0.45, headWidth: 0.6, depth: 0.28 },
+        [-0.95, 1.0, 0],
+        M.orange,
+        [0, 0, Math.PI],
+      ),
+      S(
+        'arrow-3d',
+        { length: 1.1, shaftWidth: 0.22, headLength: 0.45, headWidth: 0.6, depth: 0.28 },
+        [0, 0.05, 0],
+        M.green,
+        [0, 0, -P2],
+      ),
+    ],
+  },
+  'chart-break-even': {
+    title: 'Break-Even Analysis',
+    cat: 'data',
+    subjects: [
+      // L-shaped axes
+      S('box', { size: [3.0, 0.05, 0.05] }, [0, 0.2, 0], M.grey),
+      S('box', { size: [0.05, 2.0, 0.05] }, [-1.5, 1.2, 0], M.grey),
+      // revenue rising / cost falling — two crossing diagonal bars
+      S('box', { size: [3.2, 0.08, 0.12] }, [0, 1.15, 0], M.blue, [0, 0, 0.5]),
+      S('box', { size: [3.2, 0.08, 0.12] }, [0, 1.15, 0.04], M.orange, [0, 0, -0.5]),
+      // break-even point marker at the crossing
+      S('sphere', { radius: 0.16 }, [0, 1.15, 0.12], M.green),
+    ],
+  },
+};
+
+// ---- build + write + register -----------------------------------------------
+const indexPath = `${OUT_DIR}/index.json`;
+const index = JSON.parse(readFileSync(indexPath, 'utf8'));
+let wrote = 0;
+for (const [id, def] of Object.entries(SCENES)) {
+  const ys = def.subjects.map((s) => s.transform.translate[1]);
+  const ty = ys.reduce((a, b) => a + b, 0) / ys.length;
+  const entry = {
+    id,
+    title: def.title,
+    prompt: `${def.cat}: ${def.title}`,
+    code2d: `// vision-authored chart-product cover (PresentationLoad Charts & Diagrams).`,
+    sceneData: {
+      v: 1,
+      name: def.title,
+      source: { format: 'vision-authored', prompt: `${def.cat} chart product` },
+      subjects: def.subjects.map((s, i) => ({ id: `s${i}`, ...s })),
+      defaults: {
+        camera: {
+          yaw: 0.5,
+          pitch: 0.3,
+          distance: 10,
+          focal: 1.5,
+          targetX: 0,
+          targetY: ty,
+          targetZ: 0,
+        },
+        light: { azimuth: 0.6, altitude: 0.55, distance: 25, intensity: 1.2 },
+        shadow: { enabled: true, mode: 'darken', strength: 0.4 },
+        studioBg: 'dark',
+      },
+    },
+    meta: { generatedAt: '2026-06-21', model: 'vision-authored', pattern: def.cat, costUSD: 0 },
+  };
+  writeFileSync(`${OUT_DIR}/${id}.json`, JSON.stringify(entry, null, 2) + '\n');
+  wrote++;
+  if (!index.demos.some((d) => d.id === id)) {
+    index.demos.push({
+      id,
+      title: def.title,
+      thesisPoint: `Charts & Diagrams category cover — Atlas chart atom + dark studio.`,
+      category: 'chart-product',
+      status: 'ready',
+      file: `${id}.json`,
+      renderer: 'studio',
+      prompt: def.title,
+    });
+  }
+}
+writeFileSync(indexPath, JSON.stringify(index, null, 2) + '\n');
+console.log(`wrote ${wrote} chart-product scenes; index now ${index.demos.length} demos`);

--- a/sdf-js/scripts/gen-product-pixel.mjs
+++ b/sdf-js/scripts/gen-product-pixel.mjs
@@ -33,6 +33,7 @@ const M = {
   emerald: { hue: 0.4, sat: 0.72, value: 0.6, metal: 0.25, glow: 0 },
   crimson: { hue: 0.98, sat: 0.78, value: 0.62, metal: 0.25, glow: 0 },
   gold: { hue: 0.13, sat: 0.85, value: 0.9, metal: 0.9, glow: 0 },
+  chrome: { hue: 0.6, sat: 0.02, value: 0.85, metal: 0.98, glow: 0 },
 };
 
 const P2 = Math.PI / 2;
@@ -192,6 +193,154 @@ const SCENES = {
         [0.2, 1.2, 0.2],
         M.blue,
         [0, 0, 0.52],
+      ),
+    ],
+  },
+  // ---- Round 2: remaining 3D shape products (2026-06-21) ----
+  'product-gearwheels': {
+    title: 'Gear Wheels 3D · Meshing (grey + blue)',
+    cat: 'gear wheels',
+    subjects: [
+      S(
+        'gear-3d',
+        {
+          teeth: 16,
+          radius: 0.95,
+          thickness: 0.3,
+          toothDepth: 0.18,
+          toothWidth: 0.2,
+          holeRadius: 0.32,
+        },
+        [0, 1.0, 0],
+        M.grey,
+        [P2, 0, 0],
+      ),
+      S(
+        'gear-3d',
+        {
+          teeth: 11,
+          radius: 0.66,
+          thickness: 0.3,
+          toothDepth: 0.16,
+          toothWidth: 0.18,
+          holeRadius: 0.24,
+        },
+        [1.5, 1.55, 0],
+        M.blue,
+        [P2, 0, 0],
+      ),
+      S(
+        'gear-3d',
+        {
+          teeth: 9,
+          radius: 0.55,
+          thickness: 0.3,
+          toothDepth: 0.15,
+          toothWidth: 0.17,
+          holeRadius: 0.2,
+        },
+        [-1.2, 0.45, 0],
+        M.grey,
+        [P2, 0, 0],
+      ),
+    ],
+  },
+  'product-chrome-spheres': {
+    title: 'Chrome Spheres · Receding row',
+    cat: 'spheres',
+    subjects: [
+      S('sphere', { radius: 0.68 }, [1.3, 0.75, 0.5], M.green),
+      S('sphere', { radius: 0.54 }, [0.3, 0.85, 0.0], M.chrome),
+      S('sphere', { radius: 0.44 }, [-0.5, 0.92, -0.4], M.chrome),
+      S('sphere', { radius: 0.35 }, [-1.1, 1.0, -0.8], M.chrome),
+      S('sphere', { radius: 0.28 }, [-1.6, 1.05, -1.1], M.chrome),
+      S('sphere', { radius: 0.22 }, [-2.0, 1.1, -1.4], M.chrome),
+    ],
+  },
+  'product-spheres': {
+    title: '3D Spheres · Colour cluster',
+    cat: 'spheres',
+    subjects: [
+      S('sphere', { radius: 0.85 }, [0, 1.0, 0], M.blue),
+      S('sphere', { radius: 0.6 }, [-1.5, 0.78, 0.2], M.green),
+      S('sphere', { radius: 0.55 }, [1.4, 0.82, -0.1], M.orange),
+      S('sphere', { radius: 0.42 }, [0.6, 1.5, -0.3], M.grey),
+      S('sphere', { radius: 0.4 }, [-0.8, 1.45, -0.2], M.teal),
+    ],
+  },
+  'product-spheres-network': {
+    title: '3D Spheres · Network',
+    cat: 'spheres',
+    subjects: [
+      S(
+        'sphere-network-3d',
+        { count: 6, hubRadius: 0.45, satelliteRadius: 0.26, radius: 1.5, linkThickness: 0.05 },
+        [0, 1.3, 0],
+        M.blue,
+      ),
+    ],
+  },
+  'product-spheres-tree': {
+    title: '3D Spheres · Tree structure',
+    cat: 'spheres',
+    subjects: [
+      S(
+        'sphere-tree-3d',
+        { levels: 3, branching: 2, rootRadius: 0.4, levelHeight: 1.0, spread: 3.0 },
+        [0, 1.6, 0],
+        M.blue,
+      ),
+    ],
+  },
+  'product-circles-segmented': {
+    title: '3D Circles · Segmented ring',
+    cat: 'circles',
+    subjects: [
+      S(
+        'circle-segmented-3d',
+        { segments: 6, radius: 1.05, innerRatio: 0.5, thickness: 0.28, gapWidth: 0.14 },
+        [0, 1.0, 0],
+        M.blue,
+        [P2, 0, 0],
+      ),
+    ],
+  },
+  'product-circle-shapes': {
+    title: '3D Circle Shapes · Layered stack',
+    cat: 'circles',
+    subjects: [
+      S(
+        'circle-stack-3d',
+        { count: 5, radius: 0.95, taper: 0.82, diskHeight: 0.18, gap: 0.12 },
+        [0, 0.6, 0],
+        M.teal,
+      ),
+    ],
+  },
+  'product-cubes-segmented': {
+    title: '3D Cubes · Segmented',
+    cat: 'cubes',
+    subjects: [
+      S('cube-segmented-3d', { segments: 5, size: 1.6, gap: 0.12, axis: 'x' }, [0, 0.9, 0], M.blue),
+    ],
+  },
+  'product-puzzle-toolbox': {
+    title: 'Puzzle Toolbox 3D · Row of 5',
+    cat: 'puzzles',
+    subjects: ['blue', 'orange', 'emerald', 'crimson', 'gold'].map((c, i) =>
+      S('puzzle-piece-3d', { size: 1.0, depth: 0.3, knob: 0.24 }, [(i - 2) * 1.0, 0.8, 0], M[c]),
+    ),
+  },
+  'product-circle-looping': {
+    title: 'Circle Charts · Looping cycle',
+    cat: 'circles',
+    subjects: [
+      S(
+        'circle-loop-3d',
+        { segments: 5, radius: 1.0, tube: 0.08, headLength: 0.36, headRadius: 0.18 },
+        [0, 1.0, 0],
+        M.blue,
+        [P2, 0, 0],
       ),
     ],
   },

--- a/sdf-js/scripts/test-gauge-3d.mjs
+++ b/sdf-js/scripts/test-gauge-3d.mjs
@@ -1,0 +1,33 @@
+import { gauge3dSDF } from '../src/scene/components/charts/data/gauge-3d.js';
+import { compile } from '../src/scene/compile.js';
+import { compileSDF3ToGLSL } from '../src/sdf/sdf3.compile.js';
+let pass = 0,
+  fail = 0;
+const ok = (c, n) => (c ? (pass++, console.log(`  ✓ ${n}`)) : (fail++, console.log(`  ✗ ${n}`)));
+console.log('=== gauge-3d ===\n');
+{
+  const sdf = gauge3dSDF({ value: 0.7 }); // arc radius 0.9 tube 0.1, top half
+  ok(sdf.f([0, 0.9, 0]) < 0, 'arc top centreline inside');
+  ok(sdf.f([0, 0, 0]) < 0, 'hub at centre inside');
+  const ang = Math.PI * 0.3; // value 0.7
+  ok(sdf.f([Math.cos(ang) * 0.4, Math.sin(ang) * 0.4, 0]) < 0, 'needle midpoint inside');
+  ok(sdf.f([0, -0.9, 0]) > 0, 'lower half removed (outside)');
+  ok(sdf.f([3, 0, 0]) > 0, 'far outside');
+}
+{
+  const scene = {
+    v: 1,
+    defaults: {
+      camera: { yaw: 0.4, pitch: 0.2, distance: 6, focal: 1.5, targetX: 0, targetY: 0, targetZ: 0 },
+      light: { altitude: 0.5, azimuth: 0.6, distance: 8, intensity: 1.1 },
+    },
+    subjects: [{ type: 'gauge-3d', id: 'g', args: { value: 0.7 }, region: 'object' }],
+  };
+  const compiled = compile(scene);
+  ok(compiled.sdf.f([0, 0, 0]) < 0, 'compiled hub inside');
+  const glsl = compileSDF3ToGLSL(compiled.sdf, { time: 'u_time' });
+  const s = typeof glsl === 'string' ? glsl : glsl.expr || JSON.stringify(glsl);
+  ok(s.includes('sdTorus'), 'GLSL has sdTorus (arc)');
+}
+console.log(`\n=== Result: ${pass} passed, ${fail} failed ===`);
+process.exit(fail > 0 ? 1 : 0);

--- a/sdf-js/src/scene/compile.js
+++ b/sdf-js/src/scene/compile.js
@@ -145,6 +145,7 @@ import { venn3dSDF } from './components/charts/data/venn-3d.js';
 import { waterfall3dSDF } from './components/charts/data/waterfall-3d.js';
 import { scatter3dSDF } from './components/charts/data/scatter-3d.js';
 import { gantt3dSDF } from './components/charts/data/gantt-3d.js';
+import { gauge3dSDF } from './components/charts/data/gauge-3d.js';
 import { fishbone3dSDF } from './components/charts/diagrams/fishbone-3d.js';
 import { trafficLight3dSDF } from './components/charts/data/traffic-light-3d.js';
 import { radialSpoke3dSDF } from './components/charts/data/radial-spoke-3d.js';
@@ -693,6 +694,15 @@ const PRIMITIVE_FACTORIES = {
       barH: a.barH ?? 0.26,
       depth: a.depth ?? 0.18,
       trackLength: a.trackLength ?? 3.0,
+    }),
+  'gauge-3d': (a) =>
+    gauge3dSDF({
+      value: a.value ?? 0.7,
+      radius: a.radius ?? 0.9,
+      tube: a.tube ?? 0.1,
+      needleLen: a.needleLen ?? 0.8,
+      needleWidth: a.needleWidth ?? 0.07,
+      depth: a.depth ?? 0.2,
     }),
   'fishbone-3d': (a) =>
     fishbone3dSDF({

--- a/sdf-js/src/scene/components/charts/data/gauge-3d.js
+++ b/sdf-js/src/scene/components/charts/data/gauge-3d.js
@@ -1,0 +1,70 @@
+// =============================================================================
+// gauge-3d.js — KPI gauge / speedometer dial (Atlas chart atom).
+// -----------------------------------------------------------------------------
+// A semicircular arc (top half of a ring) + a needle pointing to a 0..1 value +
+// a hub. Covers PresentationLoad "Cockpit Charts" (dashboard gauges) and any
+// KPI speedometer. Faces +Z (camera). Composite atom (torus + box + cylinder +
+// union/difference).
+// =============================================================================
+
+import { torus, box, cylinder } from '../../../../sdf/d3.js';
+import { union, difference } from '../../../../sdf/dn.js';
+
+/**
+ * @param {object} opts
+ * @param {number} [opts.value=0.7]      needle position 0..1 (left→right)
+ * @param {number} [opts.radius=0.9]     arc radius
+ * @param {number} [opts.tube=0.1]       arc tube radius
+ * @param {number} [opts.needleLen=0.8]  needle length
+ * @param {number} [opts.needleWidth=0.07] needle width
+ * @param {number} [opts.depth=0.2]      Z thickness of needle/hub
+ * @returns {SDF3}
+ */
+export function gauge3dSDF({
+  value = 0.7,
+  radius = 0.9,
+  tube = 0.1,
+  needleLen = 0.8,
+  needleWidth = 0.07,
+  depth = 0.2,
+} = {}) {
+  const v = Math.max(0, Math.min(1, value));
+  // Ring in the XY plane; keep only the top half (y ≥ 0) → semicircular arc.
+  const ring = torus(radius, tube).rotate(Math.PI / 2, [1, 0, 0]);
+  const lowerHalf = box([radius * 3, radius * 1.5, tube * 4]).translate([0, -radius * 1.5, 0]);
+  const arc = difference(ring, lowerHalf);
+  // Needle: a box centered at origin, rotated to the value angle (v=0 → π/left,
+  // v=1 → 0/right), then shifted out so its inner end sits at the hub.
+  const ang = Math.PI * (1 - v);
+  const needle = box([needleLen, needleWidth, depth])
+    .rotate(ang, [0, 0, 1])
+    .translate([(Math.cos(ang) * needleLen) / 2, (Math.sin(ang) * needleLen) / 2, 0]);
+  // Hub: short cylinder facing the camera (axis Z).
+  const hub = cylinder(tube * 1.6, depth).rotate(Math.PI / 2, [1, 0, 0]);
+  return union(arc, needle, hub);
+}
+
+export const gauge3dSpec = {
+  type: 'gauge-3d',
+  category: 'charts/data',
+  args: {
+    value: { type: 'number', default: 0.7, min: 0, max: 1, doc: 'Needle position 0..1' },
+    radius: { type: 'number', default: 0.9, doc: 'Arc radius' },
+    tube: { type: 'number', default: 0.1, doc: 'Arc tube radius' },
+    needleLen: { type: 'number', default: 0.8, doc: 'Needle length' },
+    needleWidth: { type: 'number', default: 0.07, doc: 'Needle width' },
+    depth: { type: 'number', default: 0.2, doc: 'Z thickness of needle/hub' },
+  },
+  examples: [
+    { name: 'KPI gauge 70%', args: { value: 0.7 } },
+    { name: 'Low reading', args: { value: 0.2 } },
+    { name: 'Full', args: { value: 1.0 } },
+  ],
+  description: 'KPI gauge / speedometer dial (arc + needle) — dashboards, cockpit charts, scores',
+  source: {
+    author: 'Atlas',
+    builtAt: '2026-06-21',
+    builder: 'Charts coverage — taxonomy charts/data/',
+    license: 'PolyForm Noncommercial 1.0.0',
+  },
+};

--- a/sdf-js/src/scene/spec.js
+++ b/sdf-js/src/scene/spec.js
@@ -234,6 +234,7 @@ export const PRIMITIVE_TYPES = new Set([
   'waterfall-3d',
   'scatter-3d',
   'gantt-3d',
+  'gauge-3d', // KPI gauge / speedometer (cockpit dashboards)
   // Sprint 5 Wave C — fishbone / traffic-light / radial-spoke + puzzle-piece.
   'fishbone-3d',
   'traffic-light-3d',


### PR DESCRIPTION
## What

Sweeps the PresentationLoad **Charts & Diagrams** category like the shapes one — nearly every product maps to an existing Atlas chart atom, now rendered as **dark dramatic product covers** (`gen-chart-products.mjs`, 23 scenes, `studioBg:"dark"`).

**New atom — `gauge-3d`** (KPI gauge / speedometer: arc + needle + hub) fills the one real gap (Cockpit Charts). Registered (compile / spec / run-tests) + test 7/7.

### 23 covers
data bars / columns / pie / line · BCG (2×2) + nine-field (3×3) matrices · fishbone · radial · scatter · waterfall · gantt · venn · tree · timeline · org-chart · 3D-layers · list · 7-S model · gauge · cockpit (3 gauges) · traffic-light (housing + R/A/G) · multiple-arrows (4-way) · break-even (crossing bars + marker).

## Verification
- All 23 **compile clean (E0/W0)**; registered (`renderer:"studio"`, `studioBg:"dark"`).
- **Real-browser GPU** verified the new compositions (gauge, cockpit, traffic-light, multiple-arrows, break-even) — 0 shader errors; single-atom covers reuse already-verified atoms.
- Full suite **81/81** (gauge test added). Prettier + `node --check` clean.
- Gotchas fixed: two `line-3d` in one scene overflowed the studio shader → break-even rebuilt from crossing boxes; camera-facing parts placed on −z (traffic lights).

## ⚠️ Stacking note
This branch was cut from `shapes-3d-coverage` (**PR #65**, still open), so it also contains #65's 10 shape-product covers. Cleanest merge: **close #65 and squash-merge this PR** (it lands both #65's covers and the charts work). Or merge #65 first and ping me to rebase this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
