### PR TITLE
chore: primitive-registry sync test + STATUS/d2 GLSL-AST docs refresh (PR-B)

### DIFF
--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -2,7 +2,7 @@
 
 > Frequently-updated current state of decisions, ship status, and pending work. Vision and architecture live in [../README.md](../README.md); this file tracks **what's locked vs what's still moving**.
 >
-> Last update: 2026-05-17 (pre-M0-Day-2)
+> Last update: 2026-06-22
 
 ---
 
@@ -44,6 +44,34 @@ Full document: [memory/project_compositor_roadmap.md](../.claude/projects/-Users
 | **M4** | V1 polish — demo gallery, hero replacement, atlas.studio domain, brand surface | 1 week | ⏳ pending |
 | _deferred_ | Full 2D editor (Mini-DSL parser + Monaco + node graph dual-view) | 4–5 weeks | deferred per Saturday's revised plan — text-tab serves as 2D editor for v1; visual editor revisited if non-coder feedback demands |
 | _deferred_ | Full 3D viewport editor (three.js + transform gizmo + 3D primitive panel) | 3–4 weeks | deferred — Fly explorer + BOB GPU covers v1 "exploration" need; manual 3D composition revisited if user demands |
+
+---
+
+## Since M2 — Present layer + spatial narrative + data labels (2026-05 → 2026-06)
+
+Major capability ships after the M2 lift validation. Tracked here by capability
+(commit-level detail is in git log + memory).
+
+| Area | Status |
+|---|---|
+| **M3 Generator-S** (scatter / array / mirror variant expansion on lifted scenes) | 🟡 Phase 1–2 shipped — thesis #10 evidence in hand |
+| **Atlas Present layer** (`deck-model` / `visual-panel` / `atoms-2d` Canvas2D charts) | ✅ shipped — document-anchored decks, 6-variant picker, branding palettes |
+| **Compositor** | ✅ 10+ renderers (silhouette / hatch / bobStipple + FLY 3D / BOB GPU / studio / blueprint / crayon / topo) · **188 baked demo-lifts** |
+| **Spatial-narrative deck player** (Step 2: light chapters in one world + heavy slides own-scene; camera tour; captions; arc/grid layouts; auto-authoring) | ✅ shipped (PRs #68–#82) |
+| **Data labels** (loop-chart GLSL fix #87 · `expandChartLabels` connector #89/#93 · overlay path #86 · 6 chart atoms) — `args.labels` → SDF labels, e2e-verified with real LLM | ✅ shipped; convergence demo `deck-business` |
+| **Studio render-on-demand** (idle-stop: static scenes park the rAF loop; 0 GPU draws when idle) | ✅ shipped (#96) |
+
+---
+
+## Engineering hygiene sprint (2026-06-22)
+
+| Item | Status |
+|---|---|
+| **RendererRegistry** — single id/alias/factory source; fixes Present effect-cycle throw (lines/crayon/topo) | ✅ shipped (#97) |
+| **Primitive registry sync test** — spec `PRIMITIVE_TYPES` ↔ compile `PRIMITIVE_FACTORIES` drift guard in CI | ✅ shipped |
+| **STATUS.md / docs refresh** | ✅ this update |
+| compile.js split (`primitives/factories.js` + `registry.js`) | ⏳ planned |
+| compositor.js extract to `src/compositor/` | ⏳ planned |
 
 ---
 

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -63,6 +63,7 @@ const TESTS = [
   { category: 'scene', file: 'sdf-js/scripts/test-composite-atoms.mjs' },
   { category: 'scene', file: 'sdf-js/scripts/test-type-aliases.mjs' },
   { category: 'scene', file: 'sdf-js/scripts/test-gbms-batch.mjs' },
+  { category: 'scene', file: 'sdf-js/scripts/test-primitive-registry-sync.mjs' },
 
   // Generator-S (Phase 2 ops: array, mirror)
   { category: 'generator', file: 'sdf-js/scripts/test-generator-s.mjs' },

--- a/sdf-js/scripts/test-primitive-registry-sync.mjs
+++ b/sdf-js/scripts/test-primitive-registry-sync.mjs
@@ -1,0 +1,58 @@
+// =============================================================================
+// test-primitive-registry-sync.mjs — guards the spec ↔ factory invariant.
+// -----------------------------------------------------------------------------
+// scene/spec.js PRIMITIVE_TYPES (what validate() accepts) and scene/compile.js
+// PRIMITIVE_FACTORIES (what compile() can build) are two hand-maintained lists.
+// If they drift — a type added to spec but no factory, or vice versa — validate()
+// passes a scene that then throws in compile() (or a factory becomes dead code).
+// Every new atom must touch both; this test makes the drift a CI failure instead
+// of a runtime surprise. Mirrors compile()'s actual lookup: PRIMITIVE_FACTORIES[
+// normalizeType(type)], with extrude/revolve/extrude_to as pseudo (2D-source wrap).
+// =============================================================================
+
+import { PRIMITIVE_TYPES, normalizeType } from '../src/scene/spec.js';
+import { PRIMITIVE_FACTORY_TYPES, PSEUDO_PRIMITIVE_TYPES } from '../src/scene/compile.js';
+
+let pass = 0,
+  fail = 0;
+const ok = (c, n) => (c ? (pass++, console.log(`  ✓ ${n}`)) : (fail++, console.log(`  ✗ ${n}`)));
+
+console.log('=== primitive registry sync (spec ↔ factories) ===\n');
+
+const factorySet = new Set(PRIMITIVE_FACTORY_TYPES);
+const pseudoSet = new Set(PSEUDO_PRIMITIVE_TYPES);
+
+// FORWARD: every spec primitive type resolves to a real factory (or is pseudo) —
+// the exact lookup compile() does. This is the one that prevents "validate()
+// accepts it, compile() throws 'no factory'".
+const unbacked = [...PRIMITIVE_TYPES].filter((t) => {
+  const canonical = normalizeType(t);
+  return !pseudoSet.has(canonical) && !factorySet.has(canonical);
+});
+ok(
+  unbacked.length === 0,
+  `every spec PRIMITIVE_TYPE has a factory or is pseudo (unbacked: [${unbacked.join(', ')}])`,
+);
+
+// REVERSE: every real factory is a recognized spec type — no orphaned/dead
+// factory that validate() would reject.
+const orphan = PRIMITIVE_FACTORY_TYPES.filter((k) => !PRIMITIVE_TYPES.has(k));
+ok(
+  orphan.length === 0,
+  `every factory is in spec PRIMITIVE_TYPES (orphans: [${orphan.join(', ')}])`,
+);
+
+// sanity: counts line up (spec = real factories + pseudo, modulo aliases). Not an
+// equality (spec carries snake_case aliases) — just assert the lists are non-empty
+// and pseudo types are NOT in the factory list (they're null markers).
+ok(
+  PRIMITIVE_FACTORY_TYPES.length > 100,
+  `factory list populated (${PRIMITIVE_FACTORY_TYPES.length})`,
+);
+ok(
+  PSEUDO_PRIMITIVE_TYPES.every((p) => !factorySet.has(p)),
+  'pseudo types are not in the real-factory list',
+);
+
+console.log(`\n=== Result: ${pass} passed, ${fail} failed ===`);
+process.exit(fail > 0 ? 1 : 0);

--- a/sdf-js/src/scene/compile.js
+++ b/sdf-js/src/scene/compile.js
@@ -1049,6 +1049,15 @@ const PRIMITIVE_FACTORIES = {
 
 const PSEUDO_PRIMITIVES = new Set(['extrude', 'revolve', 'extrude_to']);
 
+// Exported for the registry-sync test (scripts/test-primitive-registry-sync.mjs):
+// the canonical types that have a real factory, and the pseudo (2D-source-wrap)
+// types. Lets the test assert spec.PRIMITIVE_TYPES ↔ factories stay in sync so a
+// type can't pass validate() but then throw in compile() for a missing factory.
+export const PRIMITIVE_FACTORY_TYPES = Object.keys(PRIMITIVE_FACTORIES).filter(
+  (k) => PRIMITIVE_FACTORIES[k] != null,
+);
+export const PSEUDO_PRIMITIVE_TYPES = [...PSEUDO_PRIMITIVES];
+
 // =============================================================================
 // Public API
 // =============================================================================

--- a/sdf-js/src/sdf/GPU-2D.md
+++ b/sdf-js/src/sdf/GPU-2D.md
@@ -1,0 +1,41 @@
+# 2D GPU path — what can compile to GLSL
+
+Short reference for the **2D** SDF → GLSL boundary. (3D is separate — see
+`sdf3.compile.js`.)
+
+## Rule
+
+A 2D primitive can be emitted to a fragment shader **only if it sets `inst.ast`**.
+The compiler walks the AST to generate GLSL; a primitive with no AST has no GLSL
+form and can only run on the CPU (its JS `f(p)` distance function).
+
+## Coverage (8 of ~38 d2 exports)
+
+Source of truth: `D2_GLSL_AST_PRIMITIVES` in [`d2.js`](./d2.js).
+
+| Has GLSL AST (GPU-capable) | CPU-only (no AST) |
+|---|---|
+| circle, ellipse, segment, arc, ring, rectangle, rounded_rectangle, polygon | heart, star, moon, hexagon, triangle, trapezoid, cross, vesica, pie, … (the rest) |
+
+## Why this is fine (not a bug)
+
+- **2D scenes default to the CPU renderers** — `silhouette` / `hatch` (Pasma
+  lines) / `bobStipple`. None of them need GLSL; they consume the CPU `f(p)` or
+  the layer geometry directly. So a 2D scene built from heart/star/etc. renders
+  perfectly — just not through a shader.
+- **The GPU path is a 3D concern.** `studio` / `fly3d` / `bob-gpu` raymarch a 3D
+  SDF compiled from `d3.js` + community ports. 2D-on-GPU is a niche (a flat scene
+  raymarched) that the product does not currently rely on.
+
+## When you'd extend it
+
+Adding `inst.ast` to the remaining 2D primitives is a **documented future
+sprint**, only worth doing if a pure-2D GPU path becomes a real requirement
+(e.g. animated 2D backgrounds at 60fps that the CPU renderers can't hit). It is
+mechanical (mirror each primitive's distance formula into a GLSL emitter in
+`sdf3.compile.js`'s 2D section) but unmotivated today.
+
+Until then: if `sdf3.compile.js` is ever handed a 2D primitive that isn't in
+`D2_GLSL_AST_PRIMITIVES`, the right behavior is a clear warning ("CPU-only
+primitive `<name>` cannot emit GLSL — use a CPU 2D renderer"), not a silent
+black shader.

--- a/sdf-js/src/sdf/d2.js
+++ b/sdf-js/src/sdf/d2.js
@@ -6,10 +6,37 @@
 //
 // 数学公式大多来自 IQ 的 2D SDF 文章：
 //   https://iquilezles.org/www/articles/distfunctions2d/distfunctions2d.htm
+//
+// ── GLSL AST coverage (CPU-only boundary) ───────────────────────────────────
+// A primitive can be emitted to GLSL (GPU path) only if it sets `inst.ast`.
+// Currently 8 of the ~38 exports do:
+//     circle · ellipse · segment · arc · ring · rectangle ·
+//     rounded_rectangle · polygon
+// The rest (heart, star, moon, hexagon, triangle, trapezoid, cross, vesica, …)
+// are CPU-ONLY — they render via the 2D pipeline (silhouette / hatch / stipple)
+// but cannot compile to a fragment shader. This is fine by design: 2D scenes
+// default to the CPU renderers; the GPU path is for 3D (d3 + community ports).
+// See src/sdf/GPU-2D.md. Adding AST to the rest is a documented future sprint,
+// NOT a bug. The exported D2_GLSL_AST_PRIMITIVES set below is the source of truth.
 // =============================================================================
 
 import { SDF2, defineOp2, defineOp23 } from './core.js';
 import * as v from './vec2.js';
+
+// The 2D primitives that carry `inst.ast` and can therefore emit GLSL (GPU 2D
+// path). Everything else is CPU-only. Kept here as the single source of truth;
+// sdf3.compile.js / future GPU-2D code can consult it to warn instead of
+// silently producing a black shader. See file header + GPU-2D.md.
+export const D2_GLSL_AST_PRIMITIVES = new Set([
+  'circle',
+  'ellipse',
+  'segment',
+  'arc',
+  'ring',
+  'rectangle',
+  'rounded_rectangle',
+  'polygon',
+]);
 
 // ---- Primitives ------------------------------------------------------------
 


### PR DESCRIPTION
## PR-B — primitive-registry sync test + docs refresh (low-risk, no behavior change)

Second of the engineering-debt sprint.

### Registry-sync guard (the valuable bit)
`spec.js PRIMITIVE_TYPES` (what `validate()` accepts) and `compile.js PRIMITIVE_FACTORIES` (what `compile()` can build) are two hand-maintained lists. Drift = a type that passes `validate()` then throws in `compile()`. We've hit this shape repeatedly (every new atom must touch both).

- `compile.js` exports `PRIMITIVE_FACTORY_TYPES` (non-null factory keys) + `PSEUDO_PRIMITIVE_TYPES`.
- new `test-primitive-registry-sync.mjs` (wired into `run-tests`, scene group):
  - **forward** — every spec type resolves to a factory or is pseudo (the exact `PRIMITIVE_FACTORIES[normalizeType(t)]` lookup `compile()` does);
  - **reverse** — no orphan factory missing from spec.
- Current state clean: **176 spec = 173 factories + 3 pseudo**, 0 unbacked / 0 orphan.

### Docs
- `docs/STATUS.md` was frozen at **2026-05-17**. Refreshed to 2026-06-22 — adds the post-M2 ships (Generator-S, Present layer, 10+ renderers + 188 demo-lifts, spatial-narrative deck player, data-label connector, studio idle-stop) + an engineering-hygiene section.
- `d2.js` header GLSL-AST coverage note + exported `D2_GLSL_AST_PRIMITIVES` (the **8 of ~38** d2 primitives that emit GLSL); new `GPU-2D.md` documenting that 2D scenes render via the CPU renderers by design — the CPU-only boundary is not a bug.

Full suite **84/84** (new sync test); eslint clean. Next: PR-C (split compile.js — now guarded by this sync test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
