### PR TITLE
feat(stage): wire stage into Present decks + facing option + keynote demo

### DIFF
--- a/sdf-js/examples/compositor/demo-lifts/deck-studio-keynote.json
+++ b/sdf-js/examples/compositor/demo-lifts/deck-studio-keynote.json
@@ -1,0 +1,18 @@
+{
+  "id": "deck-studio-keynote",
+  "name": "Studio Keynote — staged spatial deck",
+  "segments": [
+    {
+      "file": "stage-showcase.json",
+      "title": "The lineup",
+      "kind": "slide",
+      "durationSec": 7
+    },
+    {
+      "file": "stage-data-bars.json",
+      "title": "Revenue by quarter",
+      "kind": "slide",
+      "durationSec": 7
+    }
+  ]
+}

--- a/sdf-js/examples/compositor/demo-lifts/index.json
+++ b/sdf-js/examples/compositor/demo-lifts/index.json
@@ -1408,6 +1408,26 @@
       "file": "stage-showcase.json",
       "renderer": "studio",
       "prompt": "metal objects on a studio stage"
+    },
+    {
+      "id": "stage-data-bars",
+      "title": "Revenue · on the studio stage",
+      "thesisPoint": "Stage composes with data atoms — a labelled bar chart in a lit room (facing:-z so labels read).",
+      "category": "scene-templates",
+      "status": "ready",
+      "file": "stage-data-bars.json",
+      "renderer": "studio",
+      "prompt": "revenue bar chart on a studio stage"
+    },
+    {
+      "id": "deck-studio-keynote",
+      "title": "Studio Keynote (staged spatial deck)",
+      "thesisPoint": "Stage × Present: a deck whose slides are staged — hero metals + a data chart in a lit studio room. Launch via ?deck=deck-studio-keynote.",
+      "category": "scene-templates",
+      "status": "ready",
+      "file": "deck-studio-keynote.json",
+      "renderer": "studio",
+      "prompt": "staged studio keynote deck"
     }
   ]
 }

--- a/sdf-js/examples/compositor/demo-lifts/stage-data-bars.json
+++ b/sdf-js/examples/compositor/demo-lifts/stage-data-bars.json
@@ -1,0 +1,46 @@
+{
+  "id": "stage-data-bars",
+  "title": "Revenue · on the studio stage",
+  "prompt": "quarterly revenue bar chart presented on a studio stage",
+  "code2d": "// bar-3d + defaults.stage:true → chart presented inside a lit studio room.",
+  "sceneData": {
+    "v": 1,
+    "name": "staged revenue bars",
+    "subjects": [
+      {
+        "id": "bars",
+        "type": "bar-3d",
+        "args": {
+          "values": [0.4, 0.66, 1, 0.6, 0.78],
+          "labels": ["$1.2M", "$2.0M", "$3.4M", "$1.8M", "$2.6M"],
+          "barWidth": 0.5,
+          "barDepth": 0.5,
+          "gap": 0.45,
+          "maxHeight": 2.2
+        },
+        "transform": { "translate": [0, 0, 0] },
+        "material": { "hue": 0.58, "sat": 0.85, "value": 0.78, "metal": 0.45 }
+      }
+    ],
+    "cameraSequence": {
+      "loop": false,
+      "shots": [
+        {
+          "duration": 0.05,
+          "pos": [-2.4, 3.0, -9.5],
+          "target": [0, 1.15, 0],
+          "fov": 46,
+          "aperture": 0,
+          "focalDistance": 9.5,
+          "ease": "linear"
+        }
+      ]
+    },
+    "defaults": {
+      "stage": { "size": [12, 5.5, 13], "facing": "-z" }
+    }
+  },
+  "meta": {
+    "thesisPoint": "stage composes with data atoms — a labelled bar chart presented in a lit studio room."
+  }
+}

--- a/sdf-js/scripts/test-stage.mjs
+++ b/sdf-js/scripts/test-stage.mjs
@@ -93,5 +93,18 @@ const baseScene = () => ({
   ok(floor.args.dims[0] > 18, `custom size respected (floor width ${floor.args.dims[0]})`);
 }
 
+// facing:'-z' (for chart slides whose connector labels face -z) → solid back
+// wall on +z and default camera yaw flipped to π.
+{
+  const dPos = expandStage({ ...baseScene(), defaults: { stage: true } });
+  const backPos = dPos.subjects.find((x) => x.id === '__stage_wall_back').transform.translate[2];
+  ok(backPos < 0, `default facing +z → back wall on -z (z=${backPos})`);
+
+  const dNeg = expandStage({ ...baseScene(), defaults: { stage: { facing: '-z' } } });
+  const backNeg = dNeg.subjects.find((x) => x.id === '__stage_wall_back').transform.translate[2];
+  ok(backNeg > 0, `facing -z → back wall flips to +z (z=${backNeg})`);
+  ok(Math.abs(dNeg.defaults.camera.yaw - Math.PI) < 1e-6, 'facing -z → default camera yaw = π');
+}
+
 console.log(`\n=== Result: ${pass} passed, ${fail} failed ===`);
 process.exit(fail > 0 ? 1 : 0);

--- a/sdf-js/src/scene/stage.js
+++ b/sdf-js/src/scene/stage.js
@@ -48,13 +48,18 @@ export function expandStage(sceneData) {
   const t = 0.3; // wall thickness
   const wall = cfg.wall || WALL;
   const floor = cfg.floor || FLOOR;
+  // Which way the room opens (= the camera side). '+z' (default) suits hero
+  // objects; '-z' suits chart atoms, whose connector labels face -z, so the
+  // camera must sit on -z to read them. The solid back wall goes on the far side.
+  const facing = cfg.facing === '-z' ? -1 : 1;
+  const backZ = -facing * (d / 2 + t / 2); // solid wall opposite the open side
 
-  // Room shell. Front (+z) left open for the camera; floor top sits at y=0 so
-  // subjects authored on the ground plane rest on it.
+  // Room shell. Open side faces the camera; floor top sits at y=0 so subjects
+  // authored on the ground plane rest on it.
   const room = [
     box('__stage_floor', [w + 2 * t, t, d + 2 * t], [0, -t / 2, 0], floor),
     box('__stage_ceiling', [w + 2 * t, t, d + 2 * t], [0, h + t / 2, 0], CEIL),
-    box('__stage_wall_back', [w + 2 * t, h + 2 * t, t], [0, h / 2, -d / 2 - t / 2], wall),
+    box('__stage_wall_back', [w + 2 * t, h + 2 * t, t], [0, h / 2, backZ], wall),
     box('__stage_wall_left', [t, h + 2 * t, d + 2 * t], [-w / 2 - t / 2, h / 2, 0], wall),
     box('__stage_wall_right', [t, h + 2 * t, d + 2 * t], [w / 2 + t / 2, h / 2, 0], wall),
   ];
@@ -92,7 +97,7 @@ export function expandStage(sceneData) {
   // sequence below — supply a valid neutral one if the scene authored none.
   if (defaults.camera == null) {
     defaults.camera = {
-      yaw: 0,
+      yaw: facing < 0 ? Math.PI : 0,
       pitch: 0.2,
       distance: d / 2 + 3,
       focal: 1.6,
@@ -116,7 +121,7 @@ export function expandStage(sceneData) {
       shots: [
         {
           duration: 0.05,
-          pos: [w * 0.26, h * 0.62, d / 2 + 1.5],
+          pos: [w * 0.26 * facing, h * 0.62, facing * (d / 2 + 1.5)],
           target: [0, h * 0.16, 0],
           fov: 42,
           aperture: 0,


### PR DESCRIPTION
## Stage × Present — staged decks + `facing` + keynote demo

Connect the studio stage to the Atlas Present deck system. **No deck-player change** — the stage composes via the load-time `expandStage` connector, so any deck segment whose scene carries `defaults.stage` is presented in a lit studio room.

### `facing` option
Chart atoms' connector labels face `-z`, so a chart needs the camera on `-z` to read them. New `defaults.stage.facing` (`'+z'` default | `'-z'`) puts the solid back wall on the far side + flips the default camera. Hero objects keep `+z`; charts use `-z` (labels read correctly).

### New content
- `stage-data-bars.json` — a labelled revenue bar chart on a stage (`facing:'-z'`). Proves the stage composes with **data atoms**, not only hero objects.
- `deck-studio-keynote.json` — a 2-segment staged deck (hero metals → revenue chart). Plays through the existing deck-player via `?deck=deck-studio-keynote`; each segment is a normal scene with `defaults.stage`.
- All three registered in the gallery (`category: scene-templates`).

### Test
`test-stage.mjs` +3 `facing` assertions (back-wall flip + camera yaw). **16/16**.

### Verification
`?deck=deck-studio-keynote` plays segment 1 (hero metals reflecting the room) → auto-advances to segment 2 (staged chart, labels reading, deck caption) — both lit by the panel area lights.

### The stage line, complete
**#99** retrace → **#100** area lights → **#101** stage atom → **this** (Present integration). An LLM/user drops `defaults.stage` on any scene — standalone or as a deck slide — and gets a premium lit studio.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
