### PR TITLE
Step 2: hybrid deck player — light chapters in one world + heavy slides in own scenes

### DIFF
--- a/sdf-js/examples/compositor/compositor.js
+++ b/sdf-js/examples/compositor/compositor.js
@@ -780,6 +780,16 @@ async function loadDemoScene(demo) {
   }
 }
 
+// Public Layer-1 hook for the Layer-2 deck player (deck-player.js): load a
+// SceneData (by demo-manifest-shaped entry) into the active GPU renderer. The
+// deck player sequences these + drives transitions; it never touches compositor
+// internals. Returns loadDemoScene's promise so the player can await the swap.
+window.atlasLoadScene = (demoEntry) => {
+  const p = loadDemoScene(demoEntry);
+  switchToTab('text'); // reveal the render canvas (mirrors gallery card behavior)
+  return p;
+};
+
 function autofillDemoPrompt(demo) {
   const promptInput = $('prompt-input');
   if (!promptInput) return;

--- a/sdf-js/examples/compositor/deck-player.js
+++ b/sdf-js/examples/compositor/deck-player.js
@@ -1,0 +1,71 @@
+// =============================================================================
+// deck-player.js — Layer-2 Atlas Present spatial-narrative deck player.
+// -----------------------------------------------------------------------------
+// A deck is a PLAYLIST of scene "segments". Two segment kinds, both just scenes:
+//   • light "chapter" — many LIGHT atoms in ONE continuous 3D world + a touring
+//     cameraSequence (the camera flies between slide-stations). One shader.
+//   • heavy "slide"   — one RICH atom (gear / pyramid / org / tree, whose loops
+//     + modPolar overflow a shared shader) in its OWN scene/shader, with a short
+//     orbit/dolly cameraSequence so it isn't a frozen object.
+// The player sequences segments, fading the canvas between them to hide the
+// per-scene GLSL compile (200-500ms). This is the hybrid the user chose: light
+// stays one-world, heavy splits into its own scene.
+//
+// Launch: open the compositor with ?deck=<deckId> → fetches demo-lifts/<id>.json.
+// It ONLY calls the public window.atlasLoadScene hook — never compositor
+// internals (compositor = engine/Layer 1; this = app/Layer 2).
+// =============================================================================
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+async function waitFor(fn, timeoutMs) {
+  const t0 = performance.now();
+  while (!fn()) {
+    if (performance.now() - t0 > timeoutMs) throw new Error('deck-player: waitFor timed out');
+    await sleep(60);
+  }
+}
+
+async function playDeck(id) {
+  const res = await fetch(`./demo-lifts/${id}.json`);
+  if (!res.ok) throw new Error(`deck ${id}: HTTP ${res.status}`);
+  const deck = await res.json();
+  const segments = Array.isArray(deck.segments) ? deck.segments : [];
+  if (!segments.length) throw new Error(`deck ${id}: no segments`);
+
+  // The compositor module loads async — wait for its public load hook.
+  await waitFor(() => typeof window.atlasLoadScene === 'function', 10000);
+
+  const wrap = document.getElementById('canvas-wrap');
+  if (wrap) wrap.style.transition = 'opacity 0.35s ease';
+  const fade = (v) => {
+    if (wrap) wrap.style.opacity = String(v);
+  };
+
+  const FADE_MS = 380;
+  let i = 0;
+  // Loop the deck forever (a presentation reel). User navigation tears it down.
+  for (;;) {
+    const seg = segments[i];
+    fade(0);
+    await sleep(FADE_MS);
+    try {
+      await window.atlasLoadScene({
+        id: `${id}-seg${i}`,
+        title: seg.title || `${id} · ${i + 1}`,
+        file: seg.file,
+        renderer: 'studio',
+      });
+    } catch (e) {
+      console.error('[deck-player] segment load failed', seg, e);
+    }
+    await sleep(240); // let the new shader compile behind the fade
+    fade(1);
+    const dwell = Math.max(1, Number(seg.durationSec) || 6);
+    await sleep(dwell * 1000);
+    i = (i + 1) % segments.length;
+  }
+}
+
+const deckId = new URLSearchParams(location.search).get('deck');
+if (deckId) playDeck(deckId).catch((e) => console.error('[deck-player]', e));

--- a/sdf-js/examples/compositor/demo-lifts/deck-hybrid.json
+++ b/sdf-js/examples/compositor/demo-lifts/deck-hybrid.json
@@ -1,0 +1,24 @@
+{
+  "id": "deck-hybrid",
+  "name": "Hybrid spatial deck (light chapter + heavy slides)",
+  "segments": [
+    {
+      "file": "deck-seg-light.json",
+      "title": "Chapter · light continuous world",
+      "kind": "chapter",
+      "durationSec": 17
+    },
+    {
+      "file": "deck-seg-gears.json",
+      "title": "Slide · gear mechanism (heavy)",
+      "kind": "slide",
+      "durationSec": 6.5
+    },
+    {
+      "file": "deck-seg-pyramid.json",
+      "title": "Slide · pyramid (heavy)",
+      "kind": "slide",
+      "durationSec": 6.5
+    }
+  ]
+}

--- a/sdf-js/examples/compositor/demo-lifts/deck-seg-gears.json
+++ b/sdf-js/examples/compositor/demo-lifts/deck-seg-gears.json
@@ -1,0 +1,111 @@
+{
+  "id": "deck-seg-gears",
+  "title": "Slide · gear mechanism (heavy)",
+  "prompt": "Slide · gear mechanism (heavy)",
+  "code2d": "// hybrid-deck segment (Atlas Present spatial narrative).",
+  "sceneData": {
+    "v": 1,
+    "name": "Slide · gears",
+    "source": {
+      "format": "vision-authored",
+      "prompt": "gear mechanism"
+    },
+    "subjects": [
+      {
+        "id": "g1",
+        "type": "gear-3d",
+        "args": {
+          "teeth": 16,
+          "radius": 0.95,
+          "thickness": 0.3,
+          "toothDepth": 0.18,
+          "toothWidth": 0.2,
+          "holeRadius": 0.3
+        },
+        "transform": {
+          "translate": [-0.6, 1.1, 0],
+          "rotate": [1.5707963267948966, 0, 0]
+        },
+        "material": {
+          "hue": 0.6,
+          "sat": 0.05,
+          "value": 0.45,
+          "metal": 0.6,
+          "glow": 0
+        }
+      },
+      {
+        "id": "g2",
+        "type": "gear-3d",
+        "args": {
+          "teeth": 11,
+          "radius": 0.66,
+          "thickness": 0.3,
+          "toothDepth": 0.16,
+          "toothWidth": 0.18,
+          "holeRadius": 0.22
+        },
+        "transform": {
+          "translate": [1.05, 1.45, 0],
+          "rotate": [1.5707963267948966, 0, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.75,
+          "metal": 0.3,
+          "glow": 0
+        }
+      }
+    ],
+    "cameraSequence": {
+      "loop": false,
+      "shots": [
+        {
+          "duration": 0.01,
+          "pos": [-3, 2.5, -6.8],
+          "target": [0.2, 1.2, 0],
+          "fov": 32,
+          "transition": "cut"
+        },
+        {
+          "duration": 6,
+          "pos": [3.4000000000000004, 2.5, -6.8],
+          "target": [0.2, 1.2, 0],
+          "fov": 32,
+          "ease": "smooth",
+          "transition": "blend"
+        }
+      ]
+    },
+    "defaults": {
+      "camera": {
+        "yaw": 0.5,
+        "pitch": 0.3,
+        "distance": 8,
+        "focal": 1.5,
+        "targetX": 0,
+        "targetY": 1.2,
+        "targetZ": 0
+      },
+      "light": {
+        "azimuth": 0.6,
+        "altitude": 0.55,
+        "distance": 25,
+        "intensity": 1.2
+      },
+      "shadow": {
+        "enabled": true,
+        "mode": "darken",
+        "strength": 0.4
+      },
+      "studioBg": "dark"
+    }
+  },
+  "meta": {
+    "generatedAt": "2026-06-21",
+    "model": "vision-authored",
+    "pattern": "deck-segment",
+    "costUSD": 0
+  }
+}

--- a/sdf-js/examples/compositor/demo-lifts/deck-seg-light.json
+++ b/sdf-js/examples/compositor/demo-lifts/deck-seg-light.json
@@ -1,0 +1,320 @@
+{
+  "id": "deck-seg-light",
+  "title": "Chapter · light continuous world",
+  "prompt": "Chapter · light continuous world",
+  "code2d": "// hybrid-deck segment (Atlas Present spatial narrative).",
+  "sceneData": {
+    "v": 1,
+    "name": "Chapter · light",
+    "source": {
+      "format": "vision-authored",
+      "prompt": "light chapter"
+    },
+    "subjects": [
+      {
+        "id": "s0_0",
+        "type": "sphere",
+        "args": {
+          "radius": 0.4
+        },
+        "transform": {
+          "translate": [-1.2, 0.7, 0]
+        },
+        "material": {
+          "hue": 0.33,
+          "sat": 0.8,
+          "value": 0.6,
+          "metal": 0.2,
+          "glow": 0
+        }
+      },
+      {
+        "id": "s0_1",
+        "type": "sphere",
+        "args": {
+          "radius": 0.55
+        },
+        "transform": {
+          "translate": [0, 0.85, 0]
+        },
+        "material": {
+          "hue": 0,
+          "sat": 0.82,
+          "value": 0.62,
+          "metal": 0.2,
+          "glow": 0
+        }
+      },
+      {
+        "id": "s0_2",
+        "type": "sphere",
+        "args": {
+          "radius": 0.72
+        },
+        "transform": {
+          "translate": [1.35, 1, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.75,
+          "metal": 0.3,
+          "glow": 0
+        }
+      },
+      {
+        "id": "s1_0",
+        "type": "box",
+        "args": {
+          "size": [0.42, 0.6, 0.42]
+        },
+        "transform": {
+          "translate": [6.1, 0.3, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.75,
+          "metal": 0.3,
+          "glow": 0
+        }
+      },
+      {
+        "id": "s1_1",
+        "type": "box",
+        "args": {
+          "size": [0.42, 1, 0.42]
+        },
+        "transform": {
+          "translate": [6.7, 0.5, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.75,
+          "metal": 0.3,
+          "glow": 0
+        }
+      },
+      {
+        "id": "s1_2",
+        "type": "box",
+        "args": {
+          "size": [0.42, 1.45, 0.42]
+        },
+        "transform": {
+          "translate": [7.3, 0.725, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.75,
+          "metal": 0.3,
+          "glow": 0
+        }
+      },
+      {
+        "id": "s1_3",
+        "type": "box",
+        "args": {
+          "size": [0.42, 0.85, 0.42]
+        },
+        "transform": {
+          "translate": [7.9, 0.425, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.75,
+          "metal": 0.3,
+          "glow": 0
+        }
+      },
+      {
+        "id": "s2_0",
+        "type": "box",
+        "args": {
+          "size": [0.7, 0.7, 0.7]
+        },
+        "transform": {
+          "translate": [13.3, 0.35, 0.2]
+        },
+        "material": {
+          "hue": 0.5,
+          "sat": 0.72,
+          "value": 0.7,
+          "metal": 0.28,
+          "glow": 0
+        }
+      },
+      {
+        "id": "s2_1",
+        "type": "box",
+        "args": {
+          "size": [0.7, 0.7, 0.7]
+        },
+        "transform": {
+          "translate": [14.5, 0.5, -0.1]
+        },
+        "material": {
+          "hue": 0.5,
+          "sat": 0.72,
+          "value": 0.7,
+          "metal": 0.28,
+          "glow": 0
+        }
+      },
+      {
+        "id": "s2_2",
+        "type": "box",
+        "args": {
+          "size": [0.7, 0.7, 0.7]
+        },
+        "transform": {
+          "translate": [14, 1.1, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.75,
+          "metal": 0.3,
+          "glow": 0
+        }
+      },
+      {
+        "id": "s3_0",
+        "type": "cone",
+        "args": {
+          "height": 1.7,
+          "baseRadius": 0.9
+        },
+        "transform": {
+          "translate": [21, 0.85, 0]
+        },
+        "material": {
+          "hue": 0.13,
+          "sat": 0.85,
+          "value": 0.9,
+          "metal": 0.9,
+          "glow": 0
+        }
+      },
+      {
+        "id": "s3_1",
+        "type": "cone",
+        "args": {
+          "height": 1.1,
+          "baseRadius": 0.6
+        },
+        "transform": {
+          "translate": [22.2, 0.55, 0.2]
+        },
+        "material": {
+          "hue": 0.6,
+          "sat": 0.05,
+          "value": 0.45,
+          "metal": 0.6,
+          "glow": 0
+        }
+      }
+    ],
+    "cameraSequence": {
+      "loop": false,
+      "shots": [
+        {
+          "duration": 2.4,
+          "pos": [-1.3, 2, -6.6],
+          "target": [0, 0.85, 0],
+          "fov": 32,
+          "ease": "smooth",
+          "transition": "cut"
+        },
+        {
+          "duration": 1.8,
+          "pos": [-1.3, 2, -6.6],
+          "target": [0, 0.85, 0],
+          "fov": 32,
+          "ease": "smooth",
+          "transition": "blend"
+        },
+        {
+          "duration": 2.4,
+          "pos": [5.7, 2, -6.6],
+          "target": [7, 0.85, 0],
+          "fov": 32,
+          "ease": "smooth",
+          "transition": "blend"
+        },
+        {
+          "duration": 1.8,
+          "pos": [5.7, 2, -6.6],
+          "target": [7, 0.85, 0],
+          "fov": 32,
+          "ease": "smooth",
+          "transition": "blend"
+        },
+        {
+          "duration": 2.4,
+          "pos": [12.7, 2, -6.6],
+          "target": [14, 0.85, 0],
+          "fov": 32,
+          "ease": "smooth",
+          "transition": "blend"
+        },
+        {
+          "duration": 1.8,
+          "pos": [12.7, 2, -6.6],
+          "target": [14, 0.85, 0],
+          "fov": 32,
+          "ease": "smooth",
+          "transition": "blend"
+        },
+        {
+          "duration": 2.4,
+          "pos": [19.7, 2, -6.6],
+          "target": [21, 0.85, 0],
+          "fov": 32,
+          "ease": "smooth",
+          "transition": "blend"
+        },
+        {
+          "duration": 1.8,
+          "pos": [19.7, 2, -6.6],
+          "target": [21, 0.85, 0],
+          "fov": 32,
+          "ease": "smooth",
+          "transition": "blend"
+        }
+      ]
+    },
+    "defaults": {
+      "camera": {
+        "yaw": 0.5,
+        "pitch": 0.3,
+        "distance": 8,
+        "focal": 1.5,
+        "targetX": 0,
+        "targetY": 0.85,
+        "targetZ": 0
+      },
+      "light": {
+        "azimuth": 0.6,
+        "altitude": 0.55,
+        "distance": 25,
+        "intensity": 1.2
+      },
+      "shadow": {
+        "enabled": true,
+        "mode": "darken",
+        "strength": 0.4
+      },
+      "studioBg": "dark"
+    }
+  },
+  "meta": {
+    "generatedAt": "2026-06-21",
+    "model": "vision-authored",
+    "pattern": "deck-segment",
+    "costUSD": 0
+  }
+}

--- a/sdf-js/examples/compositor/demo-lifts/deck-seg-pyramid.json
+++ b/sdf-js/examples/compositor/demo-lifts/deck-seg-pyramid.json
@@ -1,0 +1,87 @@
+{
+  "id": "deck-seg-pyramid",
+  "title": "Slide · pyramid (heavy)",
+  "prompt": "Slide · pyramid (heavy)",
+  "code2d": "// hybrid-deck segment (Atlas Present spatial narrative).",
+  "sceneData": {
+    "v": 1,
+    "name": "Slide · pyramid",
+    "source": {
+      "format": "vision-authored",
+      "prompt": "pyramid"
+    },
+    "subjects": [
+      {
+        "id": "p",
+        "type": "pyramid-3d",
+        "args": {
+          "levels": 5,
+          "baseWidth": 2.2,
+          "topWidth": 0.3,
+          "layerHeight": 0.38,
+          "gap": 0.05,
+          "depth": 0.7
+        },
+        "transform": {
+          "translate": [0, 0.1, 0]
+        },
+        "material": {
+          "hue": 0.13,
+          "sat": 0.85,
+          "value": 0.9,
+          "metal": 0.9,
+          "glow": 0
+        }
+      }
+    ],
+    "cameraSequence": {
+      "loop": false,
+      "shots": [
+        {
+          "duration": 0.01,
+          "pos": [0, 3, -8.5],
+          "target": [0, 1, 0],
+          "fov": 32,
+          "transition": "cut"
+        },
+        {
+          "duration": 6,
+          "pos": [-1.6, 1.6, -5.2],
+          "target": [0, 1, 0],
+          "fov": 32,
+          "ease": "smooth",
+          "transition": "blend"
+        }
+      ]
+    },
+    "defaults": {
+      "camera": {
+        "yaw": 0.5,
+        "pitch": 0.3,
+        "distance": 8,
+        "focal": 1.5,
+        "targetX": 0,
+        "targetY": 1,
+        "targetZ": 0
+      },
+      "light": {
+        "azimuth": 0.6,
+        "altitude": 0.55,
+        "distance": 25,
+        "intensity": 1.2
+      },
+      "shadow": {
+        "enabled": true,
+        "mode": "darken",
+        "strength": 0.4
+      },
+      "studioBg": "dark"
+    }
+  },
+  "meta": {
+    "generatedAt": "2026-06-21",
+    "model": "vision-authored",
+    "pattern": "deck-segment",
+    "costUSD": 0
+  }
+}

--- a/sdf-js/examples/compositor/index.html
+++ b/sdf-js/examples/compositor/index.html
@@ -914,5 +914,7 @@
   </div>
 
   <script type="module" src="./compositor.js"></script>
+  <!-- Layer-2 Atlas Present deck player (spatial-narrative segment sequencer). -->
+  <script type="module" src="./deck-player.js"></script>
 </body>
 </html>

--- a/sdf-js/scripts/gen-deck-hybrid.mjs
+++ b/sdf-js/scripts/gen-deck-hybrid.mjs
@@ -1,0 +1,220 @@
+#!/usr/bin/env node
+// =============================================================================
+// gen-deck-hybrid.mjs — a HYBRID Atlas Present deck (the model the user chose):
+//   • one LIGHT chapter  — cover/bars/cubes/peaks as stations in ONE continuous
+//     world + a touring cameraSequence (camera flies between them). One shader.
+//   • two HEAVY slides   — a gear mechanism and a pyramid, each a RICH atom in
+//     its OWN scene/shader (single-slide shaders always fit), with a slow pan.
+// The Layer-2 deck-player.js (launched via ?deck=deck-hybrid) sequences these,
+// fading between segments. Light stays one-world; heavy splits into its scene.
+//
+// Usage: node sdf-js/scripts/gen-deck-hybrid.mjs
+// =============================================================================
+
+import { readFileSync, writeFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const OUT = resolve(__dirname, '../examples/compositor/demo-lifts');
+const P2 = Math.PI / 2;
+
+const M = {
+  grey: { hue: 0.6, sat: 0.05, value: 0.45, metal: 0.6, glow: 0 },
+  blue: { hue: 0.58, sat: 0.85, value: 0.75, metal: 0.3, glow: 0 },
+  green: { hue: 0.33, sat: 0.8, value: 0.6, metal: 0.2, glow: 0 },
+  red: { hue: 0.0, sat: 0.82, value: 0.62, metal: 0.2, glow: 0 },
+  gold: { hue: 0.13, sat: 0.85, value: 0.9, metal: 0.9, glow: 0 },
+  teal: { hue: 0.5, sat: 0.72, value: 0.7, metal: 0.28, glow: 0 },
+};
+const S = (type, args, translate, material, rotate) => ({
+  type,
+  args,
+  transform: rotate ? { translate, rotate } : { translate },
+  material,
+});
+const at = (dx, subs) =>
+  subs.map((s) => ({
+    ...s,
+    transform: {
+      ...s.transform,
+      translate: [
+        s.transform.translate[0] + dx,
+        s.transform.translate[1],
+        s.transform.translate[2],
+      ],
+    },
+  }));
+
+const defaults = (ty, seq) => ({
+  camera: { yaw: 0.5, pitch: 0.3, distance: 8, focal: 1.5, targetX: 0, targetY: ty, targetZ: 0 },
+  light: { azimuth: 0.6, altitude: 0.55, distance: 25, intensity: 1.2 },
+  shadow: { enabled: true, mode: 'darken', strength: 0.4 },
+  studioBg: 'dark',
+});
+
+function wrap(id, title, sceneData) {
+  return {
+    id,
+    title,
+    prompt: title,
+    code2d: '// hybrid-deck segment (Atlas Present spatial narrative).',
+    sceneData,
+    meta: {
+      generatedAt: '2026-06-21',
+      model: 'vision-authored',
+      pattern: 'deck-segment',
+      costUSD: 0,
+    },
+  };
+}
+
+// ---- segment 1: LIGHT chapter (continuous world + touring camera) -----------
+const GAP = 7;
+const LIGHT = [
+  [
+    S('sphere', { radius: 0.4 }, [-1.2, 0.7, 0], M.green),
+    S('sphere', { radius: 0.55 }, [0, 0.85, 0], M.red),
+    S('sphere', { radius: 0.72 }, [1.35, 1.0, 0], M.blue),
+  ],
+  [0.6, 1.0, 1.45, 0.85].map((h, i) =>
+    S('box', { size: [0.42, h, 0.42] }, [(i - 1.5) * 0.6, h / 2, 0], M.blue),
+  ),
+  [
+    S('box', { size: [0.7, 0.7, 0.7] }, [-0.7, 0.35, 0.2], M.teal),
+    S('box', { size: [0.7, 0.7, 0.7] }, [0.5, 0.5, -0.1], M.teal),
+    S('box', { size: [0.7, 0.7, 0.7] }, [0, 1.1, 0], M.blue),
+  ],
+  [
+    S('cone', { height: 1.7, baseRadius: 0.9 }, [0, 0.85, 0], M.gold),
+    S('cone', { height: 1.1, baseRadius: 0.6 }, [1.2, 0.55, 0.2], M.grey),
+  ],
+];
+const lightSubjects = [];
+const lightShots = [];
+LIGHT.forEach((subs, i) => {
+  const Xi = i * GAP;
+  at(Xi, subs).forEach((s, j) => lightSubjects.push({ id: `s${i}_${j}`, ...s }));
+  const fr = { pos: [Xi - 1.3, 2.0, -6.6], target: [Xi, 0.85, 0], fov: 32, ease: 'smooth' };
+  lightShots.push({ duration: 2.4, ...fr, transition: i === 0 ? 'cut' : 'blend' });
+  lightShots.push({ duration: 1.8, ...fr, transition: 'blend' });
+});
+const segLight = wrap('deck-seg-light', 'Chapter · light continuous world', {
+  v: 1,
+  name: 'Chapter · light',
+  source: { format: 'vision-authored', prompt: 'light chapter' },
+  subjects: lightSubjects,
+  cameraSequence: { loop: false, shots: lightShots },
+  defaults: defaults(0.85),
+});
+
+// ---- segment 2: HEAVY slide — gear mechanism (own shader) --------------------
+const panShots = (target, dur = 6) => [
+  {
+    duration: 0.01,
+    pos: [target[0] - 3.2, target[1] + 1.3, -6.8],
+    target,
+    fov: 32,
+    transition: 'cut',
+  },
+  {
+    duration: dur,
+    pos: [target[0] + 3.2, target[1] + 1.3, -6.8],
+    target,
+    fov: 32,
+    ease: 'smooth',
+    transition: 'blend',
+  },
+];
+const segGears = wrap('deck-seg-gears', 'Slide · gear mechanism (heavy)', {
+  v: 1,
+  name: 'Slide · gears',
+  source: { format: 'vision-authored', prompt: 'gear mechanism' },
+  subjects: [
+    {
+      id: 'g1',
+      ...S(
+        'gear-3d',
+        {
+          teeth: 16,
+          radius: 0.95,
+          thickness: 0.3,
+          toothDepth: 0.18,
+          toothWidth: 0.2,
+          holeRadius: 0.3,
+        },
+        [-0.6, 1.1, 0],
+        M.grey,
+        [P2, 0, 0],
+      ),
+    },
+    {
+      id: 'g2',
+      ...S(
+        'gear-3d',
+        {
+          teeth: 11,
+          radius: 0.66,
+          thickness: 0.3,
+          toothDepth: 0.16,
+          toothWidth: 0.18,
+          holeRadius: 0.22,
+        },
+        [1.05, 1.45, 0],
+        M.blue,
+        [P2, 0, 0],
+      ),
+    },
+  ],
+  cameraSequence: { loop: false, shots: panShots([0.2, 1.2, 0], 6) },
+  defaults: defaults(1.2),
+});
+
+// ---- segment 3: HEAVY slide — pyramid (own shader) ---------------------------
+const segPyramid = wrap('deck-seg-pyramid', 'Slide · pyramid (heavy)', {
+  v: 1,
+  name: 'Slide · pyramid',
+  source: { format: 'vision-authored', prompt: 'pyramid' },
+  subjects: [
+    {
+      id: 'p',
+      ...S(
+        'pyramid-3d',
+        { levels: 5, baseWidth: 2.2, topWidth: 0.3, layerHeight: 0.38, gap: 0.05, depth: 0.7 },
+        [0, 0.1, 0],
+        M.gold,
+      ),
+    },
+  ],
+  cameraSequence: {
+    loop: false,
+    shots: [
+      { duration: 0.01, pos: [0, 3.0, -8.5], target: [0, 1.0, 0], fov: 32, transition: 'cut' },
+      {
+        duration: 6,
+        pos: [-1.6, 1.6, -5.2],
+        target: [0, 1.0, 0],
+        fov: 32,
+        ease: 'smooth',
+        transition: 'blend',
+      },
+    ],
+  },
+  defaults: defaults(1.0),
+});
+
+// ---- write segment scenes + the deck playlist -------------------------------
+for (const seg of [segLight, segGears, segPyramid]) {
+  writeFileSync(`${OUT}/${seg.id}.json`, JSON.stringify(seg, null, 2) + '\n');
+}
+const deck = {
+  id: 'deck-hybrid',
+  name: 'Hybrid spatial deck (light chapter + heavy slides)',
+  segments: [
+    { file: 'deck-seg-light.json', title: segLight.title, kind: 'chapter', durationSec: 17 },
+    { file: 'deck-seg-gears.json', title: segGears.title, kind: 'slide', durationSec: 6.5 },
+    { file: 'deck-seg-pyramid.json', title: segPyramid.title, kind: 'slide', durationSec: 6.5 },
+  ],
+};
+writeFileSync(`${OUT}/deck-hybrid.json`, JSON.stringify(deck, null, 2) + '\n');
+console.log(`wrote deck-hybrid (${deck.segments.length} segments) + 3 segment scenes`);


### PR DESCRIPTION
## What — hybrid deck player (the shader-budget fix you chose)

> "轻的 ATOM 用同一个连续世界，遇到重的就分场景"

A deck is a **playlist of segments**. **Light** atoms share **one continuous 3D world** (camera flies between stations). **Heavy** atoms (gear `modPolar`, pyramid loop — which overflow a *shared* studio shader) each get their **own scene/shader**. The player sequences them, fading between segments.

## Diagnosis first (systematic)
Measured the GLSL emit: the scene SDF is **tiny** (~1–2k chars) vs the **115k** studio *library*. So the GPU overflow is the heavy atoms' loop/`modPolar` **instruction count** stacked on a library that already nears the GPU limit — **not** scene size. Empirically: single rich atoms always compile; 3 heavy atoms together overflow; 3 gauges / 4 arrows are fine. ⇒ **per-slide scenes** are the robust fix (each = library + one slide = always fits).

## Layer separation (per the locked architecture)
- **compositor (engine / L1)** exposes exactly ONE public hook: `window.atlasLoadScene(demoEntry)`.
- **deck-player.js (app / L2)** owns all sequencing / fade / `?deck=` URL — it never touches compositor internals.

## Pieces
- `deck-player.js` — `?deck=<id>` → fetch playlist → load each segment via the hook → fade `#canvas-wrap` between segments (hides the 200–500ms per-scene GLSL compile) → loop.
- `compositor.js` — the `atlasLoadScene` hook (+ reveals the canvas tab, mirroring gallery-card behavior).
- `gen-deck-hybrid.mjs` → `deck-hybrid` = 1 light chapter (cover/bars/cubes/peaks, one world + touring camera) + gear-mechanism slide + pyramid slide (each its own scene).

## Verification (real-browser GPU)
- Heavy **gear mechanism** (2 meshing gears) — own scene, **0 shader errors** (would overflow if shared).
- Heavy **5-level pyramid** — own scene, **0 errors**.
- Light chapter renders + camera tours; player advances + fades between segments.
- Full suite **81/81**; `node --check` + Prettier clean.

## Known / next
- Camera-animation smoothness across a long deck reads fine in-browser (studio's `loop()` redraws every frame); screenshot-sampling timing was just MCP latency, not a stall.
- Deck segments are loaded by file path (not registered in the gallery index) — intentional; they're deck internals launched via `?deck=`.
- Next: a deck-authoring path (turn a real lifted PDF deck into a hybrid playlist), nicer transitions (push/orbit), per-segment titles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
