### PR TITLE
feat(stage): defaults.stage studio-room expander + showcase (stage 2-3/3)

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -64,6 +64,7 @@ const TESTS = [
   { category: 'scene', file: 'sdf-js/scripts/test-type-aliases.mjs' },
   { category: 'scene', file: 'sdf-js/scripts/test-gbms-batch.mjs' },
   { category: 'scene', file: 'sdf-js/scripts/test-primitive-registry-sync.mjs' },
+  { category: 'scene', file: 'sdf-js/scripts/test-stage.mjs' },
 
   // Generator-S (Phase 2 ops: array, mirror)
   { category: 'generator', file: 'sdf-js/scripts/test-generator-s.mjs' },

--- a/sdf-js/examples/compositor/compositor.js
+++ b/sdf-js/examples/compositor/compositor.js
@@ -36,6 +36,7 @@ function getUrlTokenHash() {
 let URL_TOKEN_HASH = getUrlTokenHash(); // mutable — #btn-new-hash reroll updates this
 import { expandVariants } from '../../src/scene/generator-s.js';
 import { expandChartLabels } from '../../src/scene/chart-labels.js';
+import { expandStage } from '../../src/scene/stage.js';
 // Renderer id set + classifier: single source of truth (renderer-registry).
 import {
   GPU_RENDERER_IDS as GPU_RENDERERS,
@@ -728,8 +729,9 @@ async function loadDemoScene(demo) {
       const sceneRng = new Random(state.sceneHash);
       const variantScene = expandVariants(data.sceneData, sceneRng);
       // #84 connector: chart subjects with args.labels → SDF text-3d-pipe labels
-      // anchored on their elements (no-op if no chart carries labels).
-      const labeledScene = expandChartLabels(variantScene);
+      // anchored on their elements (no-op if no chart carries labels). Stage
+      // connector wraps subjects in a studio room when defaults.stage is set.
+      const labeledScene = expandChartLabels(expandStage(variantScene));
       compiled = compileSceneData(labeledScene, { tokenHash: URL_TOKEN_HASH });
     } catch (e) {
       throw new Error(`compile failed: ${e.message}`);
@@ -1666,6 +1668,10 @@ function renderLiftedSceneData(
   { shufflePalette = true } = {},
 ) {
   const liftInfo = $('lift-info');
+  // Stage connector: defaults.stage → studio room geometry + panel area lights +
+  // dark bg + interior camera. Reassign so BOTH the compiled SDF and the stored
+  // rawScene (state.textLiftSceneJSON below → setPostFx lights/camera) see it.
+  sceneData = expandStage(sceneData);
   let compiled;
   try {
     // #84 connector: expand chart args.labels → SDF labels before compile.

--- a/sdf-js/examples/compositor/demo-lifts/index.json
+++ b/sdf-js/examples/compositor/demo-lifts/index.json
@@ -1398,6 +1398,16 @@
       "file": "deck-business.json",
       "renderer": "studio",
       "prompt": "business data deck"
+    },
+    {
+      "id": "stage-showcase",
+      "title": "Studio Stage · metals in a lit room",
+      "thesisPoint": "Scene-level stage: defaults.stage expands to an enclosed studio room (panel area lights + reflection-retrace) so metals reflect the actual walls.",
+      "category": "scene-templates",
+      "status": "ready",
+      "file": "stage-showcase.json",
+      "renderer": "studio",
+      "prompt": "metal objects on a studio stage"
     }
   ]
 }

--- a/sdf-js/examples/compositor/demo-lifts/stage-showcase.json
+++ b/sdf-js/examples/compositor/demo-lifts/stage-showcase.json
@@ -1,0 +1,53 @@
+{
+  "id": "stage-showcase",
+  "title": "Studio Stage — metals in a lit room",
+  "prompt": "three metal objects on a studio stage, lit by ceiling softboxes",
+  "code2d": "// defaults.stage:true → expandStage injects room + panel area lights + camera.",
+  "sceneData": {
+    "v": 1,
+    "name": "studio stage showcase",
+    "subjects": [
+      {
+        "id": "gold_sphere",
+        "type": "sphere",
+        "args": { "r": 0.9 },
+        "transform": { "translate": [-2.5, 0.9, 0.2] },
+        "material": "gold"
+      },
+      {
+        "id": "silver_torus",
+        "type": "torus",
+        "args": { "R": 0.8, "r": 0.3 },
+        "transform": { "translate": [0.1, 0.9, -0.3] },
+        "material": "silver"
+      },
+      {
+        "id": "copper_box",
+        "type": "rounded_box",
+        "args": { "dims": [1.3, 1.3, 1.3], "radius": 0.12 },
+        "transform": { "translate": [2.6, 0.75, 0.2] },
+        "material": "copper"
+      }
+    ],
+    "cameraSequence": {
+      "loop": false,
+      "shots": [
+        {
+          "duration": 0.05,
+          "pos": [0.3, 1.95, 8.2],
+          "target": [0, 0.78, -0.2],
+          "fov": 50,
+          "aperture": 0,
+          "focalDistance": 8.2,
+          "ease": "linear"
+        }
+      ]
+    },
+    "defaults": {
+      "stage": true
+    }
+  },
+  "meta": {
+    "thesisPoint": "scene-level stage: defaults.stage expands to a lit studio room (area lights + reflection-retrace)."
+  }
+}

--- a/sdf-js/scripts/test-stage.mjs
+++ b/sdf-js/scripts/test-stage.mjs
@@ -1,0 +1,97 @@
+// =============================================================================
+// test-stage.mjs — expandStage connector (defaults.stage → studio room).
+// =============================================================================
+
+import { expandStage } from '../src/scene/stage.js';
+
+let pass = 0,
+  fail = 0;
+const ok = (c, n) => (c ? (pass++, console.log(`  ✓ ${n}`)) : (fail++, console.log(`  ✗ ${n}`)));
+
+console.log('=== expandStage connector ===\n');
+
+const baseScene = () => ({
+  v: 1,
+  name: 't',
+  subjects: [
+    { id: 'ball', type: 'sphere', args: { r: 0.9 }, transform: { translate: [0, 0.9, 0] } },
+  ],
+  defaults: {},
+});
+
+// no stage → untouched (same reference)
+{
+  const s = baseScene();
+  ok(expandStage(s) === s, 'no defaults.stage → returns scene unchanged');
+}
+
+// stage:true → room geometry + lights + bg + cameras injected
+{
+  const s = baseScene();
+  s.defaults.stage = true;
+  const out = expandStage(s);
+  const ids = out.subjects.map((x) => x.id);
+  const stageBoxes = ids.filter((i) => i.startsWith('__stage_'));
+  ok(
+    stageBoxes.length === 7,
+    `injects 7 room boxes (floor/ceil/3 walls/2 panels) — got ${stageBoxes.length}`,
+  );
+  ok(
+    out.subjects.some((x) => x.id === 'ball'),
+    'keeps the original subject',
+  );
+  ok(
+    out.subjects[out.subjects.length - 1].id === 'ball',
+    'original subject after the room (room prepended)',
+  );
+  ok(
+    Array.isArray(out.defaults.lights) && out.defaults.lights.length === 2,
+    'declares 2 panel area lights',
+  );
+  ok(out.defaults.studioBg === 'dark', 'sets dark studio bg');
+  ok(
+    out.defaults.camera && typeof out.defaults.camera === 'object',
+    'supplies defaults.camera (validator needs it)',
+  );
+  ok(
+    out.cameraSequence && out.cameraSequence.shots.length === 1,
+    'supplies a default interior cameraSequence',
+  );
+  // panels are emissive (glow > 0)
+  const panels = out.subjects.filter((x) => x.id.includes('panel'));
+  ok(
+    panels.every((p) => p.material && p.material.glow > 0),
+    'panels are emissive',
+  );
+}
+
+// immutability — input scene not mutated
+{
+  const s = baseScene();
+  s.defaults.stage = true;
+  const before = s.subjects.length;
+  expandStage(s);
+  ok(s.subjects.length === before, 'does not mutate input subjects');
+  ok(s.defaults.lights === undefined, 'does not mutate input defaults');
+}
+
+// authored cameraSequence is preserved (not overwritten)
+{
+  const s = baseScene();
+  s.defaults.stage = true;
+  s.cameraSequence = { loop: false, shots: [{ duration: 1, pos: [0, 0, 9], target: [0, 0, 0] }] };
+  const out = expandStage(s);
+  ok(out.cameraSequence.shots[0].pos[2] === 9, 'keeps a scene-authored cameraSequence');
+}
+
+// object config: custom size widens the room
+{
+  const s = baseScene();
+  s.defaults.stage = { size: [20, 6, 20] };
+  const out = expandStage(s);
+  const floor = out.subjects.find((x) => x.id === '__stage_floor');
+  ok(floor.args.dims[0] > 18, `custom size respected (floor width ${floor.args.dims[0]})`);
+}
+
+console.log(`\n=== Result: ${pass} passed, ${fail} failed ===`);
+process.exit(fail > 0 ? 1 : 0);

--- a/sdf-js/src/scene/stage.js
+++ b/sdf-js/src/scene/stage.js
@@ -1,0 +1,131 @@
+// =============================================================================
+// stage.js — `defaults.stage` → studio-room expander (SceneData → SceneData).
+// -----------------------------------------------------------------------------
+// A scene-level "stage": wrap the subjects in an enclosed studio room so they're
+// lit BY the room (ceiling softbox panels → area lights) and metals reflect the
+// actual walls (reflection-retrace), instead of floating in open sky. This is
+// what turns a flat object render into a premium product/keynote shot.
+//
+// Opt in with `defaults.stage: true` (sensible studio defaults) or an object for
+// overrides. The expander, a sibling of expandChartLabels (run at scene-load),
+// injects:
+//   • room geometry — floor / ceiling / back + 2 side walls (front left open for
+//     the camera), all plain boxes (the renderer needs no new primitive);
+//   • two emissive ceiling panels (cool key + warm fill) as visible softboxes;
+//   • two entries in `defaults.lights[]` at the panels (area lights — see
+//     studio.js) so the panels actually illuminate with soft shadows;
+//   • `defaults.studioBg='dark'` (dramatic cyclorama) if unset;
+//   • a default interior cameraSequence if the scene has none (studio camera
+//     ignores defaults.camera for large bounded scenes — a sequence is the
+//     reliable way to frame the room).
+//
+// Everything is additive + namespaced (`__stage_*`), and absent `defaults.stage`
+// returns the scene untouched.
+// =============================================================================
+
+const box = (id, dims, translate, material) => ({
+  id,
+  type: 'box',
+  args: { dims },
+  transform: { translate },
+  material,
+});
+
+// Default studio palette — neutral mid-grey room so colored subjects + the warm/
+// cool panels read against it. Tuned to not blow out under the panel lights.
+const WALL = { hue: 0.6, sat: 0.05, value: 0.5, metal: 0, glow: 0 };
+const FLOOR = { hue: 0.6, sat: 0.04, value: 0.42, metal: 0.1, glow: 0 };
+const CEIL = { hue: 0.6, sat: 0.04, value: 0.34, metal: 0, glow: 0 };
+const PANEL_COOL = { hue: 0.6, sat: 0.05, value: 1.0, metal: 0, glow: 1.0 };
+const PANEL_WARM = { hue: 0.09, sat: 0.06, value: 1.0, metal: 0, glow: 0.9 };
+
+export function expandStage(sceneData) {
+  if (!sceneData || !sceneData.defaults || !sceneData.defaults.stage) return sceneData;
+  if (!Array.isArray(sceneData.subjects)) return sceneData;
+
+  const cfg = sceneData.defaults.stage === true ? {} : sceneData.defaults.stage;
+  const [w, h, d] = cfg.size || [12, 5, 14];
+  const t = 0.3; // wall thickness
+  const wall = cfg.wall || WALL;
+  const floor = cfg.floor || FLOOR;
+
+  // Room shell. Front (+z) left open for the camera; floor top sits at y=0 so
+  // subjects authored on the ground plane rest on it.
+  const room = [
+    box('__stage_floor', [w + 2 * t, t, d + 2 * t], [0, -t / 2, 0], floor),
+    box('__stage_ceiling', [w + 2 * t, t, d + 2 * t], [0, h + t / 2, 0], CEIL),
+    box('__stage_wall_back', [w + 2 * t, h + 2 * t, t], [0, h / 2, -d / 2 - t / 2], wall),
+    box('__stage_wall_left', [t, h + 2 * t, d + 2 * t], [-w / 2 - t / 2, h / 2, 0], wall),
+    box('__stage_wall_right', [t, h + 2 * t, d + 2 * t], [w / 2 + t / 2, h / 2, 0], wall),
+  ];
+
+  // Two ceiling softbox panels (cool key left, warm fill right) — visible
+  // emissive geometry the metals reflect.
+  const panelY = h - 0.12;
+  const px = w * 0.2;
+  const panelDims = [w * 0.34, 0.15, d * 0.22];
+  room.push(box('__stage_panel_l', panelDims, [-px, panelY, 0], PANEL_COOL));
+  room.push(box('__stage_panel_r', panelDims, [px, panelY, 0], PANEL_WARM));
+
+  // The matching area lights (just below each panel, aimed down into the room).
+  const stageLights = [
+    {
+      pos: [-px, h - 0.4, 0],
+      color: [0.78, 0.84, 1.0],
+      intensity: cfg.intensity ?? 3.0,
+      radius: 2.3,
+    },
+    {
+      pos: [px, h - 0.4, 0],
+      color: [1.0, 0.9, 0.74],
+      intensity: cfg.intensity ?? 2.8,
+      radius: 2.3,
+    },
+  ];
+
+  const defaults = { ...sceneData.defaults };
+  // Merge lights (existing scene lights first), cap at the shader's 4.
+  const existing = Array.isArray(defaults.lights) ? defaults.lights : [];
+  defaults.lights = [...existing, ...stageLights].slice(0, 4);
+  if (defaults.studioBg == null) defaults.studioBg = 'dark';
+  // validate() requires defaults.camera even though studio frames via the
+  // sequence below — supply a valid neutral one if the scene authored none.
+  if (defaults.camera == null) {
+    defaults.camera = {
+      yaw: 0,
+      pitch: 0.2,
+      distance: d / 2 + 3,
+      focal: 1.6,
+      targetX: 0,
+      targetY: h * 0.16,
+      targetZ: 0,
+    };
+  }
+  // Soften the sun so the room panels carry the mood (keep a low key for shape).
+  if (defaults.light == null) {
+    defaults.light = { altitude: 0.85, azimuth: 0.6, distance: 50, intensity: 0.5 };
+  }
+
+  const out = { ...sceneData, defaults, subjects: [...room, ...sceneData.subjects] };
+
+  // Default interior camera (only if the scene authored none). studio ignores
+  // defaults.camera for large bounded scenes, so we drive it with a sequence.
+  if (!out.cameraSequence && !cfg.noCamera) {
+    out.cameraSequence = {
+      loop: false,
+      shots: [
+        {
+          duration: 0.05,
+          pos: [w * 0.26, h * 0.62, d / 2 + 1.5],
+          target: [0, h * 0.16, 0],
+          fov: 42,
+          aperture: 0,
+          focalDistance: d / 2 + 2,
+          ease: 'linear',
+        },
+      ],
+    };
+  }
+
+  return out;
+}


### PR DESCRIPTION
## `defaults.stage` → studio-room expander + showcase (stage feature 2-3/3)

Scene-level **stage**. Wrapping subjects in an enclosed studio room is what makes the area lights (#100) + reflection-retrace (#99) pay off — objects are lit BY the room and metals reflect the real walls instead of floating in open sky.

### `src/scene/stage.js` — `expandStage(sceneData)`
A sibling of `expandChartLabels`, run at scene-load. On `defaults.stage` (`true` or a config object) it injects — all additive + namespaced (`__stage_*`):
- **room geometry** — floor / ceiling / back + 2 side walls (front open for the camera), plain boxes (no new primitive);
- **two emissive ceiling panels** (cool key + warm fill) — visible softboxes the metals reflect;
- **two `defaults.lights[]` entries** at the panels (the area lights);
- `defaults.studioBg='dark'` + a valid `defaults.camera` (validator needs it) + a default interior `cameraSequence` — each only if the scene authored none.

Absent `defaults.stage` → scene returned untouched. Config object supports `{ size, wall, floor, intensity, noCamera }`.

### Wiring
`compositor.js`: `expandStage` at the two connector sites (next to `expandChartLabels`), incl. reassigning `sceneData` in `renderLiftedSceneData` so the expanded scene is BOTH compiled and stored as `rawScene` (lights/camera reach `setPostFx`).

### Demo
`stage-showcase.json` — gold sphere / silver torus / copper box on a stage via `defaults.stage: true`. Registered in the gallery (`category: scene-templates`).

### Test
`test-stage.mjs` (13 assertions): geometry/lights/bg/camera injection, immutability, authored-`cameraSequence` preserved, custom size. Wired into `run-tests`.

### Verification
Renders end-to-end: a lit studio room, soft floor shadows, metals reflecting the walls. Suite **85/85**; eslint clean.

This completes the stage feature: **#99 (GGX + retrace) → #100 (area lights) → this (stage atom + demo)**. An LLM/user can now drop `defaults.stage: true` on any scene to get a premium lit studio.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
