### PR TITLE
fix(studio): prevent GPU-watchdog (TDR) browser hang on heavy scenes

### DIFF
--- a/sdf-js/examples/compositor/compositor.js
+++ b/sdf-js/examples/compositor/compositor.js
@@ -2114,6 +2114,21 @@ function runActiveGpuRenderer({ keepCamera = false } = {}) {
     if (st.setVolumes) {
       st.setVolumes(rawScene && Array.isArray(rawScene.volumes) ? rawScene.volumes : []);
     }
+    // GPU-cost guard: studio renders at renderScale² (2×2 SSAA = 4× fragment
+    // cost). A heavy scene — volumetric beams, big fleets, procedural city, or a
+    // dense subject list — at that cost can blow the GPU's ~2s watchdog (TDR)
+    // and hang the WHOLE browser. Drop to 1× (no SSAA) for those; keep crisp
+    // SSAA for the cheap single-atom scenes the studio was tuned for.
+    if (st.setRenderScale) {
+      const subjCount = rawScene && Array.isArray(rawScene.subjects) ? rawScene.subjects.length : 0;
+      const hasVolumes = rawScene && Array.isArray(rawScene.volumes) && rawScene.volumes.length > 0;
+      const hasCity =
+        rawScene && Array.isArray(rawScene.subjects)
+          ? JSON.stringify(rawScene.subjects).includes('"procedural-city"')
+          : false;
+      const heavy = hasVolumes || hasCity || subjCount > 16;
+      st.setRenderScale(heavy ? 1.0 : 2.0);
+    }
     // Step 2 (spatial deck): a scene.cameraSequence flies the studio camera
     // through multiple slide-stations laid out in one 3D world. Studio already
     // plays it per-frame (draw loop) — just hand it the sequence (or null to

--- a/sdf-js/src/render/studio.js
+++ b/sdf-js/src/render/studio.js
@@ -1676,10 +1676,20 @@ export function createStudioRenderer({
 
   canvas.addEventListener('webglcontextlost', (e) => {
     console.error('[studio] WebGL context lost', e);
-    e.preventDefault();
+    e.preventDefault(); // allow the browser to restore later
+    // Park the loop — don't keep firing rAF against a dead context (which would
+    // spin uselessly, or worse re-submit work that re-trips the GPU watchdog).
+    contextLost = true;
+    if (rafId != null) {
+      cancelAnimationFrame(rafId);
+      rafId = null;
+    }
   });
   canvas.addEventListener('webglcontextrestored', () => {
-    console.warn('[studio] WebGL context restored — re-upload required');
+    console.warn('[studio] WebGL context restored — reviving loop');
+    contextLost = false;
+    program = null; // force a fresh GLSL program upload on the next render
+    wake();
   });
 
   // Studio default camera: eye 1.5 above ground, 2.5 units back, slight
@@ -1692,6 +1702,7 @@ export function createStudioRenderer({
   let program = null;
   let uniformsCache = {};
   let rafId = null;
+  let contextLost = false; // set by webglcontextlost handler — pauses the loop
   let flyHandle = null;
   // Render-on-demand (idle-stop): the rAF loop stops itself when nothing is
   // animating so a STATIC scene costs ~0 GPU after it settles (vs burning a full
@@ -1789,10 +1800,25 @@ export function createStudioRenderer({
   let sceneFboW = 0,
     sceneFboH = 0;
 
+  // Mutable internal-resolution scale (SSAA factor). setRenderScale() lowers it
+  // for heavy scenes (volumes / fleets) so the expensive fragment shader doesn't
+  // blow the GPU's ~2s watchdog (TDR) and hang the whole browser.
+  let curRenderScale = renderScale;
+
   // (Re)allocate the offscreen FBO when canvas size or renderScale changes.
+  // Hard-cap the internal long side: a hi-DPI / fullscreen canvas × SSAA can
+  // otherwise reach 3000²+ px of raymarch per frame → guaranteed TDR. Capping
+  // bounds the worst-case frame cost regardless of canvas size or DPI.
+  const MAX_INTERNAL_LONG = 1440;
   function ensureSceneFbo() {
-    const targetW = Math.max(1, Math.floor(canvas.width * renderScale));
-    const targetH = Math.max(1, Math.floor(canvas.height * renderScale));
+    let targetW = Math.max(1, Math.floor(canvas.width * curRenderScale));
+    let targetH = Math.max(1, Math.floor(canvas.height * curRenderScale));
+    const longSide = Math.max(targetW, targetH);
+    if (longSide > MAX_INTERNAL_LONG) {
+      const k = MAX_INTERNAL_LONG / longSide;
+      targetW = Math.max(1, Math.floor(targetW * k));
+      targetH = Math.max(1, Math.floor(targetH * k));
+    }
     if (sceneFbo && targetW === sceneFboW && targetH === sceneFboH) return;
     if (sceneFbo) gl.deleteFramebuffer(sceneFbo);
     if (sceneTex) gl.deleteTexture(sceneTex);
@@ -2421,7 +2447,7 @@ export function createStudioRenderer({
   // it's already running). Called by every state change that alters the image.
   function wake() {
     settleFrames = 0;
-    if (!rafId) {
+    if (!rafId && !contextLost) {
       fpsLast = performance.now();
       frameCount = 0;
       rafId = requestAnimationFrame(loop);
@@ -2429,6 +2455,10 @@ export function createStudioRenderer({
   }
 
   function loop() {
+    if (contextLost) {
+      rafId = null;
+      return;
+    }
     draw();
     frameCount++;
     const now = performance.now();
@@ -2602,6 +2632,18 @@ export function createStudioRenderer({
     setAnimated(v) {
       sceneAnimated = !!v;
       if (sceneAnimated) wake();
+    },
+
+    // Per-scene SSAA factor. The compositor lowers this for heavy scenes
+    // (volumes / fleets / theatrical stage) so the expensive fragment shader
+    // stays under the GPU watchdog (TDR) — a too-heavy frame hangs the whole
+    // browser, not just the tab. Reallocates the scene FBO on change.
+    setRenderScale(s) {
+      const v = Math.max(0.5, Math.min(2.0, Number(s) || 1.0));
+      if (v === curRenderScale) return;
+      curRenderScale = v;
+      ensureSceneFbo();
+      wake();
     },
 
     // Public nudge: re-render now / revive the parked loop. For any external


### PR DESCRIPTION
## Heavy stage scene hung the whole browser — fixed

**Symptom:** during the theatrical-stage deck, the screen went black after a few seconds, the tab wouldn''t close, and only killing the whole browser recovered it.

**Root cause:** the OS GPU watchdog (Windows **TDR**, ~2s) resets the driver if one GPU op runs too long — and a wedged GPU process freezes the whole (multi-tab) browser, not just the tab. Studio renders at `renderScale²` SSAA (**default 2.0 = 4× fragment cost**) with **no resolution cap**, so the heavy theatrical shader (volumetric beams + 2 spotlight soft-shadows + reflection-retrace + postfx) on a hi-DPI / fullscreen canvas ran at millions of px/frame → single frame > 2s → TDR.

## Three guards (cheap scenes unchanged)
1. **Hard internal-resolution cap** (long side ≤ 1440) in `ensureSceneFbo` — bounds the worst-case frame regardless of canvas size / `devicePixelRatio`.
2. **Adaptive SSAA** — new `setRenderScale()`; the compositor drops it to **1.0 (no SSAA, 4× cheaper)** for heavy scenes (volumes / procedural-city / >16 subjects) and keeps **2.0** for the cheap single-atom gallery scenes it was tuned for.
3. **Context-loss safety** — `webglcontextlost` now parks the rAF loop (instead of spinning against a dead context and re-tripping the watchdog); `webglcontextrestored` forces a fresh program upload + revives.

## Verified
- Theatrical `stage-showcase`: now **~79 fps (~12 ms/frame**, far under the 2s TDR) and visually unchanged.
- `gears` (non-heavy): keeps crisp 2× SSAA, no regression.
- Suite **85/85**; eslint clean.

Pairs with #105 (deck keyboard). Recommend merging both, then the deck is safe to play again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)