### PR TITLE
feat(charts): auto-expand chart args.labels into SDF labels (#84 connector)

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -132,6 +132,7 @@ const TESTS = [
   { category: 'diagram', file: 'sdf-js/scripts/test-scatter-3d.mjs' },
   { category: 'diagram', file: 'sdf-js/scripts/test-gantt-3d.mjs' },
   { category: 'diagram', file: 'sdf-js/scripts/test-gauge-3d.mjs' },
+  { category: 'scene', file: 'sdf-js/scripts/test-chart-labels.mjs' },
 
   // Sprint 5 Wave C: fishbone / traffic-light / radial-spoke + puzzle-piece.
   { category: 'diagram', file: 'sdf-js/scripts/test-fishbone-3d.mjs' },

--- a/sdf-js/examples/compositor/compositor.js
+++ b/sdf-js/examples/compositor/compositor.js
@@ -35,6 +35,7 @@ function getUrlTokenHash() {
 }
 let URL_TOKEN_HASH = getUrlTokenHash(); // mutable — #btn-new-hash reroll updates this
 import { expandVariants } from '../../src/scene/generator-s.js';
+import { expandChartLabels } from '../../src/scene/chart-labels.js';
 import {
   sphericalToCamState,
   parseLiftResponse,
@@ -724,7 +725,10 @@ async function loadDemoScene(demo) {
       // → SFC32 PRNG so the same hash always yields the same expansion.
       const sceneRng = new Random(state.sceneHash);
       const variantScene = expandVariants(data.sceneData, sceneRng);
-      compiled = compileSceneData(variantScene, { tokenHash: URL_TOKEN_HASH });
+      // #84 connector: chart subjects with args.labels → SDF text-3d-pipe labels
+      // anchored on their elements (no-op if no chart carries labels).
+      const labeledScene = expandChartLabels(variantScene);
+      compiled = compileSceneData(labeledScene, { tokenHash: URL_TOKEN_HASH });
     } catch (e) {
       throw new Error(`compile failed: ${e.message}`);
     }
@@ -1643,7 +1647,8 @@ function renderLiftedSceneData(
   const liftInfo = $('lift-info');
   let compiled;
   try {
-    compiled = compileSceneData(sceneData, { tokenHash: URL_TOKEN_HASH });
+    // #84 connector: expand chart args.labels → SDF labels before compile.
+    compiled = compileSceneData(expandChartLabels(sceneData), { tokenHash: URL_TOKEN_HASH });
   } catch (compileErr) {
     throw new Error(`SceneData compile failed: ${compileErr.message}`);
   }

--- a/sdf-js/examples/compositor/demo-lifts/chart-autolabel-bar.json
+++ b/sdf-js/examples/compositor/demo-lifts/chart-autolabel-bar.json
@@ -1,0 +1,66 @@
+{
+  "id": "chart-autolabel-bar",
+  "title": "Bar chart · auto-labels from args.labels (#84 connector)",
+  "prompt": "bar-3d with args.labels — connector auto-generates SDF labels",
+  "code2d": "// bar-3d carries values+labels; expandChartLabels injects the labels.",
+  "sceneData": {
+    "v": 1,
+    "name": "compare: Quarterly revenue",
+    "source": {
+      "format": "authored",
+      "prompt": "auto-label bar"
+    },
+    "subjects": [
+      {
+        "id": "bars",
+        "type": "bar-3d",
+        "args": {
+          "values": [0.4, 0.66, 1, 0.6, 0.78],
+          "labels": ["$1.2M", "$2.0M", "$3.4M", "$1.8M", "$2.6M"],
+          "barWidth": 0.5,
+          "barDepth": 0.5,
+          "gap": 0.45,
+          "maxHeight": 2.2
+        },
+        "transform": {
+          "translate": [0, 0, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.75,
+          "metal": 0.3
+        }
+      }
+    ],
+    "defaults": {
+      "camera": {
+        "yaw": 0.4,
+        "pitch": 0.2,
+        "distance": 9,
+        "focal": 1.5,
+        "targetX": 0,
+        "targetY": 1.4,
+        "targetZ": 0
+      },
+      "light": {
+        "azimuth": 0.6,
+        "altitude": 0.55,
+        "distance": 25,
+        "intensity": 1.2
+      },
+      "shadow": {
+        "enabled": true,
+        "mode": "darken",
+        "strength": 0.4
+      },
+      "studioBg": "dark"
+    }
+  },
+  "meta": {
+    "generatedAt": "2026-06-21",
+    "model": "authored",
+    "pattern": "chart-autolabel",
+    "costUSD": 0
+  }
+}

--- a/sdf-js/examples/compositor/demo-lifts/index.json
+++ b/sdf-js/examples/compositor/demo-lifts/index.json
@@ -1328,6 +1328,16 @@
       "file": "labels-pie.json",
       "renderer": "studio",
       "prompt": "Pie chart · slice labels"
+    },
+    {
+      "id": "chart-autolabel-bar",
+      "title": "Bar chart · auto-labels from args.labels (#84 connector)",
+      "thesisPoint": "#84 connector: chart args.labels auto-expand into SDF text-3d-pipe labels at load (expandChartLabels).",
+      "category": "data-labels",
+      "status": "ready",
+      "file": "chart-autolabel-bar.json",
+      "renderer": "studio",
+      "prompt": "Bar chart · auto-labels from args.labels (#84 connector)"
     }
   ]
 }

--- a/sdf-js/scripts/lib/data-labels.mjs
+++ b/sdf-js/scripts/lib/data-labels.mjs
@@ -1,106 +1,15 @@
 // =============================================================================
-// data-labels.mjs — SDF data-label PLACEMENT for chart atoms (the in-scene half
-// of the two-text-systems split; narrative text rides the overlay caption).
-// Each anchor function mirrors the corresponding chart atom's own layout math
-// so labels land exactly on the rendered elements. Labels face the −z camera
-// (no rotate — rotating a pipe-glyph mirrors it).
-//
-// Budget (measured): each short label ≈ +2k GLSL chars; ≤~10 short labels/chart
-// is GPU-safe. Long labels / stacking onto heavy loop-atoms → re-measure.
+// data-labels.mjs — re-export of the chart-label placement helpers, which now
+// live in src/scene/chart-labels.js (so the runtime expandChartLabels connector
+// and these build-time generators share one source). Kept as a stable import
+// path for the gen-* scripts.
 // =============================================================================
-
-const LABEL_MAT = { hue: 0, sat: 0, value: 1, metal: 0, glow: 0.28 };
-
-// bar-3d: bars along +X, grow up. anchor = above each bar's top, on the −z front.
-export function barAnchors(
-  values,
-  { barWidth = 0.4, barDepth = 0.4, gap = 0.1, maxHeight = 2.0, margin = 0.18 } = {},
-) {
-  const N = values.length;
-  const totalX = N * barWidth + (N - 1) * gap;
-  const xStart = -totalX / 2 + barWidth / 2;
-  return values.map((v, i) => ({
-    x: xStart + i * (barWidth + gap),
-    y: v * maxHeight + margin,
-    z: -barDepth / 2 - 0.1,
-  }));
-}
-
-// line-3d: points along +X at value heights. anchor = above each point.
-export function lineAnchors(values, { pointSpacing = 0.5, maxHeight = 2.0, margin = 0.22 } = {}) {
-  const N = values.length;
-  const xStart = -((N - 1) * pointSpacing) / 2;
-  return values.map((v, i) => ({
-    x: xStart + i * pointSpacing,
-    y: v * maxHeight + margin,
-    z: -0.12,
-  }));
-}
-
-// column-3d: horizontal bars stacked along Y, grow along +X. anchor = beyond each bar's end.
-export function columnAnchors(
-  values,
-  { barWidth = 0.4, barDepth = 0.4, gap = 0.1, maxHeight = 2.0, margin = 0.32 } = {},
-) {
-  const N = values.length;
-  const totalY = N * barWidth + (N - 1) * gap;
-  const yStart = -totalY / 2 + barWidth / 2;
-  return values.map((v, i) => ({
-    x: v * maxHeight + margin,
-    y: yStart + i * (barWidth + gap),
-    z: -barDepth / 2 - 0.1,
-  }));
-}
-
-// pie-3d (standing, unrotated, facing −z): anchor at each slice's mid-angle, just
-// outside the rim. startAngle/clockwise match the atom defaults (12 o'clock, CW).
-export function pieAnchors(
-  values,
-  {
-    outerRadius = 1.0,
-    thickness = 0.3,
-    startAngle = Math.PI / 2,
-    clockwise = true,
-    margin = 0.35,
-  } = {},
-) {
-  const sum = values.reduce((a, b) => a + (b > 0 ? b : 0), 0) || 1;
-  const R = outerRadius + margin;
-  const dir = clockwise ? -1 : 1;
-  let cum = 0;
-  return values.map((v) => {
-    const frac = Math.max(0, v) / sum;
-    const mid = cum + frac / 2;
-    cum += frac;
-    const ang = startAngle + dir * mid * 2 * Math.PI;
-    return { x: R * Math.cos(ang), y: R * Math.sin(ang), z: -thickness / 2 - 0.1 };
-  });
-}
-
-// turn anchors + label strings into text-3d-pipe subjects (camera-facing).
-export function placeLabels(
-  anchors,
-  labels,
-  {
-    height = 0.3,
-    pipeRadius = 0.05,
-    material = LABEL_MAT,
-    idPrefix = 'lbl',
-    align = 'center',
-  } = {},
-) {
-  return anchors.map((a, i) => ({
-    id: `${idPrefix}${i}`,
-    type: 'text-3d-pipe',
-    args: { text: String(labels[i] ?? ''), height, pipeRadius, align },
-    transform: { translate: [a.x, a.y, a.z] },
-    material,
-  }));
-}
-
-export const ANCHORS = {
-  bar: barAnchors,
-  line: lineAnchors,
-  column: columnAnchors,
-  pie: pieAnchors,
-};
+export {
+  barAnchors,
+  lineAnchors,
+  columnAnchors,
+  pieAnchors,
+  placeLabels,
+  ANCHOR_FOR,
+  expandChartLabels,
+} from '../../src/scene/chart-labels.js';

--- a/sdf-js/scripts/test-chart-labels.mjs
+++ b/sdf-js/scripts/test-chart-labels.mjs
@@ -1,0 +1,85 @@
+import { expandChartLabels, barAnchors } from '../src/scene/chart-labels.js';
+
+let pass = 0,
+  fail = 0;
+const ok = (c, n) => (c ? (pass++, console.log(`  ✓ ${n}`)) : (fail++, console.log(`  ✗ ${n}`)));
+console.log('=== chart-labels (expandChartLabels connector) ===\n');
+
+// bar-3d carrying args.labels → N text-3d-pipe labels appended at bar tops
+{
+  const BAR = { barWidth: 0.5, barDepth: 0.5, gap: 0.45, maxHeight: 2.2 };
+  const values = [0.4, 0.66, 1.0];
+  const labels = ['$1.2M', '$2.0M', '$3.4M'];
+  const scene = {
+    v: 1,
+    subjects: [
+      {
+        id: 'bars',
+        type: 'bar-3d',
+        args: { values, labels, ...BAR },
+        transform: { translate: [0, 0, 0] },
+      },
+    ],
+  };
+  const out = expandChartLabels(scene);
+  const added = out.subjects.filter((s) => s.type === 'text-3d-pipe');
+  ok(out.subjects.length === 1 + values.length, `appended ${values.length} label subjects`);
+  ok(added.length === values.length, 'all added are text-3d-pipe');
+  ok(
+    added.every((s, i) => s.args.text === labels[i]),
+    'label texts match args.labels in order',
+  );
+  // positions match barAnchors (offset by translate [0,0,0])
+  const anch = barAnchors(values, BAR);
+  ok(
+    added.every((s, i) => Math.abs(s.transform.translate[0] - anch[i].x) < 1e-9),
+    'label x positions match bar anchors',
+  );
+  ok(
+    added.every((s, i) => Math.abs(s.transform.translate[1] - anch[i].y) < 1e-9),
+    'label y positions sit above bar tops',
+  );
+  ok(
+    added.every((s) => /^lbl_bars_/.test(s.id)),
+    'label ids are globally unique (prefixed by subject id)',
+  );
+}
+
+// translate offset is applied
+{
+  const scene = {
+    v: 1,
+    subjects: [
+      {
+        id: 'b',
+        type: 'bar-3d',
+        args: { values: [1], labels: ['x'], barWidth: 0.5, barDepth: 0.5, gap: 0, maxHeight: 2 },
+        transform: { translate: [10, 0, -3] },
+      },
+    ],
+  };
+  const lab = expandChartLabels(scene).subjects.find((s) => s.type === 'text-3d-pipe');
+  ok(
+    Math.abs(lab.transform.translate[0] - 10) < 1e-9,
+    'single bar centred → label x offset by translate.x',
+  );
+  ok(
+    Math.abs(lab.transform.translate[2] - (-3 - 0.25 - 0.1)) < 1e-9,
+    'label z offset by translate.z',
+  );
+}
+
+// no-op cases
+{
+  const noLabels = { v: 1, subjects: [{ id: 'b', type: 'bar-3d', args: { values: [0.5, 0.7] } }] };
+  ok(expandChartLabels(noLabels).subjects.length === 1, 'no args.labels → no-op');
+  const notChart = {
+    v: 1,
+    subjects: [{ id: 's', type: 'sphere', args: { radius: 1, labels: ['x'] } }],
+  };
+  ok(expandChartLabels(notChart).subjects.length === 1, 'non-chart type with labels → no-op');
+  ok(expandChartLabels({ v: 1, subjects: [] }).subjects.length === 0, 'empty scene → no-op');
+}
+
+console.log(`\n=== Result: ${pass} passed, ${fail} failed ===`);
+process.exit(fail > 0 ? 1 : 0);

--- a/sdf-js/src/scene/chart-labels.js
+++ b/sdf-js/src/scene/chart-labels.js
@@ -1,0 +1,138 @@
+// =============================================================================
+// chart-labels.js — SDF data-label placement + expansion for chart atoms.
+// -----------------------------------------------------------------------------
+// The #84 convention: a chart subject carries parallel arrays in its args —
+// args.values + args.labels (e.g. bar-3d {values:[...], labels:['$1.2M',...]}).
+// The 3D chart atoms render geometry from `values` but ignore `labels`. This
+// module turns those labels into camera-facing text-3d-pipe subjects positioned
+// on the rendered elements (anchors mirror each atom's own layout math).
+//
+// expandChartLabels(sceneData) is a deterministic SceneData→SceneData transform
+// run at scene load (alongside expandVariants): it closes the loop from
+// "2D real data (values+labels)" → "3D labelled chart" with no manual placement.
+//
+// Studio camera faces −z; labels need no rotate (rotating a pipe-glyph mirrors
+// it). Budget: each short label ≈ +2k GLSL chars; loop atoms now render fine
+// (see sdf3.compile.js unroll), so SDF labels co-exist with bar/line/column/pie.
+// =============================================================================
+
+const LABEL_MAT = { hue: 0, sat: 0, value: 1, metal: 0, glow: 0.28 };
+
+// bar-3d: bars along +X, grow up. anchor = above each bar's top, on the −z front.
+export function barAnchors(
+  values,
+  { barWidth = 0.4, barDepth = 0.4, gap = 0.1, maxHeight = 2.0, margin = 0.18 } = {},
+) {
+  const N = values.length;
+  const totalX = N * barWidth + (N - 1) * gap;
+  const xStart = -totalX / 2 + barWidth / 2;
+  return values.map((v, i) => ({
+    x: xStart + i * (barWidth + gap),
+    y: v * maxHeight + margin,
+    z: -barDepth / 2 - 0.1,
+  }));
+}
+
+// line-3d: points along +X at value heights. anchor = above each point.
+export function lineAnchors(values, { pointSpacing = 0.5, maxHeight = 2.0, margin = 0.22 } = {}) {
+  const N = values.length;
+  const xStart = -((N - 1) * pointSpacing) / 2;
+  return values.map((v, i) => ({
+    x: xStart + i * pointSpacing,
+    y: v * maxHeight + margin,
+    z: -0.12,
+  }));
+}
+
+// column-3d: horizontal bars stacked along Y, grow along +X. anchor = beyond each bar's end.
+export function columnAnchors(
+  values,
+  { barWidth = 0.4, barDepth = 0.4, gap = 0.1, maxHeight = 2.0, margin = 0.32 } = {},
+) {
+  const N = values.length;
+  const totalY = N * barWidth + (N - 1) * gap;
+  const yStart = -totalY / 2 + barWidth / 2;
+  return values.map((v, i) => ({
+    x: v * maxHeight + margin,
+    y: yStart + i * (barWidth + gap),
+    z: -barDepth / 2 - 0.1,
+  }));
+}
+
+// pie-3d (standing, facing −z): anchor at each slice's mid-angle, just outside
+// the rim. startAngle/clockwise match the atom defaults (12 o'clock, CW).
+export function pieAnchors(
+  values,
+  {
+    outerRadius = 1.0,
+    thickness = 0.3,
+    startAngle = Math.PI / 2,
+    clockwise = true,
+    margin = 0.35,
+  } = {},
+) {
+  const sum = values.reduce((a, b) => a + (b > 0 ? b : 0), 0) || 1;
+  const R = outerRadius + margin;
+  const dir = clockwise ? -1 : 1;
+  let cum = 0;
+  return values.map((v) => {
+    const frac = Math.max(0, v) / sum;
+    const mid = cum + frac / 2;
+    cum += frac;
+    const ang = startAngle + dir * mid * 2 * Math.PI;
+    return { x: R * Math.cos(ang), y: R * Math.sin(ang), z: -thickness / 2 - 0.1 };
+  });
+}
+
+export const ANCHOR_FOR = {
+  'bar-3d': barAnchors,
+  'line-3d': lineAnchors,
+  'column-3d': columnAnchors,
+  'pie-3d': pieAnchors,
+};
+
+// turn anchors + label strings into camera-facing text-3d-pipe subjects.
+export function placeLabels(
+  anchors,
+  labels,
+  {
+    height = 0.3,
+    pipeRadius = 0.05,
+    material = LABEL_MAT,
+    idPrefix = 'lbl',
+    align = 'center',
+  } = {},
+) {
+  return anchors.map((a, i) => ({
+    id: `${idPrefix}${i}`,
+    type: 'text-3d-pipe',
+    args: { text: String(labels[i] ?? ''), height, pipeRadius, align },
+    transform: { translate: [a.x, a.y, a.z] },
+    material,
+  }));
+}
+
+// Deterministic SceneData→SceneData: for every chart subject carrying
+// args.labels (parallel to args.values), append text-3d-pipe label subjects
+// anchored on its elements (offset by the subject's own translate). No-op when
+// no chart subject has labels, so it is safe to run on every scene.
+export function expandChartLabels(sceneData) {
+  if (!sceneData || !Array.isArray(sceneData.subjects)) return sceneData;
+  const extra = [];
+  sceneData.subjects.forEach((s, si) => {
+    const fn = ANCHOR_FOR[s && s.type];
+    const args = s && s.args;
+    const labels = args && Array.isArray(args.labels) ? args.labels : null;
+    const values = args && Array.isArray(args.values) ? args.values : null;
+    if (!fn || !labels || !labels.length || !values || !values.length) return;
+    const tr = (s.transform && s.transform.translate) || [0, 0, 0];
+    const off = fn(values, args).map((a) => ({ x: a.x + tr[0], y: a.y + tr[1], z: a.z + tr[2] }));
+    // only label the elements that actually have a label string
+    const n = Math.min(off.length, labels.length);
+    extra.push(
+      ...placeLabels(off.slice(0, n), labels.slice(0, n), { idPrefix: `lbl_${s.id ?? si}_` }),
+    );
+  });
+  if (!extra.length) return sceneData;
+  return { ...sceneData, subjects: [...sceneData.subjects, ...extra] };
+}


### PR DESCRIPTION
## What — auto-expand chart `args.labels` into SDF labels (the #84 connector)

Closes the loop from **2D real data → 3D labelled chart**. The #84 convention gives chart subjects parallel arrays in args (`values:number[]` + `labels:string[]`); the 3D atoms render geometry from `values` but **ignored** `labels`. This connector reads `args.labels` and appends camera-facing `text-3d-pipe` label subjects anchored on the rendered elements — **no manual placement**.

## How
- **`src/scene/chart-labels.js`**: anchor maths (`bar` / `line` / `column` / `pie`, mirroring each atom's layout) + `placeLabels` + **`expandChartLabels(sceneData)`** — a deterministic SceneData→SceneData transform; **no-op** when no chart carries labels (safe on every scene).
- **compositor** wires it at both scene-prep points (`loadDemoScene` after `expandVariants`; `renderLiftedSceneData` before compile), so **demos AND lift output** get labels automatically.
- `scripts/lib/data-labels.mjs` now **re-exports** from the src module — one source for the runtime connector and the build-time generators.
- `test-chart-labels.mjs` (11 assertions) registered in `run-tests`; demo **`chart-autolabel-bar`** = **one** `bar-3d` subject carrying `labels`, **zero** manual label subjects.

## Verification
- Real-browser GPU: loading the 1-subject demo **auto-injects 5 SDF labels** above the bars (`$1.2M … $3.4M`); **0 errors**.
- Full suite **83/83** (new test registered); eslint clean.

## Why now
Enabled by the loop-chart GLSL fix (#87) — `bar-3d` now renders **and** takes SDF labels, so the connector can target the real chart atoms. Lift's `labels:string[]` (#84) → rendered 3D labels is now mechanical + automatic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
