### PR TITLE
feat(charts): chart-label connector handoff doc + e2e lift harness (decision A)

### DIFF
--- a/docs/chart-label-connector-handoff.md
+++ b/docs/chart-label-connector-handoff.md
@@ -1,0 +1,90 @@
+# Chart data labels: move back to `args.labels` (3D-side → 2D-side handoff)
+
+**Status:** 3D-side runtime ready (PR #89 `expandChartLabels` + #85/#86/#87/#90).
+**Ask:** update `MODE_3D_ADDENDUM` to PREFER the `args.labels` convention for the
+supported chart atoms, as the addendum itself anticipated.
+
+The addendum currently says (Phase C v2, "Data label patterns"):
+
+> *"Phase C v1 spec'd `label: string[]` as an atom arg. That was aspirational — no
+> runtime expansion exists. … A future PR may add pipeline auto-expansion from
+> `label: string[]` to positioned text-3d-pipe subjects, at which point this
+> section will move back."*
+
+**PR #89 is that future PR.** `expandChartLabels()` now runs at scene load
+(compositor `loadDemoScene` + `renderLiftedSceneData`) and deterministically
+turns `args.labels` into positioned `text-3d-pipe` subjects. So the section can
+move back.
+
+## Why `args.labels` beats LLM-emitted separate subjects
+
+1. **Move geometry math off the LLM.** The current prompt makes the model
+   *compute* each label's `translate:[x,y,z]` from the anchor formulas
+   (`xStart = -(N*barW+(N-1)*gap)/2 + barW/2`, `values[i]*maxHeight + margin`,
+   `-barDepth/2 - 0.1`, pie mid-angles, …). That is probabilistic arithmetic per
+   label — one slip and a label floats off its bar. The connector runs the *same
+   formulas in code*, deterministically. Geometry belongs in the runtime, not in
+   token-by-token model output.
+2. **Single source of truth for anchors.** Those formulas live in BOTH the prompt
+   (for the LLM) and `src/scene/chart-labels.js` (for the demos/connector). Two
+   copies drift. With `args.labels`, only `chart-labels.js` has them; the prompt
+   just says "provide `labels` parallel to `values`."
+3. **Fewer tokens, fewer failure modes.** `labels:["$1.2M","$2.0M",…]` is one
+   array vs N full `text-3d-pipe` subjects (~5 lines + computed translate each).
+   Less output, no per-label math, no mis-anchored labels.
+4. **It is the planned state.** The addendum explicitly reserved this path; this
+   is "moving the section back," not a new direction.
+5. **The hand-formulas already have a bug the connector doesn't.** The addendum's
+   anchor table uses inconsistent z-signs: `bar-3d`/`line-3d` are `-z` (correct —
+   the studio camera faces −z), but `pie-3d` (`thickness/2 + 0.05`),
+   `sphere-fill-3d` (`radius + 0.05`) and `matrix-grid-3d` (`cardCentreZ + 0.02`)
+   are `+z` — i.e. the **far side**, where the label hides behind the geometry.
+   The LLM would faithfully reproduce that. The connector uses `-z` everywhere
+   (verified by rendering, #90). Exactly why anchor math should not live in
+   prose the model copies.
+
+## What changes in `MODE_3D_ADDENDUM` (concrete)
+
+- **Re-introduce `labels` as the PREFERRED path** for the connector-backed chart
+  atoms: `bar-3d`, `column-3d`, `line-3d`, `pie-3d`, `sphere-fill-3d`,
+  `matrix-grid-3d`. Convention: the chart subject carries `args.labels: string[]`
+  (or, for `sphere-fill-3d`, parallel to `levels`; for `matrix-grid-3d`, a
+  row-major array of length `rows*cols`). The runtime positions the labels — the
+  LLM does **not** compute `translate`.
+- **LLM still pre-formats label strings** (`"$3.4M"`, `"35%"`) — unchanged.
+- **Keep Path A (separate `text-3d-pipe` subjects) and Path B (`annotations[]`)**
+  documented as fallbacks for: tree-shaped atoms (no anchor support yet — see
+  "open question for Phase D"), **>10 labels** (Path B is cheaper), or
+  non-standard placement.
+- **The anchor formula tables stay** — but reframed as *documentation of where the
+  runtime puts labels*, not as math the LLM must perform.
+- **Update the worked example**: the bar example becomes ONE `bar-3d` with
+  `args.labels`, not 6 separate subjects.
+
+Suggested decision line in the prompt:
+> *Data labels: put a `labels` array on the chart atom (parallel to `values`).
+> The runtime anchors them. Only hand-emit `text-3d-pipe` subjects / `annotations`
+> for tree atoms, >10 labels, or custom placement.*
+
+## Connector contract (what the 2D side can rely on)
+
+- `expandChartLabels(sceneData)` — deterministic SceneData→SceneData, runs at
+  scene load, **no-op when no chart carries `labels`** (so the separate-subjects
+  path keeps working; both coexist).
+- **Anchors mirror each atom's own layout** (same formulas the prompt documents),
+  so labels land exactly on the rendered elements.
+- **Coverage NOW:** `bar-3d` / `column-3d` / `line-3d` / `pie-3d` — verified
+  end-to-end (#90). The 2D side can switch these to `args.labels` immediately.
+- **Follow-up (3D side):** `sphere-fill-3d` (labels parallel to `levels`) +
+  `matrix-grid-3d` (row-major `rows*cols` array) — connector extension to land
+  before the prompt uses `labels` for them; until then keep those two on
+  hand-emitted subjects.
+- **Not covered:** tree-shaped atoms (`tree-diagram-3d` / `org-chart-3d` /
+  `mindmap-3d`) — internal node order undocumented (addendum's "open question for
+  Phase D"). Keep on hand-emitted subjects until anchors exist.
+
+## Evidence
+- `expandChartLabels` + `chart-labels.js` (#89), unit test `test-chart-labels.mjs`.
+- Demos: `chart-autolabel-bar` / `-pie` / `-line` / `-column` — one chart atom +
+  `args.labels`, labels auto-injected, 0 GPU errors (#90).
+- `bar-3d` + SDF labels renders after the ES-1.00 shader fix (#87).

--- a/sdf-js/scripts/test-lift-chart-e2e.mjs
+++ b/sdf-js/scripts/test-lift-chart-e2e.mjs
@@ -1,0 +1,132 @@
+#!/usr/bin/env node
+// =============================================================================
+// test-lift-chart-e2e.mjs — REAL end-to-end lift test for the chart-label chain.
+// Calls the Anthropic API with the actual lift system prompt (base + MODE_3D
+// addendum) on a couple of chart prompts, then reports WHICH label path the LLM
+// emits — the only link in the chain still verified by assumption, not a real
+// model run. Then it runs the #89 connector (expandChartLabels) + compiles, to
+// see whether the output is render-ready and whether the connector fires.
+//
+// Usage: ANTHROPIC_API_KEY=sk-ant-... node sdf-js/scripts/test-lift-chart-e2e.mjs
+//   optional: MODEL=claude-sonnet-4-5 (default)
+// BYOK — the key is read from the environment and only sent to api.anthropic.com.
+// =============================================================================
+
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+import { MODE_3D_ADDENDUM, parseLiftResponse } from '../src/compositor-api.js';
+import { expandChartLabels } from '../src/scene/chart-labels.js';
+import { compile } from '../src/scene/index.js';
+import { compileSDF3ToGLSL } from '../src/sdf/sdf3.compile.js';
+
+const API_KEY = process.env.ANTHROPIC_API_KEY;
+if (!API_KEY) {
+  console.error('✗ ANTHROPIC_API_KEY env var required (BYOK).');
+  console.error('  ANTHROPIC_API_KEY=sk-ant-... node sdf-js/scripts/test-lift-chart-e2e.mjs');
+  process.exit(1);
+}
+const MODEL = process.env.MODEL || 'claude-sonnet-4-5';
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const BASE_PROMPT = readFileSync(
+  resolve(__dirname, '../examples/compositor/system-prompt-lift-3d.md'),
+  'utf8',
+);
+const SYSTEM = BASE_PROMPT + MODE_3D_ADDENDUM;
+
+const CASES = [
+  {
+    name: 'bar chart (quarterly revenue, $ labels)',
+    prompt: 'Quarterly revenue bar chart: Q1 $1.2M, Q2 $2.0M, Q3 $3.4M, Q4 $2.6M',
+    code2d:
+      '// 2D bar chart: 4 bars heights [1.2,2.0,3.4,2.6], labels ["$1.2M","$2.0M","$3.4M","$2.6M"]',
+  },
+  {
+    name: 'pie chart (market share, % labels)',
+    prompt: 'Market share donut: AWS 35%, Azure 25%, GCP 22%, Other 18%',
+    code2d: '// 2D donut: values [35,25,22,18], labels ["35%","25%","22%","18%"]',
+  },
+];
+
+async function lift(c) {
+  const userMessage = `## Original user prompt\n\n${c.prompt}\n\n## 2D SDF code\n\n\`\`\`js\n${c.code2d}\n\`\`\``;
+  const res = await fetch('https://api.anthropic.com/v1/messages', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'x-api-key': API_KEY,
+      'anthropic-version': '2023-06-01',
+    },
+    body: JSON.stringify({
+      model: MODEL,
+      max_tokens: 8192,
+      system: SYSTEM,
+      messages: [{ role: 'user', content: userMessage }],
+    }),
+  });
+  if (!res.ok) throw new Error(`Anthropic ${res.status}: ${(await res.text()).slice(0, 300)}`);
+  const data = await res.json();
+  return { text: data.content[0].text, usage: data.usage };
+}
+
+const CHART_TYPES = new Set([
+  'bar-3d',
+  'column-3d',
+  'line-3d',
+  'pie-3d',
+  'sphere-fill-3d',
+  'matrix-grid-3d',
+]);
+
+for (const c of CASES) {
+  console.log(`\n=== ${c.name} ===`);
+  try {
+    const { text, usage } = await lift(c);
+    const scene = parseLiftResponse(text);
+    const subs = scene.subjects || [];
+    const types = subs.map((s) => s.type);
+    const chart = subs.find((s) => CHART_TYPES.has(s.type));
+    const pipeLabels = subs.filter((s) => s.type === 'text-3d-pipe');
+    const hasArgsLabels = !!(chart && chart.args && Array.isArray(chart.args.labels));
+    const hasAnnotations = Array.isArray(scene.annotations) && scene.annotations.length > 0;
+    const hasOverlay = !!scene.overlay;
+
+    console.log(`  tokens: in ${usage.input_tokens} / out ${usage.output_tokens}`);
+    console.log(`  subjects (${subs.length}): ${types.join(', ')}`);
+    console.log(`  chart atom: ${chart ? chart.type : '(NONE — LLM hand-rolled?)'}`);
+    console.log(`  LABEL PATH →`);
+    console.log(
+      `    • args.labels on chart atom: ${hasArgsLabels ? 'YES (connector path #89)' : 'no'}`,
+    );
+    console.log(`    • separate text-3d-pipe subjects: ${pipeLabels.length} (Path A)`);
+    console.log(
+      `    • annotations[] overlay: ${hasAnnotations ? scene.annotations.length : 0} (Path B)`,
+    );
+    console.log(`    • overlay narrative field: ${hasOverlay ? 'YES' : 'no'}`);
+
+    // run the #89 connector — does it inject anything? (only if LLM used args.labels)
+    const expanded = expandChartLabels(scene);
+    const injected = expanded.subjects.length - subs.length;
+    console.log(`  connector expandChartLabels injected: ${injected} label subjects`);
+
+    // compile (CPU) — render-ready?
+    try {
+      const comp = compile(expanded);
+      const g = compileSDF3ToGLSL(comp.sdf, {
+        sceneFnName: 'sceneSDF',
+        includeLibrary: true,
+        emitObjectIndex: true,
+      });
+      const glsl = typeof g === 'string' ? g : g.glsl;
+      const e = comp.sanityResult ? comp.sanityResult.errors.length : 0;
+      console.log(
+        `  compile: E${e}, GLSL ${glsl.length} chars (CPU-clean; GPU check needs browser)`,
+      );
+    } catch (e) {
+      console.log(`  compile FAILED: ${e.message.slice(0, 120)}`);
+    }
+  } catch (e) {
+    console.log(`  ✗ lift failed: ${e.message}`);
+  }
+}
+console.log('\n=== done ===');

--- a/sdf-js/src/compositor-api.js
+++ b/sdf-js/src/compositor-api.js
@@ -690,7 +690,7 @@ is the message.
  * atoms (text-3d-extruded, text-3d-pipe) are intentionally EXCLUDED — they are
  * implementation details of other atoms; LLM does not emit them directly.
  */
-const MODE_3D_ADDENDUM = `
+export const MODE_3D_ADDENDUM = `
 
 ## 3D atom catalog (Phase C — clean addendum, 2026-06-22)
 


### PR DESCRIPTION
Decision A prep: move the data-label spec back to args.labels (now that #89 provides the runtime). 3D-side deliverables; the MODE_3D_ADDENDUM prompt change is coordinated separately on the 2D side.\n\n- **docs/chart-label-connector-handoff.md** — rationale + concrete prompt-change spec + connector contract for the 2D team. Argues: anchor geometry belongs in the deterministic runtime, not LLM-copied prose; single source of truth; fewer tokens / mis-anchored labels; it's the state the addendum reserved. Flags a real bug: the addendum's pie/sphere-fill/matrix anchor formulas use +z (far side, label hidden) vs the connector's verified -z.\n- **export MODE_3D_ADDENDUM** so Node harnesses build the exact 3D-mode system prompt.\n- **scripts/test-lift-chart-e2e.mjs** — BYOK e2e harness: real lift on chart prompts, reports which label path the LLM emits + whether the connector fires + compiles.\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)