### PR TITLE
Step 2: data-label placement across chart types + loop-atom GPU finding

### DIFF
--- a/sdf-js/examples/compositor/demo-lifts/index.json
+++ b/sdf-js/examples/compositor/demo-lifts/index.json
@@ -1308,6 +1308,26 @@
       "file": "data-labels-proto.json",
       "renderer": "studio",
       "prompt": "bar chart with SDF value labels"
+    },
+    {
+      "id": "labels-bar",
+      "title": "Bar chart · value labels (box bars)",
+      "thesisPoint": "Data labels bound to chart geometry → SDF (non-loop atoms / box charts only; loop atoms overflow).",
+      "category": "data-labels",
+      "status": "ready",
+      "file": "labels-bar.json",
+      "renderer": "studio",
+      "prompt": "Bar chart · value labels (box bars)"
+    },
+    {
+      "id": "labels-pie",
+      "title": "Pie chart · slice labels",
+      "thesisPoint": "Data labels bound to chart geometry → SDF (non-loop atoms / box charts only; loop atoms overflow).",
+      "category": "data-labels",
+      "status": "ready",
+      "file": "labels-pie.json",
+      "renderer": "studio",
+      "prompt": "Pie chart · slice labels"
     }
   ]
 }

--- a/sdf-js/examples/compositor/demo-lifts/labels-bar.json
+++ b/sdf-js/examples/compositor/demo-lifts/labels-bar.json
@@ -1,0 +1,230 @@
+{
+  "id": "labels-bar",
+  "title": "Bar chart · value labels (box bars)",
+  "prompt": "Bar chart · value labels (box bars)",
+  "code2d": "// Bar chart · value labels (box bars) (data-labels helper).",
+  "sceneData": {
+    "v": 1,
+    "name": "Bar chart · value labels (box bars)",
+    "source": {
+      "format": "authored",
+      "prompt": "Bar chart · value labels (box bars)"
+    },
+    "subjects": [
+      {
+        "id": "bar0",
+        "type": "box",
+        "args": {
+          "size": [0.5, 0.8800000000000001, 0.5]
+        },
+        "transform": {
+          "translate": [-1.9, 0.44000000000000006, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.75,
+          "metal": 0.3,
+          "glow": 0
+        }
+      },
+      {
+        "id": "bar1",
+        "type": "box",
+        "args": {
+          "size": [0.5, 1.4520000000000002, 0.5]
+        },
+        "transform": {
+          "translate": [-0.95, 0.7260000000000001, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.75,
+          "metal": 0.3,
+          "glow": 0
+        }
+      },
+      {
+        "id": "bar2",
+        "type": "box",
+        "args": {
+          "size": [0.5, 2.2, 0.5]
+        },
+        "transform": {
+          "translate": [0, 1.1, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.75,
+          "metal": 0.3,
+          "glow": 0
+        }
+      },
+      {
+        "id": "bar3",
+        "type": "box",
+        "args": {
+          "size": [0.5, 1.32, 0.5]
+        },
+        "transform": {
+          "translate": [0.9499999999999997, 0.66, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.75,
+          "metal": 0.3,
+          "glow": 0
+        }
+      },
+      {
+        "id": "bar4",
+        "type": "box",
+        "args": {
+          "size": [0.5, 1.7160000000000002, 0.5]
+        },
+        "transform": {
+          "translate": [1.9, 0.8580000000000001, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.75,
+          "metal": 0.3,
+          "glow": 0
+        }
+      },
+      {
+        "id": "lbl0",
+        "type": "text-3d-pipe",
+        "args": {
+          "text": "$1.2M",
+          "height": 0.3,
+          "pipeRadius": 0.05,
+          "align": "center"
+        },
+        "transform": {
+          "translate": [-1.9, 1.06, -0.35]
+        },
+        "material": {
+          "hue": 0,
+          "sat": 0,
+          "value": 1,
+          "metal": 0,
+          "glow": 0.28
+        }
+      },
+      {
+        "id": "lbl1",
+        "type": "text-3d-pipe",
+        "args": {
+          "text": "$2.0M",
+          "height": 0.3,
+          "pipeRadius": 0.05,
+          "align": "center"
+        },
+        "transform": {
+          "translate": [-0.95, 1.6320000000000001, -0.35]
+        },
+        "material": {
+          "hue": 0,
+          "sat": 0,
+          "value": 1,
+          "metal": 0,
+          "glow": 0.28
+        }
+      },
+      {
+        "id": "lbl2",
+        "type": "text-3d-pipe",
+        "args": {
+          "text": "$3.4M",
+          "height": 0.3,
+          "pipeRadius": 0.05,
+          "align": "center"
+        },
+        "transform": {
+          "translate": [0, 2.3800000000000003, -0.35]
+        },
+        "material": {
+          "hue": 0,
+          "sat": 0,
+          "value": 1,
+          "metal": 0,
+          "glow": 0.28
+        }
+      },
+      {
+        "id": "lbl3",
+        "type": "text-3d-pipe",
+        "args": {
+          "text": "$1.8M",
+          "height": 0.3,
+          "pipeRadius": 0.05,
+          "align": "center"
+        },
+        "transform": {
+          "translate": [0.9499999999999997, 1.5, -0.35]
+        },
+        "material": {
+          "hue": 0,
+          "sat": 0,
+          "value": 1,
+          "metal": 0,
+          "glow": 0.28
+        }
+      },
+      {
+        "id": "lbl4",
+        "type": "text-3d-pipe",
+        "args": {
+          "text": "$2.6M",
+          "height": 0.3,
+          "pipeRadius": 0.05,
+          "align": "center"
+        },
+        "transform": {
+          "translate": [1.9, 1.8960000000000001, -0.35]
+        },
+        "material": {
+          "hue": 0,
+          "sat": 0,
+          "value": 1,
+          "metal": 0,
+          "glow": 0.28
+        }
+      }
+    ],
+    "defaults": {
+      "camera": {
+        "yaw": 0.4,
+        "pitch": 0.2,
+        "distance": 9,
+        "focal": 1.5,
+        "targetX": 0,
+        "targetY": 1.4,
+        "targetZ": 0
+      },
+      "light": {
+        "azimuth": 0.6,
+        "altitude": 0.55,
+        "distance": 25,
+        "intensity": 1.2
+      },
+      "shadow": {
+        "enabled": true,
+        "mode": "darken",
+        "strength": 0.4
+      },
+      "studioBg": "dark"
+    }
+  },
+  "meta": {
+    "generatedAt": "2026-06-21",
+    "model": "authored",
+    "pattern": "data-labels",
+    "costUSD": 0
+  }
+}

--- a/sdf-js/examples/compositor/demo-lifts/labels-pie.json
+++ b/sdf-js/examples/compositor/demo-lifts/labels-pie.json
@@ -1,0 +1,145 @@
+{
+  "id": "labels-pie",
+  "title": "Pie chart · slice labels",
+  "prompt": "Pie chart · slice labels",
+  "code2d": "// Pie chart · slice labels (data-labels helper).",
+  "sceneData": {
+    "v": 1,
+    "name": "Pie chart · slice labels",
+    "source": {
+      "format": "authored",
+      "prompt": "Pie chart · slice labels"
+    },
+    "subjects": [
+      {
+        "id": "pie",
+        "type": "pie-3d",
+        "args": {
+          "values": [0.35, 0.25, 0.22, 0.18],
+          "outerRadius": 1.1,
+          "innerRadius": 0.4,
+          "thickness": 0.35
+        },
+        "transform": {
+          "translate": [0, 1.4, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.75,
+          "metal": 0.3,
+          "glow": 0
+        }
+      },
+      {
+        "id": "lbl0",
+        "type": "text-3d-pipe",
+        "args": {
+          "text": "35%",
+          "height": 0.3,
+          "pipeRadius": 0.05,
+          "align": "center"
+        },
+        "transform": {
+          "translate": [1.2919594600731337, 2.058286224622343, -0.275]
+        },
+        "material": {
+          "hue": 0,
+          "sat": 0,
+          "value": 1,
+          "metal": 0,
+          "glow": 0.28
+        }
+      },
+      {
+        "id": "lbl1",
+        "type": "text-3d-pipe",
+        "args": {
+          "text": "25%",
+          "height": 0.3,
+          "pipeRadius": 0.05,
+          "align": "center"
+        },
+        "transform": {
+          "translate": [0.22682997430833488, -0.03214809386294992, -0.275]
+        },
+        "material": {
+          "hue": 0,
+          "sat": 0,
+          "value": 1,
+          "metal": 0,
+          "glow": 0.28
+        }
+      },
+      {
+        "id": "lbl2",
+        "type": "text-3d-pipe",
+        "args": {
+          "text": "22%",
+          "height": 0.3,
+          "pipeRadius": 0.05,
+          "align": "center"
+        },
+        "transform": {
+          "translate": [-1.404445583636515, 1.0393996636109597, -0.275]
+        },
+        "material": {
+          "hue": 0,
+          "sat": 0,
+          "value": 1,
+          "metal": 0,
+          "glow": 0.28
+        }
+      },
+      {
+        "id": "lbl3",
+        "type": "text-3d-pipe",
+        "args": {
+          "text": "18%",
+          "height": 0.3,
+          "pipeRadius": 0.05,
+          "align": "center"
+        },
+        "transform": {
+          "translate": [-0.776948852719546, 2.6242754919779214, -0.275]
+        },
+        "material": {
+          "hue": 0,
+          "sat": 0,
+          "value": 1,
+          "metal": 0,
+          "glow": 0.28
+        }
+      }
+    ],
+    "defaults": {
+      "camera": {
+        "yaw": 0.4,
+        "pitch": 0.2,
+        "distance": 8,
+        "focal": 1.5,
+        "targetX": 0,
+        "targetY": 1.4,
+        "targetZ": 0
+      },
+      "light": {
+        "azimuth": 0.6,
+        "altitude": 0.55,
+        "distance": 25,
+        "intensity": 1.2
+      },
+      "shadow": {
+        "enabled": true,
+        "mode": "darken",
+        "strength": 0.4
+      },
+      "studioBg": "dark"
+    }
+  },
+  "meta": {
+    "generatedAt": "2026-06-21",
+    "model": "authored",
+    "pattern": "data-labels",
+    "costUSD": 0
+  }
+}

--- a/sdf-js/scripts/gen-data-labels-charts.mjs
+++ b/sdf-js/scripts/gen-data-labels-charts.mjs
@@ -1,0 +1,144 @@
+#!/usr/bin/env node
+// =============================================================================
+// gen-data-labels-charts.mjs — labeled charts using the shared data-labels
+// placement helper. Generalizes the bar prototype across chart types.
+//
+// HARD CONSTRAINT FOUND (real-browser GPU, 2026-06-21):
+//   SDF text-3d-pipe labels DO NOT co-exist with the LOOP/array chart atoms
+//   (bar-3d / line-3d / column-3d use a float[32] value loop). Even ONE label
+//   on a bar-3d overflows the single studio shader — the loop's instruction
+//   count + a glyph SDF together blow the GPU limit, though each renders fine
+//   alone. NON-loop atoms (pie-3d = a plain disc formula) tolerate SDF labels.
+// → Routing (matches the two-text-systems escape hatch):
+//   • pie / radial / any non-loop atom → SDF labels OK (labels-pie).
+//   • bar / column / line → build the bars from PLAIN BOXES (no loop atom) and
+//     label those (labels-bar), OR send labels to the overlay layer.
+// The anchor math in data-labels.mjs is correct for all four (validated); the
+// constraint is purely the GPU shader budget of loop-atom + glyph.
+//
+// Usage: node sdf-js/scripts/gen-data-labels-charts.mjs
+// =============================================================================
+
+import { readFileSync, writeFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+import { compile } from '../src/scene/index.js';
+import { compileSDF3ToGLSL } from '../src/sdf/sdf3.compile.js';
+import { barAnchors, pieAnchors, placeLabels } from './lib/data-labels.mjs';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const OUT = resolve(__dirname, '../examples/compositor/demo-lifts');
+const BLUE = { hue: 0.58, sat: 0.85, value: 0.75, metal: 0.3, glow: 0 };
+
+function wrap(id, title, subjects, camera) {
+  return {
+    id,
+    title,
+    prompt: title,
+    code2d: `// ${title} (data-labels helper).`,
+    sceneData: {
+      v: 1,
+      name: title,
+      source: { format: 'authored', prompt: title },
+      subjects,
+      defaults: {
+        camera,
+        light: { azimuth: 0.6, altitude: 0.55, distance: 25, intensity: 1.2 },
+        shadow: { enabled: true, mode: 'darken', strength: 0.4 },
+        studioBg: 'dark',
+      },
+    },
+    meta: { generatedAt: '2026-06-21', model: 'authored', pattern: 'data-labels', costUSD: 0 },
+  };
+}
+const cam = (ty, dist) => ({
+  yaw: 0.4,
+  pitch: 0.2,
+  distance: dist,
+  focal: 1.5,
+  targetX: 0,
+  targetY: ty,
+  targetZ: 0,
+});
+
+const REV = [0.4, 0.66, 1.0, 0.6, 0.78];
+const REV_L = ['$1.2M', '$2.0M', '$3.4M', '$1.8M', '$2.6M'];
+const PIE = [0.35, 0.25, 0.22, 0.18];
+const PIE_L = ['35%', '25%', '22%', '18%'];
+
+// ---- labels-bar: PLAIN BOXES (no loop atom) + labels (GPU-safe) -------------
+const BAR = { barWidth: 0.5, barDepth: 0.5, gap: 0.45, maxHeight: 2.2 };
+const N = REV.length;
+const totalX = N * BAR.barWidth + (N - 1) * BAR.gap;
+const xStart = -totalX / 2 + BAR.barWidth / 2;
+const barBoxes = REV.map((v, i) => {
+  const h = v * BAR.maxHeight;
+  return {
+    id: `bar${i}`,
+    type: 'box',
+    args: { size: [BAR.barWidth, h, BAR.barDepth] },
+    transform: { translate: [xStart + i * (BAR.barWidth + BAR.gap), h / 2, 0] },
+    material: BLUE,
+  };
+});
+const barLabels = placeLabels(barAnchors(REV, BAR), REV_L, { height: 0.3, pipeRadius: 0.05 });
+
+// ---- labels-pie: pie-3d ATOM (non-loop) + labels (GPU-safe) ------------------
+const PIE_ARGS = { values: PIE, outerRadius: 1.1, innerRadius: 0.4, thickness: 0.35 };
+const pieSubj = {
+  id: 'pie',
+  type: 'pie-3d',
+  args: PIE_ARGS,
+  transform: { translate: [0, 1.4, 0] },
+  material: BLUE,
+};
+const pieLabels = placeLabels(
+  pieAnchors(PIE, { outerRadius: 1.1, thickness: 0.35 }).map((a) => ({
+    x: a.x,
+    y: a.y + 1.4,
+    z: a.z,
+  })),
+  PIE_L,
+  { height: 0.3, pipeRadius: 0.05 },
+);
+
+const charts = [
+  wrap(
+    'labels-bar',
+    'Bar chart · value labels (box bars)',
+    [...barBoxes, ...barLabels],
+    cam(1.4, 9),
+  ),
+  wrap('labels-pie', 'Pie chart · slice labels', [pieSubj, ...pieLabels], cam(1.4, 8)),
+];
+
+// build + measure + register
+const idxPath = `${OUT}/index.json`;
+const index = JSON.parse(readFileSync(idxPath, 'utf8'));
+for (const c of charts) {
+  const compiled = compile(c.sceneData);
+  const g = compileSDF3ToGLSL(compiled.sdf, {
+    sceneFnName: 'sceneSDF',
+    includeLibrary: true,
+    emitObjectIndex: true,
+  });
+  const len = (typeof g === 'string' ? g : g.glsl).length;
+  const e = compiled.sanityResult ? compiled.sanityResult.errors.length : 0;
+  console.log(`${c.id.padEnd(12)} ${c.sceneData.subjects.length} subj  GLSL ${len}  E${e}`);
+  writeFileSync(`${OUT}/${c.id}.json`, JSON.stringify(c, null, 2) + '\n');
+  if (!index.demos.some((d) => d.id === c.id)) {
+    index.demos.push({
+      id: c.id,
+      title: c.title,
+      thesisPoint:
+        'Data labels bound to chart geometry → SDF (non-loop atoms / box charts only; loop atoms overflow).',
+      category: 'data-labels',
+      status: 'ready',
+      file: `${c.id}.json`,
+      renderer: 'studio',
+      prompt: c.title,
+    });
+  }
+}
+writeFileSync(idxPath, JSON.stringify(index, null, 2) + '\n');
+console.log(`wrote ${charts.length} labeled charts; index now ${index.demos.length} demos`);

--- a/sdf-js/scripts/lib/data-labels.mjs
+++ b/sdf-js/scripts/lib/data-labels.mjs
@@ -1,0 +1,106 @@
+// =============================================================================
+// data-labels.mjs — SDF data-label PLACEMENT for chart atoms (the in-scene half
+// of the two-text-systems split; narrative text rides the overlay caption).
+// Each anchor function mirrors the corresponding chart atom's own layout math
+// so labels land exactly on the rendered elements. Labels face the −z camera
+// (no rotate — rotating a pipe-glyph mirrors it).
+//
+// Budget (measured): each short label ≈ +2k GLSL chars; ≤~10 short labels/chart
+// is GPU-safe. Long labels / stacking onto heavy loop-atoms → re-measure.
+// =============================================================================
+
+const LABEL_MAT = { hue: 0, sat: 0, value: 1, metal: 0, glow: 0.28 };
+
+// bar-3d: bars along +X, grow up. anchor = above each bar's top, on the −z front.
+export function barAnchors(
+  values,
+  { barWidth = 0.4, barDepth = 0.4, gap = 0.1, maxHeight = 2.0, margin = 0.18 } = {},
+) {
+  const N = values.length;
+  const totalX = N * barWidth + (N - 1) * gap;
+  const xStart = -totalX / 2 + barWidth / 2;
+  return values.map((v, i) => ({
+    x: xStart + i * (barWidth + gap),
+    y: v * maxHeight + margin,
+    z: -barDepth / 2 - 0.1,
+  }));
+}
+
+// line-3d: points along +X at value heights. anchor = above each point.
+export function lineAnchors(values, { pointSpacing = 0.5, maxHeight = 2.0, margin = 0.22 } = {}) {
+  const N = values.length;
+  const xStart = -((N - 1) * pointSpacing) / 2;
+  return values.map((v, i) => ({
+    x: xStart + i * pointSpacing,
+    y: v * maxHeight + margin,
+    z: -0.12,
+  }));
+}
+
+// column-3d: horizontal bars stacked along Y, grow along +X. anchor = beyond each bar's end.
+export function columnAnchors(
+  values,
+  { barWidth = 0.4, barDepth = 0.4, gap = 0.1, maxHeight = 2.0, margin = 0.32 } = {},
+) {
+  const N = values.length;
+  const totalY = N * barWidth + (N - 1) * gap;
+  const yStart = -totalY / 2 + barWidth / 2;
+  return values.map((v, i) => ({
+    x: v * maxHeight + margin,
+    y: yStart + i * (barWidth + gap),
+    z: -barDepth / 2 - 0.1,
+  }));
+}
+
+// pie-3d (standing, unrotated, facing −z): anchor at each slice's mid-angle, just
+// outside the rim. startAngle/clockwise match the atom defaults (12 o'clock, CW).
+export function pieAnchors(
+  values,
+  {
+    outerRadius = 1.0,
+    thickness = 0.3,
+    startAngle = Math.PI / 2,
+    clockwise = true,
+    margin = 0.35,
+  } = {},
+) {
+  const sum = values.reduce((a, b) => a + (b > 0 ? b : 0), 0) || 1;
+  const R = outerRadius + margin;
+  const dir = clockwise ? -1 : 1;
+  let cum = 0;
+  return values.map((v) => {
+    const frac = Math.max(0, v) / sum;
+    const mid = cum + frac / 2;
+    cum += frac;
+    const ang = startAngle + dir * mid * 2 * Math.PI;
+    return { x: R * Math.cos(ang), y: R * Math.sin(ang), z: -thickness / 2 - 0.1 };
+  });
+}
+
+// turn anchors + label strings into text-3d-pipe subjects (camera-facing).
+export function placeLabels(
+  anchors,
+  labels,
+  {
+    height = 0.3,
+    pipeRadius = 0.05,
+    material = LABEL_MAT,
+    idPrefix = 'lbl',
+    align = 'center',
+  } = {},
+) {
+  return anchors.map((a, i) => ({
+    id: `${idPrefix}${i}`,
+    type: 'text-3d-pipe',
+    args: { text: String(labels[i] ?? ''), height, pipeRadius, align },
+    transform: { translate: [a.x, a.y, a.z] },
+    material,
+  }));
+}
+
+export const ANCHORS = {
+  bar: barAnchors,
+  line: lineAnchors,
+  column: columnAnchors,
+  pie: pieAnchors,
+};


### PR DESCRIPTION
## What — data-label placement across chart types (+ a hard GPU finding)

Generalizes the bar-label prototype. `scripts/lib/data-labels.mjs` computes SDF label anchors that **mirror each chart atom's own layout** — `barAnchors` / `lineAnchors` / `columnAnchors` / `pieAnchors` + `placeLabels` (camera-facing `text-3d-pipe`). All four anchor maths validated.

## Key finding (real-browser GPU) — option-1's most useful result
**SDF labels do NOT co-exist with the LOOP/array chart atoms.** `bar-3d` / `line-3d` / `column-3d` use a `float[32]` value loop; `bar-3d` + **even ONE** `text-3d-pipe` label overflows the single studio shader (2 shader errors) — though `bar-3d` alone and a label alone each render fine.
- It's the **loop instruction count + a glyph SDF together**, not size: plain-box bars + 5 labels (~126k) render; `bar-3d` + 1 label (~125k) fails.
- **Non-loop** atoms (`pie-3d` = a disc formula) tolerate labels fine.

### Routing (the two-text-systems escape hatch, now concrete)
- pie / radial / non-loop atoms → **SDF labels OK**
- bar / column / line → build bars from **plain boxes** (no loop) + SDF labels, **or** send labels to the **overlay** layer

## Ships
Two GPU-safe labeled demos (registered in the gallery):
- `labels-bar` — box bars + value labels ($1.2M … $3.4M)
- `labels-pie` — `pie-3d` atom + slice labels (35% / 25% / 22% / 18%), placed at slice mid-angles around the rim

Both **0 console errors**; full suite **82/82**. Finding documented in the generator header + the two-text-systems memory.

## Next
When the 2D data model (values + labels) lands, wiring real labels into these anchors is mechanical. For loop-chart atoms specifically, the overlay-annotation path (cheap) is the route — or swap them to box construction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
