### PR TITLE
refactor(studio): extract shared scene-load core (decoupling Phase 1)

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -65,6 +65,7 @@ const TESTS = [
   { category: 'scene', file: 'sdf-js/scripts/test-gbms-batch.mjs' },
   { category: 'scene', file: 'sdf-js/scripts/test-primitive-registry-sync.mjs' },
   { category: 'scene', file: 'sdf-js/scripts/test-stage.mjs' },
+  { category: 'scene', file: 'sdf-js/scripts/test-apply-studio-scene.mjs' },
 
   // Generator-S (Phase 2 ops: array, mirror)
   { category: 'generator', file: 'sdf-js/scripts/test-generator-s.mjs' },

--- a/sdf-js/examples/compositor/compositor.js
+++ b/sdf-js/examples/compositor/compositor.js
@@ -34,9 +34,7 @@ function getUrlTokenHash() {
   }
 }
 let URL_TOKEN_HASH = getUrlTokenHash(); // mutable — #btn-new-hash reroll updates this
-import { expandVariants } from '../../src/scene/generator-s.js';
-import { expandChartLabels } from '../../src/scene/chart-labels.js';
-import { expandStage } from '../../src/scene/stage.js';
+import { expandAndCompile, wireStudioScene } from '../../src/runtime/apply-studio-scene.js';
 // Renderer id set + classifier: single source of truth (renderer-registry).
 import {
   GPU_RENDERER_IDS as GPU_RENDERERS,
@@ -723,29 +721,24 @@ async function loadDemoScene(demo) {
 
     let compiled;
     let stagedScene;
+    let renderSdf;
     try {
-      // Generator-S: expand `subjects[i].variants[]` into N flat subjects.
-      // No-op (zero rng draws) if no subject has variants. Uses state.sceneHash
-      // → SFC32 PRNG so the same hash always yields the same expansion.
-      const sceneRng = new Random(state.sceneHash);
-      const variantScene = expandVariants(data.sceneData, sceneRng);
-      // Stage connector wraps subjects in a studio room (+ panel lights, volumes,
-      // camera) when defaults.stage is set. Capture the staged scene so it can be
-      // stored as the rawScene below — otherwise setPostFx/setVolumes/setSequence
-      // get the UN-expanded scene and the lights/beams never reach the renderer.
-      stagedScene = expandStage(variantScene);
-      // #84 connector: chart subjects with args.labels → SDF text-3d-pipe labels
-      // anchored on their elements (no-op if no chart carries labels).
-      const labeledScene = expandChartLabels(stagedScene);
-      compiled = compileSceneData(labeledScene, { tokenHash: URL_TOKEN_HASH });
+      // Connector pipeline + compile, defined once in src/runtime: expandVariants
+      // (Generator-S, deterministic via state.sceneHash) → expandStage (studio
+      // room + lights/volumes/camera) → expandChartLabels → compile → ground-union.
+      // stagedScene is kept as the renderer's rawScene below so its lights /
+      // volumes / cameraSequence survive past compile and reach the wiring.
+      const out = expandAndCompile(data.sceneData, {
+        rng: new Random(state.sceneHash),
+        tokenHash: URL_TOKEN_HASH,
+      });
+      stagedScene = out.stagedScene;
+      compiled = out.compiled;
+      renderSdf = out.sdf;
     } catch (e) {
       throw new Error(`compile failed: ${e.message}`);
     }
 
-    const renderSdf =
-      compiled.groundSdf && compiled.sdf
-        ? sdfUnion(compiled.sdf, compiled.groundSdf)
-        : compiled.sdf || compiled.groundSdf;
     if (!renderSdf) throw new Error('empty SDF');
 
     state.textLiftScene = compiled;
@@ -813,24 +806,8 @@ window.atlasProjectPoint = (worldXYZ) =>
     ? state.studioRenderer.project(worldXYZ)
     : { x: 0, y: 0, visible: false };
 
-// Does a scene animate ON ITS OWN via u_time (independent of camera motion)?
-// In the studio shader only sea/water surfaces (sdWaves) and city traffic move
-// by u_time; volumes too. Conservative substring match — erring toward `true`
-// just means that scene keeps rendering (no idle-stop), never a frozen anim.
-// Charts / lifted slides match nothing → they qualify for the idle-stop.
-function sceneHasTimeContent(rawScene) {
-  if (!rawScene) return false;
-  if (Array.isArray(rawScene.volumes) && rawScene.volumes.length) return true;
-  const matStr = (m) => (typeof m === 'string' ? m : (m && m.preset) || '') || '';
-  const animMat = (m) => /sea|water/i.test(matStr(m));
-  const animType = (t) => /city|terrain|ocean|sea/i.test(t || '');
-  const visit = (s) =>
-    !!s &&
-    (animType(s.type) ||
-      animMat(s.material) ||
-      (Array.isArray(s.children) && s.children.some(visit)));
-  return Array.isArray(rawScene.subjects) && rawScene.subjects.some(visit);
-}
+// (sceneHasTimeContent moved to src/runtime/apply-studio-scene.js — the studio
+// idle-stop decision is part of the wiring it now owns.)
 
 function autofillDemoPrompt(demo) {
   const promptInput = $('prompt-input');
@@ -1673,27 +1650,24 @@ function renderLiftedSceneData(
   { shufflePalette = true } = {},
 ) {
   const liftInfo = $('lift-info');
-  // Stage connector: defaults.stage → studio room geometry + panel area lights +
-  // dark bg + interior camera. Reassign so BOTH the compiled SDF and the stored
-  // rawScene (state.textLiftSceneJSON below → setPostFx lights/camera) see it.
-  sceneData = expandStage(sceneData);
-  let compiled;
+  // Connector pipeline + compile, defined once in src/runtime (no variants on
+  // the lift path). expandStage rewrites the scene (studio room + lights +
+  // camera); stagedScene is stored as rawScene so those survive past compile.
+  let compiled, renderSdf, stagedScene;
   try {
-    // #84 connector: expand chart args.labels → SDF labels before compile.
-    compiled = compileSceneData(expandChartLabels(sceneData), { tokenHash: URL_TOKEN_HASH });
+    const out = expandAndCompile(sceneData, { tokenHash: URL_TOKEN_HASH });
+    stagedScene = out.stagedScene;
+    compiled = out.compiled;
+    renderSdf = out.sdf;
   } catch (compileErr) {
     throw new Error(`SceneData compile failed: ${compileErr.message}`);
   }
 
-  const renderSdf =
-    compiled.groundSdf && compiled.sdf
-      ? sdfUnion(compiled.sdf, compiled.groundSdf)
-      : compiled.sdf || compiled.groundSdf;
   if (!renderSdf) throw new Error('empty SDF — no subjects + no ground');
 
   state.textLiftScene = compiled;
   state.textLiftSdf = renderSdf;
-  state.textLiftSceneJSON = sceneData;
+  state.textLiftSceneJSON = stagedScene;
   state.textLiftSourcePrompt = originalPrompt;
   state.liftMode = true;
   gpuSceneStartTime = performance.now();
@@ -2145,54 +2119,12 @@ function runActiveGpuRenderer({ keepCamera = false } = {}) {
         }
       });
     }
-    if (st.setPostFx) {
-      st.setPostFx(
-        rawScene || {},
-        (rawScene && rawScene.defaults && rawScene.defaults.camera) || null,
-      );
-    }
-    // Sprint 12: Rune heightmap → studio texture (same data as FLY 3D).
-    if (st.setRuneHeightmap) st.setRuneHeightmap(scene.bakedHeightmap || null);
-    // Volumes (smoke / flame / fog / god-rays) — studio supports the volume
-    // raymarch pass but the dispatch never fed it (only FLY did). Wire it so
-    // stage "show" effects (spotlight beams + floor haze) actually render.
-    if (st.setVolumes) {
-      st.setVolumes(rawScene && Array.isArray(rawScene.volumes) ? rawScene.volumes : []);
-    }
-    // GPU-cost guard: studio renders at renderScale² (2×2 SSAA = 4× fragment
-    // cost). A heavy scene — volumetric beams, big fleets, procedural city, or a
-    // dense subject list — at that cost can blow the GPU's ~2s watchdog (TDR)
-    // and hang the WHOLE browser. Drop to 1× (no SSAA) for those; keep crisp
-    // SSAA for the cheap single-atom scenes the studio was tuned for.
-    if (st.setRenderScale) {
-      const subjCount = rawScene && Array.isArray(rawScene.subjects) ? rawScene.subjects.length : 0;
-      const hasVolumes = rawScene && Array.isArray(rawScene.volumes) && rawScene.volumes.length > 0;
-      const hasCity =
-        rawScene && Array.isArray(rawScene.subjects)
-          ? JSON.stringify(rawScene.subjects).includes('"procedural-city"')
-          : false;
-      // A stage is inherently heavy — enclosed room (every ray hits a wall) +
-      // reflection-retrace (metals re-march to reflect the walls) + per-light
-      // soft shadows. So ANY staged scene runs at 1× even without volumes:
-      // otherwise a plain staged chart (seg2 of a deck) renders at 4× cost and
-      // TDR-hangs weaker GPUs while the show segment (volumes → already 1×) is
-      // fine — exactly the "seg1 plays, seg2 goes black" asymmetry.
-      const hasStage = !!(rawScene && rawScene.defaults && rawScene.defaults.stage);
-      const heavy = hasVolumes || hasCity || hasStage || subjCount > 16;
-      st.setRenderScale(heavy ? 1.0 : 2.0);
-    }
-    // Step 2 (spatial deck): a scene.cameraSequence flies the studio camera
-    // through multiple slide-stations laid out in one 3D world. Studio already
-    // plays it per-frame (draw loop) — just hand it the sequence (or null to
-    // detach + fall back to WASD / auto-frame).
-    if (st.setSequence) st.setSequence((rawScene && rawScene.cameraSequence) || null);
-    // Render-on-demand: tell studio whether this scene animates ON ITS OWN via
-    // u_time (sea waves / city traffic). If not, the studio loop parks after the
-    // camera settles instead of burning GPU every frame on a static slide. A
-    // cameraSequence is handled separately (it drives the camera while playing).
-    if (st.setAnimated) st.setAnimated(sceneHasTimeContent(rawScene));
+    // All studio feature wiring (postFx / heightmap / volumes / renderScale /
+    // cameraSequence / animated) + render lives in ONE place: src/runtime's
+    // wireStudioScene. Adding a studio feature = edit that, not this dispatch.
+    // (Auto-frame above is gallery-specific framing, so it stays here.)
     try {
-      return st.render(sdf);
+      return wireStudioScene(st, rawScene, scene, sdf);
     } catch (e) {
       setStatus(`✗ studio render: ${e.message}`, true);
       console.error(e);

--- a/sdf-js/scripts/test-apply-studio-scene.mjs
+++ b/sdf-js/scripts/test-apply-studio-scene.mjs
@@ -1,0 +1,103 @@
+// =============================================================================
+// test-apply-studio-scene.mjs — src/runtime/apply-studio-scene.js
+// Guards the single shared studio scene-load core (Phase 1 of studio-decoupling).
+// =============================================================================
+
+import '../src/sdf/index.js';
+import {
+  sceneHasTimeContent,
+  pickRenderScale,
+  expandAndCompile,
+  wireStudioScene,
+} from '../src/runtime/apply-studio-scene.js';
+
+let pass = 0,
+  fail = 0;
+const ok = (c, n) => (c ? (pass++, console.log(`  ✓ ${n}`)) : (fail++, console.log(`  ✗ ${n}`)));
+
+console.log('=== apply-studio-scene (shared studio runtime) ===\n');
+
+const ball = (extra = {}) => ({
+  v: 1,
+  name: 't',
+  subjects: [{ id: 'b', type: 'sphere', args: { r: 0.5 }, transform: { translate: [0, 0, 0] } }],
+  defaults: {
+    camera: { yaw: 0, pitch: 0, distance: 5, focal: 1.5, targetX: 0, targetY: 0, targetZ: 0 },
+    light: { altitude: 0.5, azimuth: 0.5, distance: 50, intensity: 1 },
+  },
+  ...extra,
+});
+
+// ---- pickRenderScale (the heavy-detection that the seg2-black fix depends on) ----
+ok(pickRenderScale(ball()) === 2.0, 'plain scene → 2× SSAA');
+ok(pickRenderScale(ball({ volumes: [{ kind: 'fog' }] })) === 1.0, 'volumes → 1×');
+ok(
+  pickRenderScale({ ...ball(), defaults: { ...ball().defaults, stage: true } }) === 1.0,
+  'staged scene → 1× (the seg2-black fix)',
+);
+ok(
+  pickRenderScale({
+    v: 1,
+    subjects: Array.from({ length: 20 }, (_, i) => ({ id: `s${i}`, type: 'box' })),
+  }) === 1.0,
+  '>16 subjects → 1×',
+);
+ok(pickRenderScale(null) === 2.0, 'null scene → 2× (default)');
+
+// ---- sceneHasTimeContent (idle-stop decision) ----
+ok(sceneHasTimeContent(ball({ volumes: [{ kind: 'god-rays' }] })) === true, 'volumes animate');
+ok(sceneHasTimeContent(ball()) === false, 'plain spheres are static');
+{
+  const sea = ball();
+  sea.subjects[0].material = 'sea';
+  ok(sceneHasTimeContent(sea) === true, 'sea material animates');
+}
+ok(sceneHasTimeContent(null) === false, 'null → not animating');
+
+// ---- expandAndCompile (connectors → SDF) ----
+{
+  const { stagedScene, compiled, sdf } = expandAndCompile(ball(), {});
+  ok(typeof sdf.f === 'function', 'returns a renderable SDF');
+  ok(sdf.f([0, 0, 0]) < 0 && sdf.f([10, 10, 10]) > 0, 'SDF: inside negative, far positive');
+  ok(stagedScene.subjects.length === 1, 'no stage → subjects unchanged');
+  ok(compiled && compiled.sdf, 'returns the compiled result');
+}
+{
+  // staged scene → room geometry injected
+  const staged = { ...ball(), defaults: { ...ball().defaults, stage: true } };
+  const { stagedScene } = expandAndCompile(staged, {});
+  ok(
+    stagedScene.subjects.some((s) => s.id && s.id.startsWith('__stage_')),
+    'defaults.stage → room boxes injected before compile',
+  );
+}
+
+// ---- wireStudioScene (the ONE place studio features get pushed) ----
+{
+  const calls = {};
+  const mockStudio = {
+    setPostFx: (s, c) => (calls.postFx = { s, c }),
+    setRuneHeightmap: (h) => (calls.heightmap = h),
+    setVolumes: (v) => (calls.volumes = v),
+    setRenderScale: (r) => (calls.renderScale = r),
+    setSequence: (q) => (calls.sequence = q),
+    setAnimated: (a) => (calls.animated = a),
+    render: (sdf) => ((calls.rendered = !!sdf), { bytes: 42 }),
+  };
+  const raw = {
+    ...ball(),
+    volumes: [{ kind: 'fog' }],
+    cameraSequence: { shots: [{ duration: 1 }] },
+    defaults: { ...ball().defaults, stage: true },
+  };
+  const res = wireStudioScene(mockStudio, raw, { bakedHeightmap: null }, { f: () => -1 });
+  ok(calls.volumes && calls.volumes.length === 1, 'wires volumes');
+  ok(calls.renderScale === 1.0, 'wires renderScale (stage → 1×)');
+  ok(calls.sequence && calls.sequence.shots.length === 1, 'wires cameraSequence');
+  ok(calls.animated === true, 'wires animated (volumes)');
+  ok(calls.postFx && calls.postFx.c, 'wires postFx with the camera');
+  ok(calls.rendered === true && res.bytes === 42, 'renders + returns render result');
+}
+
+console.log(`\n=== Result: ${pass} passed, ${fail} failed ===`);
+process.exit(fail > 0 ? 1 : 0);

--- a/sdf-js/src/runtime/apply-studio-scene.js
+++ b/sdf-js/src/runtime/apply-studio-scene.js
@@ -1,0 +1,120 @@
+// =============================================================================
+// apply-studio-scene.js — the single source of truth for loading a SceneData
+// into the studio renderer.
+// -----------------------------------------------------------------------------
+// WHY this exists (Phase 1 of the studio-decoupling plan): the studio scene-load
+// logic used to be split across the compositor's loadDemoScene (expand + compile)
+// and its 8-renderer runActiveGpuRenderer dispatch (the setVolumes / setPostFx /
+// setSequence / setRenderScale / setAnimated / render wiring). Threading studio's
+// rich features through that generic multi-renderer dispatch caused a whole class
+// of "forgot to wire feature X to studio" bugs (volumes not fed, rawScene stored
+// un-expanded, renderScale gap → seg2 black). Defining it ONCE here kills that
+// class and lets a thin Atlas Present host reuse it without dragging in the
+// compositor playground.
+//
+// Three pure pieces (no DOM, no app state):
+//   • expandAndCompile(sceneData)  — connectors → SDF
+//   • wireStudioScene(studio, …)   — push the scene's features into the renderer
+//   • applyStudioScene(studio, …)  — both, for callers that want one call
+//
+// The studio renderer instance + canvas lifecycle stay the CALLER's job (the
+// compositor owns its renderer; Present owns its own). This module never creates
+// a renderer or touches the DOM.
+// =============================================================================
+
+import { compile as compileSceneData } from '../scene/index.js';
+import { expandVariants } from '../scene/generator-s.js';
+import { expandChartLabels } from '../scene/chart-labels.js';
+import { expandStage } from '../scene/stage.js';
+import { union as sdfUnion } from '../sdf/dn.js';
+
+// Does the scene change pixels on its own (no input)? Drives studio's idle-stop:
+// volumes (god-rays/fog shimmer) + sea/water materials + city/terrain types all
+// animate via u_time. (A playing cameraSequence is handled separately by studio.)
+export function sceneHasTimeContent(rawScene) {
+  if (!rawScene) return false;
+  if (Array.isArray(rawScene.volumes) && rawScene.volumes.length) return true;
+  const matStr = (m) => (typeof m === 'string' ? m : (m && m.preset) || '') || '';
+  const animMat = (m) => /sea|water/i.test(matStr(m));
+  const animType = (t) => /city|terrain|ocean|sea/i.test(t || '');
+  const visit = (s) =>
+    !!s &&
+    (animType(s.type) ||
+      animMat(s.material) ||
+      (Array.isArray(s.children) && s.children.some(visit)));
+  return Array.isArray(rawScene.subjects) && rawScene.subjects.some(visit);
+}
+
+// Studio renders at renderScale² SSAA (2.0 = 4× fragment cost). A heavy scene at
+// that cost can blow the GPU's ~2s watchdog (TDR) → black + browser hang. Drop
+// heavy scenes to 1× (no SSAA); keep crisp 2× for the cheap single-atom scenes.
+// "Heavy" = volumes / procedural-city / ANY stage (enclosed room raymarch +
+// reflection-retrace + per-light soft shadows) / a dense subject list.
+export function pickRenderScale(rawScene) {
+  const subjCount = rawScene && Array.isArray(rawScene.subjects) ? rawScene.subjects.length : 0;
+  const hasVolumes = rawScene && Array.isArray(rawScene.volumes) && rawScene.volumes.length > 0;
+  const hasCity =
+    rawScene && Array.isArray(rawScene.subjects)
+      ? JSON.stringify(rawScene.subjects).includes('"procedural-city"')
+      : false;
+  const hasStage = !!(rawScene && rawScene.defaults && rawScene.defaults.stage);
+  const heavy = hasVolumes || hasCity || hasStage || subjCount > 16;
+  return heavy ? 1.0 : 2.0;
+}
+
+/**
+ * Run the connector pipeline + compile a SceneData into a renderable SDF.
+ *   expandVariants(opt) → expandStage → expandChartLabels → compile → ground-union
+ * @param sceneData raw SceneData (v1)
+ * @param opts.rng        optional Random — runs Generator-S variant scatter
+ * @param opts.tokenHash  optional URL token hash (deterministic pattern seeds)
+ * @returns { stagedScene, compiled, sdf } — stagedScene is the post-expandStage
+ *          scene to keep as the renderer's rawScene (carries lights/volumes/
+ *          cameraSequence the wiring reads); sdf is ground-unioned + ready.
+ */
+export function expandAndCompile(sceneData, { rng = null, tokenHash } = {}) {
+  const variantScene = rng ? expandVariants(sceneData, rng) : sceneData;
+  const stagedScene = expandStage(variantScene);
+  const labeledScene = expandChartLabels(stagedScene);
+  const compiled = compileSceneData(labeledScene, { tokenHash });
+  const sdf =
+    compiled.groundSdf && compiled.sdf
+      ? sdfUnion(compiled.sdf, compiled.groundSdf)
+      : compiled.sdf || compiled.groundSdf;
+  return { stagedScene, compiled, sdf };
+}
+
+/**
+ * Push a (raw, expanded) scene's features into a studio renderer and render it.
+ * This is the ONE place studio features are wired — add a new studio feature
+ * here, not in N renderer dispatch branches.
+ * @param studio   a studio renderer instance (from createStudioRenderer)
+ * @param rawScene the expandStage output (defaults.camera/lights, volumes,
+ *                 cameraSequence live here)
+ * @param compiled the compile() result (carries bakedHeightmap)
+ * @param sdf      the renderable SDF (ground-unioned)
+ * @returns whatever studio.render returns (e.g. { bytes })
+ */
+export function wireStudioScene(studio, rawScene, compiled, sdf) {
+  const cam = (rawScene && rawScene.defaults && rawScene.defaults.camera) || null;
+  if (studio.setPostFx) studio.setPostFx(rawScene || {}, cam);
+  if (studio.setRuneHeightmap)
+    studio.setRuneHeightmap((compiled && compiled.bakedHeightmap) || null);
+  if (studio.setVolumes)
+    studio.setVolumes(rawScene && Array.isArray(rawScene.volumes) ? rawScene.volumes : []);
+  if (studio.setRenderScale) studio.setRenderScale(pickRenderScale(rawScene));
+  if (studio.setSequence) studio.setSequence((rawScene && rawScene.cameraSequence) || null);
+  if (studio.setAnimated) studio.setAnimated(sceneHasTimeContent(rawScene));
+  return studio.render(sdf);
+}
+
+/**
+ * Convenience: expand+compile a SceneData and render it into the studio in one
+ * call. The thin Atlas Present host uses this; the compositor uses the two
+ * pieces separately (its flow is split by app state + multi-renderer dispatch).
+ */
+export function applyStudioScene(studio, sceneData, opts = {}) {
+  const { stagedScene, compiled, sdf } = expandAndCompile(sceneData, opts);
+  wireStudioScene(studio, stagedScene, compiled, sdf);
+  return { stagedScene, compiled, sdf };
+}


### PR DESCRIPTION
## studio-decoupling Phase 1 — extract the studio scene-load core

Prerequisite for the thin Atlas Present host. **Pure extraction, zero behavior change.**

### Why
The studio scene-load logic was split across `loadDemoScene` (expand+compile) and the 8-renderer `runActiveGpuRenderer` dispatch (the `setVolumes`/`setPostFx`/`setSequence`/`setRenderScale`/`setAnimated`/render wiring). Threading studio''s rich features through that generic multi-renderer dispatch caused a whole bug class this session — **#103** (volumes never fed to studio), **#103** (rawScene stored un-expanded → lights lost), **#107** (renderScale heavy-gap → seg2 black). All "forgot to wire feature X to studio". Now there''s one place.

### What
- **NEW `src/runtime/apply-studio-scene.js`**:
  - `expandAndCompile(sceneData, {rng?, tokenHash?})` — connectors (variants → stage → chart-labels) → compile → ground-union.
  - `wireStudioScene(studio, rawScene, compiled, sdf)` — **the single place** studio features get pushed + render.
  - `applyStudioScene(studio, sceneData, opts)` — both, for a one-call host (Phase 2 / Present).
  - pure helpers `pickRenderScale` (incl. stage→1×, the seg2-black guard) + `sceneHasTimeContent`, moved out of compositor.
- `compositor.js`: `loadDemoScene` + `renderLiftedSceneData` call `expandAndCompile`; the studio dispatch branch calls `wireStudioScene`. Removed the duplicated inline logic, the local `sceneHasTimeContent`, and 3 now-unused imports. Gallery auto-frame stays in the dispatch (gallery-specific).
- **NEW `test-apply-studio-scene.mjs`** (20 assertions): pickRenderScale, sceneHasTimeContent, expandAndCompile (SDF + stage injection), wireStudioScene (mock studio records all wiring calls).

### Verified
Suite **87/87** (+ new test); the theatrical show scene + gears render **identically** through the refactored path with **no console errors**; eslint clean.

Honors the "don''t build parallel pipelines" lock — copies zero render/compile code, just centralizes orchestration. Next: Phase 2 (`apps/present/` thin host reusing `applyStudioScene`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)