### PR TITLE
feat(deck): convergence demo — real-data charts in a spatial-narrative deck

### DIFF
--- a/sdf-js/examples/compositor/demo-lifts/deck-biz-revenue.json
+++ b/sdf-js/examples/compositor/demo-lifts/deck-biz-revenue.json
@@ -1,0 +1,87 @@
+{
+  "id": "deck-biz-revenue",
+  "title": "Revenue by quarter",
+  "prompt": "Revenue by quarter",
+  "code2d": "// Revenue by quarter — chart atom + args.labels; connector auto-labels at load.",
+  "sceneData": {
+    "v": 1,
+    "name": "Revenue by quarter",
+    "source": {
+      "format": "authored",
+      "prompt": "Revenue by quarter"
+    },
+    "subjects": [
+      {
+        "id": "bar-3d",
+        "type": "bar-3d",
+        "args": {
+          "values": [0.5, 0.7, 0.85, 1],
+          "labels": ["$1.2M", "$1.8M", "$2.4M", "$3.4M"],
+          "barWidth": 0.5,
+          "barDepth": 0.5,
+          "gap": 0.45,
+          "maxHeight": 2.4
+        },
+        "transform": {
+          "translate": [0, 0, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.75,
+          "metal": 0.3,
+          "glow": 0
+        }
+      }
+    ],
+    "cameraSequence": {
+      "loop": false,
+      "shots": [
+        {
+          "duration": 0.01,
+          "pos": [-2.6, 2.2, -7.8],
+          "target": [0, 1.2, 0],
+          "fov": 33,
+          "transition": "cut"
+        },
+        {
+          "duration": 6,
+          "pos": [2.6, 2.2, -7.8],
+          "target": [0, 1.2, 0],
+          "fov": 33,
+          "ease": "smooth",
+          "transition": "blend"
+        }
+      ]
+    },
+    "defaults": {
+      "camera": {
+        "yaw": 0.4,
+        "pitch": 0.22,
+        "distance": 9,
+        "focal": 1.5,
+        "targetX": 0,
+        "targetY": 1.2,
+        "targetZ": 0
+      },
+      "light": {
+        "azimuth": 0.6,
+        "altitude": 0.55,
+        "distance": 25,
+        "intensity": 1.2
+      },
+      "shadow": {
+        "enabled": true,
+        "mode": "darken",
+        "strength": 0.4
+      },
+      "studioBg": "dark"
+    }
+  },
+  "meta": {
+    "generatedAt": "2026-06-22",
+    "model": "authored",
+    "pattern": "data-deck",
+    "costUSD": 0
+  }
+}

--- a/sdf-js/examples/compositor/demo-lifts/deck-biz-share.json
+++ b/sdf-js/examples/compositor/demo-lifts/deck-biz-share.json
@@ -1,0 +1,86 @@
+{
+  "id": "deck-biz-share",
+  "title": "Market share",
+  "prompt": "Market share",
+  "code2d": "// Market share — chart atom + args.labels; connector auto-labels at load.",
+  "sceneData": {
+    "v": 1,
+    "name": "Market share",
+    "source": {
+      "format": "authored",
+      "prompt": "Market share"
+    },
+    "subjects": [
+      {
+        "id": "pie-3d",
+        "type": "pie-3d",
+        "args": {
+          "values": [0.35, 0.25, 0.22, 0.18],
+          "labels": ["35%", "25%", "22%", "18%"],
+          "outerRadius": 1.1,
+          "innerRadius": 0.4,
+          "thickness": 0.35
+        },
+        "transform": {
+          "translate": [0, 1.4, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.75,
+          "metal": 0.3,
+          "glow": 0
+        }
+      }
+    ],
+    "cameraSequence": {
+      "loop": false,
+      "shots": [
+        {
+          "duration": 0.01,
+          "pos": [-2.6, 2.4, -7.8],
+          "target": [0, 1.4, 0],
+          "fov": 33,
+          "transition": "cut"
+        },
+        {
+          "duration": 6,
+          "pos": [2.6, 2.4, -7.8],
+          "target": [0, 1.4, 0],
+          "fov": 33,
+          "ease": "smooth",
+          "transition": "blend"
+        }
+      ]
+    },
+    "defaults": {
+      "camera": {
+        "yaw": 0.4,
+        "pitch": 0.22,
+        "distance": 9,
+        "focal": 1.5,
+        "targetX": 0,
+        "targetY": 1.4,
+        "targetZ": 0
+      },
+      "light": {
+        "azimuth": 0.6,
+        "altitude": 0.55,
+        "distance": 25,
+        "intensity": 1.2
+      },
+      "shadow": {
+        "enabled": true,
+        "mode": "darken",
+        "strength": 0.4
+      },
+      "studioBg": "dark"
+    }
+  },
+  "meta": {
+    "generatedAt": "2026-06-22",
+    "model": "authored",
+    "pattern": "data-deck",
+    "costUSD": 0
+  }
+}

--- a/sdf-js/examples/compositor/demo-lifts/deck-biz-swot.json
+++ b/sdf-js/examples/compositor/demo-lifts/deck-biz-swot.json
@@ -1,0 +1,88 @@
+{
+  "id": "deck-biz-swot",
+  "title": "SWOT",
+  "prompt": "SWOT",
+  "code2d": "// SWOT — chart atom + args.labels; connector auto-labels at load.",
+  "sceneData": {
+    "v": 1,
+    "name": "SWOT",
+    "source": {
+      "format": "authored",
+      "prompt": "SWOT"
+    },
+    "subjects": [
+      {
+        "id": "matrix-grid-3d",
+        "type": "matrix-grid-3d",
+        "args": {
+          "rows": 2,
+          "cols": 2,
+          "labels": ["S", "W", "O", "T"],
+          "cardW": 1.1,
+          "cardH": 0.85,
+          "cardD": 0.2,
+          "gap": 0.22
+        },
+        "transform": {
+          "translate": [0, 1.3, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.75,
+          "metal": 0.3,
+          "glow": 0
+        }
+      }
+    ],
+    "cameraSequence": {
+      "loop": false,
+      "shots": [
+        {
+          "duration": 0.01,
+          "pos": [-2.6, 2.3, -7.8],
+          "target": [0, 1.3, 0],
+          "fov": 33,
+          "transition": "cut"
+        },
+        {
+          "duration": 6,
+          "pos": [2.6, 2.3, -7.8],
+          "target": [0, 1.3, 0],
+          "fov": 33,
+          "ease": "smooth",
+          "transition": "blend"
+        }
+      ]
+    },
+    "defaults": {
+      "camera": {
+        "yaw": 0.4,
+        "pitch": 0.22,
+        "distance": 9,
+        "focal": 1.5,
+        "targetX": 0,
+        "targetY": 1.3,
+        "targetZ": 0
+      },
+      "light": {
+        "azimuth": 0.6,
+        "altitude": 0.55,
+        "distance": 25,
+        "intensity": 1.2
+      },
+      "shadow": {
+        "enabled": true,
+        "mode": "darken",
+        "strength": 0.4
+      },
+      "studioBg": "dark"
+    }
+  },
+  "meta": {
+    "generatedAt": "2026-06-22",
+    "model": "authored",
+    "pattern": "data-deck",
+    "costUSD": 0
+  }
+}

--- a/sdf-js/examples/compositor/demo-lifts/deck-biz-trend.json
+++ b/sdf-js/examples/compositor/demo-lifts/deck-biz-trend.json
@@ -1,0 +1,85 @@
+{
+  "id": "deck-biz-trend",
+  "title": "Growth trend",
+  "prompt": "Growth trend",
+  "code2d": "// Growth trend — chart atom + args.labels; connector auto-labels at load.",
+  "sceneData": {
+    "v": 1,
+    "name": "Growth trend",
+    "source": {
+      "format": "authored",
+      "prompt": "Growth trend"
+    },
+    "subjects": [
+      {
+        "id": "line-3d",
+        "type": "line-3d",
+        "args": {
+          "values": [0.3, 0.45, 0.5, 0.7, 0.85, 1],
+          "labels": ["12", "18", "20", "28", "34", "40"],
+          "pointSpacing": 0.95,
+          "maxHeight": 2.2
+        },
+        "transform": {
+          "translate": [0, 0, 0]
+        },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.85,
+          "value": 0.75,
+          "metal": 0.3,
+          "glow": 0
+        }
+      }
+    ],
+    "cameraSequence": {
+      "loop": false,
+      "shots": [
+        {
+          "duration": 0.01,
+          "pos": [-2.6, 2.1, -7.8],
+          "target": [0, 1.1, 0],
+          "fov": 33,
+          "transition": "cut"
+        },
+        {
+          "duration": 6,
+          "pos": [2.6, 2.1, -7.8],
+          "target": [0, 1.1, 0],
+          "fov": 33,
+          "ease": "smooth",
+          "transition": "blend"
+        }
+      ]
+    },
+    "defaults": {
+      "camera": {
+        "yaw": 0.4,
+        "pitch": 0.22,
+        "distance": 9,
+        "focal": 1.5,
+        "targetX": 0,
+        "targetY": 1.1,
+        "targetZ": 0
+      },
+      "light": {
+        "azimuth": 0.6,
+        "altitude": 0.55,
+        "distance": 25,
+        "intensity": 1.2
+      },
+      "shadow": {
+        "enabled": true,
+        "mode": "darken",
+        "strength": 0.4
+      },
+      "studioBg": "dark"
+    }
+  },
+  "meta": {
+    "generatedAt": "2026-06-22",
+    "model": "authored",
+    "pattern": "data-deck",
+    "costUSD": 0
+  }
+}

--- a/sdf-js/examples/compositor/demo-lifts/deck-business.json
+++ b/sdf-js/examples/compositor/demo-lifts/deck-business.json
@@ -1,0 +1,30 @@
+{
+  "id": "deck-business",
+  "name": "Quarterly business review (real-data charts + spatial narrative)",
+  "segments": [
+    {
+      "file": "deck-biz-revenue.json",
+      "title": "Revenue by quarter",
+      "kind": "slide",
+      "durationSec": 6.5
+    },
+    {
+      "file": "deck-biz-share.json",
+      "title": "Market share",
+      "kind": "slide",
+      "durationSec": 6.5
+    },
+    {
+      "file": "deck-biz-trend.json",
+      "title": "Growth trend",
+      "kind": "slide",
+      "durationSec": 6.5
+    },
+    {
+      "file": "deck-biz-swot.json",
+      "title": "SWOT",
+      "kind": "slide",
+      "durationSec": 6.5
+    }
+  ]
+}

--- a/sdf-js/examples/compositor/demo-lifts/index.json
+++ b/sdf-js/examples/compositor/demo-lifts/index.json
@@ -1388,6 +1388,16 @@
       "file": "chart-autolabel-matrix.json",
       "renderer": "studio",
       "prompt": "Matrix (SWOT) · auto-labels (#84 connector)"
+    },
+    {
+      "id": "deck-business",
+      "title": "Quarterly business review (data deck)",
+      "thesisPoint": "Convergence: connector-labelled real-data charts strung into a spatial-narrative deck.",
+      "category": "data-deck",
+      "status": "ready",
+      "file": "deck-business.json",
+      "renderer": "studio",
+      "prompt": "business data deck"
     }
   ]
 }

--- a/sdf-js/scripts/gen-deck-business.mjs
+++ b/sdf-js/scripts/gen-deck-business.mjs
@@ -1,0 +1,194 @@
+#!/usr/bin/env node
+// =============================================================================
+// gen-deck-business.mjs — the CONVERGENCE demo: real-data charts (args.labels,
+// auto-labelled by the #89 connector at load) strung into a spatial-narrative
+// deck (deck-player.js sequences + caption + fade). A quarterly business review:
+// each segment is ONE chart atom carrying args.labels + ZERO manual labels — the
+// connector injects the SDF value labels when the deck loads the scene. A gentle
+// pan keeps each slide alive; the deck player shows the segment title caption.
+//
+// Launch: ?deck=deck-business    Usage: node sdf-js/scripts/gen-deck-business.mjs
+// =============================================================================
+
+import { writeFileSync, readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const OUT = resolve(__dirname, '../examples/compositor/demo-lifts');
+const BLUE = { hue: 0.58, sat: 0.85, value: 0.75, metal: 0.3, glow: 0 };
+
+// gentle left→right pan framing a chart centred at `target`, fov in degrees.
+const panSeq = (target, dur = 6) => ({
+  loop: false,
+  shots: [
+    {
+      duration: 0.01,
+      pos: [target[0] - 2.6, target[1] + 1.0, -7.8],
+      target,
+      fov: 33,
+      transition: 'cut',
+    },
+    {
+      duration: dur,
+      pos: [target[0] + 2.6, target[1] + 1.0, -7.8],
+      target,
+      fov: 33,
+      ease: 'smooth',
+      transition: 'blend',
+    },
+  ],
+});
+
+function scene(id, name, subject, target) {
+  return {
+    id,
+    title: name,
+    prompt: name,
+    code2d: `// ${name} — chart atom + args.labels; connector auto-labels at load.`,
+    sceneData: {
+      v: 1,
+      name,
+      source: { format: 'authored', prompt: name },
+      subjects: [subject],
+      cameraSequence: panSeq(target),
+      defaults: {
+        camera: {
+          yaw: 0.4,
+          pitch: 0.22,
+          distance: 9,
+          focal: 1.5,
+          targetX: 0,
+          targetY: target[1],
+          targetZ: 0,
+        },
+        light: { azimuth: 0.6, altitude: 0.55, distance: 25, intensity: 1.2 },
+        shadow: { enabled: true, mode: 'darken', strength: 0.4 },
+        studioBg: 'dark',
+      },
+    },
+    meta: { generatedAt: '2026-06-22', model: 'authored', pattern: 'data-deck', costUSD: 0 },
+  };
+}
+const S = (type, args, translate) => ({
+  id: type,
+  type,
+  args,
+  transform: { translate },
+  material: BLUE,
+});
+
+const SEGMENTS = [
+  {
+    seg: scene(
+      'deck-biz-revenue',
+      'Revenue by quarter',
+      S(
+        'bar-3d',
+        {
+          values: [0.5, 0.7, 0.85, 1.0],
+          labels: ['$1.2M', '$1.8M', '$2.4M', '$3.4M'],
+          barWidth: 0.5,
+          barDepth: 0.5,
+          gap: 0.45,
+          maxHeight: 2.4,
+        },
+        [0, 0, 0],
+      ),
+      [0, 1.2, 0],
+    ),
+    durationSec: 6.5,
+  },
+  {
+    seg: scene(
+      'deck-biz-share',
+      'Market share',
+      S(
+        'pie-3d',
+        {
+          values: [0.35, 0.25, 0.22, 0.18],
+          labels: ['35%', '25%', '22%', '18%'],
+          outerRadius: 1.1,
+          innerRadius: 0.4,
+          thickness: 0.35,
+        },
+        [0, 1.4, 0],
+      ),
+      [0, 1.4, 0],
+    ),
+    durationSec: 6.5,
+  },
+  {
+    seg: scene(
+      'deck-biz-trend',
+      'Growth trend',
+      S(
+        'line-3d',
+        {
+          values: [0.3, 0.45, 0.5, 0.7, 0.85, 1.0],
+          labels: ['12', '18', '20', '28', '34', '40'],
+          pointSpacing: 0.95,
+          maxHeight: 2.2,
+        },
+        [0, 0, 0],
+      ),
+      [0, 1.1, 0],
+    ),
+    durationSec: 6.5,
+  },
+  {
+    seg: scene(
+      'deck-biz-swot',
+      'SWOT',
+      S(
+        'matrix-grid-3d',
+        {
+          rows: 2,
+          cols: 2,
+          labels: ['S', 'W', 'O', 'T'],
+          cardW: 1.1,
+          cardH: 0.85,
+          cardD: 0.2,
+          gap: 0.22,
+        },
+        [0, 1.3, 0],
+      ),
+      [0, 1.3, 0],
+    ),
+    durationSec: 6.5,
+  },
+];
+
+const idxPath = `${OUT}/index.json`;
+const index = JSON.parse(readFileSync(idxPath, 'utf8'));
+for (const { seg } of SEGMENTS) {
+  writeFileSync(`${OUT}/${seg.id}.json`, JSON.stringify(seg, null, 2) + '\n');
+}
+const deck = {
+  id: 'deck-business',
+  name: 'Quarterly business review (real-data charts + spatial narrative)',
+  segments: SEGMENTS.map(({ seg, durationSec }) => ({
+    file: `${seg.id}.json`,
+    title: seg.title,
+    kind: 'slide',
+    durationSec,
+  })),
+};
+writeFileSync(`${OUT}/deck-business.json`, JSON.stringify(deck, null, 2) + '\n');
+if (!index.demos.some((d) => d.id === 'deck-business')) {
+  index.demos.push({
+    id: 'deck-business',
+    title: 'Quarterly business review (data deck)',
+    thesisPoint:
+      'Convergence: connector-labelled real-data charts strung into a spatial-narrative deck.',
+    category: 'data-deck',
+    status: 'ready',
+    file: 'deck-business.json',
+    renderer: 'studio',
+    prompt: 'business data deck',
+  });
+}
+writeFileSync(idxPath, JSON.stringify(index, null, 2) + '\n');
+console.log(
+  `wrote deck-business (${SEGMENTS.length} chart slides) + segment scenes; index now ${index.demos.length}`,
+);


### PR DESCRIPTION
## What — convergence: real-data charts in a spatial-narrative deck

Joins the two threads built this stretch: the **#89 `args.labels` connector** (auto-labelled real-data charts) + the **deck player** (spatial narrative).

`gen-deck-business.mjs` emits a quarterly business review. Each segment is **one** chart atom carrying `args.labels` and **zero** manual labels — the connector injects the SDF value labels when the deck loads the scene, a gentle pan keeps each slide alive, and the deck player shows the segment-title caption + fades between segments.

**Segments:**
- Revenue by quarter — `bar-3d`, `$1.2M…$3.4M`
- Market share — `pie-3d`, `35% / 25% / 22% / 18%`
- Growth trend — `line-3d`
- SWOT — `matrix-grid-3d`, `S / W / O / T`

Launch: `?deck=deck-business`.

## Verification (real-browser GPU)
Charts render with connector-injected labels **inside the deck-player flow** (pie 35/25/22/18% on screen), caption advances ("Market share · Slide 2/4"), fades between, **0 errors**.

This is Atlas Present's full data-presentation form: lift real numbers → labelled 3D charts → spatial narrative. No engine changes — pure composition of shipped pieces (connector + deck-player + chart atoms).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
