### PR TITLE
Sprint 15B: Theme layer — 9 curated presets (3 macros × 3 colors)

### DIFF
--- a/sdf-js/examples/atoms-2d-demo/themes-9.html
+++ b/sdf-js/examples/atoms-2d-demo/themes-9.html
@@ -1,0 +1,117 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>Atlas Themes — 9 curated presets (3 macros × 3 colors)</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;900&family=IBM+Plex+Mono:wght@400;500;700&family=Quicksand:wght@400;500;600;700&family=Nunito+Sans:wght@400;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      body {
+        margin: 0;
+        padding: 24px;
+        font-family: 'Inter', system-ui;
+        background: #f8f7f4;
+      }
+      h1 { font-size: 22px; margin: 0 0 4px; }
+      h1 + p { margin: 0 0 24px; color: #666; font-size: 13px; }
+      .macro-section { margin-bottom: 40px; }
+      .macro-section h2 { font-size: 16px; margin: 0 0 12px; padding: 6px 14px; background: #1e1b1e; color: white; display: inline-block; font-family: 'IBM Plex Mono', monospace; }
+      .theme-row { display: flex; gap: 12px; flex-wrap: wrap; }
+      .theme-card { background: white; border: 1px solid #e0ddd5; border-radius: 4px; overflow: hidden; }
+      .theme-card .head { padding: 8px 12px; font-size: 11px; background: #1e1b1e; color: white; font-family: 'IBM Plex Mono', monospace; }
+      .canvases { display: flex; gap: 0; }
+      .canvases canvas { display: block; border-right: 1px solid #eee; }
+      .canvases canvas:last-child { border-right: none; }
+    </style>
+  </head>
+  <body>
+    <h1>Atlas Themes — 9 curated presets</h1>
+    <p>3 macro clusters (Editorial / Pitch / Organic) × 3 color variants each. Same atoms rendered under each theme.</p>
+    <div id="root"></div>
+    <script type="module">
+      import { renderAtom } from '/src/present/atoms-2d/registry.js';
+      import { ATLAS_THEMES, THEME_MACROS } from '/src/present/themes.js';
+
+      // Sample atoms to render under each theme (kept compact for the matrix view)
+      const SAMPLES = [
+        {
+          id: 'kpi-hero',
+          w: 260, h: 200,
+          atom: { type: 'kpi-card', args: { value: '$3.4M', label: 'Q3 Revenue', sublabel: 'vs Q2', trend: 'up', trendValue: '+27%' } },
+        },
+        {
+          id: 'bar',
+          w: 260, h: 200,
+          atom: { type: 'bar', args: { values: [1.2, 1.8, 2.4, 3.1], labels: ['Q1','Q2','Q3','Q4'], format: 'currency', title: 'Revenue ($M)' } },
+        },
+        {
+          id: 'sphere-fill',
+          w: 200, h: 200,
+          atom: { type: 'sphere-fill', args: { value: 72, label: '72%' } },
+        },
+        {
+          id: 'pie',
+          w: 260, h: 200,
+          atom: { type: 'pie', args: { values: [40, 30, 20, 10], labels: ['A','B','C','D'], format: 'percent', title: 'Share' } },
+        },
+      ];
+
+      const root = document.getElementById('root');
+      const rendered = {};
+
+      for (const macro of THEME_MACROS) {
+        const sec = document.createElement('div');
+        sec.className = 'macro-section';
+        const h = document.createElement('h2');
+        h.textContent = macro.label;
+        sec.appendChild(h);
+        const desc = document.createElement('div');
+        desc.style.cssText = 'font-size:11px;color:#666;margin-bottom:8px;';
+        desc.textContent = macro.description;
+        sec.appendChild(desc);
+        const row = document.createElement('div');
+        row.className = 'theme-row';
+        sec.appendChild(row);
+
+        const macroThemes = ATLAS_THEMES.filter((t) => t.macroCluster === macro.id);
+        for (const theme of macroThemes) {
+          const card = document.createElement('div');
+          card.className = 'theme-card';
+          card.style.background = `rgb(${theme.bg.join(',')})`;
+          const head = document.createElement('div');
+          head.className = 'head';
+          head.textContent = theme.id;
+          card.appendChild(head);
+          const canvWrap = document.createElement('div');
+          canvWrap.className = 'canvases';
+          for (const s of SAMPLES) {
+            const c = document.createElement('canvas');
+            c.id = `canvas-${theme.id}-${s.id}`;
+            c.width = s.w;
+            c.height = s.h;
+            canvWrap.appendChild(c);
+            const ctx = c.getContext('2d');
+            try {
+              await renderAtom(ctx, s.atom.type, s.atom.args, 'pseudo3d', {
+                x: 0, y: 0, w: s.w, h: s.h, palette: theme,
+              });
+              rendered[`${theme.id}-${s.id}`] = 'OK';
+            } catch (e) {
+              rendered[`${theme.id}-${s.id}`] = 'ERR: ' + e.message;
+            }
+          }
+          card.appendChild(canvWrap);
+          row.appendChild(card);
+        }
+        root.appendChild(sec);
+      }
+      window.__RENDERED__ = rendered;
+      window.__THEME_IDS__ = ATLAS_THEMES.map((t) => t.id);
+      console.log('Rendered:', JSON.stringify(rendered).slice(0, 200));
+    </script>
+  </body>
+</html>

--- a/sdf-js/scripts/test-branding-palettes.mjs
+++ b/sdf-js/scripts/test-branding-palettes.mjs
@@ -30,37 +30,41 @@ function ok(cond, name) {
 
 console.log('=== branding-palettes Sprint 9 smoke ===\n');
 
-console.log('--- built-in 5 still present (backward compat) ---');
+// Sprint 15B: BRANDING_PALETTES order is now [9 atlas + 5 built-in + 23 chromotome]
+// (atlas-first so UI surfaces them prioritally). Tests below use lookup-by-id
+// rather than fixed slice indices for forward-compat as new themes/palettes ship.
+
+console.log('--- built-in 5 still present (backward compat by id lookup) ---');
 {
   ok(Array.isArray(BRANDING_PALETTES), 'BRANDING_PALETTES is array');
-  const ids = BRANDING_PALETTES.slice(0, 5).map((p) => p.id);
-  const expected = ['mono-light', 'mono-dark', 'warm-paper', 'cool-mint', 'high-contrast'];
+  const builtInIds = ['mono-light', 'mono-dark', 'warm-paper', 'cool-mint', 'high-contrast'];
+  const found = builtInIds.map((id) => BRANDING_PALETTES.find((p) => p.id === id));
   ok(
-    JSON.stringify(ids) === JSON.stringify(expected),
-    `first 5 are built-in in order (got ${ids.join(',')})`,
+    found.every((p) => p),
+    `all 5 built-in still resolvable by id (${builtInIds.join(',')})`,
   );
+  const monoLight = getPalette('mono-light');
   ok(
-    BRANDING_PALETTES[0].bg.length === 3 && BRANDING_PALETTES[0].silhouetteColor.length === 3,
+    monoLight.bg.length === 3 && monoLight.silhouetteColor.length === 3,
     'built-in shape unchanged: {bg, silhouetteColor} as [r,g,b]',
   );
-  ok(
-    BRANDING_PALETTES[0].colors === undefined,
-    'built-in palettes have no colors[] field (backward compat)',
-  );
+  ok(monoLight.colors === undefined, 'built-in palettes have no colors[] field (backward compat)');
 }
 
-console.log('\n--- chromotome appended (Sprint 9) ---');
+console.log('\n--- chromotome present (Sprint 9) ---');
 {
   ok(BRANDING_PALETTES.length >= 5 + 20, `total ≥ 25 palettes (got ${BRANDING_PALETTES.length})`);
+  // Sprint 15B: total = 9 atlas themes + 5 built-in + chromotome count
+  const expectedTotal = 9 + 5 + CHROMOTOME_BRANDING_PALETTES.length;
   ok(
-    BRANDING_PALETTES.length === 5 + CHROMOTOME_BRANDING_PALETTES.length,
-    `total = 5 + chromotome count (${5 + CHROMOTOME_BRANDING_PALETTES.length})`,
+    BRANDING_PALETTES.length === expectedTotal,
+    `total = 9 atlas + 5 built-in + chromotome (${expectedTotal})`,
   );
 
-  const chromo = BRANDING_PALETTES.slice(5);
+  const chromo = BRANDING_PALETTES.filter((p) => p.id.startsWith('chromotome:'));
   ok(
-    chromo.every((p) => p.id.startsWith('chromotome:')),
-    'all appended palettes have chromotome: id prefix',
+    chromo.length === CHROMOTOME_BRANDING_PALETTES.length,
+    `chromotome palette count matches source (${chromo.length})`,
   );
   ok(
     chromo.every((p) => Array.isArray(p.colors) && p.colors.length >= 3),

--- a/sdf-js/src/present/branding-palettes.js
+++ b/sdf-js/src/present/branding-palettes.js
@@ -63,13 +63,21 @@ export const BRANDING_PALETTES = [
 ];
 
 /**
- * Get a preset by id; fallback to first preset if id not found.
+ * Get a preset by id; fallback to mono-light (neutral) if id not found.
+ * Pre-Sprint-15B fallback was BRANDING_PALETTES[0] which was always
+ * mono-light; with atlas themes prepended, [0] is now editorial-navy.
+ * Explicit mono-light fallback preserves backward compat for callers
+ * that relied on neutral defaults.
  *
  * @param {string} id
  * @returns {BrandingPreset}
  */
 export function getPalette(id) {
-  return BRANDING_PALETTES.find((p) => p.id === id) || BRANDING_PALETTES[0];
+  return (
+    BRANDING_PALETTES.find((p) => p.id === id) ||
+    BRANDING_PALETTES.find((p) => p.id === 'mono-light') ||
+    BRANDING_PALETTES[0]
+  );
 }
 
 /**

--- a/sdf-js/src/present/branding-palettes.js
+++ b/sdf-js/src/present/branding-palettes.js
@@ -25,6 +25,7 @@
 // =============================================================================
 
 import { CHROMOTOME_BRANDING_PALETTES } from './chromotome-palettes-data.js';
+import { ATLAS_THEMES } from './themes.js';
 
 /**
  * @typedef {object} BrandingPreset
@@ -50,11 +51,16 @@ const BUILT_IN_PALETTES = [
 ];
 
 /**
- * Full palette library: 5 built-in simple + ~23 chromotome multi-color (Sprint 9).
- * Iteration order: built-in first, then chromotome. Swap Branding menu cycles
- * through in this order. Total: 28 palettes.
+ * Full palette library: 9 Atlas themes (Sprint 15B, featured) + 5 built-in simple
+ * + ~23 chromotome multi-color (Sprint 9). Iteration order: Atlas themes first
+ * (3 macros × 3 colors), then legacy built-in, then chromotome. Total: 37
+ * palettes. Featured 9 are flagged `featured: true` for UI prioritization.
  */
-export const BRANDING_PALETTES = [...BUILT_IN_PALETTES, ...CHROMOTOME_BRANDING_PALETTES];
+export const BRANDING_PALETTES = [
+  ...ATLAS_THEMES,
+  ...BUILT_IN_PALETTES,
+  ...CHROMOTOME_BRANDING_PALETTES,
+];
 
 /**
  * Get a preset by id; fallback to first preset if id not found.

--- a/sdf-js/src/present/themes.js
+++ b/sdf-js/src/present/themes.js
@@ -1,0 +1,259 @@
+// =============================================================================
+// themes.js — Atlas Present 9 curated theme presets (3 macros × 3 colors)
+// -----------------------------------------------------------------------------
+// Sprint 15B: Adds 9 theme presets organized by PL/Gamma's 3-macro-cluster
+// theory (per [[gamma-8-template-observation]]):
+//
+//   - Editorial / Calm    — serif + soft photo + dark/cream + large negative space
+//   - Pitch / Punchy      — display sans + high contrast + saturated accent
+//   - Organic / Nature    — rounded sans + soft gradients + nature palette
+//
+// Each macro ships in 3 color variants (navy/forest/burgundy for editorial,
+// black-neon/cobalt-orange/charcoal-yellow for pitch, teal/coral/lavender for
+// organic) — 9 effective presets total.
+//
+// Schema EXTENDS branding-palettes.js BrandingPreset with:
+//   - macroCluster: 'editorial' | 'pitch' | 'organic'
+//   - accent: [r,g,b] — primary action color (often != colors[0])
+//   - font: { heading: string, body: string } — typography family per macro
+//   - featured: true — flagged for primary UI menu (vs. cycling through 28 chromotome)
+//
+// Backward compat: existing atoms reading {bg, silhouetteColor, colors[]} still
+// work; new atoms can opt into reading {accent, font} for richer theming.
+// =============================================================================
+
+/**
+ * @typedef {object} ThemePreset
+ * @property {string} id — stable identifier
+ * @property {string} label — display name
+ * @property {'editorial'|'pitch'|'organic'} macroCluster
+ * @property {[number,number,number]} bg — page background
+ * @property {[number,number,number]} silhouetteColor — primary text/fg color
+ * @property {[number,number,number]} accent — primary accent / action color
+ * @property {Array<[number,number,number]>} colors — multi-color series (charts, etc)
+ * @property {{heading: string, body: string}} font — typography families
+ * @property {true} featured — true for the 9 macro presets
+ * @property {[number,number,number]} [stroke] — optional explicit stroke color
+ */
+
+/** @type {ThemePreset[]} */
+export const ATLAS_THEMES = [
+  // ============================================================================
+  // EDITORIAL / CALM — serif + soft photo + large negative space
+  // ============================================================================
+  {
+    id: 'editorial-navy',
+    label: 'Editorial · Navy',
+    macroCluster: 'editorial',
+    bg: [248, 246, 240], // warm off-white paper
+    silhouetteColor: [22, 35, 70], // deep navy
+    accent: [38, 70, 130], // navy accent
+    colors: [
+      [38, 70, 130],
+      [110, 95, 75],
+      [165, 130, 90],
+      [200, 195, 180],
+    ],
+    font: { heading: 'Georgia, "Source Serif Pro", serif', body: 'Inter, system-ui, sans-serif' },
+    featured: true,
+  },
+  {
+    id: 'editorial-forest',
+    label: 'Editorial · Forest',
+    macroCluster: 'editorial',
+    bg: [244, 242, 232], // cream
+    silhouetteColor: [30, 55, 40], // deep forest
+    accent: [62, 110, 78], // forest green
+    colors: [
+      [62, 110, 78],
+      [140, 105, 70],
+      [200, 175, 130],
+      [165, 145, 115],
+    ],
+    font: { heading: 'Georgia, "Source Serif Pro", serif', body: 'Inter, system-ui, sans-serif' },
+    featured: true,
+  },
+  {
+    id: 'editorial-burgundy',
+    label: 'Editorial · Burgundy',
+    macroCluster: 'editorial',
+    bg: [250, 244, 238],
+    silhouetteColor: [70, 25, 30], // deep burgundy
+    accent: [140, 50, 60], // burgundy accent
+    colors: [
+      [140, 50, 60],
+      [170, 130, 80],
+      [200, 180, 140],
+      [110, 100, 90],
+    ],
+    font: { heading: 'Georgia, "Source Serif Pro", serif', body: 'Inter, system-ui, sans-serif' },
+    featured: true,
+  },
+
+  // ============================================================================
+  // PITCH / PUNCHY — display sans + high contrast + saturated accent
+  // ============================================================================
+  {
+    id: 'pitch-black-neon',
+    label: 'Pitch · Black Neon',
+    macroCluster: 'pitch',
+    bg: [16, 18, 22], // near-black
+    silhouetteColor: [240, 240, 245],
+    accent: [60, 230, 130], // neon green
+    colors: [
+      [60, 230, 130],
+      [240, 240, 245],
+      [120, 130, 145],
+      [255, 215, 60],
+    ],
+    font: {
+      heading: '"Inter Display", Inter, system-ui, sans-serif',
+      body: 'Inter, system-ui, sans-serif',
+    },
+    featured: true,
+  },
+  {
+    id: 'pitch-cobalt-orange',
+    label: 'Pitch · Cobalt Orange',
+    macroCluster: 'pitch',
+    bg: [255, 255, 255],
+    silhouetteColor: [20, 25, 50], // deep cobalt
+    accent: [255, 120, 40], // saturated orange
+    colors: [
+      [255, 120, 40],
+      [20, 60, 180],
+      [220, 220, 235],
+      [60, 65, 90],
+    ],
+    font: {
+      heading: '"Inter Display", Inter, system-ui, sans-serif',
+      body: 'Inter, system-ui, sans-serif',
+    },
+    featured: true,
+  },
+  {
+    id: 'pitch-charcoal-yellow',
+    label: 'Pitch · Charcoal Yellow',
+    macroCluster: 'pitch',
+    bg: [38, 40, 46], // charcoal
+    silhouetteColor: [248, 248, 245],
+    accent: [255, 215, 50], // bold yellow
+    colors: [
+      [255, 215, 50],
+      [248, 248, 245],
+      [180, 185, 195],
+      [120, 120, 130],
+    ],
+    font: {
+      heading: '"Inter Display", Inter, system-ui, sans-serif',
+      body: 'Inter, system-ui, sans-serif',
+    },
+    featured: true,
+  },
+
+  // ============================================================================
+  // ORGANIC / NATURE — rounded sans + soft gradients + nature palette
+  // ============================================================================
+  {
+    id: 'organic-teal',
+    label: 'Organic · Teal',
+    macroCluster: 'organic',
+    bg: [232, 244, 240], // mint mist
+    silhouetteColor: [25, 60, 65],
+    accent: [60, 145, 145], // teal
+    colors: [
+      [60, 145, 145],
+      [110, 175, 165],
+      [220, 200, 145],
+      [165, 145, 115],
+    ],
+    font: {
+      heading: '"Quicksand", "Nunito", Inter, system-ui, sans-serif',
+      body: '"Nunito Sans", Inter, system-ui, sans-serif',
+    },
+    featured: true,
+  },
+  {
+    id: 'organic-coral',
+    label: 'Organic · Coral',
+    macroCluster: 'organic',
+    bg: [253, 246, 238], // peach paper
+    silhouetteColor: [80, 40, 45],
+    accent: [230, 110, 90], // coral
+    colors: [
+      [230, 110, 90],
+      [245, 175, 130],
+      [200, 145, 130],
+      [255, 205, 175],
+    ],
+    font: {
+      heading: '"Quicksand", "Nunito", Inter, system-ui, sans-serif',
+      body: '"Nunito Sans", Inter, system-ui, sans-serif',
+    },
+    featured: true,
+  },
+  {
+    id: 'organic-lavender',
+    label: 'Organic · Lavender',
+    macroCluster: 'organic',
+    bg: [244, 240, 250],
+    silhouetteColor: [55, 40, 75],
+    accent: [135, 110, 195], // soft purple
+    colors: [
+      [135, 110, 195],
+      [180, 165, 220],
+      [205, 180, 230],
+      [120, 145, 200],
+    ],
+    font: {
+      heading: '"Quicksand", "Nunito", Inter, system-ui, sans-serif',
+      body: '"Nunito Sans", Inter, system-ui, sans-serif',
+    },
+    featured: true,
+  },
+];
+
+/**
+ * @returns {ThemePreset[]} all 9 curated themes
+ */
+export function getAtlasThemes() {
+  return ATLAS_THEMES.slice();
+}
+
+/**
+ * Get a theme by id. Returns null if not found.
+ * @param {string} id
+ * @returns {ThemePreset | null}
+ */
+export function getTheme(id) {
+  return ATLAS_THEMES.find((t) => t.id === id) || null;
+}
+
+/**
+ * @param {'editorial'|'pitch'|'organic'} macroCluster
+ * @returns {ThemePreset[]} 3 color variants for the macro
+ */
+export function getThemesByMacro(macroCluster) {
+  return ATLAS_THEMES.filter((t) => t.macroCluster === macroCluster);
+}
+
+/**
+ * Macro cluster definitions — for UI grouping.
+ */
+export const THEME_MACROS = [
+  {
+    id: 'editorial',
+    label: 'Editorial · Calm',
+    description: 'Serif typography, soft photography, generous negative space, deep colors.',
+  },
+  {
+    id: 'pitch',
+    label: 'Pitch · Punchy',
+    description: 'Display sans typography, high contrast, saturated accent colors.',
+  },
+  {
+    id: 'organic',
+    label: 'Organic · Nature',
+    description: 'Rounded sans typography, soft gradients, nature-inspired palette.',
+  },
+];


### PR DESCRIPTION
## Summary

Sprint 15B per the locked Sprint 15 plan: ship the theme layer. **9 curated presets** organized by Gamma/PL's 3-macro-cluster theory (Editorial / Pitch / Organic), each in 3 color variants. Backward-compat with existing 28-palette branding system.

## What's new

### Theme schema (`themes.js`)

Extends BrandingPreset with:
| Field | Type | Purpose |
|---|---|---|
| `macroCluster` | `'editorial' \| 'pitch' \| 'organic'` | UI grouping + design intent |
| `accent` | `[r,g,b]` | Primary action color (often != colors[0]) |
| `font` | `{heading, body}` | Typography family per macro |
| `featured` | `true` | Flagged for primary UI menu |

### 9 themes

**EDITORIAL · Calm** — serif headings + Inter body, soft warm bg, deep colors
- `editorial-navy`: deep navy + cream paper
- `editorial-forest`: forest green + cream
- `editorial-burgundy`: burgundy + warm off-white

**PITCH · Punchy** — display sans, high contrast, saturated accent
- `pitch-black-neon`: black bg + neon green
- `pitch-cobalt-orange`: white bg + orange accent + cobalt text
- `pitch-charcoal-yellow`: charcoal bg + bold yellow

**ORGANIC · Nature** — Quicksand rounded sans, soft gradients
- `organic-teal`: mint mist + teal
- `organic-coral`: peach paper + coral
- `organic-lavender`: lavender bg + soft purple

### Integration

`branding-palettes.js` extended: `BRANDING_PALETTES = [9 atlas themes + 5 legacy + 23 chromotome]` = 37 total. Atlas themes appear FIRST in iteration order so Swap Branding UI surfaces them prioritally.

Existing atoms reading `{bg, silhouetteColor, colors[]}` work unchanged (backward compat). New atoms can opt into reading `{accent, font}` for richer theming.

## Visual evidence

`screens/themes-9/themes-overview.png` (600KB) — 9 theme rows, each showing same 4 atoms (kpi-card / bar / sphere-fill / pie) under that theme. Clear visual character per macro × color.

Demo page: `http://localhost:8001/examples/atoms-2d-demo/themes-9.html`

## Test results

- npm test: 87/87 PASS unchanged
- Lint: clean
- All 36 (9 themes × 4 atom samples) render cells = OK, no errors

## Known follow-ups (not blockers)

1. Theme picker UI in main `atoms-2d-demo/index.html` (cycle through 9 featured themes, then fall through to 28 legacy palettes)
2. Some atoms still use hardcoded blue when palette.accent is set (e.g., cube-grid). Per-atom `accent` refactor wave can land separately
3. Typography integration: atoms currently use Inter exclusively. Reading `palette.font.heading` to switch to serif (editorial) / display sans (pitch) / Quicksand (organic) is a follow-up polish

Per CLAUDE.md: DO NOT merge. Awaiting user review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)