### PR TITLE
feat(charts): extend args.labels connector to sphere-fill-3d + matrix-grid-3d

### DIFF
--- a/docs/chart-label-connector-handoff.md
+++ b/docs/chart-label-connector-handoff.md
@@ -73,12 +73,11 @@ Suggested decision line in the prompt:
   path keeps working; both coexist).
 - **Anchors mirror each atom's own layout** (same formulas the prompt documents),
   so labels land exactly on the rendered elements.
-- **Coverage NOW:** `bar-3d` / `column-3d` / `line-3d` / `pie-3d` — verified
-  end-to-end (#90). The 2D side can switch these to `args.labels` immediately.
-- **Follow-up (3D side):** `sphere-fill-3d` (labels parallel to `levels`) +
-  `matrix-grid-3d` (row-major `rows*cols` array) — connector extension to land
-  before the prompt uses `labels` for them; until then keep those two on
-  hand-emitted subjects.
+- **Coverage NOW (all six the addendum documents):** `bar-3d` / `column-3d` /
+  `line-3d` / `pie-3d` (#90), plus `sphere-fill-3d` (labels parallel to `levels`)
+  and `matrix-grid-3d` (row-major `rows*cols` array, row 0 on top) — connector
+  extension landed + browser-verified (SWOT S/W/O/T in the right corners). The
+  2D side can switch all six to `args.labels`.
 - **Not covered:** tree-shaped atoms (`tree-diagram-3d` / `org-chart-3d` /
   `mindmap-3d`) — internal node order undocumented (addendum's "open question for
   Phase D"). Keep on hand-emitted subjects until anchors exist.

--- a/sdf-js/examples/compositor/demo-lifts/chart-autolabel-matrix.json
+++ b/sdf-js/examples/compositor/demo-lifts/chart-autolabel-matrix.json
@@ -1,0 +1,68 @@
+{
+  "id": "chart-autolabel-matrix",
+  "title": "Matrix (SWOT) · auto-labels (#84 connector)",
+  "prompt": "Matrix (SWOT) · auto-labels (#84 connector)",
+  "code2d": "// Matrix (SWOT) · auto-labels (#84 connector) — one chart atom + args.labels; connector injects labels.",
+  "sceneData": {
+    "v": 1,
+    "name": "compare: SWOT",
+    "source": {
+      "format": "authored",
+      "prompt": "Matrix (SWOT) · auto-labels (#84 connector)"
+    },
+    "subjects": [
+      {
+        "id": "mx",
+        "type": "matrix-grid-3d",
+        "args": {
+          "rows": 2,
+          "cols": 2,
+          "labels": ["S", "W", "O", "T"],
+          "cardW": 1.1,
+          "cardH": 0.85,
+          "cardD": 0.2,
+          "gap": 0.22
+        },
+        "transform": {
+          "translate": [0, 1.3, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.75,
+          "metal": 0.3,
+          "glow": 0
+        }
+      }
+    ],
+    "defaults": {
+      "camera": {
+        "yaw": 0.4,
+        "pitch": 0.2,
+        "distance": 8,
+        "focal": 1.5,
+        "targetX": 0,
+        "targetY": 1.3,
+        "targetZ": 0
+      },
+      "light": {
+        "azimuth": 0.6,
+        "altitude": 0.55,
+        "distance": 25,
+        "intensity": 1.2
+      },
+      "shadow": {
+        "enabled": true,
+        "mode": "darken",
+        "strength": 0.4
+      },
+      "studioBg": "dark"
+    }
+  },
+  "meta": {
+    "generatedAt": "2026-06-21",
+    "model": "authored",
+    "pattern": "chart-autolabel",
+    "costUSD": 0
+  }
+}

--- a/sdf-js/examples/compositor/demo-lifts/chart-autolabel-spherefill.json
+++ b/sdf-js/examples/compositor/demo-lifts/chart-autolabel-spherefill.json
@@ -1,0 +1,65 @@
+{
+  "id": "chart-autolabel-spherefill",
+  "title": "Sphere-fill · auto-labels (#84 connector)",
+  "prompt": "Sphere-fill · auto-labels (#84 connector)",
+  "code2d": "// Sphere-fill · auto-labels (#84 connector) — one chart atom + args.labels; connector injects labels.",
+  "sceneData": {
+    "v": 1,
+    "name": "kpi-hero: Fill levels",
+    "source": {
+      "format": "authored",
+      "prompt": "Sphere-fill · auto-labels (#84 connector)"
+    },
+    "subjects": [
+      {
+        "id": "sf",
+        "type": "sphere-fill-3d",
+        "args": {
+          "levels": [0.2, 0.5, 0.8, 1],
+          "labels": ["20%", "50%", "80%", "100%"],
+          "radius": 0.6,
+          "spacing": 0.4
+        },
+        "transform": {
+          "translate": [0, 1, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.75,
+          "metal": 0.3,
+          "glow": 0
+        }
+      }
+    ],
+    "defaults": {
+      "camera": {
+        "yaw": 0.4,
+        "pitch": 0.2,
+        "distance": 9,
+        "focal": 1.5,
+        "targetX": 0,
+        "targetY": 1,
+        "targetZ": 0
+      },
+      "light": {
+        "azimuth": 0.6,
+        "altitude": 0.55,
+        "distance": 25,
+        "intensity": 1.2
+      },
+      "shadow": {
+        "enabled": true,
+        "mode": "darken",
+        "strength": 0.4
+      },
+      "studioBg": "dark"
+    }
+  },
+  "meta": {
+    "generatedAt": "2026-06-21",
+    "model": "authored",
+    "pattern": "chart-autolabel",
+    "costUSD": 0
+  }
+}

--- a/sdf-js/examples/compositor/demo-lifts/index.json
+++ b/sdf-js/examples/compositor/demo-lifts/index.json
@@ -1368,6 +1368,26 @@
       "file": "chart-autolabel-column.json",
       "renderer": "studio",
       "prompt": "Column chart · auto-labels (#84 connector)"
+    },
+    {
+      "id": "chart-autolabel-spherefill",
+      "title": "Sphere-fill · auto-labels (#84 connector)",
+      "thesisPoint": "#84 connector verified across chart types — one atom + args.labels, labels auto-injected.",
+      "category": "data-labels",
+      "status": "ready",
+      "file": "chart-autolabel-spherefill.json",
+      "renderer": "studio",
+      "prompt": "Sphere-fill · auto-labels (#84 connector)"
+    },
+    {
+      "id": "chart-autolabel-matrix",
+      "title": "Matrix (SWOT) · auto-labels (#84 connector)",
+      "thesisPoint": "#84 connector verified across chart types — one atom + args.labels, labels auto-injected.",
+      "category": "data-labels",
+      "status": "ready",
+      "file": "chart-autolabel-matrix.json",
+      "renderer": "studio",
+      "prompt": "Matrix (SWOT) · auto-labels (#84 connector)"
     }
   ]
 }

--- a/sdf-js/scripts/gen-autolabel-charts.mjs
+++ b/sdf-js/scripts/gen-autolabel-charts.mjs
@@ -107,6 +107,45 @@ const DEMOS = [
     },
     cam(1.4, 9),
   ),
+  wrap(
+    'chart-autolabel-spherefill',
+    'Sphere-fill · auto-labels (#84 connector)',
+    'kpi-hero: Fill levels',
+    {
+      id: 'sf',
+      type: 'sphere-fill-3d',
+      args: {
+        levels: [0.2, 0.5, 0.8, 1.0],
+        labels: ['20%', '50%', '80%', '100%'],
+        radius: 0.6,
+        spacing: 0.4,
+      },
+      transform: { translate: [0, 1.0, 0] },
+      material: BLUE,
+    },
+    cam(1.0, 9),
+  ),
+  wrap(
+    'chart-autolabel-matrix',
+    'Matrix (SWOT) · auto-labels (#84 connector)',
+    'compare: SWOT',
+    {
+      id: 'mx',
+      type: 'matrix-grid-3d',
+      args: {
+        rows: 2,
+        cols: 2,
+        labels: ['S', 'W', 'O', 'T'],
+        cardW: 1.1,
+        cardH: 0.85,
+        cardD: 0.2,
+        gap: 0.22,
+      },
+      transform: { translate: [0, 1.3, 0] },
+      material: BLUE,
+    },
+    cam(1.3, 8),
+  ),
 ];
 
 const idxPath = `${OUT}/index.json`;

--- a/sdf-js/scripts/lib/data-labels.mjs
+++ b/sdf-js/scripts/lib/data-labels.mjs
@@ -9,6 +9,8 @@ export {
   lineAnchors,
   columnAnchors,
   pieAnchors,
+  sphereFillAnchors,
+  matrixAnchors,
   placeLabels,
   ANCHOR_FOR,
   expandChartLabels,

--- a/sdf-js/scripts/test-chart-labels.mjs
+++ b/sdf-js/scripts/test-chart-labels.mjs
@@ -69,6 +69,67 @@ console.log('=== chart-labels (expandChartLabels connector) ===\n');
   );
 }
 
+// sphere-fill-3d: labels parallel to `levels` (not `values`)
+{
+  const scene = {
+    v: 1,
+    subjects: [
+      {
+        id: 'sf',
+        type: 'sphere-fill-3d',
+        args: { levels: [0.2, 0.5, 0.8], labels: ['20%', '50%', '80%'], radius: 0.6, spacing: 0.3 },
+      },
+    ],
+  };
+  const added = expandChartLabels(scene).subjects.filter((s) => s.type === 'text-3d-pipe');
+  ok(added.length === 3, 'sphere-fill: 3 labels from levels[] (not values)');
+  ok(
+    added.every((s, i) => s.args.text === ['20%', '50%', '80%'][i]),
+    'sphere-fill label texts match',
+  );
+  // middle sphere centred at x=0 (N=3 symmetric)
+  ok(Math.abs(added[1].transform.translate[0]) < 1e-9, 'sphere-fill middle label at x=0');
+  ok(added[0].transform.translate[2] < 0, 'sphere-fill label on −z (camera-facing) front');
+}
+
+// matrix-grid-3d: row-major flat array, row 0 on top
+{
+  const scene = {
+    v: 1,
+    subjects: [
+      {
+        id: 'm',
+        type: 'matrix-grid-3d',
+        args: {
+          rows: 2,
+          cols: 2,
+          labels: ['TL', 'TR', 'BL', 'BR'],
+          cardW: 0.9,
+          cardH: 0.7,
+          cardD: 0.18,
+          gap: 0.18,
+        },
+      },
+    ],
+  };
+  const added = expandChartLabels(scene).subjects.filter((s) => s.type === 'text-3d-pipe');
+  ok(added.length === 4, 'matrix: 4 labels for 2×2 (rows*cols)');
+  // index 0 = top-left: x<0 (left col), y>0 (top row, since y=(R-1-r)*strideY-offY, r=0 → +)
+  ok(
+    added[0].transform.translate[0] < 0 && added[0].transform.translate[1] > 0,
+    'matrix label[0] = top-left',
+  );
+  ok(
+    added[1].transform.translate[0] > 0 && added[1].transform.translate[1] > 0,
+    'matrix label[1] = top-right',
+  );
+  ok(added[2].transform.translate[1] < 0, 'matrix label[2] = bottom row');
+  ok(
+    added.every((s) => s.transform.translate[2] < 0),
+    'matrix labels on −z front',
+  );
+}
+
 // no-op cases
 {
   const noLabels = { v: 1, subjects: [{ id: 'b', type: 'bar-3d', args: { values: [0.5, 0.7] } }] };

--- a/sdf-js/src/scene/chart-labels.js
+++ b/sdf-js/src/scene/chart-labels.js
@@ -84,11 +84,72 @@ export function pieAnchors(
   });
 }
 
+// sphere-fill-3d: row of spheres along +X (labels parallel to `levels`). anchor
+// = just in front of each sphere's front face (−z), centred at sphere height.
+export function sphereFillAnchors({
+  levels = [],
+  count,
+  radius = 0.6,
+  spacing = 0.3,
+  margin = 0.1,
+} = {}) {
+  const N = count != null ? Math.floor(count) : levels.length;
+  const stride = 2 * radius + spacing;
+  const offset = ((N - 1) / 2) * stride;
+  return Array.from({ length: N }, (_, i) => ({
+    x: i * stride - offset,
+    y: 0,
+    z: -(radius + margin),
+  }));
+}
+
+// matrix-grid-3d: R×C card grid, ROW-MAJOR with row 0 on TOP (matches the atom:
+// y = (R-1-r)*strideY - offY). labels[] is a flat row-major array (len R*C).
+export function matrixAnchors({
+  rows = 2,
+  cols = 2,
+  cardW = 0.9,
+  cardH = 0.7,
+  cardD = 0.18,
+  gap = 0.18,
+  margin = 0.04,
+} = {}) {
+  const R = Math.max(1, Math.min(6, Math.floor(rows)));
+  const C = Math.max(1, Math.min(6, Math.floor(cols)));
+  const strideX = cardW + gap;
+  const strideY = cardH + gap;
+  const offX = ((C - 1) / 2) * strideX;
+  const offY = ((R - 1) / 2) * strideY;
+  const out = [];
+  for (let r = 0; r < R; r++) {
+    for (let c = 0; c < C; c++) {
+      out.push({
+        x: c * strideX - offX,
+        y: (R - 1 - r) * strideY - offY,
+        z: -(cardD / 2 + margin),
+      });
+    }
+  }
+  return out;
+}
+
 export const ANCHOR_FOR = {
   'bar-3d': barAnchors,
   'line-3d': lineAnchors,
   'column-3d': columnAnchors,
   'pie-3d': pieAnchors,
+};
+
+// internal: type → (args) → anchor list. Unifies the values-array family
+// (bar/line/column/pie read args.values) with the shape-specific atoms
+// (sphere-fill reads args.levels; matrix-grid reads rows×cols).
+const ANCHORS_FROM_ARGS = {
+  'bar-3d': (a) => barAnchors(a.values || [], a),
+  'line-3d': (a) => lineAnchors(a.values || [], a),
+  'column-3d': (a) => columnAnchors(a.values || [], a),
+  'pie-3d': (a) => pieAnchors(a.values || [], a),
+  'sphere-fill-3d': (a) => sphereFillAnchors(a),
+  'matrix-grid-3d': (a) => matrixAnchors(a),
 };
 
 // turn anchors + label strings into camera-facing text-3d-pipe subjects.
@@ -120,13 +181,14 @@ export function expandChartLabels(sceneData) {
   if (!sceneData || !Array.isArray(sceneData.subjects)) return sceneData;
   const extra = [];
   sceneData.subjects.forEach((s, si) => {
-    const fn = ANCHOR_FOR[s && s.type];
+    const fn = ANCHORS_FROM_ARGS[s && s.type];
     const args = s && s.args;
     const labels = args && Array.isArray(args.labels) ? args.labels : null;
-    const values = args && Array.isArray(args.values) ? args.values : null;
-    if (!fn || !labels || !labels.length || !values || !values.length) return;
+    if (!fn || !labels || !labels.length) return;
+    const anchors = fn(args);
+    if (!anchors || !anchors.length) return;
     const tr = (s.transform && s.transform.translate) || [0, 0, 0];
-    const off = fn(values, args).map((a) => ({ x: a.x + tr[0], y: a.y + tr[1], z: a.z + tr[2] }));
+    const off = anchors.map((a) => ({ x: a.x + tr[0], y: a.y + tr[1], z: a.z + tr[2] }));
     // only label the elements that actually have a label string
     const n = Math.min(off.length, labels.length);
     extra.push(


### PR DESCRIPTION
Completes #84 connector coverage to all six chart atoms the addendum documents.

- **sphere-fill-3d** — labels parallel to `levels` (not `values`); anchor in front of each sphere's -z face.
- **matrix-grid-3d** — flat row-major `rows*cols` array, row 0 on TOP (matches the atom's `y=(R-1-r)*strideY` layout); anchor on each card's -z front.

`expandChartLabels` now resolves anchors via a per-type ANCHORS_FROM_ARGS map (unifies values-array reads with levels / rows×cols). Both use -z (camera-facing), NOT the addendum's buggy +z for these two.

Verified: unit test 20/20; real-browser GPU — sphere-fill 20/50/80/100%% labels per sphere, SWOT matrix S/W/O/T in the right corners, 0 errors. Demos chart-autolabel-spherefill + -matrix. Suite 83/83. Handoff doc updated: 2D side can use args.labels for all six.

🤖 Generated with [Claude Code](https://claude.com/claude-code)