### PR TITLE
fix(render): unify renderer ids in one registry — fixes Present effect throw (P0)

### DIFF
--- a/sdf-js/examples/compositor/compositor.js
+++ b/sdf-js/examples/compositor/compositor.js
@@ -36,6 +36,11 @@ function getUrlTokenHash() {
 let URL_TOKEN_HASH = getUrlTokenHash(); // mutable — #btn-new-hash reroll updates this
 import { expandVariants } from '../../src/scene/generator-s.js';
 import { expandChartLabels } from '../../src/scene/chart-labels.js';
+// Renderer id set + classifier: single source of truth (renderer-registry).
+import {
+  GPU_RENDERER_IDS as GPU_RENDERERS,
+  isGpuRenderer,
+} from '../../src/render/renderer-registry.js';
 import {
   sphericalToCamState,
   parseLiftResponse,
@@ -122,9 +127,6 @@ const state = {
   // ?sceneHash= URL param to roll a new variant ordering.
   sceneHash: null, // 0x... hex string
 };
-
-const GPU_RENDERERS = new Set(['fly3d', 'bob-gpu', 'blueprint', 'crayon', 'topo', 'studio']);
-const isGpuRenderer = (name) => GPU_RENDERERS.has(name);
 
 // =============================================================================
 // History storage (localStorage cap 30)

--- a/sdf-js/scripts/test-compositor-api.mjs
+++ b/sdf-js/scripts/test-compositor-api.mjs
@@ -4,6 +4,7 @@
 
 import '../src/sdf/index.js';
 import * as api from '../src/compositor-api.js';
+import { ACTIVE_EFFECTS } from '../src/present/deck-model.js';
 
 let pass = 0,
   fail = 0;
@@ -221,6 +222,43 @@ await (async () => {
       }
     }
   }
+}
+
+// P0 regression: ALL four Present effects must build a renderer WITHOUT throwing
+// (previously lines/crayon/topo hit "unknown renderer id" → Present effect cycle
+// crashed). CPU 2D renderers touch the canvas only in render(), so creation is
+// safe with a fake canvas in Node.
+{
+  ok(
+    Array.isArray(api.PRESENT_EFFECTS) && api.PRESENT_EFFECTS.length === 4,
+    'PRESENT_EFFECTS exported (4 effects)',
+  );
+  const fakeCanvas = { getContext: () => ({}) };
+  for (const id of api.PRESENT_EFFECTS) {
+    let r = null;
+    let threw = null;
+    try {
+      r = api.createRendererForId(id, fakeCanvas);
+    } catch (e) {
+      threw = e;
+    }
+    ok(threw === null, `createRendererForId('${id}'): no throw (P0 fix)`);
+    ok(
+      r && typeof r.render === 'function' && typeof r.unmount === 'function',
+      `createRendererForId('${id}'): returns {render, unmount}`,
+    );
+  }
+  ok(api.normalizeRendererId('lines') === 'hatch', "normalizeRendererId('lines') → 'hatch'");
+  ok(api.normalizeRendererId('bob') === 'bobStipple', "normalizeRendererId('bob') → 'bobStipple'");
+  ok(api.normalizeRendererId('studio') === 'studio', 'normalizeRendererId: pass-through');
+  ok(api.isGpuRenderer('studio') === true, "isGpuRenderer('studio') = true");
+  ok(api.isGpuRenderer('silhouette') === false, "isGpuRenderer('silhouette') = false");
+  ok(api.isGpuRenderer('lines') === false, "isGpuRenderer('lines') = false (CPU)");
+  // drift guard: deck-model keeps its own list (pure data model) — must match.
+  ok(
+    JSON.stringify(ACTIVE_EFFECTS) === JSON.stringify(api.PRESENT_EFFECTS),
+    'deck-model ACTIVE_EFFECTS matches registry PRESENT_EFFECTS',
+  );
 }
 
 // createRendererForId: unknown id throws

--- a/sdf-js/src/compositor-api.js
+++ b/sdf-js/src/compositor-api.js
@@ -26,10 +26,18 @@
 import { compile } from './scene/compile.js';
 import { expandVariants } from './scene/generator-s.js';
 import { union as sdfUnion } from './sdf/dn.js';
-import { createStudioRenderer } from './render/studio.js';
-import { createFly3DRenderer } from './render/flyLambert.js';
-import { silhouette } from './render/silhouette.js';
 import { Random } from './util/random.js';
+// Renderer id/alias/factory mapping lives in one place now (renderer-registry).
+// Re-exported below so existing `import { createRendererForId } from
+// '../compositor-api.js'` call sites keep working.
+import {
+  createRendererForId,
+  normalizeRendererId,
+  isGpuRenderer,
+  PRESENT_EFFECTS,
+  GPU_RENDERER_IDS,
+  RENDERER_ALIASES,
+} from './render/renderer-registry.js';
 
 // Constants
 export const DEFAULT_LIFT_MODEL = 'claude-sonnet-4-6';
@@ -1325,48 +1333,19 @@ export async function callLiftLLM(originalPrompt, code2d, apiKey, opts = {}) {
   throw lastError || new Error('Anthropic API: exhausted retries with no specific error');
 }
 
-/**
- * Create a renderer instance for the given renderer id. Returns an object
- * with `.render(sdf)` and `.unmount()` methods. Caller owns lifecycle.
- *
- * Sprint 1 supports: 'studio', 'fly3d', 'silhouette'. Sprint 2+ will add
- * 'bob-gpu', 'blueprint', 'crayon', 'topo', 'bob', 'lines'.
- *
- * @param {string} rendererId
- * @param {HTMLCanvasElement} canvas
- * @param {object} [opts]
- * @param {Function} [opts.getControls] — for GPU renderers; receives renderer time + returns camera/light state
- * @param {Function} [opts.onFps] — for GPU renderers; called per frame with FPS
- * @returns {{render:Function, unmount:Function}}
- */
-export function createRendererForId(rendererId, canvas, opts = {}) {
-  if (rendererId === 'silhouette') {
-    return {
-      render(layers, renderOpts = {}) {
-        const ctx = canvas.getContext('2d');
-        silhouette(ctx, layers, renderOpts);
-      },
-      unmount() {
-        // No-op for CPU silhouette
-      },
-    };
-  }
-  if (rendererId === 'studio') {
-    return createStudioRenderer({
-      canvas,
-      getControls: opts.getControls || (() => ({})),
-      onFps: opts.onFps || (() => {}),
-    });
-  }
-  if (rendererId === 'fly3d') {
-    return createFly3DRenderer({
-      canvas,
-      getControls: opts.getControls || (() => ({})),
-      onFps: opts.onFps || (() => {}),
-    });
-  }
-  throw new Error(`[compositor-api] unknown renderer id: ${rendererId}`);
-}
+// createRendererForId + the renderer id/alias constants now live in
+// render/renderer-registry.js (single source of truth). Re-exported here so
+// existing call sites that import them from compositor-api keep working — and
+// so Present's silhouette/lines/crayon/topo no longer hit an "unknown renderer"
+// throw (the registry maps all four to their CPU 2D renderer).
+export {
+  createRendererForId,
+  normalizeRendererId,
+  isGpuRenderer,
+  PRESENT_EFFECTS,
+  GPU_RENDERER_IDS,
+  RENDERER_ALIASES,
+};
 
 /**
  * Runtime sanitizer for 2D-mode sceneData. Defense layer 2 of 2 (paired with

--- a/sdf-js/src/present/visual-panel.js
+++ b/sdf-js/src/present/visual-panel.js
@@ -16,13 +16,16 @@
 // =============================================================================
 
 import * as deckModel from './deck-model.js';
-import { compileScene, createRendererForId } from '../compositor-api.js';
+import { compileScene, createRendererForId, PRESENT_EFFECTS } from '../compositor-api.js';
 import { BRANDING_PALETTES, getPalette } from './branding-palettes.js';
 import { mountP5Renderer } from './p5-renderer.js';
 import { renderSceneDataToCanvas } from './atoms-2d/renderer.js';
 import { isAtom2DType } from './atoms-2d/registry.js';
 
-const RENDERERS = ['silhouette', 'lines', 'crayon', 'topo'];
+// Effect cycle order — the single source of truth lives in renderer-registry
+// (re-exported via compositor-api). createRendererForId now maps all four to a
+// CPU 2D renderer, so cycling no longer throws on lines/crayon/topo.
+const RENDERERS = PRESENT_EFFECTS;
 
 /**
  * Mount a visual panel for one visual into the wrapper element.

--- a/sdf-js/src/render/renderer-registry.js
+++ b/sdf-js/src/render/renderer-registry.js
@@ -1,0 +1,103 @@
+// =============================================================================
+// renderer-registry.js — single source of truth for renderer ids, aliases, and
+// the id→factory mapping. Resolves the split that let Present's effect cycle
+// (silhouette → lines → crayon → topo) throw: createRendererForId only knew
+// silhouette|studio|fly3d, so `lines`/`crayon`/`topo` hit the "unknown renderer
+// id" throw the moment visual-panel re-rendered a variant with them.
+//
+// Two renderer families:
+//   • CPU 2D (Present effects + compositor 2D pills) — fn(ctx, layers, opts),
+//     no getControls. silhouette / hatch / bobStipple.
+//   • GPU 3D (compositor) — createXxxRenderer({canvas, getControls, onFps}).
+//     studio / fly3d here; the compositor owns the rest via its own ensure*().
+// =============================================================================
+
+import { silhouette } from './silhouette.js';
+import { hatch } from './hatch.js';
+import { bobStipple } from './bobStipple.js';
+import { createStudioRenderer } from './studio.js';
+import { createFly3DRenderer } from './flyLambert.js';
+
+// The four CPU effects Present cycles through (visual-panel + deck-model).
+export const PRESENT_EFFECTS = ['silhouette', 'lines', 'crayon', 'topo'];
+
+// Renderers that need a WebGL canvas + getControls (drive a per-frame loop).
+// Used by the compositor to pick canvas + lifecycle. crayon/topo are GPU here
+// (the compositor's 3D streamline/crayon renderers); Present's 2D crayon/topo
+// go through createRendererForId below (CPU), never this set.
+export const GPU_RENDERER_IDS = new Set([
+  'fly3d',
+  'bob-gpu',
+  'blueprint',
+  'crayon',
+  'topo',
+  'studio',
+]);
+
+// Pill / effect id → canonical CPU-renderer key. (Compositor uses 'bob' for the
+// stipple pill; Present uses 'lines' for hatch.) Unlisted ids pass through.
+export const RENDERER_ALIASES = {
+  lines: 'hatch',
+  hatch: 'hatch',
+  bob: 'bobStipple',
+};
+
+export function normalizeRendererId(id) {
+  return RENDERER_ALIASES[id] || id;
+}
+
+export function isGpuRenderer(id) {
+  return GPU_RENDERER_IDS.has(normalizeRendererId(id));
+}
+
+// Wrap a CPU 2D renderer fn(ctx, layers, opts) into the {render, unmount} shape.
+// layerPatch (optional) is merged into every layer — e.g. hatch's `pasmaStyle`.
+function cpu2dRenderer(canvas, fn, layerPatch) {
+  return {
+    render(layers, renderOpts = {}) {
+      const ctx = canvas.getContext('2d');
+      const ls = layerPatch ? layers.map((l) => ({ ...l, ...layerPatch })) : layers;
+      fn(ctx, ls, renderOpts);
+    },
+    unmount() {
+      // CPU renderers hold no GL/raf resources.
+    },
+  };
+}
+
+/**
+ * Create a renderer instance for an id. Returns { render, unmount }.
+ *
+ * Present effects (CPU 2D, no getControls needed):
+ *   silhouette → silhouette · lines → hatch · crayon → bobStipple ·
+ *   topo → hatch(pasmaStyle) — flowing contour look.
+ * Compositor 3D (need opts.getControls / opts.onFps): studio / fly3d.
+ * (Other GPU renderers — bob-gpu / blueprint / 3D crayon / 3D topo — are
+ *  created by the compositor's own ensure*() lazy singletons, not here.)
+ */
+export function createRendererForId(rendererId, canvas, opts = {}) {
+  switch (rendererId) {
+    case 'silhouette':
+      return cpu2dRenderer(canvas, silhouette);
+    case 'lines':
+      return cpu2dRenderer(canvas, hatch, { pasmaStyle: false });
+    case 'crayon':
+      return cpu2dRenderer(canvas, bobStipple);
+    case 'topo':
+      return cpu2dRenderer(canvas, hatch, { pasmaStyle: true });
+    case 'studio':
+      return createStudioRenderer({
+        canvas,
+        getControls: opts.getControls || (() => ({})),
+        onFps: opts.onFps || (() => {}),
+      });
+    case 'fly3d':
+      return createFly3DRenderer({
+        canvas,
+        getControls: opts.getControls || (() => ({})),
+        onFps: opts.onFps || (() => {}),
+      });
+    default:
+      throw new Error(`[renderer-registry] unknown renderer id: ${rendererId}`);
+  }
+}


### PR DESCRIPTION
## PR-A — unify renderer ids in one registry (fixes the confirmed P0)

**The bug (confirmed):** Present cycles effects `silhouette → lines → crayon → topo`, but `createRendererForId` only knew `silhouette|studio|fly3d` — so the moment `visual-panel.js:330` re-rendered a variant with `lines`/`crayon`/`topo` it threw `unknown renderer id`. 3 of the 4 Present effects were broken.

## Change
- **NEW `src/render/renderer-registry.js`** — single source of truth: `PRESENT_EFFECTS`, `GPU_RENDERER_IDS`, `RENDERER_ALIASES`, `normalizeRendererId`, `isGpuRenderer`, and `createRendererForId` mapping all four Present effects to a CPU 2D renderer (`silhouette`→silhouette, `lines`→hatch, `crayon`→bobStipple, `topo`→hatch+pasmaStyle) plus `studio`/`fly3d` (3D).
- `compositor-api.js`: deletes the inline `createRendererForId`, re-exports from the registry (call sites unchanged); drops now-unused renderer imports.
- `visual-panel.js`: `RENDERERS = PRESENT_EFFECTS` (dedupe).
- `compositor.js`: `GPU_RENDERERS` / `isGpuRenderer` now imported from the registry.
- `deck-model.js`: **left as-is** — it's a pure data model and shouldn't be coupled to renderer code; a test guards its `ACTIVE_EFFECTS` against the registry instead. (Deviation from the plan, by design.)

## Verification
- `test-compositor-api.mjs`: **+14 assertions, 51/51** — all four Present effects build a renderer with **no throw** (the P0 guard), `normalizeRendererId`/`isGpuRenderer`, and the `deck-model` drift guard.
- Full suite **83/83**; eslint clean; compositor loads + renders a scene with **0 errors**.

First of the engineering-debt sprint (PR-A). Next: PR-B (primitive-registry sync test + docs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
