### PR TITLE
fix(studio): staged scenes render at 1x SSAA — fixes deck seg2 black-out

### DIFF
--- a/sdf-js/examples/compositor/compositor.js
+++ b/sdf-js/examples/compositor/compositor.js
@@ -2126,7 +2126,14 @@ function runActiveGpuRenderer({ keepCamera = false } = {}) {
         rawScene && Array.isArray(rawScene.subjects)
           ? JSON.stringify(rawScene.subjects).includes('"procedural-city"')
           : false;
-      const heavy = hasVolumes || hasCity || subjCount > 16;
+      // A stage is inherently heavy — enclosed room (every ray hits a wall) +
+      // reflection-retrace (metals re-march to reflect the walls) + per-light
+      // soft shadows. So ANY staged scene runs at 1× even without volumes:
+      // otherwise a plain staged chart (seg2 of a deck) renders at 4× cost and
+      // TDR-hangs weaker GPUs while the show segment (volumes → already 1×) is
+      // fine — exactly the "seg1 plays, seg2 goes black" asymmetry.
+      const hasStage = !!(rawScene && rawScene.defaults && rawScene.defaults.stage);
+      const heavy = hasVolumes || hasCity || hasStage || subjCount > 16;
       st.setRenderScale(heavy ? 1.0 : 2.0);
     }
     // Step 2 (spatial deck): a scene.cameraSequence flies the studio camera


### PR DESCRIPTION
## "seg1 plays, seg2 goes black" — fixed

Following the GPU-TDR fix (#106): the deck still blacked out **switching to segment 2** on weaker GPUs (and a manual → blacked immediately). The user correctly intuited it was the *transition*, not an explosion.

### Root cause (systematic)
- **Isolation**: segment 2 (`stage-data-bars`) renders fine loaded **standalone** → not a scene/camera/shader bug.
- **The only differentiator is the SSAA factor.** #106 flagged a scene "heavy" (→ `renderScale 1.0`) only on `volumes / city / >16 subjects`.
  - seg1 (show stage) has volumes → **1.0** → fine.
  - seg2 (plain staged chart) has none → **renderScale 2.0 = 4× fragment cost** → on a weaker GPU one frame blows the ~2s GPU watchdog (TDR) → black.
- seg1@1.0 works for the user; seg2@2.0 doesn''t — exactly the reported asymmetry.

### Fix
A **stage is inherently heavy** (enclosed room — every ray hits a wall — + reflection-retrace + per-light soft shadows), so **any scene with `defaults.stage` now renders at 1.0**, not just the `show` variant. Also removes the 1.0↔2.0 FBO realloc churn between staged deck segments.

```js
const hasStage = !!(rawScene?.defaults?.stage);
const heavy = hasVolumes || hasCity || hasStage || subjCount > 16;
```

### Verified
Deck seg0→seg1 transition renders the staged chart correctly at 1.0 (no black, no errors); `gears` non-stage keeps 2× SSAA; suite **85/85**. The user-GPU TDR itself needs their hardware to confirm, but their show segment already runs fine at 1.0, so the cheaper non-show stage at 1.0 will too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)