### PR TITLE
test(charts): verify #84 auto-label connector across pie / line / column

### DIFF
--- a/sdf-js/examples/compositor/demo-lifts/chart-autolabel-column.json
+++ b/sdf-js/examples/compositor/demo-lifts/chart-autolabel-column.json
@@ -1,0 +1,67 @@
+{
+  "id": "chart-autolabel-column",
+  "title": "Column chart · auto-labels (#84 connector)",
+  "prompt": "Column chart · auto-labels (#84 connector)",
+  "code2d": "// Column chart · auto-labels (#84 connector) — one chart atom + args.labels; connector injects labels.",
+  "sceneData": {
+    "v": 1,
+    "name": "compare: Quarterly figures",
+    "source": {
+      "format": "authored",
+      "prompt": "Column chart · auto-labels (#84 connector)"
+    },
+    "subjects": [
+      {
+        "id": "col",
+        "type": "column-3d",
+        "args": {
+          "values": [0.4, 0.66, 1, 0.6],
+          "labels": ["Q1", "Q2", "Q3", "Q4"],
+          "barWidth": 0.5,
+          "barDepth": 0.5,
+          "gap": 0.45,
+          "maxHeight": 2.2
+        },
+        "transform": {
+          "translate": [0, 1.4, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.75,
+          "metal": 0.3,
+          "glow": 0
+        }
+      }
+    ],
+    "defaults": {
+      "camera": {
+        "yaw": 0.4,
+        "pitch": 0.2,
+        "distance": 9,
+        "focal": 1.5,
+        "targetX": 0,
+        "targetY": 1.4,
+        "targetZ": 0
+      },
+      "light": {
+        "azimuth": 0.6,
+        "altitude": 0.55,
+        "distance": 25,
+        "intensity": 1.2
+      },
+      "shadow": {
+        "enabled": true,
+        "mode": "darken",
+        "strength": 0.4
+      },
+      "studioBg": "dark"
+    }
+  },
+  "meta": {
+    "generatedAt": "2026-06-21",
+    "model": "authored",
+    "pattern": "chart-autolabel",
+    "costUSD": 0
+  }
+}

--- a/sdf-js/examples/compositor/demo-lifts/chart-autolabel-line.json
+++ b/sdf-js/examples/compositor/demo-lifts/chart-autolabel-line.json
@@ -1,0 +1,65 @@
+{
+  "id": "chart-autolabel-line",
+  "title": "Line chart · auto-labels (#84 connector)",
+  "prompt": "Line chart · auto-labels (#84 connector)",
+  "code2d": "// Line chart · auto-labels (#84 connector) — one chart atom + args.labels; connector injects labels.",
+  "sceneData": {
+    "v": 1,
+    "name": "sequence: Monthly trend",
+    "source": {
+      "format": "authored",
+      "prompt": "Line chart · auto-labels (#84 connector)"
+    },
+    "subjects": [
+      {
+        "id": "line",
+        "type": "line-3d",
+        "args": {
+          "values": [0.3, 0.5, 0.45, 0.7, 0.6, 0.9],
+          "labels": ["30", "50", "45", "70", "60", "90"],
+          "pointSpacing": 0.95,
+          "maxHeight": 2.2
+        },
+        "transform": {
+          "translate": [0, 0, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.75,
+          "metal": 0.3,
+          "glow": 0
+        }
+      }
+    ],
+    "defaults": {
+      "camera": {
+        "yaw": 0.4,
+        "pitch": 0.2,
+        "distance": 9,
+        "focal": 1.5,
+        "targetX": 0,
+        "targetY": 1.3,
+        "targetZ": 0
+      },
+      "light": {
+        "azimuth": 0.6,
+        "altitude": 0.55,
+        "distance": 25,
+        "intensity": 1.2
+      },
+      "shadow": {
+        "enabled": true,
+        "mode": "darken",
+        "strength": 0.4
+      },
+      "studioBg": "dark"
+    }
+  },
+  "meta": {
+    "generatedAt": "2026-06-21",
+    "model": "authored",
+    "pattern": "chart-autolabel",
+    "costUSD": 0
+  }
+}

--- a/sdf-js/examples/compositor/demo-lifts/chart-autolabel-pie.json
+++ b/sdf-js/examples/compositor/demo-lifts/chart-autolabel-pie.json
@@ -1,0 +1,66 @@
+{
+  "id": "chart-autolabel-pie",
+  "title": "Pie chart · auto-labels (#84 connector)",
+  "prompt": "Pie chart · auto-labels (#84 connector)",
+  "code2d": "// Pie chart · auto-labels (#84 connector) — one chart atom + args.labels; connector injects labels.",
+  "sceneData": {
+    "v": 1,
+    "name": "compare: Market share",
+    "source": {
+      "format": "authored",
+      "prompt": "Pie chart · auto-labels (#84 connector)"
+    },
+    "subjects": [
+      {
+        "id": "pie",
+        "type": "pie-3d",
+        "args": {
+          "values": [0.35, 0.25, 0.22, 0.18],
+          "labels": ["35%", "25%", "22%", "18%"],
+          "outerRadius": 1.1,
+          "innerRadius": 0.4,
+          "thickness": 0.35
+        },
+        "transform": {
+          "translate": [0, 1.4, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.75,
+          "metal": 0.3,
+          "glow": 0
+        }
+      }
+    ],
+    "defaults": {
+      "camera": {
+        "yaw": 0.4,
+        "pitch": 0.2,
+        "distance": 8,
+        "focal": 1.5,
+        "targetX": 0,
+        "targetY": 1.4,
+        "targetZ": 0
+      },
+      "light": {
+        "azimuth": 0.6,
+        "altitude": 0.55,
+        "distance": 25,
+        "intensity": 1.2
+      },
+      "shadow": {
+        "enabled": true,
+        "mode": "darken",
+        "strength": 0.4
+      },
+      "studioBg": "dark"
+    }
+  },
+  "meta": {
+    "generatedAt": "2026-06-21",
+    "model": "authored",
+    "pattern": "chart-autolabel",
+    "costUSD": 0
+  }
+}

--- a/sdf-js/examples/compositor/demo-lifts/index.json
+++ b/sdf-js/examples/compositor/demo-lifts/index.json
@@ -1338,6 +1338,36 @@
       "file": "chart-autolabel-bar.json",
       "renderer": "studio",
       "prompt": "Bar chart · auto-labels from args.labels (#84 connector)"
+    },
+    {
+      "id": "chart-autolabel-pie",
+      "title": "Pie chart · auto-labels (#84 connector)",
+      "thesisPoint": "#84 connector verified across chart types — one atom + args.labels, labels auto-injected.",
+      "category": "data-labels",
+      "status": "ready",
+      "file": "chart-autolabel-pie.json",
+      "renderer": "studio",
+      "prompt": "Pie chart · auto-labels (#84 connector)"
+    },
+    {
+      "id": "chart-autolabel-line",
+      "title": "Line chart · auto-labels (#84 connector)",
+      "thesisPoint": "#84 connector verified across chart types — one atom + args.labels, labels auto-injected.",
+      "category": "data-labels",
+      "status": "ready",
+      "file": "chart-autolabel-line.json",
+      "renderer": "studio",
+      "prompt": "Line chart · auto-labels (#84 connector)"
+    },
+    {
+      "id": "chart-autolabel-column",
+      "title": "Column chart · auto-labels (#84 connector)",
+      "thesisPoint": "#84 connector verified across chart types — one atom + args.labels, labels auto-injected.",
+      "category": "data-labels",
+      "status": "ready",
+      "file": "chart-autolabel-column.json",
+      "renderer": "studio",
+      "prompt": "Column chart · auto-labels (#84 connector)"
     }
   ]
 }

--- a/sdf-js/scripts/gen-autolabel-charts.mjs
+++ b/sdf-js/scripts/gen-autolabel-charts.mjs
@@ -1,0 +1,133 @@
+#!/usr/bin/env node
+// =============================================================================
+// gen-autolabel-charts.mjs — verify the #84 expandChartLabels connector across
+// the remaining chart types (pie / line / column). Each demo is ONE chart atom
+// carrying args.labels and ZERO manual label subjects — the connector injects
+// the SDF labels at load (loadDemoScene → expandChartLabels). The bar case ships
+// as chart-autolabel-bar; this covers the other three anchor families.
+//
+// Usage: node sdf-js/scripts/gen-autolabel-charts.mjs
+// =============================================================================
+
+import { readFileSync, writeFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const OUT = resolve(__dirname, '../examples/compositor/demo-lifts');
+const BLUE = { hue: 0.58, sat: 0.85, value: 0.75, metal: 0.3, glow: 0 };
+
+const cam = (ty, dist) => ({
+  yaw: 0.4,
+  pitch: 0.2,
+  distance: dist,
+  focal: 1.5,
+  targetX: 0,
+  targetY: ty,
+  targetZ: 0,
+});
+
+function wrap(id, title, name, subject, camera) {
+  return {
+    id,
+    title,
+    prompt: title,
+    code2d: `// ${title} — one chart atom + args.labels; connector injects labels.`,
+    sceneData: {
+      v: 1,
+      name,
+      source: { format: 'authored', prompt: title },
+      subjects: [subject],
+      defaults: {
+        camera,
+        light: { azimuth: 0.6, altitude: 0.55, distance: 25, intensity: 1.2 },
+        shadow: { enabled: true, mode: 'darken', strength: 0.4 },
+        studioBg: 'dark',
+      },
+    },
+    meta: { generatedAt: '2026-06-21', model: 'authored', pattern: 'chart-autolabel', costUSD: 0 },
+  };
+}
+
+const DEMOS = [
+  wrap(
+    'chart-autolabel-pie',
+    'Pie chart · auto-labels (#84 connector)',
+    'compare: Market share',
+    {
+      id: 'pie',
+      type: 'pie-3d',
+      args: {
+        values: [0.35, 0.25, 0.22, 0.18],
+        labels: ['35%', '25%', '22%', '18%'],
+        outerRadius: 1.1,
+        innerRadius: 0.4,
+        thickness: 0.35,
+      },
+      transform: { translate: [0, 1.4, 0] },
+      material: BLUE,
+    },
+    cam(1.4, 8),
+  ),
+  wrap(
+    'chart-autolabel-line',
+    'Line chart · auto-labels (#84 connector)',
+    'sequence: Monthly trend',
+    {
+      id: 'line',
+      type: 'line-3d',
+      args: {
+        values: [0.3, 0.5, 0.45, 0.7, 0.6, 0.9],
+        labels: ['30', '50', '45', '70', '60', '90'],
+        pointSpacing: 0.95,
+        maxHeight: 2.2,
+      },
+      transform: { translate: [0, 0, 0] },
+      material: BLUE,
+    },
+    cam(1.3, 9),
+  ),
+  wrap(
+    'chart-autolabel-column',
+    'Column chart · auto-labels (#84 connector)',
+    'compare: Quarterly figures',
+    {
+      id: 'col',
+      type: 'column-3d',
+      args: {
+        values: [0.4, 0.66, 1.0, 0.6],
+        labels: ['Q1', 'Q2', 'Q3', 'Q4'],
+        barWidth: 0.5,
+        barDepth: 0.5,
+        gap: 0.45,
+        maxHeight: 2.2,
+      },
+      transform: { translate: [0, 1.4, 0] },
+      material: BLUE,
+    },
+    cam(1.4, 9),
+  ),
+];
+
+const idxPath = `${OUT}/index.json`;
+const index = JSON.parse(readFileSync(idxPath, 'utf8'));
+for (const d of DEMOS) {
+  writeFileSync(`${OUT}/${d.id}.json`, JSON.stringify(d, null, 2) + '\n');
+  if (!index.demos.some((x) => x.id === d.id)) {
+    index.demos.push({
+      id: d.id,
+      title: d.title,
+      thesisPoint:
+        '#84 connector verified across chart types — one atom + args.labels, labels auto-injected.',
+      category: 'data-labels',
+      status: 'ready',
+      file: `${d.id}.json`,
+      renderer: 'studio',
+      prompt: d.title,
+    });
+  }
+}
+writeFileSync(idxPath, JSON.stringify(index, null, 2) + '\n');
+console.log(
+  `wrote ${DEMOS.length} auto-label demos (pie/line/column); index now ${index.demos.length} demos`,
+);


### PR DESCRIPTION
## What — verify the #84 auto-label connector across pie / line / column

`expandChartLabels` (PR #89) handled all four anchor families, but only the **bar** case was demo-verified end-to-end. This adds three demos — each **one** chart atom carrying `args.labels` and **zero** manual label subjects — so loading each exercises the connector for the remaining types:

- `chart-autolabel-pie` — slice % around the donut rim
- `chart-autolabel-line` — point values above each point
- `chart-autolabel-column` — Q1–Q4 at each horizontal bar's end

## Verification (real-browser GPU)
All three load; the connector injects the SDF labels at the correct anchors (pie around the rim at slice mid-angles, column at bar ends), **0 errors**. Confirms `expandChartLabels` generalizes across **bar / line / column / pie**.

Pure demo/verification — no engine changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
