### PR TITLE
Step 2 polish: deck title captions + chapter layouts (arc / grid)

### DIFF
--- a/sdf-js/examples/compositor/deck-player.js
+++ b/sdf-js/examples/compositor/deck-player.js
@@ -8,8 +8,7 @@
 //     + modPolar overflow a shared shader) in its OWN scene/shader, with a short
 //     orbit/dolly cameraSequence so it isn't a frozen object.
 // The player sequences segments, fading the canvas between them to hide the
-// per-scene GLSL compile (200-500ms). This is the hybrid the user chose: light
-// stays one-world, heavy splits into its own scene.
+// per-scene GLSL compile (200-500ms), and shows a per-segment title caption.
 //
 // Launch: open the compositor with ?deck=<deckId> → fetches demo-lifts/<id>.json.
 // It ONLY calls the public window.atlasLoadScene hook — never compositor
@@ -24,6 +23,57 @@ async function waitFor(fn, timeoutMs) {
     if (performance.now() - t0 > timeoutMs) throw new Error('deck-player: waitFor timed out');
     await sleep(60);
   }
+}
+
+// A title caption overlaid on the canvas: a title line + a "kind · i/N" sub-line.
+// Lives in #canvas-wrap so it tracks the render area; fades with each segment.
+function makeCaption(wrap) {
+  if (!wrap) return null;
+  if (getComputedStyle(wrap).position === 'static') wrap.style.position = 'relative';
+  const el = document.createElement('div');
+  el.id = 'deck-caption';
+  Object.assign(el.style, {
+    position: 'absolute',
+    left: '50%',
+    bottom: '6%',
+    transform: 'translateX(-50%)',
+    maxWidth: '80%',
+    padding: '10px 20px',
+    borderRadius: '12px',
+    background: 'rgba(8,11,18,0.62)',
+    backdropFilter: 'blur(6px)',
+    WebkitBackdropFilter: 'blur(6px)',
+    border: '1px solid rgba(255,255,255,0.08)',
+    color: '#f3f6fb',
+    font: '500 17px/1.25 -apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif',
+    textAlign: 'center',
+    letterSpacing: '0.01em',
+    pointerEvents: 'none',
+    opacity: '0',
+    transition: 'opacity 0.45s ease',
+    zIndex: '40',
+    textShadow: '0 1px 3px rgba(0,0,0,0.5)',
+  });
+  const sub = document.createElement('div');
+  Object.assign(sub.style, {
+    marginTop: '3px',
+    font: '600 11px/1 -apple-system,sans-serif',
+    letterSpacing: '0.14em',
+    textTransform: 'uppercase',
+    color: 'rgba(150,180,230,0.85)',
+  });
+  const main = document.createElement('div');
+  el.appendChild(main);
+  el.appendChild(sub);
+  wrap.appendChild(el);
+  return {
+    set(title, kind, i, n) {
+      main.textContent = title || '';
+      sub.textContent = `${kind === 'chapter' ? 'Chapter' : 'Slide'} · ${i + 1} / ${n}`;
+    },
+    show: () => (el.style.opacity = '1'),
+    hide: () => (el.style.opacity = '0'),
+  };
 }
 
 async function playDeck(id) {
@@ -41,12 +91,15 @@ async function playDeck(id) {
   const fade = (v) => {
     if (wrap) wrap.style.opacity = String(v);
   };
+  const caption = makeCaption(wrap);
 
   const FADE_MS = 380;
+  const n = segments.length;
   let i = 0;
   // Loop the deck forever (a presentation reel). User navigation tears it down.
   for (;;) {
     const seg = segments[i];
+    if (caption) caption.hide();
     fade(0);
     await sleep(FADE_MS);
     try {
@@ -62,8 +115,15 @@ async function playDeck(id) {
     await sleep(240); // let the new shader compile behind the fade
     fade(1);
     const dwell = Math.max(1, Number(seg.durationSec) || 6);
+    if (caption) {
+      caption.set(seg.title, seg.kind, i, n);
+      await sleep(260);
+      caption.show();
+      // hide the caption shortly before the next transition for a clean wipe
+      setTimeout(() => caption.hide(), Math.max(600, dwell * 1000 - 700));
+    }
     await sleep(dwell * 1000);
-    i = (i + 1) % segments.length;
+    i = (i + 1) % n;
   }
 }
 

--- a/sdf-js/examples/compositor/demo-lifts/deck-lay-arc.json
+++ b/sdf-js/examples/compositor/demo-lifts/deck-lay-arc.json
@@ -1,0 +1,371 @@
+{
+  "id": "deck-lay-arc",
+  "title": "Arc layout · 5 stations",
+  "prompt": "chapter layout: arc",
+  "code2d": "// chapter layout demo (arc).",
+  "sceneData": {
+    "v": 1,
+    "name": "arc layout",
+    "source": {
+      "format": "authored",
+      "prompt": "arc layout"
+    },
+    "subjects": [
+      {
+        "id": "arc0_0",
+        "type": "sphere",
+        "args": {
+          "radius": 0.4
+        },
+        "transform": {
+          "translate": [-7.389347581823647, 0.7, -4.140587913810898]
+        },
+        "material": {
+          "hue": 0.33,
+          "sat": 0.8,
+          "value": 0.6,
+          "metal": 0.2,
+          "glow": 0
+        }
+      },
+      {
+        "id": "arc0_1",
+        "type": "sphere",
+        "args": {
+          "radius": 0.55
+        },
+        "transform": {
+          "translate": [-6.389347581823647, 0.85, -4.140587913810898]
+        },
+        "material": {
+          "hue": 0,
+          "sat": 0.82,
+          "value": 0.62,
+          "metal": 0.2,
+          "glow": 0
+        }
+      },
+      {
+        "id": "arc0_2",
+        "type": "sphere",
+        "args": {
+          "radius": 0.68
+        },
+        "transform": {
+          "translate": [-5.2393475818236475, 1, -4.140587913810898]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.75,
+          "metal": 0.3,
+          "glow": 0
+        }
+      },
+      {
+        "id": "arc1_0",
+        "type": "box",
+        "args": {
+          "size": [0.4, 0.6, 0.4]
+        },
+        "transform": {
+          "translate": [-4.676843534785498, 0.3, -1.1256538830554215]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.75,
+          "metal": 0.3,
+          "glow": 0
+        }
+      },
+      {
+        "id": "arc1_1",
+        "type": "box",
+        "args": {
+          "size": [0.4, 1, 0.4]
+        },
+        "transform": {
+          "translate": [-4.096843534785498, 0.5, -1.1256538830554215]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.75,
+          "metal": 0.3,
+          "glow": 0
+        }
+      },
+      {
+        "id": "arc1_2",
+        "type": "box",
+        "args": {
+          "size": [0.4, 1.4, 0.4]
+        },
+        "transform": {
+          "translate": [-3.5168435347854983, 0.7, -1.1256538830554215]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.75,
+          "metal": 0.3,
+          "glow": 0
+        }
+      },
+      {
+        "id": "arc1_3",
+        "type": "box",
+        "args": {
+          "size": [0.4, 0.85, 0.4]
+        },
+        "transform": {
+          "translate": [-2.936843534785498, 0.425, -1.1256538830554215]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.75,
+          "metal": 0.3,
+          "glow": 0
+        }
+      },
+      {
+        "id": "arc2_0",
+        "type": "box",
+        "args": {
+          "size": [0.7, 0.7, 0.7]
+        },
+        "transform": {
+          "translate": [-0.65, 0.35, 0.15]
+        },
+        "material": {
+          "hue": 0.5,
+          "sat": 0.72,
+          "value": 0.7,
+          "metal": 0.28,
+          "glow": 0
+        }
+      },
+      {
+        "id": "arc2_1",
+        "type": "box",
+        "args": {
+          "size": [0.7, 0.7, 0.7]
+        },
+        "transform": {
+          "translate": [0.5, 0.5, -0.1]
+        },
+        "material": {
+          "hue": 0.5,
+          "sat": 0.72,
+          "value": 0.7,
+          "metal": 0.28,
+          "glow": 0
+        }
+      },
+      {
+        "id": "arc2_2",
+        "type": "box",
+        "args": {
+          "size": [0.7, 0.7, 0.7]
+        },
+        "transform": {
+          "translate": [-0.05, 1.1, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.75,
+          "metal": 0.3,
+          "glow": 0
+        }
+      },
+      {
+        "id": "arc3_0",
+        "type": "cone",
+        "args": {
+          "height": 1.6,
+          "baseRadius": 0.85
+        },
+        "transform": {
+          "translate": [3.8068435347854983, 0.8, -1.1256538830554215]
+        },
+        "material": {
+          "hue": 0.13,
+          "sat": 0.85,
+          "value": 0.9,
+          "metal": 0.9,
+          "glow": 0
+        }
+      },
+      {
+        "id": "arc3_1",
+        "type": "cone",
+        "args": {
+          "height": 1.05,
+          "baseRadius": 0.55
+        },
+        "transform": {
+          "translate": [4.906843534785498, 0.52, -0.9256538830554215]
+        },
+        "material": {
+          "hue": 0.6,
+          "sat": 0.05,
+          "value": 0.45,
+          "metal": 0.6,
+          "glow": 0
+        }
+      },
+      {
+        "id": "arc4_0",
+        "type": "torus",
+        "args": {
+          "radius": 0.7,
+          "thickness": 0.18
+        },
+        "transform": {
+          "translate": [6.389347581823647, 0.85, -4.140587913810898]
+        },
+        "material": {
+          "hue": 0.5,
+          "sat": 0.72,
+          "value": 0.7,
+          "metal": 0.28,
+          "glow": 0
+        }
+      },
+      {
+        "id": "arc4_1",
+        "type": "sphere",
+        "args": {
+          "radius": 0.34
+        },
+        "transform": {
+          "translate": [6.389347581823647, 0.85, -4.140587913810898]
+        },
+        "material": {
+          "hue": 0.13,
+          "sat": 0.85,
+          "value": 0.9,
+          "metal": 0.9,
+          "glow": 0
+        }
+      }
+    ],
+    "cameraSequence": {
+      "loop": false,
+      "shots": [
+        {
+          "duration": 2.4,
+          "pos": [-3.1946737909118235, 2.45, -10.640587913810897],
+          "target": [-6.389347581823647, 0.85, -4.140587913810898],
+          "fov": 33,
+          "ease": "smooth",
+          "transition": "cut"
+        },
+        {
+          "duration": 1.6,
+          "pos": [-3.1946737909118235, 2.45, -10.640587913810897],
+          "target": [-6.389347581823647, 0.85, -4.140587913810898],
+          "fov": 33,
+          "ease": "smooth",
+          "transition": "blend"
+        },
+        {
+          "duration": 2.4,
+          "pos": [-1.9034217673927492, 2.45, -7.6256538830554215],
+          "target": [-3.8068435347854983, 0.85, -1.1256538830554215],
+          "fov": 33,
+          "ease": "smooth",
+          "transition": "blend"
+        },
+        {
+          "duration": 1.6,
+          "pos": [-1.9034217673927492, 2.45, -7.6256538830554215],
+          "target": [-3.8068435347854983, 0.85, -1.1256538830554215],
+          "fov": 33,
+          "ease": "smooth",
+          "transition": "blend"
+        },
+        {
+          "duration": 2.4,
+          "pos": [0, 2.45, -6.5],
+          "target": [0, 0.85, 0],
+          "fov": 33,
+          "ease": "smooth",
+          "transition": "blend"
+        },
+        {
+          "duration": 1.6,
+          "pos": [0, 2.45, -6.5],
+          "target": [0, 0.85, 0],
+          "fov": 33,
+          "ease": "smooth",
+          "transition": "blend"
+        },
+        {
+          "duration": 2.4,
+          "pos": [1.9034217673927492, 2.45, -7.6256538830554215],
+          "target": [3.8068435347854983, 0.85, -1.1256538830554215],
+          "fov": 33,
+          "ease": "smooth",
+          "transition": "blend"
+        },
+        {
+          "duration": 1.6,
+          "pos": [1.9034217673927492, 2.45, -7.6256538830554215],
+          "target": [3.8068435347854983, 0.85, -1.1256538830554215],
+          "fov": 33,
+          "ease": "smooth",
+          "transition": "blend"
+        },
+        {
+          "duration": 2.4,
+          "pos": [3.1946737909118235, 2.45, -10.640587913810897],
+          "target": [6.389347581823647, 0.85, -4.140587913810898],
+          "fov": 33,
+          "ease": "smooth",
+          "transition": "blend"
+        },
+        {
+          "duration": 1.6,
+          "pos": [3.1946737909118235, 2.45, -10.640587913810897],
+          "target": [6.389347581823647, 0.85, -4.140587913810898],
+          "fov": 33,
+          "ease": "smooth",
+          "transition": "blend"
+        }
+      ]
+    },
+    "defaults": {
+      "camera": {
+        "yaw": 0.5,
+        "pitch": 0.3,
+        "distance": 9,
+        "focal": 1.5,
+        "targetX": 0,
+        "targetY": 0.85,
+        "targetZ": 0
+      },
+      "light": {
+        "azimuth": 0.6,
+        "altitude": 0.55,
+        "distance": 25,
+        "intensity": 1.2
+      },
+      "shadow": {
+        "enabled": true,
+        "mode": "darken",
+        "strength": 0.4
+      },
+      "studioBg": "dark"
+    }
+  },
+  "meta": {
+    "generatedAt": "2026-06-21",
+    "model": "authored",
+    "pattern": "deck-layout",
+    "costUSD": 0
+  }
+}

--- a/sdf-js/examples/compositor/demo-lifts/deck-lay-grid.json
+++ b/sdf-js/examples/compositor/demo-lifts/deck-lay-grid.json
@@ -1,0 +1,371 @@
+{
+  "id": "deck-lay-grid",
+  "title": "Grid layout · 5 stations",
+  "prompt": "chapter layout: grid",
+  "code2d": "// chapter layout demo (grid).",
+  "sceneData": {
+    "v": 1,
+    "name": "grid layout",
+    "source": {
+      "format": "authored",
+      "prompt": "grid layout"
+    },
+    "subjects": [
+      {
+        "id": "grid0_0",
+        "type": "sphere",
+        "args": {
+          "radius": 0.4
+        },
+        "transform": {
+          "translate": [-7, 0.7, 0]
+        },
+        "material": {
+          "hue": 0.33,
+          "sat": 0.8,
+          "value": 0.6,
+          "metal": 0.2,
+          "glow": 0
+        }
+      },
+      {
+        "id": "grid0_1",
+        "type": "sphere",
+        "args": {
+          "radius": 0.55
+        },
+        "transform": {
+          "translate": [-6, 0.85, 0]
+        },
+        "material": {
+          "hue": 0,
+          "sat": 0.82,
+          "value": 0.62,
+          "metal": 0.2,
+          "glow": 0
+        }
+      },
+      {
+        "id": "grid0_2",
+        "type": "sphere",
+        "args": {
+          "radius": 0.68
+        },
+        "transform": {
+          "translate": [-4.85, 1, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.75,
+          "metal": 0.3,
+          "glow": 0
+        }
+      },
+      {
+        "id": "grid1_0",
+        "type": "box",
+        "args": {
+          "size": [0.4, 0.6, 0.4]
+        },
+        "transform": {
+          "translate": [-0.8699999999999999, 0.3, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.75,
+          "metal": 0.3,
+          "glow": 0
+        }
+      },
+      {
+        "id": "grid1_1",
+        "type": "box",
+        "args": {
+          "size": [0.4, 1, 0.4]
+        },
+        "transform": {
+          "translate": [-0.29, 0.5, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.75,
+          "metal": 0.3,
+          "glow": 0
+        }
+      },
+      {
+        "id": "grid1_2",
+        "type": "box",
+        "args": {
+          "size": [0.4, 1.4, 0.4]
+        },
+        "transform": {
+          "translate": [0.29, 0.7, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.75,
+          "metal": 0.3,
+          "glow": 0
+        }
+      },
+      {
+        "id": "grid1_3",
+        "type": "box",
+        "args": {
+          "size": [0.4, 0.85, 0.4]
+        },
+        "transform": {
+          "translate": [0.8699999999999999, 0.425, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.75,
+          "metal": 0.3,
+          "glow": 0
+        }
+      },
+      {
+        "id": "grid2_0",
+        "type": "box",
+        "args": {
+          "size": [0.7, 0.7, 0.7]
+        },
+        "transform": {
+          "translate": [5.35, 0.35, 0.15]
+        },
+        "material": {
+          "hue": 0.5,
+          "sat": 0.72,
+          "value": 0.7,
+          "metal": 0.28,
+          "glow": 0
+        }
+      },
+      {
+        "id": "grid2_1",
+        "type": "box",
+        "args": {
+          "size": [0.7, 0.7, 0.7]
+        },
+        "transform": {
+          "translate": [6.5, 0.5, -0.1]
+        },
+        "material": {
+          "hue": 0.5,
+          "sat": 0.72,
+          "value": 0.7,
+          "metal": 0.28,
+          "glow": 0
+        }
+      },
+      {
+        "id": "grid2_2",
+        "type": "box",
+        "args": {
+          "size": [0.7, 0.7, 0.7]
+        },
+        "transform": {
+          "translate": [5.95, 1.1, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.75,
+          "metal": 0.3,
+          "glow": 0
+        }
+      },
+      {
+        "id": "grid3_0",
+        "type": "cone",
+        "args": {
+          "height": 1.6,
+          "baseRadius": 0.85
+        },
+        "transform": {
+          "translate": [-6, 0.8, 6]
+        },
+        "material": {
+          "hue": 0.13,
+          "sat": 0.85,
+          "value": 0.9,
+          "metal": 0.9,
+          "glow": 0
+        }
+      },
+      {
+        "id": "grid3_1",
+        "type": "cone",
+        "args": {
+          "height": 1.05,
+          "baseRadius": 0.55
+        },
+        "transform": {
+          "translate": [-4.9, 0.52, 6.2]
+        },
+        "material": {
+          "hue": 0.6,
+          "sat": 0.05,
+          "value": 0.45,
+          "metal": 0.6,
+          "glow": 0
+        }
+      },
+      {
+        "id": "grid4_0",
+        "type": "torus",
+        "args": {
+          "radius": 0.7,
+          "thickness": 0.18
+        },
+        "transform": {
+          "translate": [0, 0.85, 6]
+        },
+        "material": {
+          "hue": 0.5,
+          "sat": 0.72,
+          "value": 0.7,
+          "metal": 0.28,
+          "glow": 0
+        }
+      },
+      {
+        "id": "grid4_1",
+        "type": "sphere",
+        "args": {
+          "radius": 0.34
+        },
+        "transform": {
+          "translate": [0, 0.85, 6]
+        },
+        "material": {
+          "hue": 0.13,
+          "sat": 0.85,
+          "value": 0.9,
+          "metal": 0.9,
+          "glow": 0
+        }
+      }
+    ],
+    "cameraSequence": {
+      "loop": false,
+      "shots": [
+        {
+          "duration": 2.4,
+          "pos": [-6, 2.75, -7],
+          "target": [-6, 0.85, 0],
+          "fov": 33,
+          "ease": "smooth",
+          "transition": "cut"
+        },
+        {
+          "duration": 1.6,
+          "pos": [-6, 2.75, -7],
+          "target": [-6, 0.85, 0],
+          "fov": 33,
+          "ease": "smooth",
+          "transition": "blend"
+        },
+        {
+          "duration": 2.4,
+          "pos": [0, 2.75, -7],
+          "target": [0, 0.85, 0],
+          "fov": 33,
+          "ease": "smooth",
+          "transition": "blend"
+        },
+        {
+          "duration": 1.6,
+          "pos": [0, 2.75, -7],
+          "target": [0, 0.85, 0],
+          "fov": 33,
+          "ease": "smooth",
+          "transition": "blend"
+        },
+        {
+          "duration": 2.4,
+          "pos": [6, 2.75, -7],
+          "target": [6, 0.85, 0],
+          "fov": 33,
+          "ease": "smooth",
+          "transition": "blend"
+        },
+        {
+          "duration": 1.6,
+          "pos": [6, 2.75, -7],
+          "target": [6, 0.85, 0],
+          "fov": 33,
+          "ease": "smooth",
+          "transition": "blend"
+        },
+        {
+          "duration": 2.4,
+          "pos": [-6, 2.75, -1],
+          "target": [-6, 0.85, 6],
+          "fov": 33,
+          "ease": "smooth",
+          "transition": "blend"
+        },
+        {
+          "duration": 1.6,
+          "pos": [-6, 2.75, -1],
+          "target": [-6, 0.85, 6],
+          "fov": 33,
+          "ease": "smooth",
+          "transition": "blend"
+        },
+        {
+          "duration": 2.4,
+          "pos": [0, 2.75, -1],
+          "target": [0, 0.85, 6],
+          "fov": 33,
+          "ease": "smooth",
+          "transition": "blend"
+        },
+        {
+          "duration": 1.6,
+          "pos": [0, 2.75, -1],
+          "target": [0, 0.85, 6],
+          "fov": 33,
+          "ease": "smooth",
+          "transition": "blend"
+        }
+      ]
+    },
+    "defaults": {
+      "camera": {
+        "yaw": 0.5,
+        "pitch": 0.3,
+        "distance": 9,
+        "focal": 1.5,
+        "targetX": 0,
+        "targetY": 0.85,
+        "targetZ": 0
+      },
+      "light": {
+        "azimuth": 0.6,
+        "altitude": 0.55,
+        "distance": 25,
+        "intensity": 1.2
+      },
+      "shadow": {
+        "enabled": true,
+        "mode": "darken",
+        "strength": 0.4
+      },
+      "studioBg": "dark"
+    }
+  },
+  "meta": {
+    "generatedAt": "2026-06-21",
+    "model": "authored",
+    "pattern": "deck-layout",
+    "costUSD": 0
+  }
+}

--- a/sdf-js/examples/compositor/demo-lifts/deck-lay-linear.json
+++ b/sdf-js/examples/compositor/demo-lifts/deck-lay-linear.json
@@ -1,0 +1,371 @@
+{
+  "id": "deck-lay-linear",
+  "title": "Linear layout · 5 stations",
+  "prompt": "chapter layout: linear",
+  "code2d": "// chapter layout demo (linear).",
+  "sceneData": {
+    "v": 1,
+    "name": "linear layout",
+    "source": {
+      "format": "authored",
+      "prompt": "linear layout"
+    },
+    "subjects": [
+      {
+        "id": "linear0_0",
+        "type": "sphere",
+        "args": {
+          "radius": 0.4
+        },
+        "transform": {
+          "translate": [-1, 0.7, 0]
+        },
+        "material": {
+          "hue": 0.33,
+          "sat": 0.8,
+          "value": 0.6,
+          "metal": 0.2,
+          "glow": 0
+        }
+      },
+      {
+        "id": "linear0_1",
+        "type": "sphere",
+        "args": {
+          "radius": 0.55
+        },
+        "transform": {
+          "translate": [0, 0.85, 0]
+        },
+        "material": {
+          "hue": 0,
+          "sat": 0.82,
+          "value": 0.62,
+          "metal": 0.2,
+          "glow": 0
+        }
+      },
+      {
+        "id": "linear0_2",
+        "type": "sphere",
+        "args": {
+          "radius": 0.68
+        },
+        "transform": {
+          "translate": [1.15, 1, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.75,
+          "metal": 0.3,
+          "glow": 0
+        }
+      },
+      {
+        "id": "linear1_0",
+        "type": "box",
+        "args": {
+          "size": [0.4, 0.6, 0.4]
+        },
+        "transform": {
+          "translate": [5.13, 0.3, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.75,
+          "metal": 0.3,
+          "glow": 0
+        }
+      },
+      {
+        "id": "linear1_1",
+        "type": "box",
+        "args": {
+          "size": [0.4, 1, 0.4]
+        },
+        "transform": {
+          "translate": [5.71, 0.5, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.75,
+          "metal": 0.3,
+          "glow": 0
+        }
+      },
+      {
+        "id": "linear1_2",
+        "type": "box",
+        "args": {
+          "size": [0.4, 1.4, 0.4]
+        },
+        "transform": {
+          "translate": [6.29, 0.7, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.75,
+          "metal": 0.3,
+          "glow": 0
+        }
+      },
+      {
+        "id": "linear1_3",
+        "type": "box",
+        "args": {
+          "size": [0.4, 0.85, 0.4]
+        },
+        "transform": {
+          "translate": [6.87, 0.425, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.75,
+          "metal": 0.3,
+          "glow": 0
+        }
+      },
+      {
+        "id": "linear2_0",
+        "type": "box",
+        "args": {
+          "size": [0.7, 0.7, 0.7]
+        },
+        "transform": {
+          "translate": [11.35, 0.35, 0.15]
+        },
+        "material": {
+          "hue": 0.5,
+          "sat": 0.72,
+          "value": 0.7,
+          "metal": 0.28,
+          "glow": 0
+        }
+      },
+      {
+        "id": "linear2_1",
+        "type": "box",
+        "args": {
+          "size": [0.7, 0.7, 0.7]
+        },
+        "transform": {
+          "translate": [12.5, 0.5, -0.1]
+        },
+        "material": {
+          "hue": 0.5,
+          "sat": 0.72,
+          "value": 0.7,
+          "metal": 0.28,
+          "glow": 0
+        }
+      },
+      {
+        "id": "linear2_2",
+        "type": "box",
+        "args": {
+          "size": [0.7, 0.7, 0.7]
+        },
+        "transform": {
+          "translate": [11.95, 1.1, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.75,
+          "metal": 0.3,
+          "glow": 0
+        }
+      },
+      {
+        "id": "linear3_0",
+        "type": "cone",
+        "args": {
+          "height": 1.6,
+          "baseRadius": 0.85
+        },
+        "transform": {
+          "translate": [18, 0.8, 0]
+        },
+        "material": {
+          "hue": 0.13,
+          "sat": 0.85,
+          "value": 0.9,
+          "metal": 0.9,
+          "glow": 0
+        }
+      },
+      {
+        "id": "linear3_1",
+        "type": "cone",
+        "args": {
+          "height": 1.05,
+          "baseRadius": 0.55
+        },
+        "transform": {
+          "translate": [19.1, 0.52, 0.2]
+        },
+        "material": {
+          "hue": 0.6,
+          "sat": 0.05,
+          "value": 0.45,
+          "metal": 0.6,
+          "glow": 0
+        }
+      },
+      {
+        "id": "linear4_0",
+        "type": "torus",
+        "args": {
+          "radius": 0.7,
+          "thickness": 0.18
+        },
+        "transform": {
+          "translate": [24, 0.85, 0]
+        },
+        "material": {
+          "hue": 0.5,
+          "sat": 0.72,
+          "value": 0.7,
+          "metal": 0.28,
+          "glow": 0
+        }
+      },
+      {
+        "id": "linear4_1",
+        "type": "sphere",
+        "args": {
+          "radius": 0.34
+        },
+        "transform": {
+          "translate": [24, 0.85, 0]
+        },
+        "material": {
+          "hue": 0.13,
+          "sat": 0.85,
+          "value": 0.9,
+          "metal": 0.9,
+          "glow": 0
+        }
+      }
+    ],
+    "cameraSequence": {
+      "loop": false,
+      "shots": [
+        {
+          "duration": 2.4,
+          "pos": [-1.2, 2.45, -7],
+          "target": [0, 0.85, 0],
+          "fov": 33,
+          "ease": "smooth",
+          "transition": "cut"
+        },
+        {
+          "duration": 1.6,
+          "pos": [-1.2, 2.45, -7],
+          "target": [0, 0.85, 0],
+          "fov": 33,
+          "ease": "smooth",
+          "transition": "blend"
+        },
+        {
+          "duration": 2.4,
+          "pos": [4.8, 2.45, -7],
+          "target": [6, 0.85, 0],
+          "fov": 33,
+          "ease": "smooth",
+          "transition": "blend"
+        },
+        {
+          "duration": 1.6,
+          "pos": [4.8, 2.45, -7],
+          "target": [6, 0.85, 0],
+          "fov": 33,
+          "ease": "smooth",
+          "transition": "blend"
+        },
+        {
+          "duration": 2.4,
+          "pos": [10.8, 2.45, -7],
+          "target": [12, 0.85, 0],
+          "fov": 33,
+          "ease": "smooth",
+          "transition": "blend"
+        },
+        {
+          "duration": 1.6,
+          "pos": [10.8, 2.45, -7],
+          "target": [12, 0.85, 0],
+          "fov": 33,
+          "ease": "smooth",
+          "transition": "blend"
+        },
+        {
+          "duration": 2.4,
+          "pos": [16.8, 2.45, -7],
+          "target": [18, 0.85, 0],
+          "fov": 33,
+          "ease": "smooth",
+          "transition": "blend"
+        },
+        {
+          "duration": 1.6,
+          "pos": [16.8, 2.45, -7],
+          "target": [18, 0.85, 0],
+          "fov": 33,
+          "ease": "smooth",
+          "transition": "blend"
+        },
+        {
+          "duration": 2.4,
+          "pos": [22.8, 2.45, -7],
+          "target": [24, 0.85, 0],
+          "fov": 33,
+          "ease": "smooth",
+          "transition": "blend"
+        },
+        {
+          "duration": 1.6,
+          "pos": [22.8, 2.45, -7],
+          "target": [24, 0.85, 0],
+          "fov": 33,
+          "ease": "smooth",
+          "transition": "blend"
+        }
+      ]
+    },
+    "defaults": {
+      "camera": {
+        "yaw": 0.5,
+        "pitch": 0.3,
+        "distance": 9,
+        "focal": 1.5,
+        "targetX": 0,
+        "targetY": 0.85,
+        "targetZ": 0
+      },
+      "light": {
+        "azimuth": 0.6,
+        "altitude": 0.55,
+        "distance": 25,
+        "intensity": 1.2
+      },
+      "shadow": {
+        "enabled": true,
+        "mode": "darken",
+        "strength": 0.4
+      },
+      "studioBg": "dark"
+    }
+  },
+  "meta": {
+    "generatedAt": "2026-06-21",
+    "model": "authored",
+    "pattern": "deck-layout",
+    "costUSD": 0
+  }
+}

--- a/sdf-js/examples/compositor/demo-lifts/deck-layouts.json
+++ b/sdf-js/examples/compositor/demo-lifts/deck-layouts.json
@@ -1,0 +1,24 @@
+{
+  "id": "deck-layouts",
+  "name": "Chapter layouts (linear / arc / grid)",
+  "segments": [
+    {
+      "file": "deck-lay-linear.json",
+      "title": "Linear layout · 5 stations",
+      "kind": "chapter",
+      "durationSec": 11
+    },
+    {
+      "file": "deck-lay-arc.json",
+      "title": "Arc layout · 5 stations",
+      "kind": "chapter",
+      "durationSec": 11
+    },
+    {
+      "file": "deck-lay-grid.json",
+      "title": "Grid layout · 5 stations",
+      "kind": "chapter",
+      "durationSec": 11
+    }
+  ]
+}

--- a/sdf-js/scripts/gen-deck-layouts.mjs
+++ b/sdf-js/scripts/gen-deck-layouts.mjs
@@ -1,0 +1,167 @@
+#!/usr/bin/env node
+// =============================================================================
+// gen-deck-layouts.mjs — chapter LAYOUTS beyond linear. A "chapter" lays its
+// light slide-stations in 3D and the camera tours them. Same 5 light stations,
+// three layouts so the difference is pure spatial arrangement:
+//   • linear — stations along +X (the original)
+//   • arc    — stations on a shallow fan; camera curves in front of each
+//   • grid   — stations on an X/Z grid; camera weaves row by row
+// Output: deck-layouts (3 chapter segments) played by deck-player.js via
+// ?deck=deck-layouts. Each chapter is its own scene/shader (≈5 light stations
+// fit comfortably — verified in-browser).
+//
+// Usage: node sdf-js/scripts/gen-deck-layouts.mjs
+// =============================================================================
+
+import { writeFileSync, readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const OUT = resolve(__dirname, '../examples/compositor/demo-lifts');
+
+const M = {
+  grey: { hue: 0.6, sat: 0.05, value: 0.45, metal: 0.6, glow: 0 },
+  blue: { hue: 0.58, sat: 0.85, value: 0.75, metal: 0.3, glow: 0 },
+  green: { hue: 0.33, sat: 0.8, value: 0.6, metal: 0.2, glow: 0 },
+  red: { hue: 0.0, sat: 0.82, value: 0.62, metal: 0.2, glow: 0 },
+  gold: { hue: 0.13, sat: 0.85, value: 0.9, metal: 0.9, glow: 0 },
+  teal: { hue: 0.5, sat: 0.72, value: 0.7, metal: 0.28, glow: 0 },
+};
+const S = (type, args, translate, material) => ({ type, args, transform: { translate }, material });
+
+// 5 LIGHT station clusters (subjects centred near origin).
+const STATIONS = [
+  () => [
+    S('sphere', { radius: 0.4 }, [-1.0, 0.7, 0], M.green),
+    S('sphere', { radius: 0.55 }, [0, 0.85, 0], M.red),
+    S('sphere', { radius: 0.68 }, [1.15, 1.0, 0], M.blue),
+  ],
+  () =>
+    [0.6, 1.0, 1.4, 0.85].map((h, i) =>
+      S('box', { size: [0.4, h, 0.4] }, [(i - 1.5) * 0.58, h / 2, 0], M.blue),
+    ),
+  () => [
+    S('box', { size: [0.7, 0.7, 0.7] }, [-0.65, 0.35, 0.15], M.teal),
+    S('box', { size: [0.7, 0.7, 0.7] }, [0.5, 0.5, -0.1], M.teal),
+    S('box', { size: [0.7, 0.7, 0.7] }, [-0.05, 1.1, 0], M.blue),
+  ],
+  () => [
+    S('cone', { height: 1.6, baseRadius: 0.85 }, [0, 0.8, 0], M.gold),
+    S('cone', { height: 1.05, baseRadius: 0.55 }, [1.1, 0.52, 0.2], M.grey),
+  ],
+  () => [
+    S('torus', { radius: 0.7, thickness: 0.18 }, [0, 0.85, 0], M.teal),
+    S('sphere', { radius: 0.34 }, [0, 0.85, 0], M.gold),
+  ],
+];
+const TY = 0.85;
+
+// layout → per-station { pos:[x,y,z], cam:{ pos, target } } (studio camera is
+// at −z looking +z; light atoms are orientation-agnostic so we frame from −z).
+function layout(kind, n, ty) {
+  const out = [];
+  if (kind === 'linear') {
+    const GAP = 6;
+    for (let i = 0; i < n; i++) {
+      const x = i * GAP;
+      out.push({ pos: [x, 0, 0], cam: { pos: [x - 1.2, ty + 1.6, -7], target: [x, ty, 0] } });
+    }
+  } else if (kind === 'arc') {
+    const R = 7,
+      spread = 1.15; // ~66° each side
+    for (let i = 0; i < n; i++) {
+      const a = n > 1 ? -spread + (2 * spread * i) / (n - 1) : 0;
+      const px = R * Math.sin(a),
+        pz = R * Math.cos(a) - R; // fan that bulges toward −z at the ends
+      const d = 6.5;
+      out.push({
+        pos: [px, 0, pz],
+        cam: { pos: [px * 0.5, ty + 1.6, pz - d], target: [px, ty, pz] },
+      });
+    }
+  } else {
+    // grid
+    const cols = Math.ceil(Math.sqrt(n)),
+      GX = 6,
+      GZ = 6;
+    for (let i = 0; i < n; i++) {
+      const c = i % cols,
+        r = Math.floor(i / cols);
+      const px = (c - (cols - 1) / 2) * GX,
+        pz = r * GZ;
+      out.push({ pos: [px, 0, pz], cam: { pos: [px, ty + 1.9, pz - 7], target: [px, ty, pz] } });
+    }
+  }
+  return out;
+}
+
+function buildChapter(kind) {
+  const places = layout(kind, STATIONS.length, TY);
+  const subjects = [];
+  const shots = [];
+  STATIONS.forEach((build, i) => {
+    const { pos, cam } = places[i];
+    build().forEach((s, j) => {
+      subjects.push({
+        id: `${kind}${i}_${j}`,
+        ...s,
+        transform: {
+          translate: [
+            s.transform.translate[0] + pos[0],
+            s.transform.translate[1] + pos[1],
+            s.transform.translate[2] + pos[2],
+          ],
+        },
+      });
+    });
+    const fr = { pos: cam.pos, target: cam.target, fov: 33, ease: 'smooth' };
+    shots.push({ duration: 2.4, ...fr, transition: i === 0 ? 'cut' : 'blend' });
+    shots.push({ duration: 1.6, ...fr, transition: 'blend' });
+  });
+  const id = `deck-lay-${kind}`;
+  return {
+    id,
+    title: `${kind[0].toUpperCase()}${kind.slice(1)} layout · 5 stations`,
+    prompt: `chapter layout: ${kind}`,
+    code2d: `// chapter layout demo (${kind}).`,
+    sceneData: {
+      v: 1,
+      name: `${kind} layout`,
+      source: { format: 'authored', prompt: `${kind} layout` },
+      subjects,
+      cameraSequence: { loop: false, shots },
+      defaults: {
+        camera: {
+          yaw: 0.5,
+          pitch: 0.3,
+          distance: 9,
+          focal: 1.5,
+          targetX: 0,
+          targetY: TY,
+          targetZ: 0,
+        },
+        light: { azimuth: 0.6, altitude: 0.55, distance: 25, intensity: 1.2 },
+        shadow: { enabled: true, mode: 'darken', strength: 0.4 },
+        studioBg: 'dark',
+      },
+    },
+    meta: { generatedAt: '2026-06-21', model: 'authored', pattern: 'deck-layout', costUSD: 0 },
+  };
+}
+
+const chapters = ['linear', 'arc', 'grid'].map(buildChapter);
+for (const ch of chapters)
+  writeFileSync(`${OUT}/${ch.id}.json`, JSON.stringify(ch, null, 2) + '\n');
+const deck = {
+  id: 'deck-layouts',
+  name: 'Chapter layouts (linear / arc / grid)',
+  segments: chapters.map((ch) => ({
+    file: `${ch.id}.json`,
+    title: ch.title,
+    kind: 'chapter',
+    durationSec: 11,
+  })),
+};
+writeFileSync(`${OUT}/deck-layouts.json`, JSON.stringify(deck, null, 2) + '\n');
+console.log(`wrote deck-layouts (${chapters.length} chapters: linear/arc/grid) + playlist`);


### PR DESCRIPTION
## What — deck polish: title captions + chapter layouts (arc / grid)

Two explorations on top of the hybrid deck player.

### 1. Title captions (`deck-player.js`, Layer 2)
A fading caption overlaid on `#canvas-wrap` shows each segment's title + a `Chapter|Slide · i/N` sub-line. Pure DOM, no engine change — fades in after the scene loads and wipes before the next transition. Works for every deck (hybrid, authored, layouts).

### 2. Chapter layouts beyond linear (`gen-deck-layouts.mjs`)
A reusable `layout()` helper places light stations **and** frames the touring camera for three arrangements:
- **linear** — stations along +X (the original)
- **arc** — stations on a shallow fan; the camera curves in front of each
- **grid** — stations on an X/Z grid; the camera weaves

Demo deck **`deck-layouts`** shows all three over the **same 5 light stations**, so the difference is purely spatial arrangement. Launch: `?deck=deck-layouts`.

## Verification (real-browser GPU)
- Caption renders: "Linear layout · 5 stations" + "CHAPTER · 1 / 3".
- Wide establishing shots confirm **arc** fans the stations on a curve and **grid** spreads them across X/Z (vs linear's single row).
- All 3 chapters compile **E0/W0**; 0 shader errors. `node --check` + Prettier clean.

## Notes
- Layouts don't change shader cost (same atoms, different positions) — the per-chapter budget from the hybrid work still applies; 5 light stations fit comfortably.
- Next: wire the `layout` choice into the auto-authoring tool (pick arc/grid by chapter size), per-station sub-titles, transition styles (push / orbit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
