### PR TITLE
fix(charts): loop chart atoms (bar/line/column) now render in ES 1.00 studio shader

### DIFF
--- a/sdf-js/examples/compositor/demo-lifts/labels-bar.json
+++ b/sdf-js/examples/compositor/demo-lifts/labels-bar.json
@@ -1,92 +1,28 @@
 {
   "id": "labels-bar",
-  "title": "Bar chart · value labels (box bars)",
-  "prompt": "Bar chart · value labels (box bars)",
-  "code2d": "// Bar chart · value labels (box bars) (data-labels helper).",
+  "title": "Bar chart · value labels",
+  "prompt": "Bar chart · value labels",
+  "code2d": "// Bar chart · value labels (data-labels helper).",
   "sceneData": {
     "v": 1,
-    "name": "Bar chart · value labels (box bars)",
+    "name": "Bar chart · value labels",
     "source": {
       "format": "authored",
-      "prompt": "Bar chart · value labels (box bars)"
+      "prompt": "Bar chart · value labels"
     },
     "subjects": [
       {
-        "id": "bar0",
-        "type": "box",
+        "id": "bars",
+        "type": "bar-3d",
         "args": {
-          "size": [0.5, 0.8800000000000001, 0.5]
+          "values": [0.4, 0.66, 1, 0.6, 0.78],
+          "barWidth": 0.5,
+          "barDepth": 0.5,
+          "gap": 0.45,
+          "maxHeight": 2.2
         },
         "transform": {
-          "translate": [-1.9, 0.44000000000000006, 0]
-        },
-        "material": {
-          "hue": 0.58,
-          "sat": 0.85,
-          "value": 0.75,
-          "metal": 0.3,
-          "glow": 0
-        }
-      },
-      {
-        "id": "bar1",
-        "type": "box",
-        "args": {
-          "size": [0.5, 1.4520000000000002, 0.5]
-        },
-        "transform": {
-          "translate": [-0.95, 0.7260000000000001, 0]
-        },
-        "material": {
-          "hue": 0.58,
-          "sat": 0.85,
-          "value": 0.75,
-          "metal": 0.3,
-          "glow": 0
-        }
-      },
-      {
-        "id": "bar2",
-        "type": "box",
-        "args": {
-          "size": [0.5, 2.2, 0.5]
-        },
-        "transform": {
-          "translate": [0, 1.1, 0]
-        },
-        "material": {
-          "hue": 0.58,
-          "sat": 0.85,
-          "value": 0.75,
-          "metal": 0.3,
-          "glow": 0
-        }
-      },
-      {
-        "id": "bar3",
-        "type": "box",
-        "args": {
-          "size": [0.5, 1.32, 0.5]
-        },
-        "transform": {
-          "translate": [0.9499999999999997, 0.66, 0]
-        },
-        "material": {
-          "hue": 0.58,
-          "sat": 0.85,
-          "value": 0.75,
-          "metal": 0.3,
-          "glow": 0
-        }
-      },
-      {
-        "id": "bar4",
-        "type": "box",
-        "args": {
-          "size": [0.5, 1.7160000000000002, 0.5]
-        },
-        "transform": {
-          "translate": [1.9, 0.8580000000000001, 0]
+          "translate": [0, 0, 0]
         },
         "material": {
           "hue": 0.58,

--- a/sdf-js/scripts/gen-data-labels-charts.mjs
+++ b/sdf-js/scripts/gen-data-labels-charts.mjs
@@ -3,18 +3,14 @@
 // gen-data-labels-charts.mjs — labeled charts using the shared data-labels
 // placement helper. Generalizes the bar prototype across chart types.
 //
-// HARD CONSTRAINT FOUND (real-browser GPU, 2026-06-21):
-//   SDF text-3d-pipe labels DO NOT co-exist with the LOOP/array chart atoms
-//   (bar-3d / line-3d / column-3d use a float[32] value loop). Even ONE label
-//   on a bar-3d overflows the single studio shader — the loop's instruction
-//   count + a glyph SDF together blow the GPU limit, though each renders fine
-//   alone. NON-loop atoms (pie-3d = a plain disc formula) tolerate SDF labels.
-// → Routing (matches the two-text-systems escape hatch):
-//   • pie / radial / any non-loop atom → SDF labels OK (labels-pie).
-//   • bar / column / line → build the bars from PLAIN BOXES (no loop atom) and
-//     label those (labels-bar), OR send labels to the overlay layer.
-// The anchor math in data-labels.mjs is correct for all four (validated); the
-// constraint is purely the GPU shader budget of loop-atom + glyph.
+// NOTE (2026-06-21): an earlier version claimed SDF labels couldn't co-exist
+// with the loop chart atoms (bar-3d/line-3d/column-3d). That was a symptom of a
+// `float[32](...)` ARRAY-CONSTRUCTOR bug in their GLSL emit (ES 3.00 syntax in
+// the ES 1.00 studio shader) — those atoms didn't render AT ALL. The emit is now
+// unrolled (sdf3.compile.js barBoxesExpr/lineExpr), so bar-3d renders AND takes
+// SDF labels fine (verified: bar-3d + 5 labels, 0 errors). So labels-bar now uses
+// the real bar-3d atom. The overlay path (data-label-overlay.js) remains a valid
+// cheaper, camera-tracked alternative — not a forced workaround anymore.
 //
 // Usage: node sdf-js/scripts/gen-data-labels-charts.mjs
 // =============================================================================
@@ -66,21 +62,16 @@ const REV_L = ['$1.2M', '$2.0M', '$3.4M', '$1.8M', '$2.6M'];
 const PIE = [0.35, 0.25, 0.22, 0.18];
 const PIE_L = ['35%', '25%', '22%', '18%'];
 
-// ---- labels-bar: PLAIN BOXES (no loop atom) + labels (GPU-safe) -------------
+// ---- labels-bar: the real bar-3d ATOM (now renders + takes SDF labels) ------
 const BAR = { barWidth: 0.5, barDepth: 0.5, gap: 0.45, maxHeight: 2.2 };
-const N = REV.length;
-const totalX = N * BAR.barWidth + (N - 1) * BAR.gap;
-const xStart = -totalX / 2 + BAR.barWidth / 2;
-const barBoxes = REV.map((v, i) => {
-  const h = v * BAR.maxHeight;
-  return {
-    id: `bar${i}`,
-    type: 'box',
-    args: { size: [BAR.barWidth, h, BAR.barDepth] },
-    transform: { translate: [xStart + i * (BAR.barWidth + BAR.gap), h / 2, 0] },
-    material: BLUE,
-  };
-});
+const barSubj = {
+  id: 'bars',
+  type: 'bar-3d',
+  args: { values: REV, ...BAR },
+  transform: { translate: [0, 0, 0] },
+  material: BLUE,
+};
+const barBoxes = [barSubj];
 const barLabels = placeLabels(barAnchors(REV, BAR), REV_L, { height: 0.3, pipeRadius: 0.05 });
 
 // ---- labels-pie: pie-3d ATOM (non-loop) + labels (GPU-safe) ------------------
@@ -103,12 +94,7 @@ const pieLabels = placeLabels(
 );
 
 const charts = [
-  wrap(
-    'labels-bar',
-    'Bar chart · value labels (box bars)',
-    [...barBoxes, ...barLabels],
-    cam(1.4, 9),
-  ),
+  wrap('labels-bar', 'Bar chart · value labels', [...barBoxes, ...barLabels], cam(1.4, 9)),
   wrap('labels-pie', 'Pie chart · slice labels', [pieSubj, ...pieLabels], cam(1.4, 8)),
 ];
 

--- a/sdf-js/src/sdf/sdf3.compile.js
+++ b/sdf-js/src/sdf/sdf3.compile.js
@@ -309,6 +309,62 @@ function walk(sdf, p) {
 const half = (x) => mulT(x, 0.5);
 const halfNeg = (x) => mulT(x, -0.5);
 
+// Chart bars UNROLLED to an explicit min() of sdBox calls. The old emit used a
+// `float[32](...)` array constructor — that is GLSL ES 3.00 syntax and fails to
+// compile in the studio's ES 1.00 shader (so bar/column/line never rendered on
+// GPU). The values are known at compile time, so we unroll the real N bars into
+// inline sdBox expressions (no array, no loop) — ES-1.00-safe. Mirrors
+// evalBarsSDF: totalX = N*barW + (N-1)*gap; xStart = -totalX/2 + barW/2;
+// bar i centred at (xStart + i*(barW+gap), h/2, 0), half (barW/2, h/2, barD/2).
+function barBoxesExpr(point, paddedValues, count, barW, barD, gap, maxH) {
+  const N = Math.max(0, Math.min(32, Math.floor(count)));
+  const totalX = N * barW + (N - 1) * gap;
+  const xStart = -totalX / 2 + barW / 2;
+  const parts = [];
+  for (let i = 0; i < N; i++) {
+    const h = paddedValues[i] * maxH;
+    if (h <= 0) continue; // zero/negative bar → no box (matches evalBarsSDF skip)
+    const xc = xStart + i * (barW + gap);
+    parts.push(`sdBox(${point} - ${vec3([xc, h / 2, 0])}, ${vec3([barW / 2, h / 2, barD / 2])})`);
+  }
+  if (!parts.length) return '1e6';
+  return parts.reduce((a, e) => `min(${a}, ${e})`);
+}
+
+// line-3d UNROLLED (ES-1.00-safe, same reason as barBoxesExpr): sphere markers
+// at each point + capsule connectors between consecutive points + optional
+// closing capsule. Mirrors sdLine3d: totalX=(N-1)*pointSpacing; xStart=-totalX/2;
+// point i = (xStart + i*pointSpacing, values[i]*maxH, 0).
+function lineExpr(
+  point,
+  paddedValues,
+  count,
+  pointSpacing,
+  pointRadius,
+  lineThickness,
+  maxH,
+  closedFlag,
+) {
+  const N = Math.max(0, Math.min(32, Math.floor(count)));
+  const xStart = -((N - 1) * pointSpacing) / 2;
+  const pt = (i) => [xStart + i * pointSpacing, paddedValues[i] * maxH, 0];
+  const parts = [];
+  if (pointRadius > 0) {
+    for (let i = 0; i < N; i++)
+      parts.push(`sdSphere(${point} - ${vec3(pt(i))}, ${flt(pointRadius)})`);
+  }
+  if (lineThickness > 0 && N > 1) {
+    for (let i = 0; i < N - 1; i++) {
+      parts.push(`sdCapsule(${point}, ${vec3(pt(i))}, ${vec3(pt(i + 1))}, ${flt(lineThickness)})`);
+    }
+    if (closedFlag > 0.5 && N > 2) {
+      parts.push(`sdCapsule(${point}, ${vec3(pt(N - 1))}, ${vec3(pt(0))}, ${flt(lineThickness)})`);
+    }
+  }
+  if (!parts.length) return '1e6';
+  return parts.reduce((a, e) => `min(${a}, ${e})`);
+}
+
 const PRIMS = {
   sphere: ([radius, center], p) => `sdSphere(${p} - ${vec3(center)}, ${flt(radius)})`,
 
@@ -378,29 +434,24 @@ const PRIMS = {
   // bar-3d (Atlas chart atom, 2026-06-18) — see components/charts/data/bar-3d.js
   // Data-driven bar chart, N bars along X (max 32, GLSL float[32] cap).
   // First atom with array-typed input — values padded to 32 with 0s on JS side.
-  'bar-3d': ([paddedValues, count, barW, barD, gap, maxH], p) => {
-    const arrLit = `float[32](${paddedValues.map((v) => flt(v)).join(', ')})`;
-    return `sdBar3d(${p}, ${arrLit}, ${flt(count)}, ${flt(barW)}, ${flt(barD)}, ${flt(gap)}, ${flt(maxH)})`;
-  },
+  // Unrolled (ES-1.00-safe) — see barBoxesExpr above; no float[32] constructor.
+  'bar-3d': ([paddedValues, count, barW, barD, gap, maxH], p) =>
+    barBoxesExpr(p, paddedValues, count, barW, barD, gap, maxH),
 
   // column-3d (Atlas chart atom, 2026-06-18) — see components/charts/data/column-3d.js
-  // Horizontal bar chart. Same args as bar-3d, GLSL emits sdColumn3d (delegates
-  // to sdBar3d with axis swap on input).
-  'column-3d': ([paddedValues, count, barW, barD, gap, maxH], p) => {
-    const arrLit = `float[32](${paddedValues.map((v) => flt(v)).join(', ')})`;
-    return `sdColumn3d(${p}, ${arrLit}, ${flt(count)}, ${flt(barW)}, ${flt(barD)}, ${flt(gap)}, ${flt(maxH)})`;
-  },
+  // Horizontal bars: same unroll in the swapped frame the GLSL helper used —
+  // world (x,y,z) → bar input (-y, x, z).
+  'column-3d': ([paddedValues, count, barW, barD, gap, maxH], p) =>
+    barBoxesExpr(`vec3(-(${p}).y, (${p}).x, (${p}).z)`, paddedValues, count, barW, barD, gap, maxH),
 
   // line-3d (Atlas chart atom, 2026-06-18) — see components/charts/data/line-3d.js
   // Polyline with sphere markers. N points + N-1 capsule connectors + optional
   // closed loop. closedFlag = 0 or 1 (passed as float for ABI uniformity).
+  // Unrolled (ES-1.00-safe) — see lineExpr above; no float[32] constructor.
   'line-3d': (
     [paddedValues, count, pointSpacing, pointRadius, lineThickness, maxH, closedFlag],
     p,
-  ) => {
-    const arrLit = `float[32](${paddedValues.map((v) => flt(v)).join(', ')})`;
-    return `sdLine3d(${p}, ${arrLit}, ${flt(count)}, ${flt(pointSpacing)}, ${flt(pointRadius)}, ${flt(lineThickness)}, ${flt(maxH)}, ${flt(closedFlag)})`;
-  },
+  ) => lineExpr(p, paddedValues, count, pointSpacing, pointRadius, lineThickness, maxH, closedFlag),
 
   // pie-3d (Atlas chart atom, 2026-06-18) — see components/charts/data/pie-3d.js
   // GLSL only uses geometry params (disc/donut SDF). Slice values + startAngle


### PR DESCRIPTION
## What — loop chart atoms now render in the studio (ES 1.00) shader

`bar-3d` / `line-3d` / `column-3d` **never rendered on GPU**. Their GLSL emit built the values with a `float[32](...)` **array constructor** — that's **GLSL ES 3.00** syntax, but the studio shader is **ES 1.00** (no `#version 300 es`). The call site failed to compile (2 shader errors); the merged `chart-data-bars` demo was broken too.

This was also the real cause of the earlier **"loop atoms can't take SDF labels"** finding (PR #85) — it was the constructor, **not** a loop+glyph conflict.

## Fix (`src/sdf/sdf3.compile.js`)
Unroll the emit into an explicit `min()` of inline `sdBox` / `sdSphere` / `sdCapsule` calls. Values are known at compile time, so there's **no array and no loop** — ES-1.00-safe.
- `barBoxesExpr` → `bar-3d` + `column-3d` (the column uses the swapped frame `vec3(-y, x, z)`, matching the old GLSL helper).
- `lineExpr` → `line-3d` (point spheres + capsule connectors + optional closing capsule).
- The `float[32]` library defs are left in place (dead now; `float values[32]` as a **parameter** is legal ES 1.00, so they compile harmlessly).

## Verification (real-browser GPU)
- `chart-data-bars` / `chart-data-columns` / `chart-line` all **render** now (0 errors) — previously all failed.
- `bar-3d` + 5 SDF labels **renders** (0 errors) ⇒ **PR #85's constraint is obsolete**. `labels-bar` now uses the real `bar-3d` atom (was a box workaround).
- Full suite **82/82**; eslint clean; the two-text-systems memory corrected.

## Impact
Every loop chart atom (bar / column / line) is now usable in the studio renderer **and** can carry SDF data labels — the data-label routing simplifies (overlay remains a cheaper, camera-tracked option, no longer a forced workaround). General lesson captured: CPU-compile-clean but GPU-2-errors with size ruled out ⇒ check ES 1.00 vs 3.00 syntax (array constructors / non-constant indexing), not "budget".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
