### PR TITLE
Step 2: per-station subtitles + presenter controls + showcase reel

### DIFF
--- a/sdf-js/examples/compositor/deck-player.js
+++ b/sdf-js/examples/compositor/deck-player.js
@@ -67,10 +67,11 @@ function makeCaption(wrap) {
   el.appendChild(sub);
   wrap.appendChild(el);
   return {
-    set(title, kind, i, n) {
-      main.textContent = title || '';
-      sub.textContent = `${kind === 'chapter' ? 'Chapter' : 'Slide'} · ${i + 1} / ${n}`;
+    set(mainText, subText) {
+      main.textContent = mainText || '';
+      sub.textContent = subText || '';
     },
+    setMain: (mainText) => (main.textContent = mainText || ''),
     show: () => (el.style.opacity = '1'),
     hide: () => (el.style.opacity = '0'),
   };
@@ -102,6 +103,7 @@ async function playDeck(id) {
     if (caption) caption.hide();
     fade(0);
     await sleep(FADE_MS);
+    let seqStart = performance.now();
     try {
       await window.atlasLoadScene({
         id: `${id}-seg${i}`,
@@ -109,20 +111,37 @@ async function playDeck(id) {
         file: seg.file,
         renderer: 'studio',
       });
+      seqStart = performance.now(); // sequence clock starts ~now (post-load)
     } catch (e) {
       console.error('[deck-player] segment load failed', seg, e);
     }
     await sleep(240); // let the new shader compile behind the fade
     fade(1);
     const dwell = Math.max(1, Number(seg.durationSec) || 6);
+    let ticker = null;
     if (caption) {
-      caption.set(seg.title, seg.kind, i, n);
+      const stations = Array.isArray(seg.stationTitles) ? seg.stationTitles : [];
+      const subline = `${seg.kind === 'chapter' ? 'Chapter' : 'Slide'} ${i + 1} / ${n}`;
+      if (stations.length) {
+        // per-station caption: switch the MAIN line as the camera reaches each
+        // station (station.t = seconds from sequence start). Sub = deck position.
+        const pick = () => {
+          const el = (performance.now() - seqStart) / 1000;
+          let cur = stations[0];
+          for (const s of stations) if (s.t <= el) cur = s;
+          caption.set(cur.title, subline);
+        };
+        pick();
+        ticker = setInterval(pick, 150);
+      } else {
+        caption.set(seg.title, subline);
+      }
       await sleep(260);
       caption.show();
-      // hide the caption shortly before the next transition for a clean wipe
       setTimeout(() => caption.hide(), Math.max(600, dwell * 1000 - 700));
     }
     await sleep(dwell * 1000);
+    if (ticker) clearInterval(ticker);
     i = (i + 1) % n;
   }
 }

--- a/sdf-js/examples/compositor/deck-player.js
+++ b/sdf-js/examples/compositor/deck-player.js
@@ -5,12 +5,17 @@
 //   • light "chapter" — many LIGHT atoms in ONE continuous 3D world + a touring
 //     cameraSequence (the camera flies between slide-stations). One shader.
 //   • heavy "slide"   — one RICH atom (gear / pyramid / org / tree, whose loops
-//     + modPolar overflow a shared shader) in its OWN scene/shader, with a short
-//     orbit/dolly cameraSequence so it isn't a frozen object.
-// The player sequences segments, fading the canvas between them to hide the
-// per-scene GLSL compile (200-500ms), and shows a per-segment title caption.
+//     + modPolar overflow a shared shader) in its OWN scene/shader.
 //
-// Launch: open the compositor with ?deck=<deckId> → fetches demo-lifts/<id>.json.
+// This is a controllable presenter, not just an auto-reel:
+//   • per-segment fade transition (hides the per-scene GLSL compile)
+//   • per-STATION caption (overlay): the title switches as the camera reaches
+//     each station within a chapter (station.t = seconds from sequence start)
+//   • progress dots (click to jump) + keyboard: → / Space next, ← prev,
+//     P pause/resume auto-advance, R restart segment.
+//
+// Text policy (locked): narrative/title text → overlay (this file). Only data
+// labels bound to geometry → in-scene SDF. Launch: ?deck=<deckId>.
 // It ONLY calls the public window.atlasLoadScene hook — never compositor
 // internals (compositor = engine/Layer 1; this = app/Layer 2).
 // =============================================================================
@@ -25,17 +30,14 @@ async function waitFor(fn, timeoutMs) {
   }
 }
 
-// A title caption overlaid on the canvas: a title line + a "kind · i/N" sub-line.
-// Lives in #canvas-wrap so it tracks the render area; fades with each segment.
+// ---- caption overlay (title + sub-line), fades with each segment ------------
 function makeCaption(wrap) {
-  if (!wrap) return null;
   if (getComputedStyle(wrap).position === 'static') wrap.style.position = 'relative';
   const el = document.createElement('div');
-  el.id = 'deck-caption';
   Object.assign(el.style, {
     position: 'absolute',
     left: '50%',
-    bottom: '6%',
+    bottom: '7%',
     transform: 'translateX(-50%)',
     maxWidth: '80%',
     padding: '10px 20px',
@@ -47,7 +49,6 @@ function makeCaption(wrap) {
     color: '#f3f6fb',
     font: '500 17px/1.25 -apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif',
     textAlign: 'center',
-    letterSpacing: '0.01em',
     pointerEvents: 'none',
     opacity: '0',
     transition: 'opacity 0.45s ease',
@@ -67,14 +68,86 @@ function makeCaption(wrap) {
   el.appendChild(sub);
   wrap.appendChild(el);
   return {
-    set(mainText, subText) {
-      main.textContent = mainText || '';
-      sub.textContent = subText || '';
+    set: (m, s) => {
+      main.textContent = m || '';
+      sub.textContent = s || '';
     },
-    setMain: (mainText) => (main.textContent = mainText || ''),
+    setMain: (m) => (main.textContent = m || ''),
     show: () => (el.style.opacity = '1'),
     hide: () => (el.style.opacity = '0'),
   };
+}
+
+// ---- progress dots (click to jump) ------------------------------------------
+function makeDots(wrap, n, onJump) {
+  const row = document.createElement('div');
+  Object.assign(row.style, {
+    position: 'absolute',
+    top: '3.5%',
+    left: '50%',
+    transform: 'translateX(-50%)',
+    display: 'flex',
+    gap: '9px',
+    zIndex: '40',
+    padding: '7px 12px',
+    borderRadius: '20px',
+    background: 'rgba(8,11,18,0.45)',
+    backdropFilter: 'blur(5px)',
+    WebkitBackdropFilter: 'blur(5px)',
+  });
+  const dots = [];
+  for (let i = 0; i < n; i++) {
+    const d = document.createElement('div');
+    Object.assign(d.style, {
+      width: '9px',
+      height: '9px',
+      borderRadius: '50%',
+      background: 'rgba(255,255,255,0.28)',
+      cursor: 'pointer',
+      transition: 'background 0.25s ease, transform 0.25s ease',
+    });
+    d.addEventListener('click', () => onJump(i));
+    row.appendChild(d);
+    dots.push(d);
+  }
+  wrap.appendChild(row);
+  return {
+    set(cur, paused) {
+      dots.forEach((d, i) => {
+        const on = i === cur;
+        d.style.background = on
+          ? paused
+            ? 'rgba(255,196,120,0.95)'
+            : 'rgba(150,190,255,0.95)'
+          : 'rgba(255,255,255,0.28)';
+        d.style.transform = on ? 'scale(1.5)' : 'scale(1)';
+      });
+    },
+  };
+}
+
+// brief controls hint that self-fades
+function showHint(wrap) {
+  const h = document.createElement('div');
+  h.textContent = '→ / Space  next   ·   ←  prev   ·   P  pause   ·   R  restart';
+  Object.assign(h.style, {
+    position: 'absolute',
+    bottom: '2%',
+    left: '50%',
+    transform: 'translateX(-50%)',
+    font: '500 11px -apple-system,sans-serif',
+    color: 'rgba(220,230,245,0.6)',
+    background: 'rgba(8,11,18,0.4)',
+    padding: '5px 12px',
+    borderRadius: '8px',
+    zIndex: '40',
+    pointerEvents: 'none',
+    opacity: '1',
+    transition: 'opacity 0.6s ease',
+  });
+  wrap.appendChild(h);
+  setTimeout(() => (h.style.opacity = '0'), 4200);
+  setTimeout(() => h.remove(), 5000);
 }
 
 async function playDeck(id) {
@@ -83,31 +156,55 @@ async function playDeck(id) {
   const deck = await res.json();
   const segments = Array.isArray(deck.segments) ? deck.segments : [];
   if (!segments.length) throw new Error(`deck ${id}: no segments`);
+  const n = segments.length;
 
-  // The compositor module loads async — wait for its public load hook.
   await waitFor(() => typeof window.atlasLoadScene === 'function', 10000);
 
   const wrap = document.getElementById('canvas-wrap');
   if (wrap) wrap.style.transition = 'opacity 0.35s ease';
-  const fade = (v) => {
-    if (wrap) wrap.style.opacity = String(v);
-  };
+  const fade = (v) => wrap && (wrap.style.opacity = String(v));
   const caption = makeCaption(wrap);
 
   const FADE_MS = 380;
-  const n = segments.length;
-  let i = 0;
-  // Loop the deck forever (a presentation reel). User navigation tears it down.
-  for (;;) {
-    const seg = segments[i];
-    if (caption) caption.hide();
+  let cur = -1;
+  let paused = false;
+  let token = 0; // cancels stale async when a newer navigation supersedes it
+  let advanceTimer = null;
+  let ticker = null;
+
+  const dots = makeDots(wrap, n, (i) => go(i));
+
+  function clearTimers() {
+    if (advanceTimer) {
+      clearTimeout(advanceTimer);
+      advanceTimer = null;
+    }
+    if (ticker) {
+      clearInterval(ticker);
+      ticker = null;
+    }
+  }
+
+  function scheduleAdvance(seg) {
+    const dwell = Math.max(1, Number(seg.durationSec) || 6);
+    advanceTimer = setTimeout(() => go(cur + 1), dwell * 1000);
+  }
+
+  async function go(index) {
+    const mine = ++token; // supersede any in-flight transition
+    clearTimers();
+    cur = ((index % n) + n) % n;
+    dots.set(cur, paused);
+    caption.hide();
     fade(0);
     await sleep(FADE_MS);
+    if (mine !== token) return;
+    const seg = segments[cur];
     let seqStart = performance.now();
     try {
       await window.atlasLoadScene({
-        id: `${id}-seg${i}`,
-        title: seg.title || `${id} · ${i + 1}`,
+        id: `${id}-seg${cur}`,
+        title: seg.title || `${id} · ${cur + 1}`,
         file: seg.file,
         renderer: 'studio',
       });
@@ -115,35 +212,59 @@ async function playDeck(id) {
     } catch (e) {
       console.error('[deck-player] segment load failed', seg, e);
     }
+    if (mine !== token) return;
     await sleep(240); // let the new shader compile behind the fade
+    if (mine !== token) return;
     fade(1);
-    const dwell = Math.max(1, Number(seg.durationSec) || 6);
-    let ticker = null;
-    if (caption) {
-      const stations = Array.isArray(seg.stationTitles) ? seg.stationTitles : [];
-      const subline = `${seg.kind === 'chapter' ? 'Chapter' : 'Slide'} ${i + 1} / ${n}`;
-      if (stations.length) {
-        // per-station caption: switch the MAIN line as the camera reaches each
-        // station (station.t = seconds from sequence start). Sub = deck position.
-        const pick = () => {
-          const el = (performance.now() - seqStart) / 1000;
-          let cur = stations[0];
-          for (const s of stations) if (s.t <= el) cur = s;
-          caption.set(cur.title, subline);
-        };
-        pick();
-        ticker = setInterval(pick, 150);
-      } else {
-        caption.set(seg.title, subline);
-      }
-      await sleep(260);
-      caption.show();
-      setTimeout(() => caption.hide(), Math.max(600, dwell * 1000 - 700));
+
+    const subline = `${seg.kind === 'chapter' ? 'Chapter' : 'Slide'} ${cur + 1} / ${n}`;
+    const stations = Array.isArray(seg.stationTitles) ? seg.stationTitles : [];
+    if (stations.length) {
+      const pick = () => {
+        const el = (performance.now() - seqStart) / 1000;
+        let s = stations[0];
+        for (const st of stations) if (st.t <= el) s = st;
+        caption.set(s.title, subline);
+      };
+      pick();
+      ticker = setInterval(pick, 150);
+    } else {
+      caption.set(seg.title, subline);
     }
-    await sleep(dwell * 1000);
-    if (ticker) clearInterval(ticker);
-    i = (i + 1) % n;
+    await sleep(220);
+    if (mine !== token) return;
+    caption.show();
+    if (!paused) scheduleAdvance(seg);
   }
+
+  function togglePause() {
+    paused = !paused;
+    dots.set(cur, paused);
+    if (paused) {
+      if (advanceTimer) {
+        clearTimeout(advanceTimer);
+        advanceTimer = null;
+      }
+    } else if (!advanceTimer) {
+      scheduleAdvance(segments[cur]);
+    }
+  }
+
+  window.addEventListener('keydown', (e) => {
+    if (e.key === ' ' || e.key === 'ArrowRight') {
+      e.preventDefault();
+      go(cur + 1);
+    } else if (e.key === 'ArrowLeft') {
+      go(cur - 1);
+    } else if (e.key === 'p' || e.key === 'P') {
+      togglePause();
+    } else if (e.key === 'r' || e.key === 'R') {
+      go(cur);
+    }
+  });
+
+  showHint(wrap);
+  go(0);
 }
 
 const deckId = new URLSearchParams(location.search).get('deck');

--- a/sdf-js/examples/compositor/demo-lifts/deck-authored.json
+++ b/sdf-js/examples/compositor/demo-lifts/deck-authored.json
@@ -25,7 +25,17 @@
       "file": "deck-auth-ch0.json",
       "title": "Chapter 1 · 2 slides (arc)",
       "kind": "chapter",
-      "durationSec": 8.8
+      "stationTitles": [
+        {
+          "t": 0,
+          "title": "kpi-hero: Fill Levels · Hero 60%"
+        },
+        {
+          "t": 4,
+          "title": "kpi-hero: Fill Levels · Hero 100% + legend"
+        }
+      ],
+      "durationSec": 8
     },
     {
       "file": "deck-auth-solo-fill-slide-06.json",
@@ -61,7 +71,13 @@
       "file": "deck-auth-ch1.json",
       "title": "Chapter 2 · 1 slides (linear)",
       "kind": "chapter",
-      "durationSec": 4.4
+      "stationTitles": [
+        {
+          "t": 0,
+          "title": "kpi-hero: Fill Levels · Hero 30% + list"
+        }
+      ],
+      "durationSec": 4
     },
     {
       "file": "deck-auth-solo-fill-slide-12.json",
@@ -73,7 +89,13 @@
       "file": "deck-auth-ch2.json",
       "title": "Chapter 3 · 1 slides (linear)",
       "kind": "chapter",
-      "durationSec": 4.4
+      "stationTitles": [
+        {
+          "t": 0,
+          "title": "kpi-hero: Fill Levels · Hero 90% + list"
+        }
+      ],
+      "durationSec": 4
     },
     {
       "file": "deck-auth-solo-fill-slide-14.json",
@@ -85,7 +107,13 @@
       "file": "deck-auth-ch3.json",
       "title": "Chapter 4 · 1 slides (linear)",
       "kind": "chapter",
-      "durationSec": 4.4
+      "stationTitles": [
+        {
+          "t": 0,
+          "title": "kpi-hero: Fill Levels · Hero 100% + 4 labels"
+        }
+      ],
+      "durationSec": 4
     },
     {
       "file": "deck-auth-solo-fill-slide-16.json",

--- a/sdf-js/examples/compositor/demo-lifts/deck-layouts.json
+++ b/sdf-js/examples/compositor/demo-lifts/deck-layouts.json
@@ -6,19 +6,85 @@
       "file": "deck-lay-linear.json",
       "title": "Linear layout · 5 stations",
       "kind": "chapter",
-      "durationSec": 11
+      "stationTitles": [
+        {
+          "t": 0,
+          "title": "Spheres"
+        },
+        {
+          "t": 4,
+          "title": "Bars"
+        },
+        {
+          "t": 8,
+          "title": "Cubes"
+        },
+        {
+          "t": 12,
+          "title": "Peaks"
+        },
+        {
+          "t": 16,
+          "title": "Ring"
+        }
+      ],
+      "durationSec": 20
     },
     {
       "file": "deck-lay-arc.json",
       "title": "Arc layout · 5 stations",
       "kind": "chapter",
-      "durationSec": 11
+      "stationTitles": [
+        {
+          "t": 0,
+          "title": "Spheres"
+        },
+        {
+          "t": 4,
+          "title": "Bars"
+        },
+        {
+          "t": 8,
+          "title": "Cubes"
+        },
+        {
+          "t": 12,
+          "title": "Peaks"
+        },
+        {
+          "t": 16,
+          "title": "Ring"
+        }
+      ],
+      "durationSec": 20
     },
     {
       "file": "deck-lay-grid.json",
       "title": "Grid layout · 5 stations",
       "kind": "chapter",
-      "durationSec": 11
+      "stationTitles": [
+        {
+          "t": 0,
+          "title": "Spheres"
+        },
+        {
+          "t": 4,
+          "title": "Bars"
+        },
+        {
+          "t": 8,
+          "title": "Cubes"
+        },
+        {
+          "t": 12,
+          "title": "Peaks"
+        },
+        {
+          "t": 16,
+          "title": "Ring"
+        }
+      ],
+      "durationSec": 20
     }
   ]
 }

--- a/sdf-js/examples/compositor/demo-lifts/deck-showcase.json
+++ b/sdf-js/examples/compositor/demo-lifts/deck-showcase.json
@@ -1,0 +1,75 @@
+{
+  "id": "deck-showcase",
+  "name": "Atlas Present — showcase reel",
+  "note": "Curated playlist reusing existing segment scenes + narrative captions.",
+  "segments": [
+    {
+      "file": "deck-lay-arc.json",
+      "title": "Atlas Present",
+      "kind": "chapter",
+      "stationTitles": [
+        {
+          "t": 0,
+          "title": "Atlas Present"
+        },
+        {
+          "t": 4,
+          "title": "Describe your idea"
+        },
+        {
+          "t": 8,
+          "title": "AI builds the scene"
+        },
+        {
+          "t": 12,
+          "title": "Fly through it"
+        },
+        {
+          "t": 16,
+          "title": "Not slides — a world"
+        }
+      ],
+      "durationSec": 20
+    },
+    {
+      "file": "deck-seg-gears.json",
+      "title": "Rich detail gets its own scene",
+      "kind": "slide",
+      "durationSec": 6.01
+    },
+    {
+      "file": "deck-lay-grid.json",
+      "title": "Arrange in any layout",
+      "kind": "chapter",
+      "stationTitles": [
+        {
+          "t": 0,
+          "title": "Arrange in any layout"
+        },
+        {
+          "t": 4,
+          "title": "Linear rows"
+        },
+        {
+          "t": 8,
+          "title": "Sweeping arcs"
+        },
+        {
+          "t": 12,
+          "title": "Grids you weave through"
+        },
+        {
+          "t": 16,
+          "title": "Your structure, in space"
+        }
+      ],
+      "durationSec": 20
+    },
+    {
+      "file": "deck-seg-pyramid.json",
+      "title": "Hierarchies, monumental",
+      "kind": "slide",
+      "durationSec": 6.01
+    }
+  ]
+}

--- a/sdf-js/scripts/gen-deck-authored.mjs
+++ b/sdf-js/scripts/gen-deck-authored.mjs
@@ -133,8 +133,11 @@ function flushChapter() {
     cx: sl.cx,
     cy: sl.cy,
     cz: sl.cz,
+    // provenance: the per-station caption inherits the SOURCE slide's name —
+    // every word the viewer reads traces back to the real slide, never invented.
+    title: sl.sd.name || sl.id,
   }));
-  const { subjects, shots } = buildChapter(stations, kind, cy, `c${chapterIdx}s`);
+  const { subjects, shots, stationTitles } = buildChapter(stations, kind, cy, `c${chapterIdx}s`);
   const id = `deck-auth-ch${chapterIdx}`;
   const seg = wrap(id, `Chapter ${chapterIdx + 1} · ${chapterBuf.length} slides (${kind})`, {
     v: 1,
@@ -150,7 +153,8 @@ function flushChapter() {
     file: `${id}.json`,
     title: seg.title,
     kind: 'chapter',
-    durationSec: Math.round(shots.length * 2.2 * 10) / 10,
+    stationTitles,
+    durationSec: shots.reduce((a, s) => a + s.duration, 0),
   });
   chapterIdx++;
   chapterBuf = [];

--- a/sdf-js/scripts/gen-deck-layouts.mjs
+++ b/sdf-js/scripts/gen-deck-layouts.mjs
@@ -56,14 +56,22 @@ const STATIONS = [
     S('sphere', { radius: 0.34 }, [0, 0.85, 0], M.gold),
   ],
 ];
+const STATION_TITLES = ['Spheres', 'Bars', 'Cubes', 'Peaks', 'Ring'];
 const TY = 0.85;
 
 function makeChapter(kind) {
-  const stations = STATIONS.map((build) => ({ subjects: build(), cx: 0, cy: 0, cz: 0 }));
-  const { subjects, shots } = buildChapter(stations, kind, TY, kind);
+  const stations = STATIONS.map((build, i) => ({
+    subjects: build(),
+    cx: 0,
+    cy: 0,
+    cz: 0,
+    title: STATION_TITLES[i],
+  }));
+  const { subjects, shots, stationTitles } = buildChapter(stations, kind, TY, kind);
   const id = `deck-lay-${kind}`;
   return {
     id,
+    stationTitles,
     title: `${kind[0].toUpperCase()}${kind.slice(1)} layout · 5 stations`,
     prompt: `chapter layout: ${kind}`,
     code2d: `// chapter layout demo (${kind}).`,
@@ -93,8 +101,11 @@ function makeChapter(kind) {
 }
 
 const chapters = ['linear', 'arc', 'grid'].map(makeChapter);
-for (const ch of chapters)
-  writeFileSync(`${OUT}/${ch.id}.json`, JSON.stringify(ch, null, 2) + '\n');
+for (const ch of chapters) {
+  // stationTitles live on the deck PLAYLIST entry (below), not in the scene file.
+  const { stationTitles: _st, ...sceneFile } = ch;
+  writeFileSync(`${OUT}/${ch.id}.json`, JSON.stringify(sceneFile, null, 2) + '\n');
+}
 const deck = {
   id: 'deck-layouts',
   name: 'Chapter layouts (linear / arc / grid)',
@@ -102,7 +113,8 @@ const deck = {
     file: `${ch.id}.json`,
     title: ch.title,
     kind: 'chapter',
-    durationSec: 11,
+    stationTitles: ch.stationTitles,
+    durationSec: ch.sceneData.cameraSequence.shots.reduce((a, s) => a + s.duration, 0),
   })),
 };
 writeFileSync(`${OUT}/deck-layouts.json`, JSON.stringify(deck, null, 2) + '\n');

--- a/sdf-js/scripts/gen-deck-showcase.mjs
+++ b/sdf-js/scripts/gen-deck-showcase.mjs
@@ -1,0 +1,79 @@
+#!/usr/bin/env node
+// =============================================================================
+// gen-deck-showcase.mjs — a curated "hero" deck that strings the WHOLE Step-2
+// system into one ~50s narrative reel: an arc chapter (intro) → a heavy gear
+// slide → a grid chapter → a heavy pyramid slide. It writes NO new scene files —
+// it's a curated PLAYLIST that REUSES existing segment scenes and supplies the
+// narrative captions (the deck player reads titles/stationTitles from the
+// playlist entry, not the scene). Station t's are derived from each referenced
+// scene's own cameraSequence, so captions stay in sync.
+//
+// Launch: ?deck=deck-showcase
+// Usage:  node sdf-js/scripts/gen-deck-showcase.mjs
+// =============================================================================
+
+import { readFileSync, writeFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const OUT = resolve(__dirname, '../examples/compositor/demo-lifts');
+
+const readScene = (file) => JSON.parse(readFileSync(`${OUT}/${file}`, 'utf8')).sceneData;
+const totalDur = (sd) =>
+  (sd.cameraSequence?.shots || []).reduce((a, s) => a + (s.duration || 0), 0);
+
+// station start times for a chapter scene: stations are (travel + dwell) pairs,
+// so station k starts at the cumulative duration before its travel shot.
+function stationStarts(sd) {
+  const shots = sd.cameraSequence?.shots || [];
+  const starts = [];
+  let t = 0;
+  for (let i = 0; i < shots.length; i += 2) {
+    starts.push(Math.round(t * 100) / 100);
+    t += (shots[i]?.duration || 0) + (shots[i + 1]?.duration || 0);
+  }
+  return starts;
+}
+
+// pair narrative titles with a chapter scene's station start times
+function chapterSeg(file, titles) {
+  const sd = readScene(file);
+  const starts = stationStarts(sd);
+  const stationTitles = starts.map((t, i) => ({ t, title: titles[i] ?? `Station ${i + 1}` }));
+  return { file, title: titles[0], kind: 'chapter', stationTitles, durationSec: totalDur(sd) };
+}
+function slideSeg(file, title) {
+  const sd = readScene(file);
+  return { file, title, kind: 'slide', durationSec: Math.max(5, totalDur(sd)) };
+}
+
+const segments = [
+  chapterSeg('deck-lay-arc.json', [
+    'Atlas Present',
+    'Describe your idea',
+    'AI builds the scene',
+    'Fly through it',
+    'Not slides — a world',
+  ]),
+  slideSeg('deck-seg-gears.json', 'Rich detail gets its own scene'),
+  chapterSeg('deck-lay-grid.json', [
+    'Arrange in any layout',
+    'Linear rows',
+    'Sweeping arcs',
+    'Grids you weave through',
+    'Your structure, in space',
+  ]),
+  slideSeg('deck-seg-pyramid.json', 'Hierarchies, monumental'),
+];
+
+const deck = {
+  id: 'deck-showcase',
+  name: 'Atlas Present — showcase reel',
+  note: 'Curated playlist reusing existing segment scenes + narrative captions.',
+  segments,
+};
+writeFileSync(`${OUT}/deck-showcase.json`, JSON.stringify(deck, null, 2) + '\n');
+console.log(
+  `wrote deck-showcase (${segments.length} segments, ${segments.reduce((a, s) => a + s.durationSec, 0)}s total) — reuses existing scenes`,
+);

--- a/sdf-js/scripts/lib/chapter-layout.mjs
+++ b/sdf-js/scripts/lib/chapter-layout.mjs
@@ -58,13 +58,21 @@ export function pickLayout(n) {
 }
 
 // Build a chapter's flattened subjects + touring cameraSequence shots.
-// stations: [{ subjects:[…], cx, cy, cz }]  (cx/cy/cz = the station's own centre;
-// each station's subjects are recentred to its layout position).
-// idPrefix: globally-unique subject id prefix. Returns { subjects, shots }.
+// stations: [{ subjects:[…], cx, cy, cz, title? }]  (cx/cy/cz = the station's own
+// centre; each station's subjects are recentred to its layout position; title =
+// the per-station caption text — provenance, e.g. the source slide's name).
+// idPrefix: globally-unique subject id prefix.
+// Returns { subjects, shots, stationTitles:[{ t, title }] } where t = the time
+// (seconds, from the sequence start) at which the camera begins moving to that
+// station — the Layer-2 deck player switches the caption main line at each t.
+const TRAVEL = 2.4,
+  DWELL = 1.6;
 export function buildChapter(stations, kind, ty, idPrefix) {
   const places = layout(kind, stations.length, ty);
   const subjects = [];
   const shots = [];
+  const stationTitles = [];
+  let t = 0;
   stations.forEach((st, i) => {
     const { pos, cam } = places[i];
     const cx = st.cx ?? 0,
@@ -82,9 +90,11 @@ export function buildChapter(stations, kind, ty, idPrefix) {
         },
       });
     });
+    if (st.title) stationTitles.push({ t: Math.round(t * 100) / 100, title: st.title });
     const fr = { pos: cam.pos, target: cam.target, fov: 33, ease: 'smooth' };
-    shots.push({ duration: 2.4, ...fr, transition: i === 0 ? 'cut' : 'blend' });
-    shots.push({ duration: 1.6, ...fr, transition: 'blend' });
+    shots.push({ duration: TRAVEL, ...fr, transition: i === 0 ? 'cut' : 'blend' });
+    shots.push({ duration: DWELL, ...fr, transition: 'blend' });
+    t += TRAVEL + DWELL;
   });
-  return { subjects, shots };
+  return { subjects, shots, stationTitles };
 }


### PR DESCRIPTION
## What — per-station subtitles + a real presenter + a showcase reel

Three Layer-2 additions that complete the "deck player → presentable Atlas Present" arc. No engine changes.

### 1. Per-station subtitles (overlay, with provenance)
A chapter's camera visits several stations; the caption **main line now switches to each station** as the camera reaches it (sub line = deck position).
- `chapter-layout.mjs buildChapter` returns `stationTitles:[{t,title}]` — `t` = seconds-from-sequence-start (from the known shot durations), so the player switches captions on a **single time source**, no cross-layer query into the engine's camera clock.
- `gen-deck-authored`: each station title **inherits the source slide's name** — provenance: every word the viewer reads traces back to a real slide, never invented.
- Text policy (locked with the user): narrative/title text → overlay (cheap); only data labels bound to geometry → SDF.

### 2. Presenter controls
`deck-player.js` refactored from an auto-reel into a controllable presenter via a `go(index)` state machine with a token guard (rapid nav never double-loads / races):
- progress dots (one per segment, current highlighted, **click to jump**)
- keyboard: **→ / Space** next, **←** prev, **P** pause/resume, **R** restart
- self-fading controls hint

### 3. `deck-showcase` — hero reel
A curated ~52s narrative (arc chapter → heavy gear → grid chapter → heavy pyramid) that writes **no new scene files** — `gen-deck-showcase.mjs` emits a curated PLAYLIST that **reuses existing scenes** + supplies narrative captions, proving the playlist layer (titles/stationTitles) is decoupled from the scene layer. `?deck=deck-showcase`.

## Verification (real-browser GPU)
- Subtitles: caption main line tracks the visible station (Peaks caption while cones on screen; Bars while bars on screen).
- Presenter: dots render + track current; → advances (wraps 2→0); P pauses (dot turns amber, no auto-advance for 9s > any dwell).
- Showcase: 4 dots + narrative station captions ("AI builds the scene · Chapter 1/4").
- All 0 console errors. Full suite 82/82. Only genuinely-changed files in the diff.

## Architecture note
Cross-segment transitions are constrained to **fade** (two scenes can't share the screen — the shader-budget limit); within a chapter the camera already does a blend dolly. So push/orbit between segments wasn't pursued. Next new ground = data labels via SDF (the other half of the text system).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
