### PR TITLE
Sprint 15E: scaffold registry — 10 canonical deck templates + picker

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -156,6 +156,7 @@ const TESTS = [
   { category: 'present', file: 'sdf-js/scripts/test-pipeline.mjs' },
   { category: 'present', file: 'sdf-js/scripts/test-atoms-2d-framework.mjs' },
   { category: 'present', file: 'sdf-js/scripts/test-icon-library.mjs' },
+  { category: 'present', file: 'sdf-js/scripts/test-scaffolds.mjs' },
 ];
 
 // -----------------------------------------------------------------------------

--- a/sdf-js/examples/atoms-2d-demo/scaffolds.html
+++ b/sdf-js/examples/atoms-2d-demo/scaffolds.html
@@ -1,0 +1,143 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>Atlas Scaffold Registry — 10 deck templates</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;900&family=IBM+Plex+Mono:wght@400;500;700&display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      body { margin: 0; padding: 24px; font-family: 'Inter', system-ui; background: #f8f7f4; color: #1e1b1e; }
+      h1 { font-size: 24px; margin: 0 0 4px; }
+      h1 + p { margin: 0 0 24px; color: #666; font-size: 13px; }
+      .picker-box { background: white; border: 1px solid #d0cec3; border-radius: 6px; padding: 16px; margin-bottom: 24px; }
+      .picker-box label { display: block; font-size: 11px; color: #666; margin-bottom: 4px; font-family: 'IBM Plex Mono', monospace; }
+      .picker-box textarea { width: 100%; padding: 8px; border: 1px solid #ccc; border-radius: 4px; font-family: 'IBM Plex Mono', monospace; font-size: 12px; box-sizing: border-box; }
+      .picker-box input { width: 100%; padding: 8px; border: 1px solid #ccc; border-radius: 4px; font-family: 'Inter', sans-serif; font-size: 14px; box-sizing: border-box; margin-bottom: 8px; }
+      .picker-box button { background: #1e1b1e; color: white; border: none; padding: 10px 16px; border-radius: 4px; font-family: 'Inter', sans-serif; font-size: 13px; font-weight: 600; cursor: pointer; }
+      .picker-result { margin-top: 16px; padding: 14px; background: #f4f1e9; border-radius: 4px; font-size: 13px; }
+      .picker-result strong { display: inline-block; padding: 2px 8px; border-radius: 3px; background: #1e1b1e; color: white; font-family: 'IBM Plex Mono', monospace; font-size: 11px; margin-right: 8px; }
+      .scaffold-card { background: white; border: 1px solid #d0cec3; border-radius: 6px; padding: 18px; margin-bottom: 14px; }
+      .scaffold-head { display: flex; justify-content: space-between; align-items: baseline; margin-bottom: 6px; }
+      .scaffold-id { font-family: 'IBM Plex Mono', monospace; font-size: 11px; padding: 2px 8px; background: #1e1b1e; color: white; border-radius: 3px; }
+      .scaffold-label { font-size: 16px; font-weight: 700; }
+      .scaffold-desc { font-size: 12px; color: #666; margin-bottom: 12px; }
+      .scaffold-meta { display: flex; gap: 16px; font-size: 11px; color: #888; margin-bottom: 14px; }
+      .slot-row { display: flex; gap: 0; margin-bottom: 6px; }
+      .slot-cell { flex: 1; padding: 8px 10px; background: #f4f1e9; border: 1px solid #e0ddd0; border-right: none; font-size: 11px; line-height: 1.4; min-width: 0; }
+      .slot-cell:last-child { border-right: 1px solid #e0ddd0; }
+      .slot-name { font-family: 'IBM Plex Mono', monospace; font-weight: 700; font-size: 10px; color: #1e1b1e; margin-bottom: 2px; }
+      .slot-title { font-size: 11px; font-weight: 600; margin-bottom: 4px; }
+      .slot-purpose { color: #666; margin-bottom: 4px; }
+      .slot-atoms { color: #555; font-family: 'IBM Plex Mono', monospace; font-size: 10px; }
+      .slot-atoms .first { color: #1e1b1e; font-weight: 700; }
+      .theme-swatches { display: flex; gap: 4px; margin-top: 8px; }
+      .theme-swatch { width: 18px; height: 18px; border-radius: 3px; border: 1px solid rgba(0,0,0,0.15); }
+    </style>
+  </head>
+  <body>
+    <h1>Atlas Scaffold Registry — 10 canonical deck templates</h1>
+    <p>Sprint 15E: scaffold = slot sequence + recommended atoms per slot + theme affinity. Picker scores by keyword + audience + slot-count match.</p>
+
+    <div class="picker-box">
+      <label>TRY THE PICKER — type a deck title + paste rough body to see ranked scaffolds</label>
+      <input id="picker-title" placeholder="Title (e.g. Acme Series A Pitch)" />
+      <label>BODY (one paragraph per line)</label>
+      <textarea id="picker-body" rows="4" placeholder="Problem...&#10;Solution...&#10;Traction...&#10;Team..."></textarea>
+      <button id="picker-btn">Pick scaffold</button>
+      <div class="picker-result" id="picker-out" style="display:none;"></div>
+    </div>
+
+    <div id="scaffold-list"></div>
+
+    <script type="module">
+      import { SCAFFOLDS, scaffoldStats, getThemeAffinity } from '/src/present/scaffolds/registry.js';
+      import { pickScaffold, rankScaffolds } from '/src/present/scaffolds/picker.js';
+
+      const list = document.getElementById('scaffold-list');
+      for (const s of SCAFFOLDS) {
+        const card = document.createElement('div');
+        card.className = 'scaffold-card';
+        const head = document.createElement('div');
+        head.className = 'scaffold-head';
+        head.innerHTML = `<span class="scaffold-label">${s.label}</span><span class="scaffold-id">${s.id}</span>`;
+        card.appendChild(head);
+        const desc = document.createElement('div');
+        desc.className = 'scaffold-desc';
+        desc.textContent = s.description;
+        card.appendChild(desc);
+        const meta = document.createElement('div');
+        meta.className = 'scaffold-meta';
+        meta.innerHTML = `<span>${s.slots.length} slots</span><span>audience: ${s.audience}</span><span>keywords: ${s.keywords.slice(0, 4).join(', ')}…</span>`;
+        card.appendChild(meta);
+        const themes = getThemeAffinity(s);
+        const swatches = document.createElement('div');
+        swatches.className = 'theme-swatches';
+        for (const t of themes) {
+          const sw = document.createElement('div');
+          sw.className = 'theme-swatch';
+          sw.style.background = `rgb(${t.accent.join(',')})`;
+          sw.title = t.label;
+          swatches.appendChild(sw);
+        }
+        const swLabel = document.createElement('span');
+        swLabel.style.fontSize = '10px';
+        swLabel.style.color = '#666';
+        swLabel.style.marginLeft = '6px';
+        swLabel.style.fontFamily = 'IBM Plex Mono, monospace';
+        swLabel.textContent = themes.map((t) => t.id).join(' · ');
+        swatches.appendChild(swLabel);
+        card.appendChild(swatches);
+
+        const slotRow = document.createElement('div');
+        slotRow.className = 'slot-row';
+        for (const slot of s.slots) {
+          const cell = document.createElement('div');
+          cell.className = 'slot-cell';
+          const atoms = slot.recommended_atoms
+            .map((a, i) => (i === 0 ? `<span class="first">${a}</span>` : a))
+            .join(', ');
+          cell.innerHTML = `
+            <div class="slot-name">${slot.name}</div>
+            <div class="slot-title">${slot.title}</div>
+            <div class="slot-purpose">${slot.purpose}</div>
+            <div class="slot-atoms">${atoms}</div>
+          `;
+          slotRow.appendChild(cell);
+        }
+        card.appendChild(slotRow);
+        list.appendChild(card);
+      }
+
+      // Picker playground
+      document.getElementById('picker-btn').addEventListener('click', () => {
+        const title = document.getElementById('picker-title').value;
+        const body = document.getElementById('picker-body').value;
+        const bodyTexts = body.split('\n').filter((l) => l.trim());
+        const picked = pickScaffold({ title, bodyTexts });
+        const ranked = rankScaffolds({ title, bodyTexts }).slice(0, 5);
+        const out = document.getElementById('picker-out');
+        out.style.display = 'block';
+        out.innerHTML = `
+          <div style="margin-bottom:10px;">
+            <strong>WINNER</strong> ${picked.scaffold.label} (${picked.scaffold.id}) — score ${picked.score} ${picked.fallback ? '(fallback)' : ''}
+          </div>
+          <div style="margin-bottom:10px;font-size:11px;color:#666;">
+            theme: ${picked.theme.label} · signals: ${picked.signals.join(' · ') || 'none'}
+          </div>
+          <div style="margin-bottom:6px;font-weight:600;font-size:12px;">Top 5 ranked:</div>
+          ${ranked.map((r) => `<div style="font-size:11px;font-family:'IBM Plex Mono',monospace;padding:2px 0;">${r.score.toString().padStart(3)} · ${r.id.padEnd(22)} ${r.signals.slice(0, 3).join(' ')}</div>`).join('')}
+        `;
+      });
+
+      // Stats footer
+      const stats = scaffoldStats();
+      const footer = document.createElement('div');
+      footer.style.cssText = 'margin-top:32px;padding:14px;background:#1e1b1e;color:white;font-family:IBM Plex Mono,monospace;font-size:11px;border-radius:4px;';
+      footer.textContent = `📊 ${stats.scaffolds} scaffolds · ${stats.totalSlots} total slots · ${stats.avgSlotsPerScaffold} avg slots/scaffold · ${stats.uniqueAtomsReferenced} unique atoms referenced`;
+      document.body.appendChild(footer);
+    </script>
+  </body>
+</html>

--- a/sdf-js/scripts/test-scaffolds.mjs
+++ b/sdf-js/scripts/test-scaffolds.mjs
@@ -1,0 +1,176 @@
+// =============================================================================
+// test-scaffolds.mjs — Sprint 15E smoke test for scaffold registry + picker
+// =============================================================================
+
+import {
+  SCAFFOLDS,
+  getScaffold,
+  listScaffolds,
+  getThemeAffinity,
+  scaffoldStats,
+  totalSlots,
+} from '../src/present/scaffolds/registry.js';
+import { rankScaffolds, pickScaffold, distributeSources } from '../src/present/scaffolds/picker.js';
+import { getTheme } from '../src/present/themes.js';
+
+let pass = 0;
+let fail = 0;
+function ok(cond, name) {
+  if (cond) {
+    pass++;
+    console.log(`  ✓ ${name}`);
+  } else {
+    fail++;
+    console.log(`  ✗ ${name}`);
+  }
+}
+
+console.log('=== scaffolds registry smoke ===\n');
+
+console.log('--- registry shape ---');
+{
+  ok(SCAFFOLDS.length === 10, `10 scaffolds shipped (got ${SCAFFOLDS.length})`);
+  const ids = new Set(SCAFFOLDS.map((s) => s.id));
+  ok(ids.size === SCAFFOLDS.length, 'all scaffold ids unique');
+
+  for (const s of SCAFFOLDS) {
+    ok(typeof s.id === 'string' && s.id.length > 0, `${s.id}: has id`);
+    ok(Array.isArray(s.slots) && s.slots.length >= 3, `${s.id}: has ≥3 slots (${s.slots.length})`);
+    ok(s.slots[0].name === 'cover', `${s.id}: first slot is 'cover'`);
+    for (const slot of s.slots) {
+      ok(
+        Array.isArray(slot.recommended_atoms) && slot.recommended_atoms.length > 0,
+        `${s.id}.${slot.name}: has recommended_atoms`,
+      );
+    }
+    ok(
+      Array.isArray(s.theme_affinity) && s.theme_affinity.length > 0,
+      `${s.id}: has theme_affinity`,
+    );
+    for (const tid of s.theme_affinity) {
+      ok(getTheme(tid) !== null, `${s.id}: theme '${tid}' exists in registry`);
+    }
+  }
+}
+
+console.log('\n--- helper functions ---');
+{
+  ok(getScaffold('pitch-deck-vc') !== null, 'getScaffold resolves known id');
+  ok(getScaffold('nonsense-deck') === null, 'getScaffold returns null for unknown');
+  ok(listScaffolds().length === 10, 'listScaffolds returns 10');
+  ok(totalSlots() > 50, `totalSlots > 50 (got ${totalSlots()})`);
+  const stats = scaffoldStats();
+  ok(stats.scaffolds === 10, 'stats.scaffolds = 10');
+  ok(stats.avgSlotsPerScaffold > 5, `stats.avgSlotsPerScaffold > 5 (${stats.avgSlotsPerScaffold})`);
+  const themes = getThemeAffinity('pitch-deck-vc');
+  ok(themes.length === 3, 'getThemeAffinity returns 3 themes for pitch-deck-vc');
+  ok(themes[0].id === 'pitch-cobalt-orange', 'pitch-deck-vc top theme is cobalt-orange');
+}
+
+console.log('\n--- picker: rank + pick ---');
+{
+  // VC pitch input
+  const vcInput = {
+    title: 'Acme Series A Pitch',
+    bodyTexts: [
+      'We are raising Series A to scale our SaaS platform',
+      'Problem statement about pain points',
+      'Total addressable market is $10B',
+      'Our solution differentiates via X',
+      'Traction: $3M ARR growing 30% MoM',
+      'Team: 3 ex-Google founders',
+      'Ask: $15M for product and growth',
+    ],
+  };
+  const vcRanked = rankScaffolds(vcInput);
+  ok(vcRanked.length === 10, 'rankScaffolds returns all scaffolds');
+  ok(
+    vcRanked[0].id === 'pitch-deck-vc',
+    `VC input → pitch-deck-vc top (got ${vcRanked[0].id} score=${vcRanked[0].score})`,
+  );
+
+  // QBR input
+  const qbrInput = {
+    title: 'Q3 Business Review',
+    bodyTexts: [
+      'Q3 review for the executive team',
+      'KPI dashboard showing key metrics',
+      'Quarterly wins and milestones',
+      'Challenges we faced',
+      'Outlook for next quarter',
+    ],
+  };
+  const qbrRanked = rankScaffolds(qbrInput);
+  ok(
+    qbrRanked[0].id === 'qbr',
+    `QBR input → qbr top (got ${qbrRanked[0].id} score=${qbrRanked[0].score})`,
+  );
+
+  // Training input
+  const trainInput = {
+    title: 'How to use Atlas — Onboarding Tutorial',
+    bodyTexts: [
+      'Welcome to onboarding',
+      'Learning objectives',
+      'Step by step guide',
+      'Try it yourself',
+    ],
+  };
+  const trainRanked = rankScaffolds(trainInput);
+  ok(
+    trainRanked[0].id === 'training',
+    `Training input → training top (got ${trainRanked[0].id} score=${trainRanked[0].score})`,
+  );
+
+  // OKR input
+  const okrInput = {
+    title: 'Q4 OKR Plan',
+    bodyTexts: ['North star objective', 'Key result 1', 'Key result 2'],
+  };
+  const okrRanked = rankScaffolds(okrInput);
+  ok(
+    okrRanked[0].id === 'okr-goal-setting',
+    `OKR input → okr-goal-setting top (got ${okrRanked[0].id} score=${okrRanked[0].score})`,
+  );
+
+  // pickScaffold should return scaffold + theme + signals
+  const picked = pickScaffold(vcInput);
+  ok(picked.scaffold.id === 'pitch-deck-vc', 'pickScaffold returns scaffold');
+  ok(picked.theme && picked.theme.id, 'pickScaffold returns theme');
+  ok(Array.isArray(picked.signals) && picked.signals.length > 0, 'pickScaffold returns signals');
+  ok(!picked.fallback, 'pickScaffold not fallback for good input');
+
+  // Empty input falls back
+  const emptyPick = pickScaffold({ title: '', bodyTexts: [] });
+  ok(emptyPick.fallback === true, 'pickScaffold falls back on empty input');
+  ok(emptyPick.scaffold.id === 'company-overview', 'fallback is company-overview');
+}
+
+console.log('\n--- picker: distributeSources ---');
+{
+  const scaffold = getScaffold('qbr'); // 7 slots
+  const sources7 = Array.from({ length: 7 }, (_, i) => ({ title: `Source ${i}` }));
+  const dist7 = distributeSources(scaffold, sources7);
+  ok(dist7.length === 7, '7-source → 7 distribution');
+  ok(dist7[0].slot.name === 'cover', 'first slot is cover');
+  ok(dist7[0].source.title === 'Source 0', 'first source to first slot');
+
+  const sources3 = Array.from({ length: 3 }, (_, i) => ({ title: `S${i}` }));
+  const dist3 = distributeSources(scaffold, sources3);
+  ok(dist3.length === 7, 'fewer sources → still 7 slots');
+  ok(dist3.filter((d) => d.source !== null).length >= 3, 'at least 3 slots have sources');
+
+  const sources15 = Array.from({ length: 15 }, (_, i) => ({ title: `S${i}` }));
+  const dist15 = distributeSources(scaffold, sources15);
+  ok(dist15.length === 7, 'more sources → 7 slots');
+  ok(
+    dist15.every((d) => d.source !== null),
+    'all slots have sources when over-supplied',
+  );
+
+  const empty = distributeSources(scaffold, []);
+  ok(empty.length === 7 && empty.every((d) => d.source === null), 'empty → all null sources');
+}
+
+console.log(`\n=== Result: ${pass} passed, ${fail} failed ===`);
+process.exit(fail > 0 ? 1 : 0);

--- a/sdf-js/src/present/scaffolds/picker.js
+++ b/sdf-js/src/present/scaffolds/picker.js
@@ -1,0 +1,133 @@
+// =============================================================================
+// scaffolds/picker.js — Deterministic scaffold picker (v1, no LLM)
+// -----------------------------------------------------------------------------
+// Sprint 15E v1: simple keyword + content-shape scoring. Given input text
+// (titles + body), return ranked scaffolds with scores. A v2 LLM-wrapped
+// picker can land later — this v1 is the deterministic fallback (and the
+// guidance the v2 prompt builds on top of).
+//
+// Scoring:
+//   - Keyword match (substring on lowercase) — each hit = 3
+//   - Title match (any of scaffold.label or scaffold.id parts in title) = 5
+//   - Slot-count fit (#paragraphs vs scaffold.slots.length, prefer ±2) = 2
+// =============================================================================
+
+import { SCAFFOLDS, getScaffold, getThemeAffinity } from './registry.js';
+
+/**
+ * Score a scaffold against input text content.
+ *
+ * @param {object} input
+ * @param {string} [input.title] — deck title or first-paragraph heading
+ * @param {string[]} [input.bodyTexts] — paragraph texts (one per slide-source)
+ * @param {string} [input.audienceHint] — optional explicit audience hint
+ * @returns {{id: string, label: string, score: number, signals: string[]}[]} ranked
+ */
+export function rankScaffolds(input) {
+  const title = (input.title || '').toLowerCase();
+  const bodyJoined = (input.bodyTexts || []).join(' ').toLowerCase();
+  const sourceCount = (input.bodyTexts || []).length;
+  const audienceHint = (input.audienceHint || '').toLowerCase();
+
+  const ranked = SCAFFOLDS.map((s) => {
+    const signals = [];
+    let score = 0;
+
+    // Title direct match
+    const labelParts = s.label.toLowerCase().split(/\s+/);
+    if (labelParts.some((p) => p.length > 3 && title.includes(p))) {
+      score += 5;
+      signals.push(`title-match:${s.label}`);
+    }
+
+    // Keyword match in title+body
+    for (const kw of s.keywords) {
+      if (title.includes(kw) || bodyJoined.includes(kw)) {
+        score += 3;
+        signals.push(`keyword:${kw}`);
+      }
+    }
+
+    // Slot-count fit: distance penalty
+    if (sourceCount > 0) {
+      const diff = Math.abs(s.slots.length - sourceCount);
+      if (diff <= 2) {
+        score += 2;
+        signals.push(`slot-fit:±${diff}`);
+      } else if (diff <= 5) {
+        score += 1;
+      }
+    }
+
+    // Audience hint match
+    if (audienceHint && s.audience.toLowerCase().includes(audienceHint)) {
+      score += 4;
+      signals.push(`audience:${audienceHint}`);
+    }
+
+    return { id: s.id, label: s.label, score, signals };
+  });
+
+  ranked.sort((a, b) => b.score - a.score);
+  return ranked;
+}
+
+/**
+ * Convenience: pick the top scaffold for given input. Returns the scaffold
+ * object + recommended theme + matched signals. Falls back to 'company-overview'
+ * if no scaffold scored > 0 (a benign default).
+ *
+ * @param {object} input — see rankScaffolds
+ * @returns {{scaffold: import('./registry.js').Scaffold, theme: import('../themes.js').ThemePreset, score: number, signals: string[], fallback: boolean}}
+ */
+export function pickScaffold(input) {
+  const ranked = rankScaffolds(input);
+  const top = ranked[0];
+  const fallback = !top || top.score === 0;
+  const chosenId = fallback ? 'company-overview' : top.id;
+  const scaffold = getScaffold(chosenId);
+  const themes = getThemeAffinity(scaffold);
+  return {
+    scaffold,
+    theme: themes[0],
+    score: top ? top.score : 0,
+    signals: top ? top.signals : [],
+    fallback,
+  };
+}
+
+/**
+ * Distribute N source paragraphs across scaffold slots. Deterministic v1:
+ * - Always assigns first source to first slot (cover).
+ * - Then maps remaining proportionally by index ratio.
+ * If sourceCount < slotCount, leaves trailing slots unassigned (returns null
+ * for those).
+ *
+ * @param {import('./registry.js').Scaffold} scaffold
+ * @param {Array<{title?: string, body?: string[]}>} sources
+ * @returns {Array<{slot: import('./registry.js').ScaffoldSlot, source: object|null, slotIndex: number}>}
+ */
+export function distributeSources(scaffold, sources) {
+  if (!scaffold || !Array.isArray(sources)) return [];
+  const slots = scaffold.slots;
+  const result = [];
+  const N = sources.length;
+  const S = slots.length;
+
+  for (let i = 0; i < S; i++) {
+    let src = null;
+    if (N === 0) {
+      src = null;
+    } else if (N >= S) {
+      // More sources than slots — pick proportional index
+      const idx = Math.min(N - 1, Math.round((i / (S - 1 || 1)) * (N - 1)));
+      src = sources[idx] || null;
+    } else {
+      // Fewer sources than slots — assign by ratio, leave gaps
+      const expectedIdx = Math.round((i / (S - 1 || 1)) * (N - 1));
+      src = sources[expectedIdx] || null;
+    }
+    result.push({ slot: slots[i], source: src, slotIndex: i });
+  }
+  return result;
+}

--- a/sdf-js/src/present/scaffolds/registry.js
+++ b/sdf-js/src/present/scaffolds/registry.js
@@ -1,0 +1,701 @@
+// =============================================================================
+// scaffolds/registry.js — Atlas Present 10 canonical deck scaffolds
+// -----------------------------------------------------------------------------
+// Sprint 15E: The final layer of Sprint 15. A "scaffold" is a slot-sequence
+// template for a deck — e.g. pitch-deck-vc is [cover, problem, market-size,
+// solution, product, traction, model, team, ask]. Each slot declares what
+// kind of content goes there + which atoms-2d are recommended/forbidden.
+//
+// Two-call lift pipeline (when wired by visual-panel/pipeline.js):
+//   1. Scaffold-picker call: classify input text → pick best-fit scaffold
+//   2. Slot-fill call: for each slot, pick + parameterize atoms from
+//      recommended_atoms (with forbidden_atoms as negative constraints)
+//
+// This file is JUST the registry data. The picker logic lives in picker.js
+// (deterministic v1; LLM wrap can land in v2).
+// =============================================================================
+
+import { ATLAS_THEMES } from '../themes.js';
+
+/**
+ * @typedef {object} ScaffoldSlot
+ * @property {string} name — slot identifier (e.g. 'problem', 'cover')
+ * @property {string} title — slot display title
+ * @property {string} purpose — what content goes here (LLM hint)
+ * @property {string[]} recommended_atoms — atom types ranked best-first
+ * @property {string[]} [forbidden_atoms] — atoms that DON'T fit here
+ * @property {{minH?: number, maxH?: number, aspectHint?: 'tall'|'wide'|'square'}} [layout]
+ */
+
+/**
+ * @typedef {object} Scaffold
+ * @property {string} id — kebab-case stable identifier
+ * @property {string} label — display name
+ * @property {string} description — one-line summary
+ * @property {string} audience — comma-separated audience tags
+ * @property {ScaffoldSlot[]} slots — slot sequence (matters; first = cover, last = close)
+ * @property {string[]} theme_affinity — ranked theme ids best for this scaffold
+ * @property {string[]} keywords — match hints for deterministic picker
+ */
+
+/** @type {Scaffold[]} */
+export const SCAFFOLDS = [
+  // ============================================================================
+  // pitch-deck-vc — Sequoia/YC-style VC pitch
+  // ============================================================================
+  {
+    id: 'pitch-deck-vc',
+    label: 'VC Pitch Deck',
+    description: 'Seed/Series A fundraise pitch (Sequoia / YC structure)',
+    audience: 'vc, angel, partners',
+    keywords: ['pitch', 'fundraise', 'series', 'seed', 'investor', 'vc', 'ask', 'tam'],
+    slots: [
+      {
+        name: 'cover',
+        title: 'Title',
+        purpose: 'Company name + one-line tagline + author/date',
+        recommended_atoms: ['cover'],
+      },
+      {
+        name: 'problem',
+        title: 'Problem',
+        purpose: 'Pain point — who hurts and how much',
+        recommended_atoms: ['bullet-list', 'kpi-card', 'icon-badge'],
+        forbidden_atoms: ['org-chart', 'gantt'],
+      },
+      {
+        name: 'market-size',
+        title: 'Market Size',
+        purpose: 'TAM/SAM/SOM with numbers',
+        recommended_atoms: ['pyramid', 'kpi-card', 'sphere-fill', 'bar'],
+      },
+      {
+        name: 'solution',
+        title: 'Our Solution',
+        purpose: 'Product overview + value prop',
+        recommended_atoms: ['bullet-list', 'flow-chart', 'icon-badge'],
+      },
+      {
+        name: 'product',
+        title: 'Product Demo',
+        purpose: 'Screenshot mockup or feature highlight',
+        recommended_atoms: ['device-mockup-frame', 'device-mockup-row', 'bullet-list'],
+      },
+      {
+        name: 'traction',
+        title: 'Traction',
+        purpose: 'Revenue / users / growth charts',
+        recommended_atoms: ['line', 'bar', 'kpi-card', 'dashboard-multi-kpi-composite'],
+        forbidden_atoms: ['mindmap', 'venn'],
+      },
+      {
+        name: 'business-model',
+        title: 'Business Model',
+        purpose: 'How we make money — unit economics',
+        recommended_atoms: ['break-even', 'waterfall', 'kpi-card', 'pie'],
+      },
+      {
+        name: 'team',
+        title: 'Team',
+        purpose: 'Founders + key hires with credentials',
+        recommended_atoms: ['circle-image-hub-spoke', 'isotype-stat-comparison', 'bullet-list'],
+      },
+      {
+        name: 'ask',
+        title: 'The Ask',
+        purpose: 'Funding amount + use of funds + milestones',
+        recommended_atoms: ['kpi-card', 'pie', 'progression', 'timeline'],
+      },
+    ],
+    theme_affinity: ['pitch-cobalt-orange', 'pitch-black-neon', 'pitch-charcoal-yellow'],
+  },
+
+  // ============================================================================
+  // company-overview — recruiting / business-dev / sales intro
+  // ============================================================================
+  {
+    id: 'company-overview',
+    label: 'Company Overview',
+    description: 'Intro deck for prospects, partners, or recruits',
+    audience: 'prospect, partner, candidate, customer',
+    keywords: ['overview', 'about', 'company', 'introduction', 'who we are'],
+    slots: [
+      {
+        name: 'cover',
+        title: 'Title',
+        purpose: 'Company name + tagline',
+        recommended_atoms: ['cover'],
+      },
+      {
+        name: 'mission',
+        title: 'Mission',
+        purpose: 'Why we exist',
+        recommended_atoms: ['bullet-list', 'icon-badge'],
+      },
+      {
+        name: 'what-we-do',
+        title: 'What We Do',
+        purpose: 'Products + service overview',
+        recommended_atoms: ['flow-chart', 'magazine-column-grid', 'bullet-list'],
+      },
+      {
+        name: 'products',
+        title: 'Products',
+        purpose: 'Feature lineup',
+        recommended_atoms: ['device-mockup-row', 'magazine-column-grid', 'bullet-list'],
+      },
+      {
+        name: 'market',
+        title: 'Market',
+        purpose: 'Where we play',
+        recommended_atoms: ['pie', 'bar', 'sphere-fill', 'kpi-card'],
+      },
+      {
+        name: 'team',
+        title: 'Team',
+        purpose: 'Leadership and culture',
+        recommended_atoms: ['org-chart', 'circle-image-hub-spoke', 'bullet-list'],
+      },
+      {
+        name: 'contact',
+        title: 'Get in Touch',
+        purpose: 'Contact + CTA',
+        recommended_atoms: ['bullet-list', 'icon-badge'],
+      },
+    ],
+    theme_affinity: ['editorial-navy', 'editorial-forest', 'organic-teal'],
+  },
+
+  // ============================================================================
+  // product-launch — internal announcement / press / blog companion
+  // ============================================================================
+  {
+    id: 'product-launch',
+    label: 'Product Launch',
+    description: 'Announce a new product, feature, or release',
+    audience: 'customer, press, internal',
+    keywords: ['launch', 'release', 'announcement', 'new', 'introducing'],
+    slots: [
+      {
+        name: 'cover',
+        title: 'Title',
+        purpose: 'Product name + reveal teaser',
+        recommended_atoms: ['cover'],
+      },
+      {
+        name: 'problem',
+        title: 'Why We Built It',
+        purpose: 'The pain we are addressing',
+        recommended_atoms: ['bullet-list', 'icon-badge'],
+      },
+      {
+        name: 'feature-1',
+        title: 'Feature Highlight',
+        purpose: 'Lead feature with detail',
+        recommended_atoms: ['device-mockup-frame', 'bullet-list'],
+      },
+      {
+        name: 'feature-2',
+        title: 'Feature Highlight',
+        purpose: 'Second feature with detail',
+        recommended_atoms: ['device-mockup-frame', 'bullet-list'],
+      },
+      {
+        name: 'feature-3',
+        title: 'Feature Highlight',
+        purpose: 'Third feature with detail',
+        recommended_atoms: ['device-mockup-frame', 'bullet-list'],
+      },
+      {
+        name: 'demo',
+        title: 'See It In Action',
+        purpose: 'Visual demo / mockup',
+        recommended_atoms: ['device-mockup-row', 'flow-chart'],
+      },
+      {
+        name: 'pricing',
+        title: 'Pricing',
+        purpose: 'Plans + pricing tiers',
+        recommended_atoms: ['magazine-column-grid', 'kpi-card'],
+      },
+      {
+        name: 'cta',
+        title: 'Get Started',
+        purpose: 'CTA + next steps',
+        recommended_atoms: ['bullet-list', 'icon-badge'],
+      },
+    ],
+    theme_affinity: ['pitch-cobalt-orange', 'organic-coral', 'pitch-charcoal-yellow'],
+  },
+
+  // ============================================================================
+  // qbr — Quarterly Business Review
+  // ============================================================================
+  {
+    id: 'qbr',
+    label: 'Quarterly Business Review',
+    description: 'Internal Q review — KPIs, wins, challenges, outlook',
+    audience: 'exec, board, manager, customer-success',
+    keywords: ['qbr', 'quarterly', 'review', 'q1', 'q2', 'q3', 'q4', 'business review'],
+    slots: [
+      {
+        name: 'cover',
+        title: 'Title',
+        purpose: 'Q-name + reviewer + period',
+        recommended_atoms: ['cover'],
+      },
+      {
+        name: 'executive-summary',
+        title: 'Executive Summary',
+        purpose: '3-5 highlights at-a-glance',
+        recommended_atoms: ['dashboard-multi-kpi-composite', 'bullet-list'],
+      },
+      {
+        name: 'kpis',
+        title: 'KPI Dashboard',
+        purpose: 'Critical metrics quarter-over-quarter',
+        recommended_atoms: ['dashboard-multi-kpi-composite', 'kpi-card', 'line', 'bar'],
+      },
+      {
+        name: 'wins',
+        title: 'Wins',
+        purpose: 'What went well this quarter',
+        recommended_atoms: ['bullet-list', 'kpi-card', 'icon-badge'],
+      },
+      {
+        name: 'challenges',
+        title: 'Challenges',
+        purpose: 'What did not go to plan',
+        recommended_atoms: ['bullet-list', 'fishbone', 'waterfall'],
+      },
+      {
+        name: 'outlook',
+        title: 'Outlook',
+        purpose: 'Forecast + next-Q targets',
+        recommended_atoms: ['line', 'progression', 'kpi-card'],
+      },
+      {
+        name: 'next-steps',
+        title: 'Next Steps',
+        purpose: 'Action items + owners + dates',
+        recommended_atoms: ['bullet-list', 'timeline', 'gantt'],
+      },
+    ],
+    theme_affinity: ['editorial-navy', 'editorial-burgundy', 'pitch-cobalt-orange'],
+  },
+
+  // ============================================================================
+  // training — workshop / onboarding / how-to
+  // ============================================================================
+  {
+    id: 'training',
+    label: 'Training',
+    description: 'Workshop / onboarding / how-to-do-X',
+    audience: 'employee, customer, student',
+    keywords: ['training', 'workshop', 'tutorial', 'onboard', 'how to', 'guide'],
+    slots: [
+      {
+        name: 'cover',
+        title: 'Title',
+        purpose: 'Topic + facilitator + duration',
+        recommended_atoms: ['cover'],
+      },
+      {
+        name: 'objectives',
+        title: 'Learning Objectives',
+        purpose: 'What you will know after this',
+        recommended_atoms: ['bullet-list', 'icon-badge'],
+      },
+      {
+        name: 'context',
+        title: 'Why This Matters',
+        purpose: 'Stakes + motivation',
+        recommended_atoms: ['bullet-list', 'kpi-card', 'isotype-people-grid'],
+      },
+      {
+        name: 'concept',
+        title: 'Core Concept',
+        purpose: 'The main idea visualized',
+        recommended_atoms: ['flow-chart', 'mindmap', 'venn', 'layer-stack'],
+      },
+      {
+        name: 'steps',
+        title: 'Step by Step',
+        purpose: 'Sequential process',
+        recommended_atoms: ['progression', 'flow-chart', 'timeline'],
+      },
+      {
+        name: 'example',
+        title: 'Worked Example',
+        purpose: 'Concrete walk-through',
+        recommended_atoms: ['bullet-list', 'device-mockup-frame', 'flow-chart'],
+      },
+      {
+        name: 'exercise',
+        title: 'Try It Yourself',
+        purpose: 'Hands-on activity',
+        recommended_atoms: ['bullet-list', 'icon-badge'],
+      },
+      {
+        name: 'summary',
+        title: 'Summary',
+        purpose: 'Key takeaways',
+        recommended_atoms: ['bullet-list', 'icon-badge'],
+      },
+    ],
+    theme_affinity: ['organic-teal', 'organic-coral', 'editorial-forest'],
+  },
+
+  // ============================================================================
+  // thesis-defense — academic
+  // ============================================================================
+  {
+    id: 'thesis-defense',
+    label: 'Thesis Defense',
+    description: "PhD / Master's defense — research question, method, results",
+    audience: 'committee, examiner, peer',
+    keywords: ['thesis', 'defense', 'dissertation', 'research', 'phd', 'master'],
+    slots: [
+      {
+        name: 'cover',
+        title: 'Title',
+        purpose: 'Thesis title + author + advisor + date',
+        recommended_atoms: ['cover'],
+      },
+      {
+        name: 'research-question',
+        title: 'Research Question',
+        purpose: 'The central question',
+        recommended_atoms: ['bullet-list', 'icon-badge'],
+      },
+      {
+        name: 'literature',
+        title: 'Literature Review',
+        purpose: 'Prior work + gap',
+        recommended_atoms: ['mindmap', 'tree-diagram', 'bullet-list'],
+      },
+      {
+        name: 'methodology',
+        title: 'Methodology',
+        purpose: 'How we investigated',
+        recommended_atoms: ['flow-chart', 'progression', 'bullet-list'],
+      },
+      {
+        name: 'data',
+        title: 'Data',
+        purpose: 'What we collected',
+        recommended_atoms: ['bar', 'line', 'scatter', 'histogram', 'isotype-people-grid'],
+      },
+      {
+        name: 'results',
+        title: 'Results',
+        purpose: 'What we found',
+        recommended_atoms: ['scatter', 'bar', 'line', 'kpi-card', 'matrix-grid'],
+      },
+      {
+        name: 'discussion',
+        title: 'Discussion',
+        purpose: 'What it means',
+        recommended_atoms: ['bullet-list', 'venn', 'nine-field-matrix'],
+      },
+      {
+        name: 'limitations',
+        title: 'Limitations',
+        purpose: 'What we did not cover',
+        recommended_atoms: ['bullet-list', 'icon-badge'],
+      },
+      {
+        name: 'conclusion',
+        title: 'Conclusion',
+        purpose: 'Contribution + next steps',
+        recommended_atoms: ['bullet-list', 'icon-badge'],
+      },
+    ],
+    theme_affinity: ['editorial-navy', 'editorial-forest', 'editorial-burgundy'],
+  },
+
+  // ============================================================================
+  // business-plan — formal multi-section plan
+  // ============================================================================
+  {
+    id: 'business-plan',
+    label: 'Business Plan',
+    description: 'Formal multi-section plan for bank / advisor / partner',
+    audience: 'bank, advisor, partner, internal',
+    keywords: ['business plan', 'plan', 'strategy', 'roadmap', 'go-to-market'],
+    slots: [
+      {
+        name: 'cover',
+        title: 'Title',
+        purpose: 'Plan title + period + author',
+        recommended_atoms: ['cover'],
+      },
+      {
+        name: 'executive-summary',
+        title: 'Executive Summary',
+        purpose: 'One-pager overview',
+        recommended_atoms: ['dashboard-multi-kpi-composite', 'bullet-list'],
+      },
+      {
+        name: 'market-analysis',
+        title: 'Market Analysis',
+        purpose: 'Size + segments + competition',
+        recommended_atoms: ['pie', 'bar', 'pyramid', 'nine-field-matrix'],
+      },
+      {
+        name: 'strategy',
+        title: 'Strategy',
+        purpose: 'Positioning + go-to-market',
+        recommended_atoms: ['matrix-grid', 'venn', 'flow-chart'],
+      },
+      {
+        name: 'operations',
+        title: 'Operations',
+        purpose: 'How we deliver',
+        recommended_atoms: ['flow-chart', 'org-chart', 'progression'],
+      },
+      {
+        name: 'financials',
+        title: 'Financials',
+        purpose: 'Forecast + break-even + burn',
+        recommended_atoms: ['line', 'waterfall', 'break-even', 'kpi-card'],
+      },
+      {
+        name: 'risks',
+        title: 'Risks',
+        purpose: 'What could go wrong',
+        recommended_atoms: ['fishbone', 'matrix-grid', 'bullet-list'],
+      },
+      {
+        name: 'milestones',
+        title: 'Milestones',
+        purpose: 'Timeline + deliverables',
+        recommended_atoms: ['timeline', 'gantt', 'progression'],
+      },
+    ],
+    theme_affinity: ['editorial-navy', 'editorial-burgundy', 'pitch-cobalt-orange'],
+  },
+
+  // ============================================================================
+  // vision-mission — values / brand identity
+  // ============================================================================
+  {
+    id: 'vision-mission',
+    label: 'Vision & Mission',
+    description: 'Company vision, mission, values, principles',
+    audience: 'employee, prospect, partner',
+    keywords: ['vision', 'mission', 'values', 'principles', 'culture', 'manifesto'],
+    slots: [
+      { name: 'cover', title: 'Title', purpose: 'Brand statement', recommended_atoms: ['cover'] },
+      {
+        name: 'vision',
+        title: 'Vision',
+        purpose: 'Where we are going',
+        recommended_atoms: ['bullet-list', 'icon-badge', 'kpi-water-drop'],
+      },
+      {
+        name: 'mission',
+        title: 'Mission',
+        purpose: 'Why we exist',
+        recommended_atoms: ['bullet-list', 'icon-badge'],
+      },
+      {
+        name: 'values',
+        title: 'Values',
+        purpose: 'What we stand for (3-7)',
+        recommended_atoms: ['magazine-column-grid', 'isotype-prop-row', 'bullet-list'],
+      },
+      {
+        name: 'principles',
+        title: 'Principles',
+        purpose: 'How we work',
+        recommended_atoms: ['bullet-list', 'icon-badge', 'flow-chart'],
+      },
+      {
+        name: 'commitments',
+        title: 'Commitments',
+        purpose: 'What we promise',
+        recommended_atoms: ['bullet-list', 'icon-badge'],
+      },
+    ],
+    theme_affinity: ['organic-teal', 'organic-coral', 'organic-lavender'],
+  },
+
+  // ============================================================================
+  // strategic-plan — annual planning
+  // ============================================================================
+  {
+    id: 'strategic-plan',
+    label: 'Strategic Plan',
+    description: 'Annual planning — SWOT + goals + initiatives + metrics',
+    audience: 'exec, board, manager',
+    keywords: ['strategic', 'strategy', 'annual', 'planning', 'swot', 'goals', 'initiatives'],
+    slots: [
+      {
+        name: 'cover',
+        title: 'Title',
+        purpose: 'Plan title + period',
+        recommended_atoms: ['cover'],
+      },
+      {
+        name: 'mission',
+        title: 'Mission',
+        purpose: 'Reaffirm purpose',
+        recommended_atoms: ['bullet-list', 'icon-badge'],
+      },
+      {
+        name: 'swot',
+        title: 'SWOT',
+        purpose: 'Strengths/Weaknesses/Opportunities/Threats',
+        recommended_atoms: ['matrix-grid', 'nine-field-matrix'],
+      },
+      {
+        name: 'goals',
+        title: 'Strategic Goals',
+        purpose: '3-5 north stars',
+        recommended_atoms: ['bullet-list', 'pyramid', 'icon-badge'],
+      },
+      {
+        name: 'initiatives',
+        title: 'Initiatives',
+        purpose: 'Workstreams that move goals',
+        recommended_atoms: ['matrix-grid', 'gantt', 'magazine-column-grid'],
+      },
+      {
+        name: 'metrics',
+        title: 'Success Metrics',
+        purpose: 'How we measure progress',
+        recommended_atoms: ['dashboard-multi-kpi-composite', 'line', 'kpi-card'],
+      },
+      {
+        name: 'timeline',
+        title: 'Timeline',
+        purpose: 'Milestones across the year',
+        recommended_atoms: ['gantt', 'timeline', 'progression'],
+      },
+    ],
+    theme_affinity: ['editorial-navy', 'editorial-forest', 'pitch-cobalt-orange'],
+  },
+
+  // ============================================================================
+  // okr-goal-setting — quarterly objectives
+  // ============================================================================
+  {
+    id: 'okr-goal-setting',
+    label: 'OKR Goal-Setting',
+    description: 'Objectives + Key Results for the quarter',
+    audience: 'team, individual, manager',
+    keywords: ['okr', 'goal', 'objective', 'key result', 'kr', 'north star'],
+    slots: [
+      {
+        name: 'cover',
+        title: 'Title',
+        purpose: 'OKR period + owner',
+        recommended_atoms: ['cover'],
+      },
+      {
+        name: 'north-star',
+        title: 'North Star',
+        purpose: 'The big-picture company KR',
+        recommended_atoms: ['kpi-card', 'sphere-fill', 'kpi-water-drop'],
+      },
+      {
+        name: 'objective-1',
+        title: 'Objective',
+        purpose: 'Aspirational, qualitative',
+        recommended_atoms: ['bullet-list', 'icon-badge'],
+      },
+      {
+        name: 'key-results-1',
+        title: 'Key Results',
+        purpose: 'Measurable outcomes for O1',
+        recommended_atoms: ['dashboard-multi-kpi-composite', 'progression', 'kpi-card'],
+      },
+      {
+        name: 'objective-2',
+        title: 'Objective',
+        purpose: 'Aspirational, qualitative',
+        recommended_atoms: ['bullet-list', 'icon-badge'],
+      },
+      {
+        name: 'key-results-2',
+        title: 'Key Results',
+        purpose: 'Measurable outcomes for O2',
+        recommended_atoms: ['dashboard-multi-kpi-composite', 'progression', 'kpi-card'],
+      },
+      {
+        name: 'actions',
+        title: 'Top Actions',
+        purpose: 'This-week / this-month priorities',
+        recommended_atoms: ['bullet-list', 'gantt', 'timeline'],
+      },
+      {
+        name: 'milestones',
+        title: 'Milestones',
+        purpose: 'Date-anchored checkpoints',
+        recommended_atoms: ['timeline', 'progression', 'gantt'],
+      },
+    ],
+    theme_affinity: ['pitch-cobalt-orange', 'pitch-black-neon', 'organic-teal'],
+  },
+];
+
+/**
+ * Total slots across all scaffolds — useful for stats.
+ * @returns {number}
+ */
+export function totalSlots() {
+  return SCAFFOLDS.reduce((sum, s) => sum + s.slots.length, 0);
+}
+
+/**
+ * Look up a scaffold by id. Returns null if not found.
+ * @param {string} id
+ * @returns {Scaffold|null}
+ */
+export function getScaffold(id) {
+  return SCAFFOLDS.find((s) => s.id === id) || null;
+}
+
+/**
+ * List all scaffolds (clones the array, safe to mutate).
+ * @returns {Scaffold[]}
+ */
+export function listScaffolds() {
+  return SCAFFOLDS.slice();
+}
+
+/**
+ * For a given scaffold, return the affine theme objects ranked best-first.
+ * Falls back to the first 3 atlas themes if affinity is empty.
+ * @param {Scaffold|string} scaffoldOrId
+ * @returns {import('../themes.js').ThemePreset[]}
+ */
+export function getThemeAffinity(scaffoldOrId) {
+  const scaffold = typeof scaffoldOrId === 'string' ? getScaffold(scaffoldOrId) : scaffoldOrId;
+  if (!scaffold) return [];
+  const ranked = scaffold.theme_affinity
+    .map((id) => ATLAS_THEMES.find((t) => t.id === id))
+    .filter(Boolean);
+  return ranked.length > 0 ? ranked : ATLAS_THEMES.slice(0, 3);
+}
+
+/**
+ * Aggregate stats — useful for inventory dashboards.
+ */
+export function scaffoldStats() {
+  const totalScaffoldCount = SCAFFOLDS.length;
+  const slotCount = totalSlots();
+  const uniqueAtomsRecommended = new Set();
+  for (const s of SCAFFOLDS) {
+    for (const slot of s.slots) {
+      for (const a of slot.recommended_atoms) uniqueAtomsRecommended.add(a);
+    }
+  }
+  return {
+    scaffolds: totalScaffoldCount,
+    totalSlots: slotCount,
+    uniqueAtomsReferenced: uniqueAtomsRecommended.size,
+    avgSlotsPerScaffold: Math.round((slotCount / totalScaffoldCount) * 10) / 10,
+  };
+}


### PR DESCRIPTION
## Summary

Final sub-sprint of Sprint 15. A **scaffold** is a slot-sequence template for a deck — e.g. `pitch-deck-vc` = `[cover, problem, market-size, solution, product, traction, business-model, team, ask]`. Each slot declares purpose + recommended atoms + (optional) forbidden atoms + theme affinity.

Foundation for a **2-call lift pipeline** (will be wired by `visual-panel/pipeline.js` in a follow-up):
1. **Scaffold-picker call** — classifies input text → picks best-fit scaffold
2. **Slot-fill call** — for each slot, picks + parameterizes atoms from `recommended_atoms[]` menu

## 10 scaffolds shipped

| id | slots | audience |
|----|-------|----------|
| pitch-deck-vc | 9 | vc/angel/partners |
| company-overview | 7 | prospect/partner/candidate |
| product-launch | 8 | customer/press/internal |
| qbr | 7 | exec/board/manager |
| training | 8 | employee/customer/student |
| thesis-defense | 9 | committee/examiner/peer |
| business-plan | 8 | bank/advisor/partner |
| vision-mission | 6 | employee/prospect |
| strategic-plan | 7 | exec/board/manager |
| okr-goal-setting | 8 | team/individual/manager |

**Total**: 77 slots across 10 scaffolds, ~36 unique atom types referenced.

## Each scaffold ships with

- `slots[]` — ordered slot sequence with `name/title/purpose/recommended_atoms`
- `theme_affinity[]` — ranked theme ids that fit best (3 themes each, references existing 9 atlas themes from PR #121)
- `keywords[]` — match hints for deterministic picker
- `audience` — comma-separated audience tags for picker boost

## Deterministic picker (v1)

`pickScaffold({title, bodyTexts, audienceHint?})` returns best-fit scaffold + top theme + match signals. Scoring:
- Title direct match: **+5**
- Each keyword hit (title+body): **+3**
- Slot-count fit (±2): **+2**
- Audience hint match: **+4**
- Fallback to `company-overview` when no scaffold scores > 0

`distributeSources(scaffold, sources)` maps N source paragraphs to scaffold slots (proportional indexing; first source → cover; gaps left as null when N < S).

**v2 LLM-wrapped picker** can land later — the v1 picker is the deterministic fallback AND the guidance the v2 prompt builds on.

## Testing

- New: `sdf-js/scripts/test-scaffolds.mjs` — **176 assertions**
- Registered in `scripts/run-tests.mjs` — **88/88 PASS** (was 87)
- All 4 representative inputs pick correct top: VC → pitch-deck-vc (16), QBR → qbr (19), Training → training (13), OKR → okr-goal-setting (16)

## Demo

`examples/atoms-2d-demo/scaffolds.html` — visual registry showing each scaffold as a card (slot row + theme swatches) + interactive picker playground at top. Screenshot: `screens/scaffolds/registry-page.png`

## Sprint 15 complete

- ✅ 15c icon library
- ✅ 15a chart atoms (8)
- ✅ Polish wave 1 (13)
- ✅ 15b infographic idioms (10)
- ✅ 3D polish 1+2 (9)
- ✅ E2E sphere-fill demo (5 iter)
- ✅ Theme layer (9 themes)
- ✅ Polish wave 3 (6)
- ✅ Polish wave 4 audit
- ✅ **15E scaffold registry — this PR**

Next: wire scaffold-picker into `visual-panel/pipeline.js` for end-to-end PDF → scaffolded deck flow.

Per CLAUDE.md: DO NOT merge. Awaiting user review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)