### PR TITLE
Step 2: wire chapter layouts into auto-authoring + shared layout module

### DIFF
--- a/sdf-js/examples/compositor/demo-lifts/deck-auth-ch0.json
+++ b/sdf-js/examples/compositor/demo-lifts/deck-auth-ch0.json
@@ -1,18 +1,18 @@
 {
   "id": "deck-auth-ch0",
-  "title": "Chapter 1 · 2 slides",
-  "prompt": "Chapter 1 · 2 slides",
+  "title": "Chapter 1 · 2 slides (arc)",
+  "prompt": "Chapter 1 · 2 slides (arc)",
   "code2d": "// auto-authored deck segment.",
   "sceneData": {
     "v": 1,
     "name": "Chapter 1",
     "source": {
       "format": "authored",
-      "prompt": "light chapter"
+      "prompt": "light chapter (arc)"
     },
     "subjects": [
       {
-        "id": "c0s0_0",
+        "id": "liq0",
         "type": "sphere-fill-3d",
         "args": {
           "levels": [0.6],
@@ -21,7 +21,7 @@
           "fillScale": 1
         },
         "transform": {
-          "translate": [0, 1, 0]
+          "translate": [-6.389347581823647, 1, -4.140587913810898]
         },
         "material": {
           "hue": 0.58,
@@ -32,19 +32,19 @@
         }
       },
       {
-        "id": "c0s0_1",
+        "id": "emp0",
         "type": "cut-sphere",
         "args": {
           "radius": 1.05,
           "h": 0.20999999999999996
         },
         "transform": {
-          "translate": [0, 1, 0]
+          "translate": [-6.389347581823647, 1, -4.140587913810898]
         },
         "material": "porcelain"
       },
       {
-        "id": "c0s1_0",
+        "id": "liq0",
         "type": "sphere-fill-3d",
         "args": {
           "levels": [1],
@@ -53,7 +53,7 @@
           "fillScale": 1
         },
         "transform": {
-          "translate": [5, 1, 0]
+          "translate": [6.389347581823647, 1, -4.140587913810898]
         },
         "material": {
           "hue": 0.58,
@@ -68,34 +68,34 @@
       "loop": false,
       "shots": [
         {
-          "duration": 2.6,
-          "pos": [-1.2, 2.2, -6],
-          "target": [0, 1, 0],
-          "fov": 34,
+          "duration": 2.4,
+          "pos": [-3.1946737909118235, 2.6, -10.640587913810897],
+          "target": [-6.389347581823647, 1, -4.140587913810898],
+          "fov": 33,
           "ease": "smooth",
           "transition": "cut"
         },
         {
-          "duration": 1.8,
-          "pos": [-1.2, 2.2, -6],
-          "target": [0, 1, 0],
-          "fov": 34,
+          "duration": 1.6,
+          "pos": [-3.1946737909118235, 2.6, -10.640587913810897],
+          "target": [-6.389347581823647, 1, -4.140587913810898],
+          "fov": 33,
           "ease": "smooth",
           "transition": "blend"
         },
         {
-          "duration": 2.6,
-          "pos": [3.8, 2.2, -6],
-          "target": [5, 1, 0],
-          "fov": 34,
+          "duration": 2.4,
+          "pos": [3.1946737909118235, 2.6, -10.640587913810897],
+          "target": [6.389347581823647, 1, -4.140587913810898],
+          "fov": 33,
           "ease": "smooth",
           "transition": "blend"
         },
         {
-          "duration": 1.8,
-          "pos": [3.8, 2.2, -6],
-          "target": [5, 1, 0],
-          "fov": 34,
+          "duration": 1.6,
+          "pos": [3.1946737909118235, 2.6, -10.640587913810897],
+          "target": [6.389347581823647, 1, -4.140587913810898],
+          "fov": 33,
           "ease": "smooth",
           "transition": "blend"
         }

--- a/sdf-js/examples/compositor/demo-lifts/deck-auth-ch1.json
+++ b/sdf-js/examples/compositor/demo-lifts/deck-auth-ch1.json
@@ -1,18 +1,18 @@
 {
   "id": "deck-auth-ch1",
-  "title": "Chapter 2 · 1 slides",
-  "prompt": "Chapter 2 · 1 slides",
+  "title": "Chapter 2 · 1 slides (linear)",
+  "prompt": "Chapter 2 · 1 slides (linear)",
   "code2d": "// auto-authored deck segment.",
   "sceneData": {
     "v": 1,
     "name": "Chapter 2",
     "source": {
       "format": "authored",
-      "prompt": "light chapter"
+      "prompt": "light chapter (linear)"
     },
     "subjects": [
       {
-        "id": "c1s0_0",
+        "id": "liq0",
         "type": "sphere-fill-3d",
         "args": {
           "levels": [0.3],
@@ -32,7 +32,7 @@
         }
       },
       {
-        "id": "c1s0_1",
+        "id": "emp0",
         "type": "cut-sphere",
         "args": {
           "radius": 1.05,
@@ -48,18 +48,18 @@
       "loop": false,
       "shots": [
         {
-          "duration": 2.6,
-          "pos": [-1.2, 2.2, -6],
+          "duration": 2.4,
+          "pos": [-1.2, 2.6, -7],
           "target": [0, 1, 0],
-          "fov": 34,
+          "fov": 33,
           "ease": "smooth",
           "transition": "cut"
         },
         {
-          "duration": 1.8,
-          "pos": [-1.2, 2.2, -6],
+          "duration": 1.6,
+          "pos": [-1.2, 2.6, -7],
           "target": [0, 1, 0],
-          "fov": 34,
+          "fov": 33,
           "ease": "smooth",
           "transition": "blend"
         }

--- a/sdf-js/examples/compositor/demo-lifts/deck-auth-ch2.json
+++ b/sdf-js/examples/compositor/demo-lifts/deck-auth-ch2.json
@@ -1,18 +1,18 @@
 {
   "id": "deck-auth-ch2",
-  "title": "Chapter 3 · 1 slides",
-  "prompt": "Chapter 3 · 1 slides",
+  "title": "Chapter 3 · 1 slides (linear)",
+  "prompt": "Chapter 3 · 1 slides (linear)",
   "code2d": "// auto-authored deck segment.",
   "sceneData": {
     "v": 1,
     "name": "Chapter 3",
     "source": {
       "format": "authored",
-      "prompt": "light chapter"
+      "prompt": "light chapter (linear)"
     },
     "subjects": [
       {
-        "id": "c2s0_0",
+        "id": "liq0",
         "type": "sphere-fill-3d",
         "args": {
           "levels": [0.9],
@@ -32,7 +32,7 @@
         }
       },
       {
-        "id": "c2s0_1",
+        "id": "emp0",
         "type": "cut-sphere",
         "args": {
           "radius": 1.05,
@@ -48,18 +48,18 @@
       "loop": false,
       "shots": [
         {
-          "duration": 2.6,
-          "pos": [-1.2, 2.2, -6],
+          "duration": 2.4,
+          "pos": [-1.2, 2.6, -7],
           "target": [0, 1, 0],
-          "fov": 34,
+          "fov": 33,
           "ease": "smooth",
           "transition": "cut"
         },
         {
-          "duration": 1.8,
-          "pos": [-1.2, 2.2, -6],
+          "duration": 1.6,
+          "pos": [-1.2, 2.6, -7],
           "target": [0, 1, 0],
-          "fov": 34,
+          "fov": 33,
           "ease": "smooth",
           "transition": "blend"
         }

--- a/sdf-js/examples/compositor/demo-lifts/deck-auth-ch3.json
+++ b/sdf-js/examples/compositor/demo-lifts/deck-auth-ch3.json
@@ -1,18 +1,18 @@
 {
   "id": "deck-auth-ch3",
-  "title": "Chapter 4 · 1 slides",
-  "prompt": "Chapter 4 · 1 slides",
+  "title": "Chapter 4 · 1 slides (linear)",
+  "prompt": "Chapter 4 · 1 slides (linear)",
   "code2d": "// auto-authored deck segment.",
   "sceneData": {
     "v": 1,
     "name": "Chapter 4",
     "source": {
       "format": "authored",
-      "prompt": "light chapter"
+      "prompt": "light chapter (linear)"
     },
     "subjects": [
       {
-        "id": "c3s0_0",
+        "id": "liq0",
         "type": "sphere-fill-3d",
         "args": {
           "levels": [1],
@@ -36,18 +36,18 @@
       "loop": false,
       "shots": [
         {
-          "duration": 2.6,
-          "pos": [-1.2, 2.2, -6],
+          "duration": 2.4,
+          "pos": [-1.2, 2.6, -7],
           "target": [0, 1, 0],
-          "fov": 34,
+          "fov": 33,
           "ease": "smooth",
           "transition": "cut"
         },
         {
-          "duration": 1.8,
-          "pos": [-1.2, 2.2, -6],
+          "duration": 1.6,
+          "pos": [-1.2, 2.6, -7],
           "target": [0, 1, 0],
-          "fov": 34,
+          "fov": 33,
           "ease": "smooth",
           "transition": "blend"
         }

--- a/sdf-js/examples/compositor/demo-lifts/deck-authored.json
+++ b/sdf-js/examples/compositor/demo-lifts/deck-authored.json
@@ -23,7 +23,7 @@
     },
     {
       "file": "deck-auth-ch0.json",
-      "title": "Chapter 1 · 2 slides",
+      "title": "Chapter 1 · 2 slides (arc)",
       "kind": "chapter",
       "durationSec": 8.8
     },
@@ -59,7 +59,7 @@
     },
     {
       "file": "deck-auth-ch1.json",
-      "title": "Chapter 2 · 1 slides",
+      "title": "Chapter 2 · 1 slides (linear)",
       "kind": "chapter",
       "durationSec": 4.4
     },
@@ -71,7 +71,7 @@
     },
     {
       "file": "deck-auth-ch2.json",
-      "title": "Chapter 3 · 1 slides",
+      "title": "Chapter 3 · 1 slides (linear)",
       "kind": "chapter",
       "durationSec": 4.4
     },
@@ -83,7 +83,7 @@
     },
     {
       "file": "deck-auth-ch3.json",
-      "title": "Chapter 4 · 1 slides",
+      "title": "Chapter 4 · 1 slides (linear)",
       "kind": "chapter",
       "durationSec": 4.4
     },

--- a/sdf-js/scripts/gen-deck-authored.mjs
+++ b/sdf-js/scripts/gen-deck-authored.mjs
@@ -21,6 +21,7 @@ import { fileURLToPath } from 'node:url';
 import { dirname, resolve } from 'node:path';
 import { compile } from '../src/scene/index.js';
 import { compileSDF3ToGLSL } from '../src/sdf/sdf3.compile.js';
+import { buildChapter, pickLayout } from './lib/chapter-layout.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const OUT = resolve(__dirname, '../examples/compositor/demo-lifts');
@@ -34,7 +35,6 @@ const CHAPTER_BUDGET = 2600; // max cumulative added-GLSL chars in one chapter s
 const SIMPLE_SUBJ = 2; // ≤ this many top subjects → chapterable
 const SIMPLE_EXTENT = 2.6; // ≤ this x-extent (world units) → chapterable
 const HEAVY_WEIGHT = 3000; // single-slide added chars above this → always solo
-const STATION_GAP = 5.0;
 
 const BASELINE = (() => {
   const c = compile({
@@ -124,36 +124,22 @@ let segIdx = 0;
 
 function flushChapter() {
   if (!chapterBuf.length) return;
-  // lay each buffered slide at a station along +X, shift subjects, tour camera
-  const subjects = [];
-  const shots = [];
-  chapterBuf.forEach((sl, i) => {
-    const Xi = i * STATION_GAP;
-    sl.sd.subjects.forEach((s, j) => {
-      const c = clone(s);
-      c.id = `c${chapterIdx}s${i}_${j}`;
-      c.transform = c.transform || {};
-      const tr = c.transform.translate || [0, 0, 0];
-      c.transform.translate = [tr[0] - sl.cx + Xi, tr[1], tr[2]];
-      subjects.push(c);
-    });
-    const hw = sl.extent / 2;
-    const zback = -Math.max(6, 1.7 * hw + 2.5);
-    const fr = {
-      pos: [Xi - 1.2, sl.cy + 1.2, zback],
-      target: [Xi, sl.cy, sl.cz],
-      fov: 34,
-      ease: 'smooth',
-    };
-    shots.push({ duration: 2.6, ...fr, transition: i === 0 ? 'cut' : 'blend' });
-    shots.push({ duration: 1.8, ...fr, transition: 'blend' });
-  });
-  const id = `deck-auth-ch${chapterIdx}`;
+  // auto-pick a layout by station count, then lay slides + tour camera via the
+  // shared chapter-layout helper (1 → linear, 2-3 → arc, 4+ → grid).
+  const kind = pickLayout(chapterBuf.length);
   const cy = chapterBuf.reduce((a, b) => a + b.cy, 0) / chapterBuf.length;
-  const seg = wrap(id, `Chapter ${chapterIdx + 1} · ${chapterBuf.length} slides`, {
+  const stations = chapterBuf.map((sl) => ({
+    subjects: sl.sd.subjects.map(clone),
+    cx: sl.cx,
+    cy: sl.cy,
+    cz: sl.cz,
+  }));
+  const { subjects, shots } = buildChapter(stations, kind, cy, `c${chapterIdx}s`);
+  const id = `deck-auth-ch${chapterIdx}`;
+  const seg = wrap(id, `Chapter ${chapterIdx + 1} · ${chapterBuf.length} slides (${kind})`, {
     v: 1,
     name: `Chapter ${chapterIdx + 1}`,
-    source: { format: 'authored', prompt: 'light chapter' },
+    source: { format: 'authored', prompt: `light chapter (${kind})` },
     subjects,
     cameraSequence: { loop: false, shots },
     defaults: DEFAULTS(cy),

--- a/sdf-js/scripts/gen-deck-layouts.mjs
+++ b/sdf-js/scripts/gen-deck-layouts.mjs
@@ -13,9 +13,10 @@
 // Usage: node sdf-js/scripts/gen-deck-layouts.mjs
 // =============================================================================
 
-import { writeFileSync, readFileSync } from 'node:fs';
+import { writeFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { dirname, resolve } from 'node:path';
+import { buildChapter } from './lib/chapter-layout.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const OUT = resolve(__dirname, '../examples/compositor/demo-lifts');
@@ -57,68 +58,9 @@ const STATIONS = [
 ];
 const TY = 0.85;
 
-// layout → per-station { pos:[x,y,z], cam:{ pos, target } } (studio camera is
-// at −z looking +z; light atoms are orientation-agnostic so we frame from −z).
-function layout(kind, n, ty) {
-  const out = [];
-  if (kind === 'linear') {
-    const GAP = 6;
-    for (let i = 0; i < n; i++) {
-      const x = i * GAP;
-      out.push({ pos: [x, 0, 0], cam: { pos: [x - 1.2, ty + 1.6, -7], target: [x, ty, 0] } });
-    }
-  } else if (kind === 'arc') {
-    const R = 7,
-      spread = 1.15; // ~66° each side
-    for (let i = 0; i < n; i++) {
-      const a = n > 1 ? -spread + (2 * spread * i) / (n - 1) : 0;
-      const px = R * Math.sin(a),
-        pz = R * Math.cos(a) - R; // fan that bulges toward −z at the ends
-      const d = 6.5;
-      out.push({
-        pos: [px, 0, pz],
-        cam: { pos: [px * 0.5, ty + 1.6, pz - d], target: [px, ty, pz] },
-      });
-    }
-  } else {
-    // grid
-    const cols = Math.ceil(Math.sqrt(n)),
-      GX = 6,
-      GZ = 6;
-    for (let i = 0; i < n; i++) {
-      const c = i % cols,
-        r = Math.floor(i / cols);
-      const px = (c - (cols - 1) / 2) * GX,
-        pz = r * GZ;
-      out.push({ pos: [px, 0, pz], cam: { pos: [px, ty + 1.9, pz - 7], target: [px, ty, pz] } });
-    }
-  }
-  return out;
-}
-
-function buildChapter(kind) {
-  const places = layout(kind, STATIONS.length, TY);
-  const subjects = [];
-  const shots = [];
-  STATIONS.forEach((build, i) => {
-    const { pos, cam } = places[i];
-    build().forEach((s, j) => {
-      subjects.push({
-        id: `${kind}${i}_${j}`,
-        ...s,
-        transform: {
-          translate: [
-            s.transform.translate[0] + pos[0],
-            s.transform.translate[1] + pos[1],
-            s.transform.translate[2] + pos[2],
-          ],
-        },
-      });
-    });
-    const fr = { pos: cam.pos, target: cam.target, fov: 33, ease: 'smooth' };
-    shots.push({ duration: 2.4, ...fr, transition: i === 0 ? 'cut' : 'blend' });
-    shots.push({ duration: 1.6, ...fr, transition: 'blend' });
-  });
+function makeChapter(kind) {
+  const stations = STATIONS.map((build) => ({ subjects: build(), cx: 0, cy: 0, cz: 0 }));
+  const { subjects, shots } = buildChapter(stations, kind, TY, kind);
   const id = `deck-lay-${kind}`;
   return {
     id,
@@ -150,7 +92,7 @@ function buildChapter(kind) {
   };
 }
 
-const chapters = ['linear', 'arc', 'grid'].map(buildChapter);
+const chapters = ['linear', 'arc', 'grid'].map(makeChapter);
 for (const ch of chapters)
   writeFileSync(`${OUT}/${ch.id}.json`, JSON.stringify(ch, null, 2) + '\n');
 const deck = {

--- a/sdf-js/scripts/lib/chapter-layout.mjs
+++ b/sdf-js/scripts/lib/chapter-layout.mjs
@@ -1,0 +1,90 @@
+// =============================================================================
+// chapter-layout.mjs — shared chapter spatial layouts for deck authoring.
+// A "chapter" places its light slide-stations in 3D and frames a touring camera.
+// Used by gen-deck-layouts.mjs (showcase) + gen-deck-authored.mjs (real decks).
+//
+//   layout(kind, n, ty)        → per-station { pos:[x,y,z], cam:{ pos, target } }
+//   pickLayout(n)              → auto-choose linear/arc/grid by station count
+//   buildChapter(stations, …)  → { subjects, shots } ready for a SceneData
+//
+// Studio camera is at −z looking +z; light atoms are orientation-agnostic so
+// every layout frames each station from its −z front.
+// =============================================================================
+
+// per-station placement + camera framing for a layout of n stations
+export function layout(kind, n, ty) {
+  const out = [];
+  if (kind === 'linear') {
+    const GAP = 6;
+    for (let i = 0; i < n; i++) {
+      const x = i * GAP;
+      out.push({ pos: [x, 0, 0], cam: { pos: [x - 1.2, ty + 1.6, -7], target: [x, ty, 0] } });
+    }
+  } else if (kind === 'arc') {
+    const R = 7,
+      spread = 1.15; // ~66° each side
+    for (let i = 0; i < n; i++) {
+      const a = n > 1 ? -spread + (2 * spread * i) / (n - 1) : 0;
+      const px = R * Math.sin(a),
+        pz = R * Math.cos(a) - R; // fan that bulges toward −z at the ends
+      const d = 6.5;
+      out.push({
+        pos: [px, 0, pz],
+        cam: { pos: [px * 0.5, ty + 1.6, pz - d], target: [px, ty, pz] },
+      });
+    }
+  } else {
+    // grid
+    const cols = Math.ceil(Math.sqrt(n)),
+      GX = 6,
+      GZ = 6;
+    for (let i = 0; i < n; i++) {
+      const c = i % cols,
+        r = Math.floor(i / cols);
+      const px = (c - (cols - 1) / 2) * GX,
+        pz = r * GZ;
+      out.push({ pos: [px, 0, pz], cam: { pos: [px, ty + 1.9, pz - 7], target: [px, ty, pz] } });
+    }
+  }
+  return out;
+}
+
+// auto-choose a layout by station count: 1 → linear, 2-3 → arc (a nice fan),
+// 4+ → grid (a single row past 3 reads as a wall; grid stays legible).
+export function pickLayout(n) {
+  if (n <= 1) return 'linear';
+  if (n <= 3) return 'arc';
+  return 'grid';
+}
+
+// Build a chapter's flattened subjects + touring cameraSequence shots.
+// stations: [{ subjects:[…], cx, cy, cz }]  (cx/cy/cz = the station's own centre;
+// each station's subjects are recentred to its layout position).
+// idPrefix: globally-unique subject id prefix. Returns { subjects, shots }.
+export function buildChapter(stations, kind, ty, idPrefix) {
+  const places = layout(kind, stations.length, ty);
+  const subjects = [];
+  const shots = [];
+  stations.forEach((st, i) => {
+    const { pos, cam } = places[i];
+    const cx = st.cx ?? 0,
+      cz = st.cz ?? 0;
+    st.subjects.forEach((s, j) => {
+      const tr = s.transform?.translate || [0, 0, 0];
+      // recentre the station horizontally (x,z) to its layout position; keep y
+      // (natural height above the ground — never recentre vertically).
+      subjects.push({
+        id: `${idPrefix}${i}_${j}`,
+        ...s,
+        transform: {
+          ...s.transform,
+          translate: [tr[0] - cx + pos[0], tr[1] + pos[1], tr[2] - cz + pos[2]],
+        },
+      });
+    });
+    const fr = { pos: cam.pos, target: cam.target, fov: 33, ease: 'smooth' };
+    shots.push({ duration: 2.4, ...fr, transition: i === 0 ? 'cut' : 'blend' });
+    shots.push({ duration: 1.6, ...fr, transition: 'blend' });
+  });
+  return { subjects, shots };
+}


### PR DESCRIPTION
## What — chapter layouts wired into auto-authoring (+ shared module)

Extracts the chapter spatial-layout logic into **`scripts/lib/chapter-layout.mjs`** (`layout` / `pickLayout` / `buildChapter`), shared by both deck generators (DRY). The auto-authoring tool now **picks a layout by station count**:

- `pickLayout`: 1 → **linear**, 2-3 → **arc**, 4+ → **grid**

so a chapter's camera tour matches its shape instead of always being a line.

## Changes
- `gen-deck-layouts.mjs` — refactored onto the shared module. Output is **byte-identical** to the inline version it replaced (`deck-lay-*` unchanged) — a clean regression signal that the extraction preserved behavior.
- `gen-deck-authored.mjs` — chapters now build via `buildChapter` + `pickLayout`; titles note the chosen layout. On the fill deck: **Chapter 1 (2 slides) → arc**, the rest → linear.

## Verification
- Real-browser GPU: `deck-lay-arc` (refactor) and `deck-auth-ch0` (the new arc chapter) both render with **0 shader errors**.
- Full suite **82/82**; `node --check` clean. Only the genuinely-changed files are in the diff (the layout extraction left `deck-lay-*` and every solo segment byte-identical).

## Next
- Per-station sub-titles synced to the cameraSequence shots (caption changes as the camera reaches each station within a chapter).
- Transition styles (push / orbit) between segments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
