### PR TITLE
Step 2: auto-author a real deck into a hybrid spatial deck (measured light/heavy classifier)

### DIFF
--- a/sdf-js/examples/compositor/demo-lifts/deck-auth-ch0.json
+++ b/sdf-js/examples/compositor/demo-lifts/deck-auth-ch0.json
@@ -1,0 +1,134 @@
+{
+  "id": "deck-auth-ch0",
+  "title": "Chapter 1 · 2 slides",
+  "prompt": "Chapter 1 · 2 slides",
+  "code2d": "// auto-authored deck segment.",
+  "sceneData": {
+    "v": 1,
+    "name": "Chapter 1",
+    "source": {
+      "format": "authored",
+      "prompt": "light chapter"
+    },
+    "subjects": [
+      {
+        "id": "c0s0_0",
+        "type": "sphere-fill-3d",
+        "args": {
+          "levels": [0.6],
+          "radius": 1.05,
+          "cage": false,
+          "fillScale": 1
+        },
+        "transform": {
+          "translate": [0, 1, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.72,
+          "metal": 0.3,
+          "glow": 0
+        }
+      },
+      {
+        "id": "c0s0_1",
+        "type": "cut-sphere",
+        "args": {
+          "radius": 1.05,
+          "h": 0.20999999999999996
+        },
+        "transform": {
+          "translate": [0, 1, 0]
+        },
+        "material": "porcelain"
+      },
+      {
+        "id": "c0s1_0",
+        "type": "sphere-fill-3d",
+        "args": {
+          "levels": [1],
+          "radius": 1.05,
+          "cage": false,
+          "fillScale": 1
+        },
+        "transform": {
+          "translate": [5, 1, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.72,
+          "metal": 0.3,
+          "glow": 0
+        }
+      }
+    ],
+    "cameraSequence": {
+      "loop": false,
+      "shots": [
+        {
+          "duration": 2.6,
+          "pos": [-1.2, 2.2, -6],
+          "target": [0, 1, 0],
+          "fov": 34,
+          "ease": "smooth",
+          "transition": "cut"
+        },
+        {
+          "duration": 1.8,
+          "pos": [-1.2, 2.2, -6],
+          "target": [0, 1, 0],
+          "fov": 34,
+          "ease": "smooth",
+          "transition": "blend"
+        },
+        {
+          "duration": 2.6,
+          "pos": [3.8, 2.2, -6],
+          "target": [5, 1, 0],
+          "fov": 34,
+          "ease": "smooth",
+          "transition": "blend"
+        },
+        {
+          "duration": 1.8,
+          "pos": [3.8, 2.2, -6],
+          "target": [5, 1, 0],
+          "fov": 34,
+          "ease": "smooth",
+          "transition": "blend"
+        }
+      ]
+    },
+    "defaults": {
+      "camera": {
+        "yaw": 0.5,
+        "pitch": 0.3,
+        "distance": 9,
+        "focal": 1.5,
+        "targetX": 0,
+        "targetY": 1,
+        "targetZ": 0
+      },
+      "light": {
+        "azimuth": 0.6,
+        "altitude": 0.55,
+        "distance": 25,
+        "intensity": 1.2
+      },
+      "shadow": {
+        "enabled": true,
+        "mode": "darken",
+        "strength": 0.4
+      },
+      "studioBg": "dark"
+    }
+  },
+  "meta": {
+    "generatedAt": "2026-06-21",
+    "model": "authored",
+    "pattern": "deck-segment",
+    "costUSD": 0
+  }
+}

--- a/sdf-js/examples/compositor/demo-lifts/deck-auth-ch1.json
+++ b/sdf-js/examples/compositor/demo-lifts/deck-auth-ch1.json
@@ -1,0 +1,98 @@
+{
+  "id": "deck-auth-ch1",
+  "title": "Chapter 2 · 1 slides",
+  "prompt": "Chapter 2 · 1 slides",
+  "code2d": "// auto-authored deck segment.",
+  "sceneData": {
+    "v": 1,
+    "name": "Chapter 2",
+    "source": {
+      "format": "authored",
+      "prompt": "light chapter"
+    },
+    "subjects": [
+      {
+        "id": "c1s0_0",
+        "type": "sphere-fill-3d",
+        "args": {
+          "levels": [0.3],
+          "radius": 1.05,
+          "cage": false,
+          "fillScale": 1
+        },
+        "transform": {
+          "translate": [0, 1, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.72,
+          "metal": 0.3,
+          "glow": 0
+        }
+      },
+      {
+        "id": "c1s0_1",
+        "type": "cut-sphere",
+        "args": {
+          "radius": 1.05,
+          "h": -0.42000000000000004
+        },
+        "transform": {
+          "translate": [0, 1, 0]
+        },
+        "material": "porcelain"
+      }
+    ],
+    "cameraSequence": {
+      "loop": false,
+      "shots": [
+        {
+          "duration": 2.6,
+          "pos": [-1.2, 2.2, -6],
+          "target": [0, 1, 0],
+          "fov": 34,
+          "ease": "smooth",
+          "transition": "cut"
+        },
+        {
+          "duration": 1.8,
+          "pos": [-1.2, 2.2, -6],
+          "target": [0, 1, 0],
+          "fov": 34,
+          "ease": "smooth",
+          "transition": "blend"
+        }
+      ]
+    },
+    "defaults": {
+      "camera": {
+        "yaw": 0.5,
+        "pitch": 0.3,
+        "distance": 9,
+        "focal": 1.5,
+        "targetX": 0,
+        "targetY": 1,
+        "targetZ": 0
+      },
+      "light": {
+        "azimuth": 0.6,
+        "altitude": 0.55,
+        "distance": 25,
+        "intensity": 1.2
+      },
+      "shadow": {
+        "enabled": true,
+        "mode": "darken",
+        "strength": 0.4
+      },
+      "studioBg": "dark"
+    }
+  },
+  "meta": {
+    "generatedAt": "2026-06-21",
+    "model": "authored",
+    "pattern": "deck-segment",
+    "costUSD": 0
+  }
+}

--- a/sdf-js/examples/compositor/demo-lifts/deck-auth-ch2.json
+++ b/sdf-js/examples/compositor/demo-lifts/deck-auth-ch2.json
@@ -1,0 +1,98 @@
+{
+  "id": "deck-auth-ch2",
+  "title": "Chapter 3 · 1 slides",
+  "prompt": "Chapter 3 · 1 slides",
+  "code2d": "// auto-authored deck segment.",
+  "sceneData": {
+    "v": 1,
+    "name": "Chapter 3",
+    "source": {
+      "format": "authored",
+      "prompt": "light chapter"
+    },
+    "subjects": [
+      {
+        "id": "c2s0_0",
+        "type": "sphere-fill-3d",
+        "args": {
+          "levels": [0.9],
+          "radius": 1.05,
+          "cage": false,
+          "fillScale": 1
+        },
+        "transform": {
+          "translate": [0, 1, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.72,
+          "metal": 0.3,
+          "glow": 0
+        }
+      },
+      {
+        "id": "c2s0_1",
+        "type": "cut-sphere",
+        "args": {
+          "radius": 1.05,
+          "h": 0.8400000000000001
+        },
+        "transform": {
+          "translate": [0, 1, 0]
+        },
+        "material": "porcelain"
+      }
+    ],
+    "cameraSequence": {
+      "loop": false,
+      "shots": [
+        {
+          "duration": 2.6,
+          "pos": [-1.2, 2.2, -6],
+          "target": [0, 1, 0],
+          "fov": 34,
+          "ease": "smooth",
+          "transition": "cut"
+        },
+        {
+          "duration": 1.8,
+          "pos": [-1.2, 2.2, -6],
+          "target": [0, 1, 0],
+          "fov": 34,
+          "ease": "smooth",
+          "transition": "blend"
+        }
+      ]
+    },
+    "defaults": {
+      "camera": {
+        "yaw": 0.5,
+        "pitch": 0.3,
+        "distance": 9,
+        "focal": 1.5,
+        "targetX": 0,
+        "targetY": 1,
+        "targetZ": 0
+      },
+      "light": {
+        "azimuth": 0.6,
+        "altitude": 0.55,
+        "distance": 25,
+        "intensity": 1.2
+      },
+      "shadow": {
+        "enabled": true,
+        "mode": "darken",
+        "strength": 0.4
+      },
+      "studioBg": "dark"
+    }
+  },
+  "meta": {
+    "generatedAt": "2026-06-21",
+    "model": "authored",
+    "pattern": "deck-segment",
+    "costUSD": 0
+  }
+}

--- a/sdf-js/examples/compositor/demo-lifts/deck-auth-ch3.json
+++ b/sdf-js/examples/compositor/demo-lifts/deck-auth-ch3.json
@@ -1,0 +1,86 @@
+{
+  "id": "deck-auth-ch3",
+  "title": "Chapter 4 · 1 slides",
+  "prompt": "Chapter 4 · 1 slides",
+  "code2d": "// auto-authored deck segment.",
+  "sceneData": {
+    "v": 1,
+    "name": "Chapter 4",
+    "source": {
+      "format": "authored",
+      "prompt": "light chapter"
+    },
+    "subjects": [
+      {
+        "id": "c3s0_0",
+        "type": "sphere-fill-3d",
+        "args": {
+          "levels": [1],
+          "radius": 1.1,
+          "cage": false,
+          "fillScale": 1
+        },
+        "transform": {
+          "translate": [0, 1, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.72,
+          "metal": 0.3,
+          "glow": 0
+        }
+      }
+    ],
+    "cameraSequence": {
+      "loop": false,
+      "shots": [
+        {
+          "duration": 2.6,
+          "pos": [-1.2, 2.2, -6],
+          "target": [0, 1, 0],
+          "fov": 34,
+          "ease": "smooth",
+          "transition": "cut"
+        },
+        {
+          "duration": 1.8,
+          "pos": [-1.2, 2.2, -6],
+          "target": [0, 1, 0],
+          "fov": 34,
+          "ease": "smooth",
+          "transition": "blend"
+        }
+      ]
+    },
+    "defaults": {
+      "camera": {
+        "yaw": 0.5,
+        "pitch": 0.3,
+        "distance": 9,
+        "focal": 1.5,
+        "targetX": 0,
+        "targetY": 1,
+        "targetZ": 0
+      },
+      "light": {
+        "azimuth": 0.6,
+        "altitude": 0.55,
+        "distance": 25,
+        "intensity": 1.2
+      },
+      "shadow": {
+        "enabled": true,
+        "mode": "darken",
+        "strength": 0.4
+      },
+      "studioBg": "dark"
+    }
+  },
+  "meta": {
+    "generatedAt": "2026-06-21",
+    "model": "authored",
+    "pattern": "deck-segment",
+    "costUSD": 0
+  }
+}

--- a/sdf-js/examples/compositor/demo-lifts/deck-auth-solo-fill-slide-01.json
+++ b/sdf-js/examples/compositor/demo-lifts/deck-auth-solo-fill-slide-01.json
@@ -1,0 +1,239 @@
+{
+  "id": "deck-auth-solo-fill-slide-01",
+  "title": "kpi-hero: Fill Levels · Cover (20/40/80)",
+  "prompt": "kpi-hero: Fill Levels · Cover (20/40/80)",
+  "code2d": "// auto-authored deck segment.",
+  "sceneData": {
+    "v": 1,
+    "name": "kpi-hero: Fill Levels · Cover (20/40/80)",
+    "source": {
+      "format": "vision-authored",
+      "prompt": "Cover — three overlapping glass fill spheres 20% green / 40% red / 80% blue, increasing in size, dark glassy domes."
+    },
+    "subjects": [
+      {
+        "id": "liq0",
+        "type": "sphere-fill-3d",
+        "args": {
+          "levels": [0.2],
+          "radius": 0.5,
+          "cage": false,
+          "fillScale": 1
+        },
+        "transform": {
+          "translate": [-2.05, 1, -0.6]
+        },
+        "material": {
+          "hue": 0.28,
+          "sat": 0.78,
+          "value": 0.62,
+          "metal": 0.2,
+          "glow": 0
+        }
+      },
+      {
+        "id": "emp0",
+        "type": "cut-sphere",
+        "args": {
+          "radius": 0.5,
+          "h": -0.3
+        },
+        "transform": {
+          "translate": [-2.05, 1, -0.6]
+        },
+        "material": {
+          "hue": 0.6,
+          "sat": 0.28,
+          "value": 0.07,
+          "metal": 0.55,
+          "glow": 0
+        }
+      },
+      {
+        "id": "lab0",
+        "type": "text-3d-pipe",
+        "args": {
+          "text": "20%",
+          "height": 0.275,
+          "pipeRadius": 0.05,
+          "align": "center"
+        },
+        "transform": {
+          "translate": [-2.05, 0.8025, -1.2000000000000002]
+        },
+        "material": {
+          "hue": 0,
+          "sat": 0,
+          "value": 1,
+          "metal": 0,
+          "glow": 0.25
+        }
+      },
+      {
+        "id": "liq1",
+        "type": "sphere-fill-3d",
+        "args": {
+          "levels": [0.4],
+          "radius": 0.7,
+          "cage": false,
+          "fillScale": 1
+        },
+        "transform": {
+          "translate": [-0.95, 0.95, -0.2]
+        },
+        "material": {
+          "hue": 0,
+          "sat": 0.82,
+          "value": 0.62,
+          "metal": 0.2,
+          "glow": 0
+        }
+      },
+      {
+        "id": "emp1",
+        "type": "cut-sphere",
+        "args": {
+          "radius": 0.7,
+          "h": -0.13999999999999996
+        },
+        "transform": {
+          "translate": [-0.95, 0.95, -0.2]
+        },
+        "material": {
+          "hue": 0.6,
+          "sat": 0.28,
+          "value": 0.07,
+          "metal": 0.55,
+          "glow": 0
+        }
+      },
+      {
+        "id": "lab1",
+        "type": "text-3d-pipe",
+        "args": {
+          "text": "40%",
+          "height": 0.385,
+          "pipeRadius": 0.05,
+          "align": "center"
+        },
+        "transform": {
+          "translate": [-0.95, 0.6735, -0.9999999999999999]
+        },
+        "material": {
+          "hue": 0,
+          "sat": 0,
+          "value": 1,
+          "metal": 0,
+          "glow": 0.25
+        }
+      },
+      {
+        "id": "liq2",
+        "type": "sphere-fill-3d",
+        "args": {
+          "levels": [0.8],
+          "radius": 1,
+          "cage": false,
+          "fillScale": 1
+        },
+        "transform": {
+          "translate": [0.75, 0.9, 0.35]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.72,
+          "metal": 0.3,
+          "glow": 0
+        }
+      },
+      {
+        "id": "emp2",
+        "type": "cut-sphere",
+        "args": {
+          "radius": 1,
+          "h": 0.6000000000000001
+        },
+        "transform": {
+          "translate": [0.75, 0.9, 0.35]
+        },
+        "material": {
+          "hue": 0.6,
+          "sat": 0.28,
+          "value": 0.07,
+          "metal": 0.55,
+          "glow": 0
+        }
+      },
+      {
+        "id": "lab2",
+        "type": "text-3d-pipe",
+        "args": {
+          "text": "80%",
+          "height": 0.5,
+          "pipeRadius": 0.05,
+          "align": "center"
+        },
+        "transform": {
+          "translate": [0.75, 0.53, -0.75]
+        },
+        "material": {
+          "hue": 0,
+          "sat": 0,
+          "value": 1,
+          "metal": 0,
+          "glow": 0.25
+        }
+      }
+    ],
+    "defaults": {
+      "camera": {
+        "yaw": 0.5,
+        "pitch": 0.28,
+        "distance": 10,
+        "focal": 1.5,
+        "targetX": 0,
+        "targetY": 0.9500000000000001,
+        "targetZ": 0
+      },
+      "light": {
+        "azimuth": 0.6,
+        "altitude": 0.55,
+        "distance": 25,
+        "intensity": 1.2
+      },
+      "shadow": {
+        "enabled": true,
+        "mode": "darken",
+        "strength": 0.4
+      },
+      "studioBg": "dark"
+    },
+    "cameraSequence": {
+      "loop": false,
+      "shots": [
+        {
+          "duration": 0.01,
+          "pos": [-2.25, 2.0562222222222224, -6.24],
+          "target": [-0.7499999999999998, 0.8562222222222223, -0.4277777777777778],
+          "fov": 34,
+          "transition": "cut"
+        },
+        {
+          "duration": 6,
+          "pos": [0.7500000000000002, 2.0562222222222224, -6.24],
+          "target": [-0.7499999999999998, 0.8562222222222223, -0.4277777777777778],
+          "fov": 34,
+          "ease": "smooth",
+          "transition": "blend"
+        }
+      ]
+    }
+  },
+  "meta": {
+    "generatedAt": "2026-06-21",
+    "model": "authored",
+    "pattern": "deck-segment",
+    "costUSD": 0
+  }
+}

--- a/sdf-js/examples/compositor/demo-lifts/deck-auth-solo-fill-slide-02.json
+++ b/sdf-js/examples/compositor/demo-lifts/deck-auth-solo-fill-slide-02.json
@@ -1,0 +1,273 @@
+{
+  "id": "deck-auth-solo-fill-slide-02",
+  "title": "compare: Fill Levels · Row of 4 (20/60/80/90)",
+  "prompt": "compare: Fill Levels · Row of 4 (20/60/80/90)",
+  "code2d": "// auto-authored deck segment.",
+  "sceneData": {
+    "v": 1,
+    "name": "compare: Fill Levels · Row of 4 (20/60/80/90)",
+    "source": {
+      "format": "vision-authored",
+      "prompt": "A row of four fill spheres at 20/60/80/90%."
+    },
+    "subjects": [
+      {
+        "id": "liq0",
+        "type": "sphere-fill-3d",
+        "args": {
+          "levels": [0.2],
+          "radius": 0.55,
+          "cage": false,
+          "fillScale": 1
+        },
+        "transform": {
+          "translate": [-2.4000000000000004, 0.9, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.72,
+          "metal": 0.3,
+          "glow": 0
+        }
+      },
+      {
+        "id": "emp0",
+        "type": "cut-sphere",
+        "args": {
+          "radius": 0.55,
+          "h": -0.33
+        },
+        "transform": {
+          "translate": [-2.4000000000000004, 0.9, 0]
+        },
+        "material": "porcelain"
+      },
+      {
+        "id": "lab0",
+        "type": "text-3d-pipe",
+        "args": {
+          "text": "20%",
+          "height": 0.30250000000000005,
+          "pipeRadius": 0.05,
+          "align": "center"
+        },
+        "transform": {
+          "translate": [-2.4000000000000004, 0.68275, -0.65]
+        },
+        "material": {
+          "hue": 0,
+          "sat": 0,
+          "value": 1,
+          "metal": 0,
+          "glow": 0.25
+        }
+      },
+      {
+        "id": "liq1",
+        "type": "sphere-fill-3d",
+        "args": {
+          "levels": [0.6],
+          "radius": 0.55,
+          "cage": false,
+          "fillScale": 1
+        },
+        "transform": {
+          "translate": [-0.8000000000000003, 0.9, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.72,
+          "metal": 0.3,
+          "glow": 0
+        }
+      },
+      {
+        "id": "emp1",
+        "type": "cut-sphere",
+        "args": {
+          "radius": 0.55,
+          "h": 0.10999999999999999
+        },
+        "transform": {
+          "translate": [-0.8000000000000003, 0.9, 0]
+        },
+        "material": "porcelain"
+      },
+      {
+        "id": "lab1",
+        "type": "text-3d-pipe",
+        "args": {
+          "text": "60%",
+          "height": 0.30250000000000005,
+          "pipeRadius": 0.05,
+          "align": "center"
+        },
+        "transform": {
+          "translate": [-0.8000000000000003, 0.68275, -0.65]
+        },
+        "material": {
+          "hue": 0,
+          "sat": 0,
+          "value": 1,
+          "metal": 0,
+          "glow": 0.25
+        }
+      },
+      {
+        "id": "liq2",
+        "type": "sphere-fill-3d",
+        "args": {
+          "levels": [0.8],
+          "radius": 0.55,
+          "cage": false,
+          "fillScale": 1
+        },
+        "transform": {
+          "translate": [0.7999999999999998, 0.9, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.72,
+          "metal": 0.3,
+          "glow": 0
+        }
+      },
+      {
+        "id": "emp2",
+        "type": "cut-sphere",
+        "args": {
+          "radius": 0.55,
+          "h": 0.33000000000000007
+        },
+        "transform": {
+          "translate": [0.7999999999999998, 0.9, 0]
+        },
+        "material": "porcelain"
+      },
+      {
+        "id": "lab2",
+        "type": "text-3d-pipe",
+        "args": {
+          "text": "80%",
+          "height": 0.30250000000000005,
+          "pipeRadius": 0.05,
+          "align": "center"
+        },
+        "transform": {
+          "translate": [0.7999999999999998, 0.68275, -0.65]
+        },
+        "material": {
+          "hue": 0,
+          "sat": 0,
+          "value": 1,
+          "metal": 0,
+          "glow": 0.25
+        }
+      },
+      {
+        "id": "liq3",
+        "type": "sphere-fill-3d",
+        "args": {
+          "levels": [0.9],
+          "radius": 0.55,
+          "cage": false,
+          "fillScale": 1
+        },
+        "transform": {
+          "translate": [2.4000000000000004, 0.9, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.72,
+          "metal": 0.3,
+          "glow": 0
+        }
+      },
+      {
+        "id": "emp3",
+        "type": "cut-sphere",
+        "args": {
+          "radius": 0.55,
+          "h": 0.44000000000000006
+        },
+        "transform": {
+          "translate": [2.4000000000000004, 0.9, 0]
+        },
+        "material": "porcelain"
+      },
+      {
+        "id": "lab3",
+        "type": "text-3d-pipe",
+        "args": {
+          "text": "90%",
+          "height": 0.30250000000000005,
+          "pipeRadius": 0.05,
+          "align": "center"
+        },
+        "transform": {
+          "translate": [2.4000000000000004, 0.68275, -0.65]
+        },
+        "material": {
+          "hue": 0,
+          "sat": 0,
+          "value": 1,
+          "metal": 0,
+          "glow": 0.25
+        }
+      }
+    ],
+    "defaults": {
+      "camera": {
+        "yaw": 0.5,
+        "pitch": 0.28,
+        "distance": 10,
+        "focal": 1.5,
+        "targetX": 0,
+        "targetY": 0.9,
+        "targetZ": 0
+      },
+      "light": {
+        "azimuth": 0.6,
+        "altitude": 0.55,
+        "distance": 25,
+        "intensity": 1.2
+      },
+      "shadow": {
+        "enabled": true,
+        "mode": "darken",
+        "strength": 0.4
+      },
+      "studioBg": "dark"
+    },
+    "cameraSequence": {
+      "loop": false,
+      "shots": [
+        {
+          "duration": 0.01,
+          "pos": [-1.5000000000000002, 2.0275833333333333, -7.94],
+          "target": [-2.220446049250313e-16, 0.8275833333333336, -0.21666666666666667],
+          "fov": 34,
+          "transition": "cut"
+        },
+        {
+          "duration": 6,
+          "pos": [1.4999999999999998, 2.0275833333333333, -7.94],
+          "target": [-2.220446049250313e-16, 0.8275833333333336, -0.21666666666666667],
+          "fov": 34,
+          "ease": "smooth",
+          "transition": "blend"
+        }
+      ]
+    }
+  },
+  "meta": {
+    "generatedAt": "2026-06-21",
+    "model": "authored",
+    "pattern": "deck-segment",
+    "costUSD": 0
+  }
+}

--- a/sdf-js/examples/compositor/demo-lifts/deck-auth-solo-fill-slide-03.json
+++ b/sdf-js/examples/compositor/demo-lifts/deck-auth-solo-fill-slide-03.json
@@ -1,0 +1,191 @@
+{
+  "id": "deck-auth-solo-fill-slide-03",
+  "title": "sequence: Fill Levels · Framed row + arrows (10/60/50)",
+  "prompt": "sequence: Fill Levels · Framed row + arrows (10/60/50)",
+  "code2d": "// auto-authored deck segment.",
+  "sceneData": {
+    "v": 1,
+    "name": "sequence: Fill Levels · Framed row + arrows (10/60/50)",
+    "source": {
+      "format": "vision-authored",
+      "prompt": "Three framed fill spheres 10/60/50% connected left-to-right by arrows."
+    },
+    "subjects": [
+      {
+        "id": "liq0",
+        "type": "sphere-fill-3d",
+        "args": {
+          "levels": [0.1],
+          "radius": 0.7,
+          "cage": false,
+          "fillScale": 1
+        },
+        "transform": {
+          "translate": [-2.4, 0.9, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.72,
+          "metal": 0.3,
+          "glow": 0
+        }
+      },
+      {
+        "id": "emp0",
+        "type": "cut-sphere",
+        "args": {
+          "radius": 0.7,
+          "h": -0.5599999999999999
+        },
+        "transform": {
+          "translate": [-2.4, 0.9, 0]
+        },
+        "material": "porcelain"
+      },
+      {
+        "id": "liq1",
+        "type": "sphere-fill-3d",
+        "args": {
+          "levels": [0.6],
+          "radius": 0.7,
+          "cage": false,
+          "fillScale": 1
+        },
+        "transform": {
+          "translate": [0, 0.9, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.72,
+          "metal": 0.3,
+          "glow": 0
+        }
+      },
+      {
+        "id": "emp1",
+        "type": "cut-sphere",
+        "args": {
+          "radius": 0.7,
+          "h": 0.13999999999999996
+        },
+        "transform": {
+          "translate": [0, 0.9, 0]
+        },
+        "material": "porcelain"
+      },
+      {
+        "id": "liq2",
+        "type": "sphere-fill-3d",
+        "args": {
+          "levels": [0.5],
+          "radius": 0.7,
+          "cage": false,
+          "fillScale": 1
+        },
+        "transform": {
+          "translate": [2.4, 0.9, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.72,
+          "metal": 0.3,
+          "glow": 0
+        }
+      },
+      {
+        "id": "emp2",
+        "type": "cut-sphere",
+        "args": {
+          "radius": 0.7,
+          "h": 0
+        },
+        "transform": {
+          "translate": [2.4, 0.9, 0]
+        },
+        "material": "porcelain"
+      },
+      {
+        "id": "arrow0",
+        "type": "arrow-3d",
+        "args": {
+          "length": 0.9,
+          "shaftWidth": 0.1,
+          "headLength": 0.28,
+          "headWidth": 0.34,
+          "depth": 0.18
+        },
+        "transform": {
+          "translate": [-1.2, 0.9, 0]
+        },
+        "material": "silver"
+      },
+      {
+        "id": "arrow1",
+        "type": "arrow-3d",
+        "args": {
+          "length": 0.9,
+          "shaftWidth": 0.1,
+          "headLength": 0.28,
+          "headWidth": 0.34,
+          "depth": 0.18
+        },
+        "transform": {
+          "translate": [1.2, 0.9, 0]
+        },
+        "material": "silver"
+      }
+    ],
+    "defaults": {
+      "camera": {
+        "yaw": 0.5,
+        "pitch": 0.28,
+        "distance": 10,
+        "focal": 1.5,
+        "targetX": 0,
+        "targetY": 0.9,
+        "targetZ": 0
+      },
+      "light": {
+        "azimuth": 0.6,
+        "altitude": 0.55,
+        "distance": 25,
+        "intensity": 1.2
+      },
+      "shadow": {
+        "enabled": true,
+        "mode": "darken",
+        "strength": 0.4
+      },
+      "studioBg": "dark"
+    },
+    "cameraSequence": {
+      "loop": false,
+      "shots": [
+        {
+          "duration": 0.01,
+          "pos": [-1.5, 2.1, -7.94],
+          "target": [0, 0.9000000000000001, 0],
+          "fov": 34,
+          "transition": "cut"
+        },
+        {
+          "duration": 6,
+          "pos": [1.5, 2.1, -7.94],
+          "target": [0, 0.9000000000000001, 0],
+          "fov": 34,
+          "ease": "smooth",
+          "transition": "blend"
+        }
+      ]
+    }
+  },
+  "meta": {
+    "generatedAt": "2026-06-21",
+    "model": "authored",
+    "pattern": "deck-segment",
+    "costUSD": 0
+  }
+}

--- a/sdf-js/examples/compositor/demo-lifts/deck-auth-solo-fill-slide-06.json
+++ b/sdf-js/examples/compositor/demo-lifts/deck-auth-solo-fill-slide-06.json
@@ -1,0 +1,313 @@
+{
+  "id": "deck-auth-solo-fill-slide-06",
+  "title": "compare: Fill Levels · Cluster of 5 (50/20/100/40/80)",
+  "prompt": "compare: Fill Levels · Cluster of 5 (50/20/100/40/80)",
+  "code2d": "// auto-authored deck segment.",
+  "sceneData": {
+    "v": 1,
+    "name": "compare: Fill Levels · Cluster of 5 (50/20/100/40/80)",
+    "source": {
+      "format": "vision-authored",
+      "prompt": "Five varied-size fill spheres clustered around a large 100% sphere."
+    },
+    "subjects": [
+      {
+        "id": "liq0",
+        "type": "sphere-fill-3d",
+        "args": {
+          "levels": [1],
+          "radius": 0.95,
+          "cage": false,
+          "fillScale": 1
+        },
+        "transform": {
+          "translate": [0, 0.95, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.72,
+          "metal": 0.3,
+          "glow": 0
+        }
+      },
+      {
+        "id": "lab0",
+        "type": "text-3d-pipe",
+        "args": {
+          "text": "100%",
+          "height": 0.5,
+          "pipeRadius": 0.05,
+          "align": "center"
+        },
+        "transform": {
+          "translate": [0, 0.586, -1.05]
+        },
+        "material": {
+          "hue": 0,
+          "sat": 0,
+          "value": 1,
+          "metal": 0,
+          "glow": 0.25
+        }
+      },
+      {
+        "id": "liq1",
+        "type": "sphere-fill-3d",
+        "args": {
+          "levels": [0.5],
+          "radius": 0.6,
+          "cage": false,
+          "fillScale": 1
+        },
+        "transform": {
+          "translate": [-2.15, 0.7, 0.2]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.72,
+          "metal": 0.3,
+          "glow": 0
+        }
+      },
+      {
+        "id": "emp1",
+        "type": "cut-sphere",
+        "args": {
+          "radius": 0.6,
+          "h": 0
+        },
+        "transform": {
+          "translate": [-2.15, 0.7, 0.2]
+        },
+        "material": "porcelain"
+      },
+      {
+        "id": "lab1",
+        "type": "text-3d-pipe",
+        "args": {
+          "text": "50%",
+          "height": 0.33,
+          "pipeRadius": 0.05,
+          "align": "center"
+        },
+        "transform": {
+          "translate": [-2.15, 0.4629999999999999, -0.5]
+        },
+        "material": {
+          "hue": 0,
+          "sat": 0,
+          "value": 1,
+          "metal": 0,
+          "glow": 0.25
+        }
+      },
+      {
+        "id": "liq2",
+        "type": "sphere-fill-3d",
+        "args": {
+          "levels": [0.2],
+          "radius": 0.42,
+          "cage": false,
+          "fillScale": 1
+        },
+        "transform": {
+          "translate": [-1.05, 1.35, -0.3]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.72,
+          "metal": 0.3,
+          "glow": 0
+        }
+      },
+      {
+        "id": "emp2",
+        "type": "cut-sphere",
+        "args": {
+          "radius": 0.42,
+          "h": -0.252
+        },
+        "transform": {
+          "translate": [-1.05, 1.35, -0.3]
+        },
+        "material": "porcelain"
+      },
+      {
+        "id": "lab2",
+        "type": "text-3d-pipe",
+        "args": {
+          "text": "20%",
+          "height": 0.26,
+          "pipeRadius": 0.05,
+          "align": "center"
+        },
+        "transform": {
+          "translate": [-1.05, 1.1696000000000002, -0.82]
+        },
+        "material": {
+          "hue": 0,
+          "sat": 0,
+          "value": 1,
+          "metal": 0,
+          "glow": 0.25
+        }
+      },
+      {
+        "id": "liq3",
+        "type": "sphere-fill-3d",
+        "args": {
+          "levels": [0.4],
+          "radius": 0.42,
+          "cage": false,
+          "fillScale": 1
+        },
+        "transform": {
+          "translate": [1.05, 1.35, -0.3]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.72,
+          "metal": 0.3,
+          "glow": 0
+        }
+      },
+      {
+        "id": "emp3",
+        "type": "cut-sphere",
+        "args": {
+          "radius": 0.42,
+          "h": -0.08399999999999998
+        },
+        "transform": {
+          "translate": [1.05, 1.35, -0.3]
+        },
+        "material": "porcelain"
+      },
+      {
+        "id": "lab3",
+        "type": "text-3d-pipe",
+        "args": {
+          "text": "40%",
+          "height": 0.26,
+          "pipeRadius": 0.05,
+          "align": "center"
+        },
+        "transform": {
+          "translate": [1.05, 1.1696000000000002, -0.82]
+        },
+        "material": {
+          "hue": 0,
+          "sat": 0,
+          "value": 1,
+          "metal": 0,
+          "glow": 0.25
+        }
+      },
+      {
+        "id": "liq4",
+        "type": "sphere-fill-3d",
+        "args": {
+          "levels": [0.8],
+          "radius": 0.6,
+          "cage": false,
+          "fillScale": 1
+        },
+        "transform": {
+          "translate": [2.15, 0.7, 0.2]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.72,
+          "metal": 0.3,
+          "glow": 0
+        }
+      },
+      {
+        "id": "emp4",
+        "type": "cut-sphere",
+        "args": {
+          "radius": 0.6,
+          "h": 0.36000000000000004
+        },
+        "transform": {
+          "translate": [2.15, 0.7, 0.2]
+        },
+        "material": "porcelain"
+      },
+      {
+        "id": "lab4",
+        "type": "text-3d-pipe",
+        "args": {
+          "text": "80%",
+          "height": 0.33,
+          "pipeRadius": 0.05,
+          "align": "center"
+        },
+        "transform": {
+          "translate": [2.15, 0.4629999999999999, -0.5]
+        },
+        "material": {
+          "hue": 0,
+          "sat": 0,
+          "value": 1,
+          "metal": 0,
+          "glow": 0.25
+        }
+      }
+    ],
+    "defaults": {
+      "camera": {
+        "yaw": 0.5,
+        "pitch": 0.28,
+        "distance": 10,
+        "focal": 1.5,
+        "targetX": 0,
+        "targetY": 1.01,
+        "targetZ": 0
+      },
+      "light": {
+        "azimuth": 0.6,
+        "altitude": 0.55,
+        "distance": 25,
+        "intensity": 1.2
+      },
+      "shadow": {
+        "enabled": true,
+        "mode": "darken",
+        "strength": 0.4
+      },
+      "studioBg": "dark"
+    },
+    "cameraSequence": {
+      "loop": false,
+      "shots": [
+        {
+          "duration": 0.01,
+          "pos": [-1.5, 2.1286571428571426, -7.515000000000001],
+          "target": [6.344131569286608e-17, 0.9286571428571427, -0.29214285714285715],
+          "fov": 34,
+          "transition": "cut"
+        },
+        {
+          "duration": 6,
+          "pos": [1.5, 2.1286571428571426, -7.515000000000001],
+          "target": [6.344131569286608e-17, 0.9286571428571427, -0.29214285714285715],
+          "fov": 34,
+          "ease": "smooth",
+          "transition": "blend"
+        }
+      ]
+    }
+  },
+  "meta": {
+    "generatedAt": "2026-06-21",
+    "model": "authored",
+    "pattern": "deck-segment",
+    "costUSD": 0
+  }
+}

--- a/sdf-js/examples/compositor/demo-lifts/deck-auth-solo-fill-slide-07.json
+++ b/sdf-js/examples/compositor/demo-lifts/deck-auth-solo-fill-slide-07.json
@@ -1,0 +1,149 @@
+{
+  "id": "deck-auth-solo-fill-slide-07",
+  "title": "compare: Fill Levels · Row of 3 (50/100/80)",
+  "prompt": "compare: Fill Levels · Row of 3 (50/100/80)",
+  "code2d": "// auto-authored deck segment.",
+  "sceneData": {
+    "v": 1,
+    "name": "compare: Fill Levels · Row of 3 (50/100/80)",
+    "source": {
+      "format": "vision-authored",
+      "prompt": "A row of three fill spheres 50/100/80%, the middle one largest."
+    },
+    "subjects": [
+      {
+        "id": "liq0",
+        "type": "sphere-fill-3d",
+        "args": {
+          "levels": [0.5],
+          "radius": 0.62,
+          "cage": false,
+          "fillScale": 1
+        },
+        "transform": {
+          "translate": [-1.9, 0.85, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.72,
+          "metal": 0.3,
+          "glow": 0
+        }
+      },
+      {
+        "id": "emp0",
+        "type": "cut-sphere",
+        "args": {
+          "radius": 0.62,
+          "h": 0
+        },
+        "transform": {
+          "translate": [-1.9, 0.85, 0]
+        },
+        "material": "porcelain"
+      },
+      {
+        "id": "liq1",
+        "type": "sphere-fill-3d",
+        "args": {
+          "levels": [1],
+          "radius": 0.85,
+          "cage": false,
+          "fillScale": 1
+        },
+        "transform": {
+          "translate": [0, 1, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.72,
+          "metal": 0.3,
+          "glow": 0
+        }
+      },
+      {
+        "id": "liq2",
+        "type": "sphere-fill-3d",
+        "args": {
+          "levels": [0.8],
+          "radius": 0.62,
+          "cage": false,
+          "fillScale": 1
+        },
+        "transform": {
+          "translate": [1.9, 0.85, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.72,
+          "metal": 0.3,
+          "glow": 0
+        }
+      },
+      {
+        "id": "emp2",
+        "type": "cut-sphere",
+        "args": {
+          "radius": 0.62,
+          "h": 0.37200000000000005
+        },
+        "transform": {
+          "translate": [1.9, 0.85, 0]
+        },
+        "material": "porcelain"
+      }
+    ],
+    "defaults": {
+      "camera": {
+        "yaw": 0.5,
+        "pitch": 0.28,
+        "distance": 10,
+        "focal": 1.5,
+        "targetX": 0,
+        "targetY": 0.9,
+        "targetZ": 0
+      },
+      "light": {
+        "azimuth": 0.6,
+        "altitude": 0.55,
+        "distance": 25,
+        "intensity": 1.2
+      },
+      "shadow": {
+        "enabled": true,
+        "mode": "darken",
+        "strength": 0.4
+      },
+      "studioBg": "dark"
+    },
+    "cameraSequence": {
+      "loop": false,
+      "shots": [
+        {
+          "duration": 0.01,
+          "pos": [-1.5, 2.08, -7.09],
+          "target": [0, 0.8800000000000001, 0],
+          "fov": 34,
+          "transition": "cut"
+        },
+        {
+          "duration": 6,
+          "pos": [1.5, 2.08, -7.09],
+          "target": [0, 0.8800000000000001, 0],
+          "fov": 34,
+          "ease": "smooth",
+          "transition": "blend"
+        }
+      ]
+    }
+  },
+  "meta": {
+    "generatedAt": "2026-06-21",
+    "model": "authored",
+    "pattern": "deck-segment",
+    "costUSD": 0
+  }
+}

--- a/sdf-js/examples/compositor/demo-lifts/deck-auth-solo-fill-slide-08.json
+++ b/sdf-js/examples/compositor/demo-lifts/deck-auth-solo-fill-slide-08.json
@@ -1,0 +1,161 @@
+{
+  "id": "deck-auth-solo-fill-slide-08",
+  "title": "compare: Fill Levels · Cluster of 3 (60/50/80)",
+  "prompt": "compare: Fill Levels · Cluster of 3 (60/50/80)",
+  "code2d": "// auto-authored deck segment.",
+  "sceneData": {
+    "v": 1,
+    "name": "compare: Fill Levels · Cluster of 3 (60/50/80)",
+    "source": {
+      "format": "vision-authored",
+      "prompt": "Three overlapping varied-size fill spheres 60/50/80%."
+    },
+    "subjects": [
+      {
+        "id": "liq0",
+        "type": "sphere-fill-3d",
+        "args": {
+          "levels": [0.6],
+          "radius": 0.78,
+          "cage": false,
+          "fillScale": 1
+        },
+        "transform": {
+          "translate": [-1.35, 0.95, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.72,
+          "metal": 0.3,
+          "glow": 0
+        }
+      },
+      {
+        "id": "emp0",
+        "type": "cut-sphere",
+        "args": {
+          "radius": 0.78,
+          "h": 0.15599999999999997
+        },
+        "transform": {
+          "translate": [-1.35, 0.95, 0]
+        },
+        "material": "porcelain"
+      },
+      {
+        "id": "liq1",
+        "type": "sphere-fill-3d",
+        "args": {
+          "levels": [0.5],
+          "radius": 0.55,
+          "cage": false,
+          "fillScale": 1
+        },
+        "transform": {
+          "translate": [0.1, 0.7, 0.25]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.72,
+          "metal": 0.3,
+          "glow": 0
+        }
+      },
+      {
+        "id": "emp1",
+        "type": "cut-sphere",
+        "args": {
+          "radius": 0.55,
+          "h": 0
+        },
+        "transform": {
+          "translate": [0.1, 0.7, 0.25]
+        },
+        "material": "porcelain"
+      },
+      {
+        "id": "liq2",
+        "type": "sphere-fill-3d",
+        "args": {
+          "levels": [0.8],
+          "radius": 0.72,
+          "cage": false,
+          "fillScale": 1
+        },
+        "transform": {
+          "translate": [1.4, 1, -0.1]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.72,
+          "metal": 0.3,
+          "glow": 0
+        }
+      },
+      {
+        "id": "emp2",
+        "type": "cut-sphere",
+        "args": {
+          "radius": 0.72,
+          "h": 0.43200000000000005
+        },
+        "transform": {
+          "translate": [1.4, 1, -0.1]
+        },
+        "material": "porcelain"
+      }
+    ],
+    "defaults": {
+      "camera": {
+        "yaw": 0.5,
+        "pitch": 0.28,
+        "distance": 10,
+        "focal": 1.5,
+        "targetX": 0,
+        "targetY": 0.8833333333333333,
+        "targetZ": 0
+      },
+      "light": {
+        "azimuth": 0.6,
+        "altitude": 0.55,
+        "distance": 25,
+        "intensity": 1.2
+      },
+      "shadow": {
+        "enabled": true,
+        "mode": "darken",
+        "strength": 0.4
+      },
+      "studioBg": "dark"
+    },
+    "cameraSequence": {
+      "loop": false,
+      "shots": [
+        {
+          "duration": 0.01,
+          "pos": [-1.45, 2.083333333333333, -6.1975],
+          "target": [0.04999999999999997, 0.8833333333333333, 0.05000000000000001],
+          "fov": 34,
+          "transition": "cut"
+        },
+        {
+          "duration": 6,
+          "pos": [1.55, 2.083333333333333, -6.1975],
+          "target": [0.04999999999999997, 0.8833333333333333, 0.05000000000000001],
+          "fov": 34,
+          "ease": "smooth",
+          "transition": "blend"
+        }
+      ]
+    }
+  },
+  "meta": {
+    "generatedAt": "2026-06-21",
+    "model": "authored",
+    "pattern": "deck-segment",
+    "costUSD": 0
+  }
+}

--- a/sdf-js/examples/compositor/demo-lifts/deck-auth-solo-fill-slide-09.json
+++ b/sdf-js/examples/compositor/demo-lifts/deck-auth-solo-fill-slide-09.json
@@ -1,0 +1,225 @@
+{
+  "id": "deck-auth-solo-fill-slide-09",
+  "title": "compare: Fill Levels · Row of 5 (10..90)",
+  "prompt": "compare: Fill Levels · Row of 5 (10..90)",
+  "code2d": "// auto-authored deck segment.",
+  "sceneData": {
+    "v": 1,
+    "name": "compare: Fill Levels · Row of 5 (10..90)",
+    "source": {
+      "format": "vision-authored",
+      "prompt": "A row of five small fill spheres rising 10/30/50/70/90%."
+    },
+    "subjects": [
+      {
+        "id": "liq0",
+        "type": "sphere-fill-3d",
+        "args": {
+          "levels": [0.1],
+          "radius": 0.45,
+          "cage": false,
+          "fillScale": 1
+        },
+        "transform": {
+          "translate": [-2.5, 0.8, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.72,
+          "metal": 0.3,
+          "glow": 0
+        }
+      },
+      {
+        "id": "emp0",
+        "type": "cut-sphere",
+        "args": {
+          "radius": 0.45,
+          "h": -0.36000000000000004
+        },
+        "transform": {
+          "translate": [-2.5, 0.8, 0]
+        },
+        "material": "porcelain"
+      },
+      {
+        "id": "liq1",
+        "type": "sphere-fill-3d",
+        "args": {
+          "levels": [0.3],
+          "radius": 0.45,
+          "cage": false,
+          "fillScale": 1
+        },
+        "transform": {
+          "translate": [-1.25, 0.8, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.72,
+          "metal": 0.3,
+          "glow": 0
+        }
+      },
+      {
+        "id": "emp1",
+        "type": "cut-sphere",
+        "args": {
+          "radius": 0.45,
+          "h": -0.18000000000000002
+        },
+        "transform": {
+          "translate": [-1.25, 0.8, 0]
+        },
+        "material": "porcelain"
+      },
+      {
+        "id": "liq2",
+        "type": "sphere-fill-3d",
+        "args": {
+          "levels": [0.5],
+          "radius": 0.45,
+          "cage": false,
+          "fillScale": 1
+        },
+        "transform": {
+          "translate": [0, 0.8, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.72,
+          "metal": 0.3,
+          "glow": 0
+        }
+      },
+      {
+        "id": "emp2",
+        "type": "cut-sphere",
+        "args": {
+          "radius": 0.45,
+          "h": 0
+        },
+        "transform": {
+          "translate": [0, 0.8, 0]
+        },
+        "material": "porcelain"
+      },
+      {
+        "id": "liq3",
+        "type": "sphere-fill-3d",
+        "args": {
+          "levels": [0.7],
+          "radius": 0.45,
+          "cage": false,
+          "fillScale": 1
+        },
+        "transform": {
+          "translate": [1.25, 0.8, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.72,
+          "metal": 0.3,
+          "glow": 0
+        }
+      },
+      {
+        "id": "emp3",
+        "type": "cut-sphere",
+        "args": {
+          "radius": 0.45,
+          "h": 0.17999999999999997
+        },
+        "transform": {
+          "translate": [1.25, 0.8, 0]
+        },
+        "material": "porcelain"
+      },
+      {
+        "id": "liq4",
+        "type": "sphere-fill-3d",
+        "args": {
+          "levels": [0.9],
+          "radius": 0.45,
+          "cage": false,
+          "fillScale": 1
+        },
+        "transform": {
+          "translate": [2.5, 0.8, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.72,
+          "metal": 0.3,
+          "glow": 0
+        }
+      },
+      {
+        "id": "emp4",
+        "type": "cut-sphere",
+        "args": {
+          "radius": 0.45,
+          "h": 0.36000000000000004
+        },
+        "transform": {
+          "translate": [2.5, 0.8, 0]
+        },
+        "material": "porcelain"
+      }
+    ],
+    "defaults": {
+      "camera": {
+        "yaw": 0.5,
+        "pitch": 0.28,
+        "distance": 10,
+        "focal": 1.5,
+        "targetX": 0,
+        "targetY": 0.8,
+        "targetZ": 0
+      },
+      "light": {
+        "azimuth": 0.6,
+        "altitude": 0.55,
+        "distance": 25,
+        "intensity": 1.2
+      },
+      "shadow": {
+        "enabled": true,
+        "mode": "darken",
+        "strength": 0.4
+      },
+      "studioBg": "dark"
+    },
+    "cameraSequence": {
+      "loop": false,
+      "shots": [
+        {
+          "duration": 0.01,
+          "pos": [-1.5, 2, -8.11],
+          "target": [0, 0.7999999999999999, 0],
+          "fov": 34,
+          "transition": "cut"
+        },
+        {
+          "duration": 6,
+          "pos": [1.5, 2, -8.11],
+          "target": [0, 0.7999999999999999, 0],
+          "fov": 34,
+          "ease": "smooth",
+          "transition": "blend"
+        }
+      ]
+    }
+  },
+  "meta": {
+    "generatedAt": "2026-06-21",
+    "model": "authored",
+    "pattern": "deck-segment",
+    "costUSD": 0
+  }
+}

--- a/sdf-js/examples/compositor/demo-lifts/deck-auth-solo-fill-slide-10.json
+++ b/sdf-js/examples/compositor/demo-lifts/deck-auth-solo-fill-slide-10.json
@@ -1,0 +1,257 @@
+{
+  "id": "deck-auth-solo-fill-slide-10",
+  "title": "list: Fill Levels · Grid of 6 (framed)",
+  "prompt": "list: Fill Levels · Grid of 6 (framed)",
+  "code2d": "// auto-authored deck segment.",
+  "sceneData": {
+    "v": 1,
+    "name": "list: Fill Levels · Grid of 6 (framed)",
+    "source": {
+      "format": "vision-authored",
+      "prompt": "A grid of six framed fill spheres at mixed levels."
+    },
+    "subjects": [
+      {
+        "id": "liq0",
+        "type": "sphere-fill-3d",
+        "args": {
+          "levels": [0.55],
+          "radius": 0.5,
+          "cage": false,
+          "fillScale": 1
+        },
+        "transform": {
+          "translate": [-1.5, 1.8, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.72,
+          "metal": 0.3,
+          "glow": 0
+        }
+      },
+      {
+        "id": "emp0",
+        "type": "cut-sphere",
+        "args": {
+          "radius": 0.5,
+          "h": 0.050000000000000044
+        },
+        "transform": {
+          "translate": [-1.5, 1.8, 0]
+        },
+        "material": "porcelain"
+      },
+      {
+        "id": "liq1",
+        "type": "sphere-fill-3d",
+        "args": {
+          "levels": [0.75],
+          "radius": 0.5,
+          "cage": false,
+          "fillScale": 1
+        },
+        "transform": {
+          "translate": [0, 1.8, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.72,
+          "metal": 0.3,
+          "glow": 0
+        }
+      },
+      {
+        "id": "emp1",
+        "type": "cut-sphere",
+        "args": {
+          "radius": 0.5,
+          "h": 0.25
+        },
+        "transform": {
+          "translate": [0, 1.8, 0]
+        },
+        "material": "porcelain"
+      },
+      {
+        "id": "liq2",
+        "type": "sphere-fill-3d",
+        "args": {
+          "levels": [0.6],
+          "radius": 0.5,
+          "cage": false,
+          "fillScale": 1
+        },
+        "transform": {
+          "translate": [1.5, 1.8, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.72,
+          "metal": 0.3,
+          "glow": 0
+        }
+      },
+      {
+        "id": "emp2",
+        "type": "cut-sphere",
+        "args": {
+          "radius": 0.5,
+          "h": 0.09999999999999998
+        },
+        "transform": {
+          "translate": [1.5, 1.8, 0]
+        },
+        "material": "porcelain"
+      },
+      {
+        "id": "liq3",
+        "type": "sphere-fill-3d",
+        "args": {
+          "levels": [0.2],
+          "radius": 0.5,
+          "cage": false,
+          "fillScale": 1
+        },
+        "transform": {
+          "translate": [-1.5, 0.19999999999999996, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.72,
+          "metal": 0.3,
+          "glow": 0
+        }
+      },
+      {
+        "id": "emp3",
+        "type": "cut-sphere",
+        "args": {
+          "radius": 0.5,
+          "h": -0.3
+        },
+        "transform": {
+          "translate": [-1.5, 0.19999999999999996, 0]
+        },
+        "material": "porcelain"
+      },
+      {
+        "id": "liq4",
+        "type": "sphere-fill-3d",
+        "args": {
+          "levels": [0.4],
+          "radius": 0.5,
+          "cage": false,
+          "fillScale": 1
+        },
+        "transform": {
+          "translate": [0, 0.19999999999999996, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.72,
+          "metal": 0.3,
+          "glow": 0
+        }
+      },
+      {
+        "id": "emp4",
+        "type": "cut-sphere",
+        "args": {
+          "radius": 0.5,
+          "h": -0.09999999999999998
+        },
+        "transform": {
+          "translate": [0, 0.19999999999999996, 0]
+        },
+        "material": "porcelain"
+      },
+      {
+        "id": "liq5",
+        "type": "sphere-fill-3d",
+        "args": {
+          "levels": [0.65],
+          "radius": 0.5,
+          "cage": false,
+          "fillScale": 1
+        },
+        "transform": {
+          "translate": [1.5, 0.19999999999999996, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.72,
+          "metal": 0.3,
+          "glow": 0
+        }
+      },
+      {
+        "id": "emp5",
+        "type": "cut-sphere",
+        "args": {
+          "radius": 0.5,
+          "h": 0.15000000000000002
+        },
+        "transform": {
+          "translate": [1.5, 0.19999999999999996, 0]
+        },
+        "material": "porcelain"
+      }
+    ],
+    "defaults": {
+      "camera": {
+        "yaw": 0.5,
+        "pitch": 0.28,
+        "distance": 10,
+        "focal": 1.5,
+        "targetX": 0,
+        "targetY": 1.0000000000000002,
+        "targetZ": 0
+      },
+      "light": {
+        "azimuth": 0.6,
+        "altitude": 0.55,
+        "distance": 25,
+        "intensity": 1.2
+      },
+      "shadow": {
+        "enabled": true,
+        "mode": "darken",
+        "strength": 0.4
+      },
+      "studioBg": "dark"
+    },
+    "cameraSequence": {
+      "loop": false,
+      "shots": [
+        {
+          "duration": 0.01,
+          "pos": [-1.5, 2.1999999999999997, -6.41],
+          "target": [0, 0.9999999999999997, 0],
+          "fov": 34,
+          "transition": "cut"
+        },
+        {
+          "duration": 6,
+          "pos": [1.5, 2.1999999999999997, -6.41],
+          "target": [0, 0.9999999999999997, 0],
+          "fov": 34,
+          "ease": "smooth",
+          "transition": "blend"
+        }
+      ]
+    }
+  },
+  "meta": {
+    "generatedAt": "2026-06-21",
+    "model": "authored",
+    "pattern": "deck-segment",
+    "costUSD": 0
+  }
+}

--- a/sdf-js/examples/compositor/demo-lifts/deck-auth-solo-fill-slide-12.json
+++ b/sdf-js/examples/compositor/demo-lifts/deck-auth-solo-fill-slide-12.json
@@ -1,0 +1,225 @@
+{
+  "id": "deck-auth-solo-fill-slide-12",
+  "title": "compare: Fill Levels · Row of 5 + captions",
+  "prompt": "compare: Fill Levels · Row of 5 + captions",
+  "code2d": "// auto-authored deck segment.",
+  "sceneData": {
+    "v": 1,
+    "name": "compare: Fill Levels · Row of 5 + captions",
+    "source": {
+      "format": "vision-authored",
+      "prompt": "A row of five fill spheres 20/40/60/50/80% over caption columns."
+    },
+    "subjects": [
+      {
+        "id": "liq0",
+        "type": "sphere-fill-3d",
+        "args": {
+          "levels": [0.2],
+          "radius": 0.5,
+          "cage": false,
+          "fillScale": 1
+        },
+        "transform": {
+          "translate": [-2.8, 0.85, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.72,
+          "metal": 0.3,
+          "glow": 0
+        }
+      },
+      {
+        "id": "emp0",
+        "type": "cut-sphere",
+        "args": {
+          "radius": 0.5,
+          "h": -0.3
+        },
+        "transform": {
+          "translate": [-2.8, 0.85, 0]
+        },
+        "material": "porcelain"
+      },
+      {
+        "id": "liq1",
+        "type": "sphere-fill-3d",
+        "args": {
+          "levels": [0.4],
+          "radius": 0.5,
+          "cage": false,
+          "fillScale": 1
+        },
+        "transform": {
+          "translate": [-1.4, 0.85, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.72,
+          "metal": 0.3,
+          "glow": 0
+        }
+      },
+      {
+        "id": "emp1",
+        "type": "cut-sphere",
+        "args": {
+          "radius": 0.5,
+          "h": -0.09999999999999998
+        },
+        "transform": {
+          "translate": [-1.4, 0.85, 0]
+        },
+        "material": "porcelain"
+      },
+      {
+        "id": "liq2",
+        "type": "sphere-fill-3d",
+        "args": {
+          "levels": [0.6],
+          "radius": 0.5,
+          "cage": false,
+          "fillScale": 1
+        },
+        "transform": {
+          "translate": [0, 0.85, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.72,
+          "metal": 0.3,
+          "glow": 0
+        }
+      },
+      {
+        "id": "emp2",
+        "type": "cut-sphere",
+        "args": {
+          "radius": 0.5,
+          "h": 0.09999999999999998
+        },
+        "transform": {
+          "translate": [0, 0.85, 0]
+        },
+        "material": "porcelain"
+      },
+      {
+        "id": "liq3",
+        "type": "sphere-fill-3d",
+        "args": {
+          "levels": [0.5],
+          "radius": 0.5,
+          "cage": false,
+          "fillScale": 1
+        },
+        "transform": {
+          "translate": [1.3999999999999995, 0.85, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.72,
+          "metal": 0.3,
+          "glow": 0
+        }
+      },
+      {
+        "id": "emp3",
+        "type": "cut-sphere",
+        "args": {
+          "radius": 0.5,
+          "h": 0
+        },
+        "transform": {
+          "translate": [1.3999999999999995, 0.85, 0]
+        },
+        "material": "porcelain"
+      },
+      {
+        "id": "liq4",
+        "type": "sphere-fill-3d",
+        "args": {
+          "levels": [0.8],
+          "radius": 0.5,
+          "cage": false,
+          "fillScale": 1
+        },
+        "transform": {
+          "translate": [2.8, 0.85, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.72,
+          "metal": 0.3,
+          "glow": 0
+        }
+      },
+      {
+        "id": "emp4",
+        "type": "cut-sphere",
+        "args": {
+          "radius": 0.5,
+          "h": 0.30000000000000004
+        },
+        "transform": {
+          "translate": [2.8, 0.85, 0]
+        },
+        "material": "porcelain"
+      }
+    ],
+    "defaults": {
+      "camera": {
+        "yaw": 0.5,
+        "pitch": 0.28,
+        "distance": 10,
+        "focal": 1.5,
+        "targetX": 0,
+        "targetY": 0.85,
+        "targetZ": 0
+      },
+      "light": {
+        "azimuth": 0.6,
+        "altitude": 0.55,
+        "distance": 25,
+        "intensity": 1.2
+      },
+      "shadow": {
+        "enabled": true,
+        "mode": "darken",
+        "strength": 0.4
+      },
+      "studioBg": "dark"
+    },
+    "cameraSequence": {
+      "loop": false,
+      "shots": [
+        {
+          "duration": 0.01,
+          "pos": [-1.5000000000000002, 2.05, -8.62],
+          "target": [-1.7763568394002506e-16, 0.8499999999999999, 0],
+          "fov": 34,
+          "transition": "cut"
+        },
+        {
+          "duration": 6,
+          "pos": [1.4999999999999998, 2.05, -8.62],
+          "target": [-1.7763568394002506e-16, 0.8499999999999999, 0],
+          "fov": 34,
+          "ease": "smooth",
+          "transition": "blend"
+        }
+      ]
+    }
+  },
+  "meta": {
+    "generatedAt": "2026-06-21",
+    "model": "authored",
+    "pattern": "deck-segment",
+    "costUSD": 0
+  }
+}

--- a/sdf-js/examples/compositor/demo-lifts/deck-auth-solo-fill-slide-14.json
+++ b/sdf-js/examples/compositor/demo-lifts/deck-auth-solo-fill-slide-14.json
@@ -1,0 +1,193 @@
+{
+  "id": "deck-auth-solo-fill-slide-14",
+  "title": "list: Fill Levels · Bullet list of 4",
+  "prompt": "list: Fill Levels · Bullet list of 4",
+  "code2d": "// auto-authored deck segment.",
+  "sceneData": {
+    "v": 1,
+    "name": "list: Fill Levels · Bullet list of 4",
+    "source": {
+      "format": "vision-authored",
+      "prompt": "A vertical list of four items, each marked by a small fill sphere."
+    },
+    "subjects": [
+      {
+        "id": "liq0",
+        "type": "sphere-fill-3d",
+        "args": {
+          "levels": [0.4],
+          "radius": 0.34,
+          "cage": false,
+          "fillScale": 1
+        },
+        "transform": {
+          "translate": [-1.6, 2.595, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.72,
+          "metal": 0.3,
+          "glow": 0
+        }
+      },
+      {
+        "id": "emp0",
+        "type": "cut-sphere",
+        "args": {
+          "radius": 0.34,
+          "h": -0.06799999999999999
+        },
+        "transform": {
+          "translate": [-1.6, 2.595, 0]
+        },
+        "material": "porcelain"
+      },
+      {
+        "id": "liq1",
+        "type": "sphere-fill-3d",
+        "args": {
+          "levels": [0.6],
+          "radius": 0.34,
+          "cage": false,
+          "fillScale": 1
+        },
+        "transform": {
+          "translate": [-1.6, 1.465, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.72,
+          "metal": 0.3,
+          "glow": 0
+        }
+      },
+      {
+        "id": "emp1",
+        "type": "cut-sphere",
+        "args": {
+          "radius": 0.34,
+          "h": 0.06799999999999999
+        },
+        "transform": {
+          "translate": [-1.6, 1.465, 0]
+        },
+        "material": "porcelain"
+      },
+      {
+        "id": "liq2",
+        "type": "sphere-fill-3d",
+        "args": {
+          "levels": [0.5],
+          "radius": 0.34,
+          "cage": false,
+          "fillScale": 1
+        },
+        "transform": {
+          "translate": [-1.6, 0.33499999999999996, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.72,
+          "metal": 0.3,
+          "glow": 0
+        }
+      },
+      {
+        "id": "emp2",
+        "type": "cut-sphere",
+        "args": {
+          "radius": 0.34,
+          "h": 0
+        },
+        "transform": {
+          "translate": [-1.6, 0.33499999999999996, 0]
+        },
+        "material": "porcelain"
+      },
+      {
+        "id": "liq3",
+        "type": "sphere-fill-3d",
+        "args": {
+          "levels": [0.7],
+          "radius": 0.34,
+          "cage": false,
+          "fillScale": 1
+        },
+        "transform": {
+          "translate": [-1.6, -0.7950000000000004, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.72,
+          "metal": 0.3,
+          "glow": 0
+        }
+      },
+      {
+        "id": "emp3",
+        "type": "cut-sphere",
+        "args": {
+          "radius": 0.34,
+          "h": 0.13599999999999998
+        },
+        "transform": {
+          "translate": [-1.6, -0.7950000000000004, 0]
+        },
+        "material": "porcelain"
+      }
+    ],
+    "defaults": {
+      "camera": {
+        "yaw": 0.5,
+        "pitch": 0.28,
+        "distance": 10,
+        "focal": 1.5,
+        "targetX": 0,
+        "targetY": 0.9,
+        "targetZ": 0
+      },
+      "light": {
+        "azimuth": 0.6,
+        "altitude": 0.55,
+        "distance": 25,
+        "intensity": 1.2
+      },
+      "shadow": {
+        "enabled": true,
+        "mode": "darken",
+        "strength": 0.4
+      },
+      "studioBg": "dark"
+    },
+    "cameraSequence": {
+      "loop": false,
+      "shots": [
+        {
+          "duration": 0.01,
+          "pos": [-3.0999999999999996, 2.1000000000000005, -6],
+          "target": [-1.5999999999999999, 0.9000000000000004, 0],
+          "fov": 34,
+          "transition": "cut"
+        },
+        {
+          "duration": 6,
+          "pos": [-0.09999999999999987, 2.1000000000000005, -6],
+          "target": [-1.5999999999999999, 0.9000000000000004, 0],
+          "fov": 34,
+          "ease": "smooth",
+          "transition": "blend"
+        }
+      ]
+    }
+  },
+  "meta": {
+    "generatedAt": "2026-06-21",
+    "model": "authored",
+    "pattern": "deck-segment",
+    "costUSD": 0
+  }
+}

--- a/sdf-js/examples/compositor/demo-lifts/deck-auth-solo-fill-slide-16.json
+++ b/sdf-js/examples/compositor/demo-lifts/deck-auth-solo-fill-slide-16.json
@@ -1,0 +1,161 @@
+{
+  "id": "deck-auth-solo-fill-slide-16",
+  "title": "list: Fill Levels · Vertical 3 (30/80/70)",
+  "prompt": "list: Fill Levels · Vertical 3 (30/80/70)",
+  "code2d": "// auto-authored deck segment.",
+  "sceneData": {
+    "v": 1,
+    "name": "list: Fill Levels · Vertical 3 (30/80/70)",
+    "source": {
+      "format": "vision-authored",
+      "prompt": "Three fill spheres stacked vertically 30/80/70% with connector lines."
+    },
+    "subjects": [
+      {
+        "id": "liq0",
+        "type": "sphere-fill-3d",
+        "args": {
+          "levels": [0.3],
+          "radius": 0.5,
+          "cage": false,
+          "fillScale": 1
+        },
+        "transform": {
+          "translate": [-1.8, 2.3499999999999996, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.72,
+          "metal": 0.3,
+          "glow": 0
+        }
+      },
+      {
+        "id": "emp0",
+        "type": "cut-sphere",
+        "args": {
+          "radius": 0.5,
+          "h": -0.2
+        },
+        "transform": {
+          "translate": [-1.8, 2.3499999999999996, 0]
+        },
+        "material": "porcelain"
+      },
+      {
+        "id": "liq1",
+        "type": "sphere-fill-3d",
+        "args": {
+          "levels": [0.8],
+          "radius": 0.5,
+          "cage": false,
+          "fillScale": 1
+        },
+        "transform": {
+          "translate": [-1.8, 0.9499999999999997, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.72,
+          "metal": 0.3,
+          "glow": 0
+        }
+      },
+      {
+        "id": "emp1",
+        "type": "cut-sphere",
+        "args": {
+          "radius": 0.5,
+          "h": 0.30000000000000004
+        },
+        "transform": {
+          "translate": [-1.8, 0.9499999999999997, 0]
+        },
+        "material": "porcelain"
+      },
+      {
+        "id": "liq2",
+        "type": "sphere-fill-3d",
+        "args": {
+          "levels": [0.7],
+          "radius": 0.5,
+          "cage": false,
+          "fillScale": 1
+        },
+        "transform": {
+          "translate": [-1.8, -0.4500000000000002, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.72,
+          "metal": 0.3,
+          "glow": 0
+        }
+      },
+      {
+        "id": "emp2",
+        "type": "cut-sphere",
+        "args": {
+          "radius": 0.5,
+          "h": 0.19999999999999996
+        },
+        "transform": {
+          "translate": [-1.8, -0.4500000000000002, 0]
+        },
+        "material": "porcelain"
+      }
+    ],
+    "defaults": {
+      "camera": {
+        "yaw": 0.5,
+        "pitch": 0.28,
+        "distance": 10,
+        "focal": 1.5,
+        "targetX": 0,
+        "targetY": 0.9499999999999997,
+        "targetZ": 0
+      },
+      "light": {
+        "azimuth": 0.6,
+        "altitude": 0.55,
+        "distance": 25,
+        "intensity": 1.2
+      },
+      "shadow": {
+        "enabled": true,
+        "mode": "darken",
+        "strength": 0.4
+      },
+      "studioBg": "dark"
+    },
+    "cameraSequence": {
+      "loop": false,
+      "shots": [
+        {
+          "duration": 0.01,
+          "pos": [-3.3, 2.1499999999999995, -6],
+          "target": [-1.8, 0.9499999999999996, 0],
+          "fov": 34,
+          "transition": "cut"
+        },
+        {
+          "duration": 6,
+          "pos": [-0.30000000000000004, 2.1499999999999995, -6],
+          "target": [-1.8, 0.9499999999999996, 0],
+          "fov": 34,
+          "ease": "smooth",
+          "transition": "blend"
+        }
+      ]
+    }
+  },
+  "meta": {
+    "generatedAt": "2026-06-21",
+    "model": "authored",
+    "pattern": "deck-segment",
+    "costUSD": 0
+  }
+}

--- a/sdf-js/examples/compositor/demo-lifts/deck-auth-solo-fill-slide-17.json
+++ b/sdf-js/examples/compositor/demo-lifts/deck-auth-solo-fill-slide-17.json
@@ -1,0 +1,129 @@
+{
+  "id": "deck-auth-solo-fill-slide-17",
+  "title": "compare: Fill Levels · Two heroes (80/90)",
+  "prompt": "compare: Fill Levels · Two heroes (80/90)",
+  "code2d": "// auto-authored deck segment.",
+  "sceneData": {
+    "v": 1,
+    "name": "compare: Fill Levels · Two heroes (80/90)",
+    "source": {
+      "format": "vision-authored",
+      "prompt": "Two large fill spheres 80% and 90% stacked with side text."
+    },
+    "subjects": [
+      {
+        "id": "liq0",
+        "type": "sphere-fill-3d",
+        "args": {
+          "levels": [0.8],
+          "radius": 0.7,
+          "cage": false,
+          "fillScale": 1
+        },
+        "transform": {
+          "translate": [-1.4, 1.45, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.72,
+          "metal": 0.3,
+          "glow": 0
+        }
+      },
+      {
+        "id": "emp0",
+        "type": "cut-sphere",
+        "args": {
+          "radius": 0.7,
+          "h": 0.42000000000000004
+        },
+        "transform": {
+          "translate": [-1.4, 1.45, 0]
+        },
+        "material": "porcelain"
+      },
+      {
+        "id": "liq1",
+        "type": "sphere-fill-3d",
+        "args": {
+          "levels": [0.9],
+          "radius": 0.75,
+          "cage": false,
+          "fillScale": 1
+        },
+        "transform": {
+          "translate": [-1.4, -0.05, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.72,
+          "metal": 0.3,
+          "glow": 0
+        }
+      },
+      {
+        "id": "emp1",
+        "type": "cut-sphere",
+        "args": {
+          "radius": 0.75,
+          "h": 0.6000000000000001
+        },
+        "transform": {
+          "translate": [-1.4, -0.05, 0]
+        },
+        "material": "porcelain"
+      }
+    ],
+    "defaults": {
+      "camera": {
+        "yaw": 0.5,
+        "pitch": 0.28,
+        "distance": 10,
+        "focal": 1.5,
+        "targetX": 0,
+        "targetY": 0.7,
+        "targetZ": 0
+      },
+      "light": {
+        "azimuth": 0.6,
+        "altitude": 0.55,
+        "distance": 25,
+        "intensity": 1.2
+      },
+      "shadow": {
+        "enabled": true,
+        "mode": "darken",
+        "strength": 0.4
+      },
+      "studioBg": "dark"
+    },
+    "cameraSequence": {
+      "loop": false,
+      "shots": [
+        {
+          "duration": 0.01,
+          "pos": [-2.9, 1.9, -6],
+          "target": [-1.4, 0.7000000000000001, 0],
+          "fov": 34,
+          "transition": "cut"
+        },
+        {
+          "duration": 6,
+          "pos": [0.10000000000000009, 1.9, -6],
+          "target": [-1.4, 0.7000000000000001, 0],
+          "fov": 34,
+          "ease": "smooth",
+          "transition": "blend"
+        }
+      ]
+    }
+  },
+  "meta": {
+    "generatedAt": "2026-06-21",
+    "model": "authored",
+    "pattern": "deck-segment",
+    "costUSD": 0
+  }
+}

--- a/sdf-js/examples/compositor/demo-lifts/deck-auth-solo-fill-slide-18.json
+++ b/sdf-js/examples/compositor/demo-lifts/deck-auth-solo-fill-slide-18.json
@@ -1,0 +1,309 @@
+{
+  "id": "deck-auth-solo-fill-slide-18",
+  "title": "sequence: Fill Levels · Progression grid 2×4",
+  "prompt": "sequence: Fill Levels · Progression grid 2×4",
+  "code2d": "// auto-authored deck segment.",
+  "sceneData": {
+    "v": 1,
+    "name": "sequence: Fill Levels · Progression grid 2×4",
+    "source": {
+      "format": "vision-authored",
+      "prompt": "Two rows of four spheres showing a fill progression up to 100%."
+    },
+    "subjects": [
+      {
+        "id": "liq0",
+        "type": "sphere-fill-3d",
+        "args": {
+          "levels": [0.15],
+          "radius": 0.42,
+          "cage": false,
+          "fillScale": 1
+        },
+        "transform": {
+          "translate": [-1.935, 1.695, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.72,
+          "metal": 0.3,
+          "glow": 0
+        }
+      },
+      {
+        "id": "emp0",
+        "type": "cut-sphere",
+        "args": {
+          "radius": 0.42,
+          "h": -0.294
+        },
+        "transform": {
+          "translate": [-1.935, 1.695, 0]
+        },
+        "material": "porcelain"
+      },
+      {
+        "id": "liq1",
+        "type": "sphere-fill-3d",
+        "args": {
+          "levels": [0.25],
+          "radius": 0.42,
+          "cage": false,
+          "fillScale": 1
+        },
+        "transform": {
+          "translate": [-0.645, 1.695, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.72,
+          "metal": 0.3,
+          "glow": 0
+        }
+      },
+      {
+        "id": "emp1",
+        "type": "cut-sphere",
+        "args": {
+          "radius": 0.42,
+          "h": -0.21
+        },
+        "transform": {
+          "translate": [-0.645, 1.695, 0]
+        },
+        "material": "porcelain"
+      },
+      {
+        "id": "liq2",
+        "type": "sphere-fill-3d",
+        "args": {
+          "levels": [0.35],
+          "radius": 0.42,
+          "cage": false,
+          "fillScale": 1
+        },
+        "transform": {
+          "translate": [0.645, 1.695, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.72,
+          "metal": 0.3,
+          "glow": 0
+        }
+      },
+      {
+        "id": "emp2",
+        "type": "cut-sphere",
+        "args": {
+          "radius": 0.42,
+          "h": -0.126
+        },
+        "transform": {
+          "translate": [0.645, 1.695, 0]
+        },
+        "material": "porcelain"
+      },
+      {
+        "id": "liq3",
+        "type": "sphere-fill-3d",
+        "args": {
+          "levels": [0.45],
+          "radius": 0.42,
+          "cage": false,
+          "fillScale": 1
+        },
+        "transform": {
+          "translate": [1.935, 1.695, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.72,
+          "metal": 0.3,
+          "glow": 0
+        }
+      },
+      {
+        "id": "emp3",
+        "type": "cut-sphere",
+        "args": {
+          "radius": 0.42,
+          "h": -0.04199999999999999
+        },
+        "transform": {
+          "translate": [1.935, 1.695, 0]
+        },
+        "material": "porcelain"
+      },
+      {
+        "id": "liq4",
+        "type": "sphere-fill-3d",
+        "args": {
+          "levels": [0.6],
+          "radius": 0.42,
+          "cage": false,
+          "fillScale": 1
+        },
+        "transform": {
+          "translate": [-1.935, 0.30499999999999994, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.72,
+          "metal": 0.3,
+          "glow": 0
+        }
+      },
+      {
+        "id": "emp4",
+        "type": "cut-sphere",
+        "args": {
+          "radius": 0.42,
+          "h": 0.08399999999999998
+        },
+        "transform": {
+          "translate": [-1.935, 0.30499999999999994, 0]
+        },
+        "material": "porcelain"
+      },
+      {
+        "id": "liq5",
+        "type": "sphere-fill-3d",
+        "args": {
+          "levels": [0.8],
+          "radius": 0.42,
+          "cage": false,
+          "fillScale": 1
+        },
+        "transform": {
+          "translate": [-0.645, 0.30499999999999994, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.72,
+          "metal": 0.3,
+          "glow": 0
+        }
+      },
+      {
+        "id": "emp5",
+        "type": "cut-sphere",
+        "args": {
+          "radius": 0.42,
+          "h": 0.252
+        },
+        "transform": {
+          "translate": [-0.645, 0.30499999999999994, 0]
+        },
+        "material": "porcelain"
+      },
+      {
+        "id": "liq6",
+        "type": "sphere-fill-3d",
+        "args": {
+          "levels": [0.9],
+          "radius": 0.42,
+          "cage": false,
+          "fillScale": 1
+        },
+        "transform": {
+          "translate": [0.645, 0.30499999999999994, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.72,
+          "metal": 0.3,
+          "glow": 0
+        }
+      },
+      {
+        "id": "emp6",
+        "type": "cut-sphere",
+        "args": {
+          "radius": 0.42,
+          "h": 0.336
+        },
+        "transform": {
+          "translate": [0.645, 0.30499999999999994, 0]
+        },
+        "material": "porcelain"
+      },
+      {
+        "id": "liq7",
+        "type": "sphere-fill-3d",
+        "args": {
+          "levels": [1],
+          "radius": 0.42,
+          "cage": false,
+          "fillScale": 1
+        },
+        "transform": {
+          "translate": [1.935, 0.30499999999999994, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.72,
+          "metal": 0.3,
+          "glow": 0
+        }
+      }
+    ],
+    "defaults": {
+      "camera": {
+        "yaw": 0.5,
+        "pitch": 0.28,
+        "distance": 10,
+        "focal": 1.5,
+        "targetX": 0,
+        "targetY": 0.9999999999999999,
+        "targetZ": 0
+      },
+      "light": {
+        "azimuth": 0.6,
+        "altitude": 0.55,
+        "distance": 25,
+        "intensity": 1.2
+      },
+      "shadow": {
+        "enabled": true,
+        "mode": "darken",
+        "strength": 0.4
+      },
+      "studioBg": "dark"
+    },
+    "cameraSequence": {
+      "loop": false,
+      "shots": [
+        {
+          "duration": 0.01,
+          "pos": [-1.629, 2.2463333333333333, -7.149500000000001],
+          "target": [-0.12900000000000003, 1.0463333333333333, 0],
+          "fov": 34,
+          "transition": "cut"
+        },
+        {
+          "duration": 6,
+          "pos": [1.371, 2.2463333333333333, -7.149500000000001],
+          "target": [-0.12900000000000003, 1.0463333333333333, 0],
+          "fov": 34,
+          "ease": "smooth",
+          "transition": "blend"
+        }
+      ]
+    }
+  },
+  "meta": {
+    "generatedAt": "2026-06-21",
+    "model": "authored",
+    "pattern": "deck-segment",
+    "costUSD": 0
+  }
+}

--- a/sdf-js/examples/compositor/demo-lifts/deck-auth-solo-fill-slide-19.json
+++ b/sdf-js/examples/compositor/demo-lifts/deck-auth-solo-fill-slide-19.json
@@ -1,0 +1,213 @@
+{
+  "id": "deck-auth-solo-fill-slide-19",
+  "title": "sequence: Fill Levels · Row of 5 (20..100)",
+  "prompt": "sequence: Fill Levels · Row of 5 (20..100)",
+  "code2d": "// auto-authored deck segment.",
+  "sceneData": {
+    "v": 1,
+    "name": "sequence: Fill Levels · Row of 5 (20..100)",
+    "source": {
+      "format": "vision-authored",
+      "prompt": "A clean row of five fill spheres rising 20/40/60/80/100%."
+    },
+    "subjects": [
+      {
+        "id": "liq0",
+        "type": "sphere-fill-3d",
+        "args": {
+          "levels": [0.2],
+          "radius": 0.5,
+          "cage": false,
+          "fillScale": 1
+        },
+        "transform": {
+          "translate": [-2.8, 0.85, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.72,
+          "metal": 0.3,
+          "glow": 0
+        }
+      },
+      {
+        "id": "emp0",
+        "type": "cut-sphere",
+        "args": {
+          "radius": 0.5,
+          "h": -0.3
+        },
+        "transform": {
+          "translate": [-2.8, 0.85, 0]
+        },
+        "material": "porcelain"
+      },
+      {
+        "id": "liq1",
+        "type": "sphere-fill-3d",
+        "args": {
+          "levels": [0.4],
+          "radius": 0.5,
+          "cage": false,
+          "fillScale": 1
+        },
+        "transform": {
+          "translate": [-1.4, 0.85, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.72,
+          "metal": 0.3,
+          "glow": 0
+        }
+      },
+      {
+        "id": "emp1",
+        "type": "cut-sphere",
+        "args": {
+          "radius": 0.5,
+          "h": -0.09999999999999998
+        },
+        "transform": {
+          "translate": [-1.4, 0.85, 0]
+        },
+        "material": "porcelain"
+      },
+      {
+        "id": "liq2",
+        "type": "sphere-fill-3d",
+        "args": {
+          "levels": [0.6],
+          "radius": 0.5,
+          "cage": false,
+          "fillScale": 1
+        },
+        "transform": {
+          "translate": [0, 0.85, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.72,
+          "metal": 0.3,
+          "glow": 0
+        }
+      },
+      {
+        "id": "emp2",
+        "type": "cut-sphere",
+        "args": {
+          "radius": 0.5,
+          "h": 0.09999999999999998
+        },
+        "transform": {
+          "translate": [0, 0.85, 0]
+        },
+        "material": "porcelain"
+      },
+      {
+        "id": "liq3",
+        "type": "sphere-fill-3d",
+        "args": {
+          "levels": [0.8],
+          "radius": 0.5,
+          "cage": false,
+          "fillScale": 1
+        },
+        "transform": {
+          "translate": [1.3999999999999995, 0.85, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.72,
+          "metal": 0.3,
+          "glow": 0
+        }
+      },
+      {
+        "id": "emp3",
+        "type": "cut-sphere",
+        "args": {
+          "radius": 0.5,
+          "h": 0.30000000000000004
+        },
+        "transform": {
+          "translate": [1.3999999999999995, 0.85, 0]
+        },
+        "material": "porcelain"
+      },
+      {
+        "id": "liq4",
+        "type": "sphere-fill-3d",
+        "args": {
+          "levels": [1],
+          "radius": 0.5,
+          "cage": false,
+          "fillScale": 1
+        },
+        "transform": {
+          "translate": [2.8, 0.85, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.72,
+          "metal": 0.3,
+          "glow": 0
+        }
+      }
+    ],
+    "defaults": {
+      "camera": {
+        "yaw": 0.5,
+        "pitch": 0.28,
+        "distance": 10,
+        "focal": 1.5,
+        "targetX": 0,
+        "targetY": 0.85,
+        "targetZ": 0
+      },
+      "light": {
+        "azimuth": 0.6,
+        "altitude": 0.55,
+        "distance": 25,
+        "intensity": 1.2
+      },
+      "shadow": {
+        "enabled": true,
+        "mode": "darken",
+        "strength": 0.4
+      },
+      "studioBg": "dark"
+    },
+    "cameraSequence": {
+      "loop": false,
+      "shots": [
+        {
+          "duration": 0.01,
+          "pos": [-1.8111111111111113, 2.05, -8.62],
+          "target": [-0.3111111111111113, 0.8499999999999999, 0],
+          "fov": 34,
+          "transition": "cut"
+        },
+        {
+          "duration": 6,
+          "pos": [1.1888888888888887, 2.05, -8.62],
+          "target": [-0.3111111111111113, 0.8499999999999999, 0],
+          "fov": 34,
+          "ease": "smooth",
+          "transition": "blend"
+        }
+      ]
+    }
+  },
+  "meta": {
+    "generatedAt": "2026-06-21",
+    "model": "authored",
+    "pattern": "deck-segment",
+    "costUSD": 0
+  }
+}

--- a/sdf-js/examples/compositor/demo-lifts/deck-auth-solo-fill-slide-20.json
+++ b/sdf-js/examples/compositor/demo-lifts/deck-auth-solo-fill-slide-20.json
@@ -1,0 +1,373 @@
+{
+  "id": "deck-auth-solo-fill-slide-20",
+  "title": "list: Fill Levels · Grid 2×5",
+  "prompt": "list: Fill Levels · Grid 2×5",
+  "code2d": "// auto-authored deck segment.",
+  "sceneData": {
+    "v": 1,
+    "name": "list: Fill Levels · Grid 2×5",
+    "source": {
+      "format": "vision-authored",
+      "prompt": "Two rows of five fill spheres at mixed levels."
+    },
+    "subjects": [
+      {
+        "id": "liq0",
+        "type": "sphere-fill-3d",
+        "args": {
+          "levels": [0.1],
+          "radius": 0.4,
+          "cage": false,
+          "fillScale": 1
+        },
+        "transform": {
+          "translate": [-2.3, 1.6, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.72,
+          "metal": 0.3,
+          "glow": 0
+        }
+      },
+      {
+        "id": "emp0",
+        "type": "cut-sphere",
+        "args": {
+          "radius": 0.4,
+          "h": -0.32000000000000006
+        },
+        "transform": {
+          "translate": [-2.3, 1.6, 0]
+        },
+        "material": "porcelain"
+      },
+      {
+        "id": "liq1",
+        "type": "sphere-fill-3d",
+        "args": {
+          "levels": [0.3],
+          "radius": 0.4,
+          "cage": false,
+          "fillScale": 1
+        },
+        "transform": {
+          "translate": [-1.15, 1.6, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.72,
+          "metal": 0.3,
+          "glow": 0
+        }
+      },
+      {
+        "id": "emp1",
+        "type": "cut-sphere",
+        "args": {
+          "radius": 0.4,
+          "h": -0.16000000000000003
+        },
+        "transform": {
+          "translate": [-1.15, 1.6, 0]
+        },
+        "material": "porcelain"
+      },
+      {
+        "id": "liq2",
+        "type": "sphere-fill-3d",
+        "args": {
+          "levels": [0.5],
+          "radius": 0.4,
+          "cage": false,
+          "fillScale": 1
+        },
+        "transform": {
+          "translate": [0, 1.6, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.72,
+          "metal": 0.3,
+          "glow": 0
+        }
+      },
+      {
+        "id": "emp2",
+        "type": "cut-sphere",
+        "args": {
+          "radius": 0.4,
+          "h": 0
+        },
+        "transform": {
+          "translate": [0, 1.6, 0]
+        },
+        "material": "porcelain"
+      },
+      {
+        "id": "liq3",
+        "type": "sphere-fill-3d",
+        "args": {
+          "levels": [0.7],
+          "radius": 0.4,
+          "cage": false,
+          "fillScale": 1
+        },
+        "transform": {
+          "translate": [1.15, 1.6, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.72,
+          "metal": 0.3,
+          "glow": 0
+        }
+      },
+      {
+        "id": "emp3",
+        "type": "cut-sphere",
+        "args": {
+          "radius": 0.4,
+          "h": 0.15999999999999998
+        },
+        "transform": {
+          "translate": [1.15, 1.6, 0]
+        },
+        "material": "porcelain"
+      },
+      {
+        "id": "liq4",
+        "type": "sphere-fill-3d",
+        "args": {
+          "levels": [0.9],
+          "radius": 0.4,
+          "cage": false,
+          "fillScale": 1
+        },
+        "transform": {
+          "translate": [2.3, 1.6, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.72,
+          "metal": 0.3,
+          "glow": 0
+        }
+      },
+      {
+        "id": "emp4",
+        "type": "cut-sphere",
+        "args": {
+          "radius": 0.4,
+          "h": 0.32000000000000006
+        },
+        "transform": {
+          "translate": [2.3, 1.6, 0]
+        },
+        "material": "porcelain"
+      },
+      {
+        "id": "liq5",
+        "type": "sphere-fill-3d",
+        "args": {
+          "levels": [0.2],
+          "radius": 0.4,
+          "cage": false,
+          "fillScale": 1
+        },
+        "transform": {
+          "translate": [-2.3, 0.30000000000000004, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.72,
+          "metal": 0.3,
+          "glow": 0
+        }
+      },
+      {
+        "id": "emp5",
+        "type": "cut-sphere",
+        "args": {
+          "radius": 0.4,
+          "h": -0.24
+        },
+        "transform": {
+          "translate": [-2.3, 0.30000000000000004, 0]
+        },
+        "material": "porcelain"
+      },
+      {
+        "id": "liq6",
+        "type": "sphere-fill-3d",
+        "args": {
+          "levels": [0.45],
+          "radius": 0.4,
+          "cage": false,
+          "fillScale": 1
+        },
+        "transform": {
+          "translate": [-1.15, 0.30000000000000004, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.72,
+          "metal": 0.3,
+          "glow": 0
+        }
+      },
+      {
+        "id": "emp6",
+        "type": "cut-sphere",
+        "args": {
+          "radius": 0.4,
+          "h": -0.039999999999999994
+        },
+        "transform": {
+          "translate": [-1.15, 0.30000000000000004, 0]
+        },
+        "material": "porcelain"
+      },
+      {
+        "id": "liq7",
+        "type": "sphere-fill-3d",
+        "args": {
+          "levels": [0.65],
+          "radius": 0.4,
+          "cage": false,
+          "fillScale": 1
+        },
+        "transform": {
+          "translate": [0, 0.30000000000000004, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.72,
+          "metal": 0.3,
+          "glow": 0
+        }
+      },
+      {
+        "id": "emp7",
+        "type": "cut-sphere",
+        "args": {
+          "radius": 0.4,
+          "h": 0.12000000000000002
+        },
+        "transform": {
+          "translate": [0, 0.30000000000000004, 0]
+        },
+        "material": "porcelain"
+      },
+      {
+        "id": "liq8",
+        "type": "sphere-fill-3d",
+        "args": {
+          "levels": [0.8],
+          "radius": 0.4,
+          "cage": false,
+          "fillScale": 1
+        },
+        "transform": {
+          "translate": [1.15, 0.30000000000000004, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.72,
+          "metal": 0.3,
+          "glow": 0
+        }
+      },
+      {
+        "id": "emp8",
+        "type": "cut-sphere",
+        "args": {
+          "radius": 0.4,
+          "h": 0.24000000000000005
+        },
+        "transform": {
+          "translate": [1.15, 0.30000000000000004, 0]
+        },
+        "material": "porcelain"
+      },
+      {
+        "id": "liq9",
+        "type": "sphere-fill-3d",
+        "args": {
+          "levels": [1],
+          "radius": 0.4,
+          "cage": false,
+          "fillScale": 1
+        },
+        "transform": {
+          "translate": [2.3, 0.30000000000000004, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.72,
+          "metal": 0.3,
+          "glow": 0
+        }
+      }
+    ],
+    "defaults": {
+      "camera": {
+        "yaw": 0.5,
+        "pitch": 0.28,
+        "distance": 10,
+        "focal": 1.5,
+        "targetX": 0,
+        "targetY": 0.9500000000000004,
+        "targetZ": 0
+      },
+      "light": {
+        "azimuth": 0.6,
+        "altitude": 0.55,
+        "distance": 25,
+        "intensity": 1.2
+      },
+      "shadow": {
+        "enabled": true,
+        "mode": "darken",
+        "strength": 0.4
+      },
+      "studioBg": "dark"
+    },
+    "cameraSequence": {
+      "loop": false,
+      "shots": [
+        {
+          "duration": 0.01,
+          "pos": [-1.6210526315789473, 2.1842105263157894, -7.77],
+          "target": [-0.12105263157894736, 0.9842105263157896, 0],
+          "fov": 34,
+          "transition": "cut"
+        },
+        {
+          "duration": 6,
+          "pos": [1.3789473684210527, 2.1842105263157894, -7.77],
+          "target": [-0.12105263157894736, 0.9842105263157896, 0],
+          "fov": 34,
+          "ease": "smooth",
+          "transition": "blend"
+        }
+      ]
+    }
+  },
+  "meta": {
+    "generatedAt": "2026-06-21",
+    "model": "authored",
+    "pattern": "deck-segment",
+    "costUSD": 0
+  }
+}

--- a/sdf-js/examples/compositor/demo-lifts/deck-authored.json
+++ b/sdf-js/examples/compositor/demo-lifts/deck-authored.json
@@ -1,0 +1,121 @@
+{
+  "id": "deck-authored",
+  "name": "Auto-authored hybrid deck (20 fill slides)",
+  "source": "fill-slide-01..20",
+  "segments": [
+    {
+      "file": "deck-auth-solo-fill-slide-01.json",
+      "title": "kpi-hero: Fill Levels · Cover (20/40/80)",
+      "kind": "slide",
+      "durationSec": 6.5
+    },
+    {
+      "file": "deck-auth-solo-fill-slide-02.json",
+      "title": "compare: Fill Levels · Row of 4 (20/60/80/90)",
+      "kind": "slide",
+      "durationSec": 6.5
+    },
+    {
+      "file": "deck-auth-solo-fill-slide-03.json",
+      "title": "sequence: Fill Levels · Framed row + arrows (10/60/50)",
+      "kind": "slide",
+      "durationSec": 6.5
+    },
+    {
+      "file": "deck-auth-ch0.json",
+      "title": "Chapter 1 · 2 slides",
+      "kind": "chapter",
+      "durationSec": 8.8
+    },
+    {
+      "file": "deck-auth-solo-fill-slide-06.json",
+      "title": "compare: Fill Levels · Cluster of 5 (50/20/100/40/80)",
+      "kind": "slide",
+      "durationSec": 6.5
+    },
+    {
+      "file": "deck-auth-solo-fill-slide-07.json",
+      "title": "compare: Fill Levels · Row of 3 (50/100/80)",
+      "kind": "slide",
+      "durationSec": 6.5
+    },
+    {
+      "file": "deck-auth-solo-fill-slide-08.json",
+      "title": "compare: Fill Levels · Cluster of 3 (60/50/80)",
+      "kind": "slide",
+      "durationSec": 6.5
+    },
+    {
+      "file": "deck-auth-solo-fill-slide-09.json",
+      "title": "compare: Fill Levels · Row of 5 (10..90)",
+      "kind": "slide",
+      "durationSec": 6.5
+    },
+    {
+      "file": "deck-auth-solo-fill-slide-10.json",
+      "title": "list: Fill Levels · Grid of 6 (framed)",
+      "kind": "slide",
+      "durationSec": 6.5
+    },
+    {
+      "file": "deck-auth-ch1.json",
+      "title": "Chapter 2 · 1 slides",
+      "kind": "chapter",
+      "durationSec": 4.4
+    },
+    {
+      "file": "deck-auth-solo-fill-slide-12.json",
+      "title": "compare: Fill Levels · Row of 5 + captions",
+      "kind": "slide",
+      "durationSec": 6.5
+    },
+    {
+      "file": "deck-auth-ch2.json",
+      "title": "Chapter 3 · 1 slides",
+      "kind": "chapter",
+      "durationSec": 4.4
+    },
+    {
+      "file": "deck-auth-solo-fill-slide-14.json",
+      "title": "list: Fill Levels · Bullet list of 4",
+      "kind": "slide",
+      "durationSec": 6.5
+    },
+    {
+      "file": "deck-auth-ch3.json",
+      "title": "Chapter 4 · 1 slides",
+      "kind": "chapter",
+      "durationSec": 4.4
+    },
+    {
+      "file": "deck-auth-solo-fill-slide-16.json",
+      "title": "list: Fill Levels · Vertical 3 (30/80/70)",
+      "kind": "slide",
+      "durationSec": 6.5
+    },
+    {
+      "file": "deck-auth-solo-fill-slide-17.json",
+      "title": "compare: Fill Levels · Two heroes (80/90)",
+      "kind": "slide",
+      "durationSec": 6.5
+    },
+    {
+      "file": "deck-auth-solo-fill-slide-18.json",
+      "title": "sequence: Fill Levels · Progression grid 2×4",
+      "kind": "slide",
+      "durationSec": 6.5
+    },
+    {
+      "file": "deck-auth-solo-fill-slide-19.json",
+      "title": "sequence: Fill Levels · Row of 5 (20..100)",
+      "kind": "slide",
+      "durationSec": 6.5
+    },
+    {
+      "file": "deck-auth-solo-fill-slide-20.json",
+      "title": "list: Fill Levels · Grid 2×5",
+      "kind": "slide",
+      "durationSec": 6.5
+    }
+  ]
+}

--- a/sdf-js/scripts/gen-deck-authored.mjs
+++ b/sdf-js/scripts/gen-deck-authored.mjs
@@ -1,0 +1,210 @@
+#!/usr/bin/env node
+// =============================================================================
+// gen-deck-authored.mjs — AUTO-AUTHOR a real lifted deck into a hybrid spatial
+// deck (the Step-2 payoff). Takes an ordered list of existing slide scenes
+// (default: the 20 fill-slide-* presentation slides) and classifies each:
+//
+//   • SIMPLE + NARROW slide  → groupable into a continuous "chapter": several
+//     slides become stations in ONE world + a touring cameraSequence.
+//   • COMPLEX / WIDE / HEAVY → its own "slide" segment (own scene/shader),
+//     framed by its own camera + a gentle lateral pan so it isn't frozen.
+//
+// Classification is measured, not guessed: per-slide added-GLSL weight (vs the
+// studio library baseline) + x-extent. Output = a deck playlist + the chapter /
+// solo segment scenes, played by deck-player.js via ?deck=deck-authored.
+//
+// Usage: node sdf-js/scripts/gen-deck-authored.mjs
+// =============================================================================
+
+import { readFileSync, writeFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+import { compile } from '../src/scene/index.js';
+import { compileSDF3ToGLSL } from '../src/sdf/sdf3.compile.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const OUT = resolve(__dirname, '../examples/compositor/demo-lifts');
+
+// ---- tunables (validated by the browser GPU check after generation) ---------
+const SOURCE_IDS = Array.from(
+  { length: 20 },
+  (_, i) => `fill-slide-${String(i + 1).padStart(2, '0')}`,
+);
+const CHAPTER_BUDGET = 2600; // max cumulative added-GLSL chars in one chapter shader
+const SIMPLE_SUBJ = 2; // ≤ this many top subjects → chapterable
+const SIMPLE_EXTENT = 2.6; // ≤ this x-extent (world units) → chapterable
+const HEAVY_WEIGHT = 3000; // single-slide added chars above this → always solo
+const STATION_GAP = 5.0;
+
+const BASELINE = (() => {
+  const c = compile({
+    v: 1,
+    defaults: {
+      camera: { yaw: 0.4, pitch: 0.2, distance: 8, focal: 1.5, targetX: 0, targetY: 0, targetZ: 0 },
+      light: { altitude: 0.5, azimuth: 0.6, distance: 8, intensity: 1.1 },
+    },
+    subjects: [{ id: 's', type: 'sphere', args: { radius: 0.5 }, region: 'object' }],
+  });
+  const g = compileSDF3ToGLSL(c.sdf, {
+    sceneFnName: 'sceneSDF',
+    includeLibrary: true,
+    emitObjectIndex: true,
+  });
+  return (typeof g === 'string' ? g : g.glsl).length;
+})();
+
+const clone = (o) => JSON.parse(JSON.stringify(o));
+
+function loadSlide(id) {
+  const d = JSON.parse(readFileSync(`${OUT}/${id}.json`, 'utf8'));
+  const sd = d.sceneData;
+  const xs = sd.subjects.map((s) => s.transform?.translate?.[0] ?? 0);
+  const ys = sd.subjects.map((s) => s.transform?.translate?.[1] ?? 0);
+  const zs = sd.subjects.map((s) => s.transform?.translate?.[2] ?? 0);
+  const extent = Math.max(...xs) - Math.min(...xs) + 1.6; // + radius pad
+  const c = compile(sd);
+  const g = compileSDF3ToGLSL(c.sdf, {
+    sceneFnName: 'sceneSDF',
+    includeLibrary: true,
+    emitObjectIndex: true,
+  });
+  const weight = (typeof g === 'string' ? g : g.glsl).length - BASELINE;
+  const cx = xs.reduce((a, b) => a + b, 0) / xs.length;
+  const cy = ys.reduce((a, b) => a + b, 0) / ys.length;
+  const cz = zs.reduce((a, b) => a + b, 0) / zs.length;
+  return { id, sd, extent, weight, n: sd.subjects.length, cx, cy, cz };
+}
+
+const DEFAULTS = (ty) => ({
+  camera: { yaw: 0.5, pitch: 0.3, distance: 9, focal: 1.5, targetX: 0, targetY: ty, targetZ: 0 },
+  light: { azimuth: 0.6, altitude: 0.55, distance: 25, intensity: 1.2 },
+  shadow: { enabled: true, mode: 'darken', strength: 0.4 },
+  studioBg: 'dark',
+});
+
+// lateral pan that frames a slide of half-width hw centred at (cx,cy,cz)
+function panSeq(cx, cy, cz, hw, dur = 6) {
+  const zback = -Math.max(6, 1.7 * hw + 2.5);
+  const t = [cx, cy, cz];
+  return {
+    loop: false,
+    shots: [
+      { duration: 0.01, pos: [cx - 1.5, cy + 1.2, zback], target: t, fov: 34, transition: 'cut' },
+      {
+        duration: dur,
+        pos: [cx + 1.5, cy + 1.2, zback],
+        target: t,
+        fov: 34,
+        ease: 'smooth',
+        transition: 'blend',
+      },
+    ],
+  };
+}
+
+function wrap(id, title, sceneData) {
+  return {
+    id,
+    title,
+    prompt: title,
+    code2d: '// auto-authored deck segment.',
+    sceneData,
+    meta: { generatedAt: '2026-06-21', model: 'authored', pattern: 'deck-segment', costUSD: 0 },
+  };
+}
+
+// ---- classify + pack --------------------------------------------------------
+const slides = SOURCE_IDS.map(loadSlide);
+const segments = []; // {file, title, kind, durationSec}
+const written = [];
+let chapterBuf = [];
+let chapterWeight = 0;
+let chapterIdx = 0;
+let segIdx = 0;
+
+function flushChapter() {
+  if (!chapterBuf.length) return;
+  // lay each buffered slide at a station along +X, shift subjects, tour camera
+  const subjects = [];
+  const shots = [];
+  chapterBuf.forEach((sl, i) => {
+    const Xi = i * STATION_GAP;
+    sl.sd.subjects.forEach((s, j) => {
+      const c = clone(s);
+      c.id = `c${chapterIdx}s${i}_${j}`;
+      c.transform = c.transform || {};
+      const tr = c.transform.translate || [0, 0, 0];
+      c.transform.translate = [tr[0] - sl.cx + Xi, tr[1], tr[2]];
+      subjects.push(c);
+    });
+    const hw = sl.extent / 2;
+    const zback = -Math.max(6, 1.7 * hw + 2.5);
+    const fr = {
+      pos: [Xi - 1.2, sl.cy + 1.2, zback],
+      target: [Xi, sl.cy, sl.cz],
+      fov: 34,
+      ease: 'smooth',
+    };
+    shots.push({ duration: 2.6, ...fr, transition: i === 0 ? 'cut' : 'blend' });
+    shots.push({ duration: 1.8, ...fr, transition: 'blend' });
+  });
+  const id = `deck-auth-ch${chapterIdx}`;
+  const cy = chapterBuf.reduce((a, b) => a + b.cy, 0) / chapterBuf.length;
+  const seg = wrap(id, `Chapter ${chapterIdx + 1} · ${chapterBuf.length} slides`, {
+    v: 1,
+    name: `Chapter ${chapterIdx + 1}`,
+    source: { format: 'authored', prompt: 'light chapter' },
+    subjects,
+    cameraSequence: { loop: false, shots },
+    defaults: DEFAULTS(cy),
+  });
+  writeFileSync(`${OUT}/${id}.json`, JSON.stringify(seg, null, 2) + '\n');
+  written.push(id);
+  segments.push({
+    file: `${id}.json`,
+    title: seg.title,
+    kind: 'chapter',
+    durationSec: Math.round(shots.length * 2.2 * 10) / 10,
+  });
+  chapterIdx++;
+  chapterBuf = [];
+  chapterWeight = 0;
+}
+
+for (const sl of slides) {
+  const chapterable = sl.n <= SIMPLE_SUBJ && sl.extent <= SIMPLE_EXTENT && sl.weight < HEAVY_WEIGHT;
+  if (chapterable) {
+    if (chapterWeight + sl.weight > CHAPTER_BUDGET || chapterBuf.length >= 5) flushChapter();
+    chapterBuf.push(sl);
+    chapterWeight += sl.weight;
+  } else {
+    flushChapter(); // close any open chapter before a solo
+    // solo segment: keep the slide's own subjects + dark bg + a gentle pan
+    const sd = clone(sl.sd);
+    sd.defaults = { ...sd.defaults, studioBg: 'dark' };
+    sd.cameraSequence = panSeq(sl.cx, sl.cy, sl.cz, sl.extent / 2, 6);
+    const id = `deck-auth-solo-${sl.id}`;
+    const seg = wrap(id, `${sl.sd.name || sl.id}`, sd);
+    writeFileSync(`${OUT}/${id}.json`, JSON.stringify(seg, null, 2) + '\n');
+    written.push(id);
+    segments.push({ file: `${id}.json`, title: seg.title, kind: 'slide', durationSec: 6.5 });
+  }
+  segIdx++;
+}
+flushChapter();
+
+const deck = {
+  id: 'deck-authored',
+  name: 'Auto-authored hybrid deck (20 fill slides)',
+  source: 'fill-slide-01..20',
+  segments,
+};
+writeFileSync(`${OUT}/deck-authored.json`, JSON.stringify(deck, null, 2) + '\n');
+
+const nCh = segments.filter((s) => s.kind === 'chapter').length;
+const nSolo = segments.filter((s) => s.kind === 'slide').length;
+console.log(`baseline ${BASELINE} chars`);
+console.log(
+  `classified ${slides.length} slides → ${segments.length} segments (${nCh} chapters + ${nSolo} solo)`,
+);
+console.log(`wrote ${written.length} segment scenes + deck-authored.json`);


### PR DESCRIPTION
## What — auto-author a real lifted deck into a hybrid spatial deck

The Step-2 payoff: take an existing 20-slide presentation (`fill-slide-01..20`) and turn it into a hybrid spatial deck **automatically**. `gen-deck-authored.mjs` **measures** each slide and classifies it:

- **SIMPLE + NARROW** (≤2 subjects, x-extent ≤ 2.6, light) → grouped into a continuous **chapter**: several slides become stations in one world + a touring `cameraSequence`.
- **COMPLEX / WIDE / HEAVY** → its own scene/shader, framed by its own camera + a gentle lateral **pan**.

Classification is **measured, not guessed** — per-slide added-GLSL weight vs the studio-library baseline + x-extent. The same heuristic generalizes to any lifted deck (this is the reusable authoring step, not a one-off).

## Result
- 20 slides → **19 segments (4 chapters + 15 solo)**, all compile **E0/W0**.
- Played by the existing `deck-player.js` via **`?deck=deck-authored`**.

## Verification (real-browser GPU)
- A chapter tours its station (single fill-sphere).
- The widest solo slide (`slide-20`, a full row of two-tone fill spheres) renders + pans.
- The whole deck plays through with **0 shader errors**.

## Notes
- Segment scenes are loaded by file path (not in the gallery index) — deck internals.
- Tunables (`CHAPTER_BUDGET`, `SIMPLE_*`, `STATION_GAP`) are at the top of the script; the chosen values were validated by the browser GPU check.
- Next candidates: chapter layouts beyond a line (arc/grid), per-station titles, and pointing the authoring tool at a genuinely lifted PDF deck (vs the fill deck).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
