### PR TITLE
feat(stage): studio show v1 — volume-wiring fix + atmosphere + cinematic camera

### DIFF
--- a/sdf-js/examples/compositor/compositor.js
+++ b/sdf-js/examples/compositor/compositor.js
@@ -722,16 +722,21 @@ async function loadDemoScene(demo) {
     const data = await res.json();
 
     let compiled;
+    let stagedScene;
     try {
       // Generator-S: expand `subjects[i].variants[]` into N flat subjects.
       // No-op (zero rng draws) if no subject has variants. Uses state.sceneHash
       // → SFC32 PRNG so the same hash always yields the same expansion.
       const sceneRng = new Random(state.sceneHash);
       const variantScene = expandVariants(data.sceneData, sceneRng);
+      // Stage connector wraps subjects in a studio room (+ panel lights, volumes,
+      // camera) when defaults.stage is set. Capture the staged scene so it can be
+      // stored as the rawScene below — otherwise setPostFx/setVolumes/setSequence
+      // get the UN-expanded scene and the lights/beams never reach the renderer.
+      stagedScene = expandStage(variantScene);
       // #84 connector: chart subjects with args.labels → SDF text-3d-pipe labels
-      // anchored on their elements (no-op if no chart carries labels). Stage
-      // connector wraps subjects in a studio room when defaults.stage is set.
-      const labeledScene = expandChartLabels(expandStage(variantScene));
+      // anchored on their elements (no-op if no chart carries labels).
+      const labeledScene = expandChartLabels(stagedScene);
       compiled = compileSceneData(labeledScene, { tokenHash: URL_TOKEN_HASH });
     } catch (e) {
       throw new Error(`compile failed: ${e.message}`);
@@ -745,7 +750,7 @@ async function loadDemoScene(demo) {
 
     state.textLiftScene = compiled;
     state.textLiftSdf = renderSdf;
-    state.textLiftSceneJSON = data.sceneData; // raw — keeps cameraSequence / defaults.postFx alive past compile
+    state.textLiftSceneJSON = stagedScene || data.sceneData; // staged (expandStage) → keeps lights/volumes/camera/cameraSequence alive past compile
     state.textLiftSourcePrompt = data.prompt;
     state.liftMode = true;
     state.selectedHistoryId = null;
@@ -2103,6 +2108,12 @@ function runActiveGpuRenderer({ keepCamera = false } = {}) {
     }
     // Sprint 12: Rune heightmap → studio texture (same data as FLY 3D).
     if (st.setRuneHeightmap) st.setRuneHeightmap(scene.bakedHeightmap || null);
+    // Volumes (smoke / flame / fog / god-rays) — studio supports the volume
+    // raymarch pass but the dispatch never fed it (only FLY did). Wire it so
+    // stage "show" effects (spotlight beams + floor haze) actually render.
+    if (st.setVolumes) {
+      st.setVolumes(rawScene && Array.isArray(rawScene.volumes) ? rawScene.volumes : []);
+    }
     // Step 2 (spatial deck): a scene.cameraSequence flies the studio camera
     // through multiple slide-stations laid out in one 3D world. Studio already
     // plays it per-frame (draw loop) — just hand it the sequence (or null to

--- a/sdf-js/examples/compositor/demo-lifts/stage-data-bars.json
+++ b/sdf-js/examples/compositor/demo-lifts/stage-data-bars.json
@@ -26,13 +26,24 @@
       "loop": false,
       "shots": [
         {
-          "duration": 0.05,
-          "pos": [-2.4, 3.0, -9.5],
-          "target": [0, 1.15, 0],
+          "duration": 2.4,
+          "pos": [-3.0, 3.4, -10.5],
+          "target": [0, 1.2, 0],
           "fov": 46,
           "aperture": 0,
-          "focalDistance": 9.5,
-          "ease": "linear"
+          "focalDistance": 10.5,
+          "ease": "smooth",
+          "exposure": [0, 1]
+        },
+        {
+          "duration": 5.0,
+          "pos": [-1.6, 2.7, -8.6],
+          "target": [0, 1.05, 0],
+          "fov": 47,
+          "aperture": 0,
+          "focalDistance": 8.6,
+          "ease": "smooth",
+          "transition": "blend"
         }
       ]
     },

--- a/sdf-js/examples/compositor/demo-lifts/stage-showcase.json
+++ b/sdf-js/examples/compositor/demo-lifts/stage-showcase.json
@@ -44,7 +44,7 @@
       ]
     },
     "defaults": {
-      "stage": true
+      "stage": { "show": true }
     }
   },
   "meta": {

--- a/sdf-js/examples/compositor/demo-lifts/stage-showcase.json
+++ b/sdf-js/examples/compositor/demo-lifts/stage-showcase.json
@@ -33,13 +33,24 @@
       "loop": false,
       "shots": [
         {
-          "duration": 0.05,
-          "pos": [0.3, 1.95, 8.2],
-          "target": [0, 0.78, -0.2],
-          "fov": 50,
+          "duration": 2.6,
+          "pos": [3.6, 3.3, 10.5],
+          "target": [0, 0.9, -0.1],
+          "fov": 44,
           "aperture": 0,
-          "focalDistance": 8.2,
-          "ease": "linear"
+          "focalDistance": 10.5,
+          "ease": "smooth",
+          "exposure": [0, 1]
+        },
+        {
+          "duration": 5.4,
+          "pos": [-1.8, 2.0, 8.0],
+          "target": [0, 0.82, -0.25],
+          "fov": 47,
+          "aperture": 0,
+          "focalDistance": 8.0,
+          "ease": "smooth",
+          "transition": "blend"
         }
       ]
     },

--- a/sdf-js/scripts/test-stage.mjs
+++ b/sdf-js/scripts/test-stage.mjs
@@ -106,5 +106,20 @@ const baseScene = () => ({
   ok(Math.abs(dNeg.defaults.camera.yaw - Math.PI) < 1e-6, 'facing -z → default camera yaw = π');
 }
 
+// show mode: injects volumetric beams + floor haze
+{
+  const plain = expandStage({ ...baseScene(), defaults: { stage: true } });
+  ok(!plain.volumes || plain.volumes.length === 0, 'no show → no volumes');
+
+  const show = expandStage({ ...baseScene(), defaults: { stage: { show: true } } });
+  const vols = show.volumes || [];
+  ok(vols.length === 3, `show → 3 volumes (2 beams + haze), got ${vols.length}`);
+  ok(vols.filter((v) => v.kind === 'god-rays').length === 2, 'show → 2 god-ray beams');
+  ok(
+    vols.some((v) => v.kind === 'fog'),
+    'show → floor haze (fog)',
+  );
+}
+
 console.log(`\n=== Result: ${pass} passed, ${fail} failed ===`);
 process.exit(fail > 0 ? 1 : 0);

--- a/sdf-js/src/scene/stage.js
+++ b/sdf-js/src/scene/stage.js
@@ -113,6 +113,37 @@ export function expandStage(sceneData) {
 
   const out = { ...sceneData, defaults, subjects: [...room, ...sceneData.subjects] };
 
+  // Show mode: dramatic volumetric lighting — a spotlight beam under each panel
+  // + a low floor haze for the beams to glow in. Rendered by the studio volume
+  // raymarch pass (kind god-rays / fog). Turns a lit room into a "stage".
+  if (cfg.show) {
+    const beam = (id, x, color) => ({
+      id,
+      kind: 'god-rays',
+      center: [x, h * 0.48, 0],
+      size: [Math.max(2.2, w * 0.2), h * 0.95, Math.max(2.2, d * 0.18)],
+      density: 0.28,
+      color,
+      noiseScale: 1.4,
+      colorIntensity: 1.0,
+    });
+    const showVols = [
+      beam('__stage_beam_l', -px, [150, 180, 255]),
+      beam('__stage_beam_r', px, [255, 208, 150]),
+      {
+        id: '__stage_haze',
+        kind: 'fog',
+        center: [0, 0.5, 0],
+        size: [w, 1.0, d],
+        density: 0.05,
+        color: [184, 198, 222],
+        noiseScale: 0.8,
+      },
+    ];
+    const existingVols = Array.isArray(sceneData.volumes) ? sceneData.volumes : [];
+    out.volumes = [...existingVols, ...showVols];
+  }
+
   // Default interior camera (only if the scene authored none). studio ignores
   // defaults.camera for large bounded scenes, so we drive it with a sequence.
   if (!out.cameraSequence && !cfg.noCamera) {


### PR DESCRIPTION
## Studio volumes wiring fix + stage 'show' atmosphere

Two real bugs surfaced while starting the stage "show" effects, plus a subtle volumetric atmosphere.

### Bugs fixed
1. **Studio never received volumes.** The renderer has a full volume raymarch pass (smoke / flame / fog / god-rays) + a `setVolumes()`, but the compositor dispatch only called `fly.setVolumes` — so volumes silently did nothing on studio. Wired `st.setVolumes(rawScene.volumes)`.
2. **`loadDemoScene` stored the un-expanded scene as `rawScene`** (`state.textLiftSceneJSON = data.sceneData`). A staged demo compiled its room geometry, but the renderer's `setPostFx` / `setVolumes` / `setSequence` got the *original* scene — so `expandStage`'s **panel area lights, volumes, studioBg and camera never reached the GPU**. The "lit room" was only the sun + glowing panels; the area lights were silently dropped. Now stores the staged scene. (`renderLiftedSceneData` already did this; `loadDemoScene` didn't.)

### Stage 'show'
- `defaults.stage.show: true` adds a spotlight beam (god-rays) under each panel + a low floor haze (fog), tuned subtle so the reflection-retrace metals stay crisp. `stage-showcase` uses it.
- `test-stage.mjs`: +4 assertions (show → 3 volumes / 2 beams / fog; no-show → none). **20/20**.

With both fixes, staged scenes now actually render their panel area lights (dual soft shadows) + volumetric atmosphere. Suite **85/85**; eslint clean.

### Deferred (pending VFX-reference direction)
Dramatic theatrical light **shafts** need a darker beam-lit mode (objects lit *by* the beams, not ambient) — and other show effects (cinematic camera moves, reveals, particles) want an art direction. This PR lands the **plumbing + a tasteful atmosphere** so those effects have somewhere to plug in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
