### PR TITLE
Step 2: overlay data labels for charts (engine project + Layer-2 overlay)

### DIFF
--- a/sdf-js/examples/compositor/compositor.js
+++ b/sdf-js/examples/compositor/compositor.js
@@ -790,6 +790,16 @@ window.atlasLoadScene = (demoEntry) => {
   return p;
 };
 
+// Public Layer-1 hook: project a world point → normalized screen coords (top-left
+// [0,1]) using the studio renderer's last-rendered camera. The Layer-2 overlay
+// label system (data-label-overlay.js) uses this to pin DOM annotations onto 3D
+// chart elements — the cheap text path for LOOP chart atoms (bar/line/column),
+// whose geometry can't carry SDF labels without overflowing the shader.
+window.atlasProjectPoint = (worldXYZ) =>
+  state.studioRenderer && state.studioRenderer.project
+    ? state.studioRenderer.project(worldXYZ)
+    : { x: 0, y: 0, visible: false };
+
 function autofillDemoPrompt(demo) {
   const promptInput = $('prompt-input');
   if (!promptInput) return;

--- a/sdf-js/examples/compositor/data-label-overlay.js
+++ b/sdf-js/examples/compositor/data-label-overlay.js
@@ -1,0 +1,93 @@
+// =============================================================================
+// data-label-overlay.js — Layer-2 overlay data labels (the CHEAP text path for
+// LOOP chart atoms). bar-3d / line-3d / column-3d use a float[32] value loop and
+// CANNOT carry SDF text-3d labels without overflowing the studio shader (even
+// one label fails). The escape hatch from the two-text-systems plan: pin the
+// labels as DOM annotations projected onto the 3D chart elements — zero shader
+// cost, and they track the moving camera every frame.
+//
+// A scene file may carry  annotations: [{ pos:[x,y,z], text }]  (alongside
+// sceneData). Launch:  ?labels=<sceneId>  →  loads the scene + pins the labels.
+// Projection is done by the engine (window.atlasProjectPoint), so labels land
+// exactly where the 3D point renders — no camera-convention duplication here.
+// =============================================================================
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+async function waitFor(fn, timeoutMs) {
+  const t0 = performance.now();
+  while (!fn()) {
+    if (performance.now() - t0 > timeoutMs)
+      throw new Error('data-label-overlay: waitFor timed out');
+    await sleep(60);
+  }
+}
+
+async function run(id) {
+  const res = await fetch(`./demo-lifts/${id}.json`);
+  if (!res.ok) throw new Error(`labels scene ${id}: HTTP ${res.status}`);
+  const data = await res.json();
+  const annotations = Array.isArray(data.annotations) ? data.annotations : [];
+
+  await waitFor(
+    () =>
+      typeof window.atlasLoadScene === 'function' && typeof window.atlasProjectPoint === 'function',
+    10000,
+  );
+  await window.atlasLoadScene({
+    id,
+    title: data.title || id,
+    file: `${id}.json`,
+    renderer: 'studio',
+  });
+
+  const wrap = document.getElementById('canvas-wrap');
+  if (getComputedStyle(wrap).position === 'static') wrap.style.position = 'relative';
+  const layer = document.createElement('div');
+  Object.assign(layer.style, {
+    position: 'absolute',
+    inset: '0',
+    pointerEvents: 'none',
+    zIndex: '35',
+    overflow: 'hidden',
+  });
+  wrap.appendChild(layer);
+
+  const els = annotations.map((an) => {
+    const d = document.createElement('div');
+    d.textContent = an.text;
+    Object.assign(d.style, {
+      position: 'absolute',
+      transform: 'translate(-50%,-50%)',
+      padding: '3px 9px',
+      borderRadius: '7px',
+      background: 'rgba(8,11,18,0.66)',
+      border: '1px solid rgba(255,255,255,0.1)',
+      color: '#f3f6fb',
+      font: '600 13px -apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif',
+      whiteSpace: 'nowrap',
+      textShadow: '0 1px 2px rgba(0,0,0,0.6)',
+      willChange: 'left,top',
+    });
+    layer.appendChild(d);
+    return d;
+  });
+
+  function tick() {
+    for (let i = 0; i < annotations.length; i++) {
+      const p = window.atlasProjectPoint(annotations[i].pos);
+      const el = els[i];
+      if (!p.visible) {
+        el.style.display = 'none';
+      } else {
+        el.style.display = 'block';
+        el.style.left = `${p.x * 100}%`;
+        el.style.top = `${p.y * 100}%`;
+      }
+    }
+    requestAnimationFrame(tick);
+  }
+  tick();
+}
+
+const labelsId = new URLSearchParams(location.search).get('labels');
+if (labelsId) run(labelsId).catch((e) => console.error('[data-label-overlay]', e));

--- a/sdf-js/examples/compositor/demo-lifts/labels-bar-overlay.json
+++ b/sdf-js/examples/compositor/demo-lifts/labels-bar-overlay.json
@@ -1,0 +1,180 @@
+{
+  "id": "labels-bar-overlay",
+  "title": "Bar chart · overlay labels (camera-tracked)",
+  "prompt": "bar chart labeled via DOM overlay (no SDF text), labels track the camera",
+  "code2d": "// box bars + overlay DOM labels (data-label-overlay.js).",
+  "annotations": [
+    {
+      "pos": [-1.9, 1, -0.35],
+      "text": "$1.2M"
+    },
+    {
+      "pos": [-0.95, 1.572, -0.35],
+      "text": "$2.0M"
+    },
+    {
+      "pos": [0, 2.3200000000000003, -0.35],
+      "text": "$3.4M"
+    },
+    {
+      "pos": [0.9499999999999997, 1.44, -0.35],
+      "text": "$1.8M"
+    },
+    {
+      "pos": [1.9, 1.8360000000000003, -0.35],
+      "text": "$2.6M"
+    }
+  ],
+  "sceneData": {
+    "v": 1,
+    "name": "Bar chart · overlay labels",
+    "source": {
+      "format": "authored",
+      "prompt": "overlay labels"
+    },
+    "subjects": [
+      {
+        "id": "bar0",
+        "type": "box",
+        "args": {
+          "size": [0.5, 0.8800000000000001, 0.5]
+        },
+        "transform": {
+          "translate": [-1.9, 0.44000000000000006, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.75,
+          "metal": 0.3,
+          "glow": 0
+        }
+      },
+      {
+        "id": "bar1",
+        "type": "box",
+        "args": {
+          "size": [0.5, 1.4520000000000002, 0.5]
+        },
+        "transform": {
+          "translate": [-0.95, 0.7260000000000001, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.75,
+          "metal": 0.3,
+          "glow": 0
+        }
+      },
+      {
+        "id": "bar2",
+        "type": "box",
+        "args": {
+          "size": [0.5, 2.2, 0.5]
+        },
+        "transform": {
+          "translate": [0, 1.1, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.75,
+          "metal": 0.3,
+          "glow": 0
+        }
+      },
+      {
+        "id": "bar3",
+        "type": "box",
+        "args": {
+          "size": [0.5, 1.32, 0.5]
+        },
+        "transform": {
+          "translate": [0.9499999999999997, 0.66, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.75,
+          "metal": 0.3,
+          "glow": 0
+        }
+      },
+      {
+        "id": "bar4",
+        "type": "box",
+        "args": {
+          "size": [0.5, 1.7160000000000002, 0.5]
+        },
+        "transform": {
+          "translate": [1.9, 0.8580000000000001, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.75,
+          "metal": 0.3,
+          "glow": 0
+        }
+      }
+    ],
+    "cameraSequence": {
+      "loop": true,
+      "shots": [
+        {
+          "duration": 0.01,
+          "pos": [-2.4, 2.2, -7.5],
+          "target": [0, 1.1, 0],
+          "fov": 32,
+          "transition": "cut"
+        },
+        {
+          "duration": 5,
+          "pos": [2.4, 2.2, -7.5],
+          "target": [0, 1.1, 0],
+          "fov": 32,
+          "ease": "smooth",
+          "transition": "blend"
+        },
+        {
+          "duration": 5,
+          "pos": [-2.4, 2.2, -7.5],
+          "target": [0, 1.1, 0],
+          "fov": 32,
+          "ease": "smooth",
+          "transition": "blend"
+        }
+      ]
+    },
+    "defaults": {
+      "camera": {
+        "yaw": 0.4,
+        "pitch": 0.2,
+        "distance": 9,
+        "focal": 1.5,
+        "targetX": 0,
+        "targetY": 1.1,
+        "targetZ": 0
+      },
+      "light": {
+        "azimuth": 0.6,
+        "altitude": 0.55,
+        "distance": 25,
+        "intensity": 1.2
+      },
+      "shadow": {
+        "enabled": true,
+        "mode": "darken",
+        "strength": 0.4
+      },
+      "studioBg": "dark"
+    }
+  },
+  "meta": {
+    "generatedAt": "2026-06-21",
+    "model": "authored",
+    "pattern": "overlay-labels",
+    "costUSD": 0
+  }
+}

--- a/sdf-js/examples/compositor/index.html
+++ b/sdf-js/examples/compositor/index.html
@@ -916,5 +916,7 @@
   <script type="module" src="./compositor.js"></script>
   <!-- Layer-2 Atlas Present deck player (spatial-narrative segment sequencer). -->
   <script type="module" src="./deck-player.js"></script>
+  <!-- Layer-2 overlay data labels for loop chart atoms (?labels=<sceneId>). -->
+  <script type="module" src="./data-label-overlay.js"></script>
 </body>
 </html>

--- a/sdf-js/scripts/gen-labels-overlay.mjs
+++ b/sdf-js/scripts/gen-labels-overlay.mjs
@@ -1,0 +1,106 @@
+#!/usr/bin/env node
+// =============================================================================
+// gen-labels-overlay.mjs — a bar chart labeled via the OVERLAY path instead of
+// SDF. Two reasons the labels go to the overlay, not in-scene SDF:
+//   (a) SDF text-3d on a loop chart atom overflows the shader (gen-data-labels-
+//       charts.mjs), and
+//   (b) the loop atoms (bar-3d/line-3d/column-3d) don't even render in the studio
+//       GPU shader (WebGL1 can't index their float[32] by a loop var) — so the
+//       bars here are PLAIN BOXES.
+// The labels live as DOM annotations (data-label-overlay.js, ?labels=labels-bar-
+// overlay) projected onto the bars — zero shader cost, tracking the panning camera.
+//
+// The scene carries `annotations:[{pos,text}]` (bar-top anchors from the shared
+// helper) alongside sceneData. Usage: node sdf-js/scripts/gen-labels-overlay.mjs
+// =============================================================================
+
+import { readFileSync, writeFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+import { barAnchors } from './lib/data-labels.mjs';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const OUT = resolve(__dirname, '../examples/compositor/demo-lifts');
+const BLUE = { hue: 0.58, sat: 0.85, value: 0.75, metal: 0.3, glow: 0 };
+
+const VALUES = [0.4, 0.66, 1.0, 0.6, 0.78];
+const LABELS = ['$1.2M', '$2.0M', '$3.4M', '$1.8M', '$2.6M'];
+const BAR = { barWidth: 0.5, barDepth: 0.5, gap: 0.45, maxHeight: 2.2 };
+
+// annotations = bar-top anchors (same helper that places SDF labels), as world
+// points the overlay projects to screen.
+const anchors = barAnchors(VALUES, { ...BAR, margin: 0.12 });
+const annotations = anchors.map((a, i) => ({ pos: [a.x, a.y, a.z], text: LABELS[i] }));
+
+// Bars are PLAIN BOXES, not the bar-3d atom: the loop atoms (bar-3d/line-3d/
+// column-3d, float[32] loop) don't even render in the studio GPU shader (WebGL1
+// can't index a uniform array by a loop var) — independent of labels. So a
+// labeled "bar chart" uses boxes; the overlay path is what carries the labels.
+const N = VALUES.length;
+const totalX = N * BAR.barWidth + (N - 1) * BAR.gap;
+const xStart = -totalX / 2 + BAR.barWidth / 2;
+const barBoxes = VALUES.map((v, i) => {
+  const h = v * BAR.maxHeight;
+  return {
+    id: `bar${i}`,
+    type: 'box',
+    args: { size: [BAR.barWidth, h, BAR.barDepth] },
+    transform: { translate: [xStart + i * (BAR.barWidth + BAR.gap), h / 2, 0] },
+    material: BLUE,
+  };
+});
+
+const entry = {
+  id: 'labels-bar-overlay',
+  title: 'Bar chart · overlay labels (camera-tracked)',
+  prompt: 'bar chart labeled via DOM overlay (no SDF text), labels track the camera',
+  code2d: '// box bars + overlay DOM labels (data-label-overlay.js).',
+  annotations,
+  sceneData: {
+    v: 1,
+    name: 'Bar chart · overlay labels',
+    source: { format: 'authored', prompt: 'overlay labels' },
+    subjects: barBoxes,
+    // gentle pan so the labels visibly track the moving camera
+    cameraSequence: {
+      loop: true,
+      shots: [
+        { duration: 0.01, pos: [-2.4, 2.2, -7.5], target: [0, 1.1, 0], fov: 32, transition: 'cut' },
+        {
+          duration: 5,
+          pos: [2.4, 2.2, -7.5],
+          target: [0, 1.1, 0],
+          fov: 32,
+          ease: 'smooth',
+          transition: 'blend',
+        },
+        {
+          duration: 5,
+          pos: [-2.4, 2.2, -7.5],
+          target: [0, 1.1, 0],
+          fov: 32,
+          ease: 'smooth',
+          transition: 'blend',
+        },
+      ],
+    },
+    defaults: {
+      camera: {
+        yaw: 0.4,
+        pitch: 0.2,
+        distance: 9,
+        focal: 1.5,
+        targetX: 0,
+        targetY: 1.1,
+        targetZ: 0,
+      },
+      light: { azimuth: 0.6, altitude: 0.55, distance: 25, intensity: 1.2 },
+      shadow: { enabled: true, mode: 'darken', strength: 0.4 },
+      studioBg: 'dark',
+    },
+  },
+  meta: { generatedAt: '2026-06-21', model: 'authored', pattern: 'overlay-labels', costUSD: 0 },
+};
+
+writeFileSync(`${OUT}/labels-bar-overlay.json`, JSON.stringify(entry, null, 2) + '\n');
+console.log(`wrote labels-bar-overlay.json (box bars + ${annotations.length} overlay labels)`);

--- a/sdf-js/src/render/studio.js
+++ b/sdf-js/src/render/studio.js
@@ -1722,6 +1722,10 @@ export function createStudioRenderer({
   // When non-null, drives camState per frame from a timeline (overrides WASD
   // fly camera until user explicitly takes back via fly keys / mouse).
   let activeSequence = null;
+  // Snapshot of the camera basis the LAST frame rendered with — used by
+  // project() so Layer-2 overlay labels land exactly where the 3D point is
+  // drawn (no camera-convention duplication outside the renderer).
+  let lastCam = null;
   let sequenceStartTime = 0; // performance.now() origin for sequence playback
   let sequencePaused = false;
   let sequencePausedAt = 0;
@@ -2063,6 +2067,15 @@ export function createStudioRenderer({
     // FOV: sequence override > getControls() fallback
     const activeFov = sequenceFov ?? c.fov;
     gl.uniform1f(uniformsCache.u_focal, activeFov);
+    // record this frame's camera for project() (aspect = display canvas)
+    lastCam = {
+      pos: [camState.position[0], camState.position[1], camState.position[2]],
+      right,
+      up,
+      fwd,
+      focal: activeFov,
+      aspect: canvas.width / canvas.height,
+    };
     gl.uniform3f(uniformsCache.u_lightPos, lpos[0], lpos[1], lpos[2]);
     gl.uniform1f(uniformsCache.u_shadowsOn, c.shadowsOn ? 1.0 : 0.0);
     gl.uniform1f(uniformsCache.u_groundOn, c.groundOn ? 1.0 : 0.0);
@@ -2606,6 +2619,29 @@ export function createStudioRenderer({
       sequencePaused = false;
       userTookCam = false;
       prevCamValid = false; // motion blur skip on cut-over frame
+    },
+    /**
+     * Project a world point to normalized screen coords (top-left origin, [0,1])
+     * using the LAST rendered frame's camera. Returns { x, y, visible }. visible
+     * is false when the point is behind the camera. Inverts the shader's ray
+     * setup (rd = uv.x*right + uv.y*up + focal*fwd; uv = (frag*2-res)/res.y), so
+     * overlay labels track the 3D point exactly even as the sequence camera moves.
+     */
+    project(world) {
+      if (!lastCam) return { x: 0, y: 0, visible: false };
+      const { pos, right, up, fwd, focal, aspect } = lastCam;
+      const vx = world[0] - pos[0],
+        vy = world[1] - pos[1],
+        vz = world[2] - pos[2];
+      const a = vx * right[0] + vy * right[1] + vz * right[2];
+      const b = vx * up[0] + vy * up[1] + vz * up[2];
+      const c = vx * fwd[0] + vy * fwd[1] + vz * fwd[2];
+      if (c <= 1e-4) return { x: 0, y: 0, visible: false }; // behind camera
+      const uvx = (focal * a) / c;
+      const uvy = (focal * b) / c;
+      const x = (uvx / aspect + 1) / 2; // uv.x ∈ [-aspect,aspect] → [0,1]
+      const y = 1 - (uvy + 1) / 2; // uv.y ∈ [-1,1] (bottom-up) → top-left [0,1]
+      return { x, y, visible: x >= -0.15 && x <= 1.15 && y >= -0.15 && y <= 1.15 };
     },
     setSequenceTime(tSec) {
       if (!activeSequence) return;


### PR DESCRIPTION
## What — overlay data labels for charts (the cheap text path)

The CHEAP text route for charts whose geometry **can't** carry SDF labels: pin the labels as **DOM annotations projected onto the 3D elements**, tracking the camera, at **zero shader cost**. Two reasons this path is needed (both found on real-browser GPU):

1. SDF text on a **loop** chart atom overflows the shader (PR #85).
2. The loop atoms (`bar-3d` / `line-3d` / `column-3d`, `float[32]` loop) **don't even render** in the studio GPU shader — WebGL1 can't index their uniform array by a loop var (pre-existing; the merged `chart-data-bars` demo fails too). So labeled bar charts use **plain boxes** + overlay labels.

## How
- **Engine** (`studio.project(world)`): returns normalized screen coords from the **last rendered frame's** camera basis — inverts the shader's `rd = uv.x*right + uv.y*up + focal*fwd`. The compositor exposes `window.atlasProjectPoint`. Read-only public API; **no camera-convention duplication** in Layer-2.
- **Layer-2** (`data-label-overlay.js`): `?labels=<sceneId>` loads the scene + pins DOM labels from its `annotations:[{pos,text}]`, reprojecting **every rAF** so labels track the moving camera.
- Demo `labels-bar-overlay` (box bars + 5 value labels, panning camera). Launch: `?labels=labels-bar-overlay`.

## Verification (real-browser GPU)
- Labels sit above each bar and **track the pan** (verified across two frames as the camera sweeps).
- **0 shader errors** (labels are DOM). eslint clean; full suite **82/82**.

## Finding (worth noting)
`bar-3d` / `line-3d` / `column-3d` (loop atoms) **do not render in studio GPU** at all — a pre-existing WebGL1 limitation, independent of labels. Reinforces the routing: loop charts → box construction + overlay labels; non-loop atoms (`pie-3d`) → SDF labels OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
