### PR TITLE
fix(deck-player): keyboard nav robustness (capture phase + focus grab)

### DIFF
--- a/sdf-js/examples/compositor/deck-player.js
+++ b/sdf-js/examples/compositor/deck-player.js
@@ -250,18 +250,43 @@ async function playDeck(id) {
     }
   }
 
-  window.addEventListener('keydown', (e) => {
+  const onDeckKey = (e) => {
+    // ignore while typing in a field (prompt / api-key / code editors)
+    const t = e.target;
+    if (t && (t.tagName === 'INPUT' || t.tagName === 'TEXTAREA' || t.isContentEditable)) return;
     if (e.key === ' ' || e.key === 'ArrowRight') {
       e.preventDefault();
       go(cur + 1);
     } else if (e.key === 'ArrowLeft') {
+      e.preventDefault();
       go(cur - 1);
     } else if (e.key === 'p' || e.key === 'P') {
       togglePause();
     } else if (e.key === 'r' || e.key === 'R') {
       go(cur);
     }
-  });
+  };
+  // Capture phase so deck nav wins over any bubble-phase consumer (fly controls
+  // etc.). One listener only (window capture fires before document/target) —
+  // the focus-grab below ensures the event actually dispatches.
+  window.addEventListener('keydown', onDeckKey, true);
+
+  // Make sure the page actually has keyboard focus (the #1 cause of "arrows do
+  // nothing"): focus a focusable wrap on load + whenever the stage is clicked.
+  if (wrap) {
+    if (!wrap.hasAttribute('tabindex')) wrap.tabIndex = -1;
+    wrap.style.outline = 'none';
+    const grab = () => {
+      try {
+        wrap.focus({ preventScroll: true });
+      } catch {
+        /* older browsers: focus() takes no options */
+        wrap.focus();
+      }
+    };
+    grab();
+    wrap.addEventListener('pointerdown', grab);
+  }
 
   showHint(wrap);
   go(0);


### PR DESCRIPTION
## Deck keyboard controls often did nothing — fixed

The deck nav keys (Space / ←→ / P / R) frequently had no effect: the listener was a **bubble-phase window** handler, so a keydown only reached it when the page body held focus. After load (or after clicking a UI field / the canvas) the keys went nowhere — which reads as "the deck played one segment and froze."

### Fix
- **Capture phase**: the keydown listener now runs in the capture phase, so deck nav fires before any bubble-phase consumer.
- **Focus grab**: the deck wrapper gets a `tabindex` and is `focus()`ed on load + on pointerdown, so the page reliably has keyboard focus (the #1 cause of "arrows do nothing"). Click anywhere on the stage → keys work.
- Ignores keys while typing in INPUT / TEXTAREA / contenteditable; `preventDefault` on ←→ (stop page scroll).

### Verified
With auto-advance paused, **one ArrowRight = exactly one segment advance** (no double-fire — earlier double-loads were the auto-advance timer firing during the test, not a bug). Auto-advance + wrap-around already worked.

Note: hard-refresh (Ctrl/Cmd+Shift+R) to pick up the new deck-player.js.

🤖 Generated with [Claude Code](https://claude.com/claude-code)