### PR TITLE
feat(stage): theatrical spotlight mode — cone lights + ambient suppression

### DIFF
--- a/sdf-js/scripts/test-stage.mjs
+++ b/sdf-js/scripts/test-stage.mjs
@@ -119,6 +119,27 @@ const baseScene = () => ({
     vols.some((v) => v.kind === 'fog'),
     'show → floor haze (fog)',
   );
+  // theatrical: spotlight dir on panel lights + dark interior + dark walls
+  ok(
+    show.defaults.lights.every((l) => l.dir && l.dir[1] === -1),
+    'show → panel lights are downward spotlights (dir)',
+  );
+  ok(
+    show.defaults.interiorDark != null && show.defaults.interiorDark < 1,
+    'show → interiorDark set',
+  );
+  const swall = show.subjects.find((x) => x.id === '__stage_wall_back');
+  ok(swall.material.value < 0.2, `show → dark walls (value ${swall.material.value})`);
+
+  // plain (no show) keeps omni lights + full ambient + mid-grey walls
+  const plainLit = expandStage({ ...baseScene(), defaults: { stage: true } });
+  ok(
+    plainLit.defaults.lights.every(
+      (l) => !l.dir || (l.dir[0] === 0 && l.dir[1] === 0 && l.dir[2] === 0),
+    ),
+    'no show → omni lights (no spotlight dir)',
+  );
+  ok(plainLit.defaults.interiorDark == null, 'no show → no interiorDark (full ambient)');
 }
 
 console.log(`\n=== Result: ${pass} passed, ${fail} failed ===`);

--- a/sdf-js/src/render/studio.js
+++ b/sdf-js/src/render/studio.js
@@ -49,6 +49,8 @@ uniform int   u_numExtraLights;
 uniform vec3  u_extraLightPos[MAX_EXTRA_LIGHTS];
 uniform vec3  u_extraLightColor[MAX_EXTRA_LIGHTS];   // rgb * intensity (premultiplied)
 uniform float u_extraLightRadius[MAX_EXTRA_LIGHTS];  // penumbra softness, world units
+uniform vec3  u_extraLightDir[MAX_EXTRA_LIGHTS];     // spotlight aim; zero vec = omni point
+uniform float u_ambientScale;  // 1 = normal; ~0.18 for theatrical dark interior
 uniform float u_shadowsOn;
 uniform float u_groundOn;
 uniform float u_checkerOn;
@@ -1439,8 +1441,12 @@ void main() {
       // trimmed rim. Ambient terms stay multiplied by AO so crevices/contacts
       // darken (grounds the subject — the main thing flat studio lighting lacked).
       lin += base * sunCol    * diff * shadowK * 1.55 * diffK;
-      lin += base * skyCol    * skyL * ao      * 0.38 * diffK;
-      lin += base * bounceCol * bnc  * ao      * 0.16 * diffK;
+      // Sky ambient + ground bounce scale by u_ambientScale. A theatrical stage
+      // (interiorDark) drops it near 0 so dark walls stay dark and the spotlight
+      // cones + volumetric beams read; the spots + sun still pick out the hero.
+      // Default 1.0 = unchanged for every other scene.
+      lin += base * skyCol    * skyL * ao      * 0.38 * diffK * u_ambientScale;
+      lin += base * bounceCol * bnc  * ao      * 0.16 * diffK * u_ambientScale;
       // GGX microfacet specular (replaces the old Phong pow lobe). Roughness
       // tracks metalK: metals get a tight bright glint that reads as polished
       // metal, matte surfaces a broad soft sheen. specBoost keeps the prior
@@ -1466,6 +1472,16 @@ void main() {
         float ndl = max(dot(n, toL), 0.0);
         if (ndl <= 0.0) continue;
         float atten = 1.0 / (1.0 + 0.035 * ldist * ldist);
+        // Spotlight cone: if the light carries an aim direction, fall off outside
+        // a cone so it pools light on the subject and leaves the walls dark (a
+        // theatrical stage spot). Zero dir = omni point light (no cone). -toL is
+        // the light's outgoing direction toward this surface point.
+        vec3 sdir = u_extraLightDir[li];
+        if (dot(sdir, sdir) > 0.25) {
+          float ca = dot(-toL, normalize(sdir));
+          atten *= smoothstep(0.32, 0.72, ca); // ~71° outer, ~44° inner half-angle
+        }
+        if (atten <= 0.001) continue;
         float sh = 1.0;
         if (u_shadowsOn > 0.5) {
           float ksh = mix(18.0, 5.0, clamp(u_extraLightRadius[li] / 2.5, 0.0, 1.0));
@@ -1723,7 +1739,9 @@ export function createStudioRenderer({
   const extraLightPosLUT = new Float32Array(MAX_EXTRA_LIGHTS * 3);
   const extraLightColorLUT = new Float32Array(MAX_EXTRA_LIGHTS * 3);
   const extraLightRadiusLUT = new Float32Array(MAX_EXTRA_LIGHTS);
+  const extraLightDirLUT = new Float32Array(MAX_EXTRA_LIGHTS * 3);
   let numExtraLights = 0;
+  let ambientScale = 1.0; // theatrical interiorDark drops sky-ambient near 0
   // Sprint 6: heat-haze flame positions (xyz, radius) for postfx composite.
   // Mirrors MAX_HEAT_HAZE = 8 in postfx.js. Packed each frame from the active
   // flame subset of the volume LUTs.
@@ -1968,6 +1986,8 @@ export function createStudioRenderer({
       'u_extraLightPos[0]',
       'u_extraLightColor[0]',
       'u_extraLightRadius[0]',
+      'u_extraLightDir[0]',
+      'u_ambientScale',
       // Sprint 4 subject motion offset uniform array
       'u_subjectOffset[0]',
       // Sprint 8 Blueprint-as-shot toggle
@@ -2262,6 +2282,9 @@ export function createStudioRenderer({
     if (uniformsCache['u_numExtraLights'] != null) {
       gl.uniform1i(uniformsCache['u_numExtraLights'], numExtraLights);
     }
+    if (uniformsCache['u_ambientScale'] != null) {
+      gl.uniform1f(uniformsCache['u_ambientScale'], ambientScale);
+    }
     if (numExtraLights > 0) {
       if (uniformsCache['u_extraLightPos[0]'] != null)
         gl.uniform3fv(uniformsCache['u_extraLightPos[0]'], extraLightPosLUT);
@@ -2269,6 +2292,8 @@ export function createStudioRenderer({
         gl.uniform3fv(uniformsCache['u_extraLightColor[0]'], extraLightColorLUT);
       if (uniformsCache['u_extraLightRadius[0]'] != null)
         gl.uniform1fv(uniformsCache['u_extraLightRadius[0]'], extraLightRadiusLUT);
+      if (uniformsCache['u_extraLightDir[0]'] != null)
+        gl.uniform3fv(uniformsCache['u_extraLightDir[0]'], extraLightDirLUT);
     }
     // LUTs are uploaded once per program load in uploadSDF — uniforms persist
     // on the program object, so re-uploading per frame would be pure waste.
@@ -2609,9 +2634,15 @@ export function createStudioRenderer({
       // → dark cyclorama + punchier spec/rim/vignette (showcase decks). Default
       // (absent) keeps the neutral light test stage used by the atom gallery.
       studioBgDark = !!(scene && scene.defaults && scene.defaults.studioBg === 'dark');
+      // Theatrical dark interior: suppress sky ambient so the spotlight cones +
+      // beams pop against dark walls. defaults.interiorDark = true (→ 0.18) or a
+      // 0-1 number; absent → 1.0 (unchanged).
+      const idark = scene && scene.defaults ? scene.defaults.interiorDark : null;
+      ambientScale =
+        idark == null || idark === false ? 1.0 : typeof idark === 'number' ? idark : 0.18;
       // Stage area lights: pack scene.defaults.lights → LUTs (color premultiplied
-      // by intensity; 0-255 auto-normalized like volumes). Absent/empty → 0 lights
-      // = no-op, every existing scene byte-identical.
+      // by intensity; 0-255 auto-normalized like volumes). A light with `dir`
+      // becomes a spotlight cone. Absent/empty → 0 lights = no-op.
       numExtraLights = 0;
       const lights = scene && scene.defaults && scene.defaults.lights;
       if (Array.isArray(lights)) {
@@ -2630,6 +2661,10 @@ export function createStudioRenderer({
           extraLightColorLUT[i * 3 + 1] = col[1] * cs * inten;
           extraLightColorLUT[i * 3 + 2] = col[2] * cs * inten;
           extraLightRadiusLUT[i] = L.radius == null ? 1.0 : L.radius;
+          const dir = L.dir || L.direction || [0, 0, 0]; // zero = omni point
+          extraLightDirLUT[i * 3] = dir[0];
+          extraLightDirLUT[i * 3 + 1] = dir[1];
+          extraLightDirLUT[i * 3 + 2] = dir[2];
         }
         numExtraLights = n;
       }

--- a/sdf-js/src/scene/stage.js
+++ b/sdf-js/src/scene/stage.js
@@ -39,6 +39,14 @@ const CEIL = { hue: 0.6, sat: 0.04, value: 0.34, metal: 0, glow: 0 };
 const PANEL_COOL = { hue: 0.6, sat: 0.05, value: 1.0, metal: 0, glow: 1.0 };
 const PANEL_WARM = { hue: 0.09, sat: 0.06, value: 1.0, metal: 0, glow: 0.9 };
 
+// Theatrical (show) palette — near-black room so the spotlight cones + volumetric
+// beams read as bright shafts against darkness (a lit mid-grey room washes them
+// out). Paired with defaults.interiorDark (kills sky ambient) + spotlight `dir`
+// on the panel lights so only the hero is lit and the walls stay dark.
+const WALL_DARK = { hue: 0.62, sat: 0.18, value: 0.09, metal: 0, glow: 0 };
+const FLOOR_DARK = { hue: 0.62, sat: 0.12, value: 0.13, metal: 0.25, glow: 0 };
+const CEIL_DARK = { hue: 0.62, sat: 0.2, value: 0.05, metal: 0, glow: 0 };
+
 export function expandStage(sceneData) {
   if (!sceneData || !sceneData.defaults || !sceneData.defaults.stage) return sceneData;
   if (!Array.isArray(sceneData.subjects)) return sceneData;
@@ -46,8 +54,10 @@ export function expandStage(sceneData) {
   const cfg = sceneData.defaults.stage === true ? {} : sceneData.defaults.stage;
   const [w, h, d] = cfg.size || [12, 5, 14];
   const t = 0.3; // wall thickness
-  const wall = cfg.wall || WALL;
-  const floor = cfg.floor || FLOOR;
+  const show = !!cfg.show;
+  const wall = cfg.wall || (show ? WALL_DARK : WALL);
+  const floor = cfg.floor || (show ? FLOOR_DARK : FLOOR);
+  const ceil = show ? CEIL_DARK : CEIL;
   // Which way the room opens (= the camera side). '+z' (default) suits hero
   // objects; '-z' suits chart atoms, whose connector labels face -z, so the
   // camera must sit on -z to read them. The solid back wall goes on the far side.
@@ -58,7 +68,7 @@ export function expandStage(sceneData) {
   // authored on the ground plane rest on it.
   const room = [
     box('__stage_floor', [w + 2 * t, t, d + 2 * t], [0, -t / 2, 0], floor),
-    box('__stage_ceiling', [w + 2 * t, t, d + 2 * t], [0, h + t / 2, 0], CEIL),
+    box('__stage_ceiling', [w + 2 * t, t, d + 2 * t], [0, h + t / 2, 0], ceil),
     box('__stage_wall_back', [w + 2 * t, h + 2 * t, t], [0, h / 2, backZ], wall),
     box('__stage_wall_left', [t, h + 2 * t, d + 2 * t], [-w / 2 - t / 2, h / 2, 0], wall),
     box('__stage_wall_right', [t, h + 2 * t, d + 2 * t], [w / 2 + t / 2, h / 2, 0], wall),
@@ -73,19 +83,20 @@ export function expandStage(sceneData) {
   room.push(box('__stage_panel_r', panelDims, [px, panelY, 0], PANEL_WARM));
 
   // The matching area lights (just below each panel, aimed down into the room).
+  // In show mode they become downward SPOTLIGHTS (dir) + run hotter, so the cones
+  // pool light on the hero and the dark walls stay dark; otherwise omni fill.
+  const spotDir = show ? [0, -1, 0] : [0, 0, 0];
+  const keyI = cfg.intensity ?? (show ? 4.5 : 3.0);
+  const fillI = cfg.intensity ?? (show ? 4.0 : 2.8);
   const stageLights = [
     {
       pos: [-px, h - 0.4, 0],
       color: [0.78, 0.84, 1.0],
-      intensity: cfg.intensity ?? 3.0,
+      intensity: keyI,
       radius: 2.3,
+      dir: spotDir,
     },
-    {
-      pos: [px, h - 0.4, 0],
-      color: [1.0, 0.9, 0.74],
-      intensity: cfg.intensity ?? 2.8,
-      radius: 2.3,
-    },
+    { pos: [px, h - 0.4, 0], color: [1.0, 0.9, 0.74], intensity: fillI, radius: 2.3, dir: spotDir },
   ];
 
   const defaults = { ...sceneData.defaults };
@@ -93,6 +104,9 @@ export function expandStage(sceneData) {
   const existing = Array.isArray(defaults.lights) ? defaults.lights : [];
   defaults.lights = [...existing, ...stageLights].slice(0, 4);
   if (defaults.studioBg == null) defaults.studioBg = 'dark';
+  // Show mode → theatrical dark interior: suppress sky ambient so the dark walls
+  // stay dark and the spotlight cones + beams read (renderer reads interiorDark).
+  if (show && defaults.interiorDark == null) defaults.interiorDark = 0.16;
   // validate() requires defaults.camera even though studio frames via the
   // sequence below — supply a valid neutral one if the scene authored none.
   if (defaults.camera == null) {
@@ -116,16 +130,16 @@ export function expandStage(sceneData) {
   // Show mode: dramatic volumetric lighting — a spotlight beam under each panel
   // + a low floor haze for the beams to glow in. Rendered by the studio volume
   // raymarch pass (kind god-rays / fog). Turns a lit room into a "stage".
-  if (cfg.show) {
+  if (show) {
     const beam = (id, x, color) => ({
       id,
       kind: 'god-rays',
       center: [x, h * 0.48, 0],
       size: [Math.max(2.2, w * 0.2), h * 0.95, Math.max(2.2, d * 0.18)],
-      density: 0.28,
+      density: 0.7,
       color,
       noiseScale: 1.4,
-      colorIntensity: 1.0,
+      colorIntensity: 1.6,
     });
     const showVols = [
       beam('__stage_beam_l', -px, [150, 180, 255]),


### PR DESCRIPTION
## Theatrical spotlight mode — cone lights + ambient suppression

The dramatic **dark-stage** "show" look (option 1). A lit mid-grey room washes out the volumetric beams; theatrical drama needs the room *dark* with the hero *spotlit*. Three pieces:

### 1. Spotlight cones
A `defaults.lights[]` light may carry a `dir` → the studio area-light loop applies a cone falloff (`smoothstep`, ~71° outer / ~44° inner half-angle) so the light **pools on the subject and leaves the walls dark**. Zero `dir` = omni point light (unchanged).

### 2. Ambient suppression
New `u_ambientScale` uniform scales the sky-ambient + ground bounce. `defaults.interiorDark` (`true` → 0.18, or a 0-1 number) drops it so dark walls stay dark. **Default 1.0 = every existing scene byte-identical.**

### 3. `stage.show` → theatrical
`show:true` now switches to a near-black palette, makes the two panel lights **downward spotlights**, sets `interiorDark`, and runs the beams hotter (they read against the darkness now).

So `defaults.stage.show: true` → a **spotlit hero on a dark stage** with volumetric beams + soft shadows; the plain stage (no `show`) stays the bright studio.

### Verification
- `stage-showcase` renders the dark spotlit look (walls dark, hero pooled in light, gold sphere bright).
- `gears` (non-stage): **byte-identical** (ambientScale=1, no cone, numExtraLights=0).
- `test-stage` **25/25** (+5: spotlight dir, interiorDark, dark walls, omni/full-ambient for plain); suite **85/85**; eslint clean.

Completes the "show" arc: **#99 retrace → #100 area lights → #101 stage atom → #102 Present decks → #103 show v1 (volume fix + atmosphere + cinematic camera) → this (theatrical spotlights)**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
