### PR TITLE
Sprint 16: scaffold-driven 2-call pipeline (PDF → assembled deck E2E)

### DIFF
--- a/sdf-js/examples/atoms-2d-demo/scaffold-deck-viewer.html
+++ b/sdf-js/examples/atoms-2d-demo/scaffold-deck-viewer.html
@@ -1,0 +1,167 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>Scaffold Deck Viewer — assembled deck preview</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;900&family=IBM+Plex+Mono:wght@400;500;700&display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      body { margin: 0; padding: 24px; font-family: 'Inter', system-ui; background: #f8f7f4; color: #1e1b1e; }
+      h1 { font-size: 24px; margin: 0 0 4px; }
+      h1 + p { margin: 0 0 24px; color: #666; font-size: 13px; }
+      .deck-meta { background: white; border: 1px solid #d0cec3; border-radius: 6px; padding: 14px; margin-bottom: 24px; font-size: 13px; }
+      .deck-meta strong { font-family: 'IBM Plex Mono', monospace; font-size: 11px; padding: 2px 8px; background: #1e1b1e; color: white; border-radius: 3px; margin-right: 8px; }
+      .slot-card { background: white; border: 1px solid #d0cec3; border-radius: 6px; margin-bottom: 24px; overflow: hidden; }
+      .slot-head { padding: 12px 18px; display: flex; justify-content: space-between; align-items: baseline; border-bottom: 1px solid #e8e5dc; }
+      .slot-head .left { display: flex; gap: 14px; align-items: baseline; }
+      .slot-num { font-family: 'IBM Plex Mono', monospace; font-size: 11px; background: #1e1b1e; color: white; padding: 3px 8px; border-radius: 3px; }
+      .slot-title { font-size: 17px; font-weight: 700; }
+      .slot-purpose { font-size: 12px; color: #666; }
+      .slot-meta { font-family: 'IBM Plex Mono', monospace; font-size: 10px; color: #888; }
+      .slot-canvas-wrap { padding: 16px; background: #f4f1e9; display: flex; justify-content: center; }
+      canvas { box-shadow: 0 4px 12px rgba(0,0,0,0.08); border-radius: 4px; }
+      .controls { margin-bottom: 18px; }
+      .controls select { padding: 8px 12px; font-family: 'Inter'; font-size: 14px; border: 1px solid #ccc; border-radius: 4px; background: white; }
+      .controls button { padding: 8px 14px; margin-left: 8px; font-family: 'Inter'; font-size: 13px; font-weight: 600; background: #1e1b1e; color: white; border: none; border-radius: 4px; cursor: pointer; }
+      .empty-banner { padding: 40px; text-align: center; color: #888; font-style: italic; }
+    </style>
+  </head>
+  <body>
+    <h1>Scaffold Deck Viewer</h1>
+    <p>End-to-end PDF → scaffolded deck. Loads <code>deck.json</code> + per-slot lift JSONs → renders each slot to canvas. Sprint 16 v1.</p>
+
+    <div class="controls">
+      <label>Deck:</label>
+      <select id="deck-picker">
+        <option value="examples/scaffold-pipeline/vc-pitch/deck.json">VC Pitch (synthetic 9-slide)</option>
+        <option value="examples/scaffold-pipeline/slidedata/deck.json">PD sphere-fill 20-slide</option>
+      </select>
+      <button id="reload-btn">Reload</button>
+    </div>
+
+    <div id="root"></div>
+
+    <script type="module">
+      import { renderAtom } from '/src/present/atoms-2d/registry.js';
+
+      async function loadDeck() {
+        const url = document.getElementById('deck-picker').value;
+        const root = document.getElementById('root');
+        root.innerHTML = '<div style="padding:40px;text-align:center;color:#888;">Loading...</div>';
+
+        let manifest;
+        try {
+          const res = await fetch(`/${url}?_=${Date.now()}`);
+          if (!res.ok) throw new Error(`HTTP ${res.status}`);
+          manifest = await res.json();
+        } catch (e) {
+          root.innerHTML = `<div class="empty-banner">Failed to load /${url}: ${e.message}<br><br>Bake first via <code>node sdf-js/scripts/bake-scaffold-pipeline.mjs</code></div>`;
+          return;
+        }
+
+        root.innerHTML = '';
+
+        // Deck-level meta
+        const meta = document.createElement('div');
+        meta.className = 'deck-meta';
+        meta.innerHTML = `
+          <div><strong>SCAFFOLD</strong> ${manifest.scaffold.label} (${manifest.scaffold.id}) · pick score ${manifest.scaffold.pickScore}${manifest.scaffold.fallback ? ' [FALLBACK]' : ''}</div>
+          <div style="margin-top:6px;"><strong>THEME</strong> ${manifest.theme.label} · ${manifest.theme.macroCluster}</div>
+          <div style="margin-top:6px;"><strong>STATS</strong> ${manifest.totals.slotsBaked}/${manifest.slots.length} slots baked · cost $${manifest.totals.totalCostUSD.toFixed(4)} · ${manifest.meta.model}</div>
+          ${manifest.scaffold.pickSignals && manifest.scaffold.pickSignals.length > 0 ? `<div style="margin-top:6px;font-size:11px;color:#666;font-family:'IBM Plex Mono',monospace;">signals: ${manifest.scaffold.pickSignals.join(', ')}</div>` : ''}
+        `;
+        root.appendChild(meta);
+
+        // Render each slot
+        for (const slotRef of manifest.slots) {
+          const card = document.createElement('div');
+          card.className = 'slot-card';
+
+          const head = document.createElement('div');
+          head.className = 'slot-head';
+          head.innerHTML = `
+            <div class="left">
+              <span class="slot-num">${slotRef.slotIdx}</span>
+              <div>
+                <div class="slot-title">${slotRef.slotTitle}</div>
+                <div class="slot-purpose">${slotRef.slotPurpose}</div>
+              </div>
+            </div>
+            <div class="slot-meta">
+              ${slotRef.slotName} · src slide ${slotRef.sourceSlideIdx} · atoms: ${slotRef.subjectTypes.join(', ') || '—'}
+            </div>
+          `;
+          card.appendChild(head);
+
+          const canvWrap = document.createElement('div');
+          canvWrap.className = 'slot-canvas-wrap';
+
+          if (slotRef.error) {
+            canvWrap.innerHTML = `<div style="color:#a00;padding:40px;">ERROR: ${slotRef.error}</div>`;
+            card.appendChild(canvWrap);
+            root.appendChild(card);
+            continue;
+          }
+
+          if (!slotRef.liftFile) {
+            canvWrap.innerHTML = `<div class="empty-banner">No lift file (dry-run or skipped)</div>`;
+            card.appendChild(canvWrap);
+            root.appendChild(card);
+            continue;
+          }
+
+          // Fetch slot lift
+          const slotLiftUrl = `/examples/scaffold-pipeline/${manifest.deckName}/${slotRef.liftFile}`;
+          let slotLift;
+          try {
+            const r = await fetch(slotLiftUrl + `?_=${Date.now()}`);
+            slotLift = await r.json();
+          } catch (e) {
+            canvWrap.innerHTML = `<div style="color:#a00;padding:40px;">Failed to fetch ${slotLiftUrl}: ${e.message}</div>`;
+            card.appendChild(canvWrap);
+            root.appendChild(card);
+            continue;
+          }
+
+          const canvas = document.createElement('canvas');
+          canvas.width = 1280;
+          canvas.height = 720;
+          canvas.style.background = `rgb(${manifest.theme.bg.join(',')})`;
+          canvas.style.width = '960px';
+          canvas.style.height = '540px';
+          canvWrap.appendChild(canvas);
+          card.appendChild(canvWrap);
+          root.appendChild(card);
+
+          const ctx = canvas.getContext('2d');
+          ctx.fillStyle = `rgb(${manifest.theme.bg.join(',')})`;
+          ctx.fillRect(0, 0, canvas.width, canvas.height);
+
+          // Render each subject
+          for (const subject of (slotLift.sceneData.subjects || [])) {
+            try {
+              await renderAtom(ctx, subject.type, subject.args, 'pseudo3d', {
+                x: subject.x ?? 0,
+                y: subject.y ?? 0,
+                w: subject.w ?? 320,
+                h: subject.h ?? 240,
+                palette: manifest.theme,
+              });
+            } catch (e) {
+              console.error(`Failed to render ${subject.type}:`, e);
+              ctx.fillStyle = 'rgba(200,0,0,0.3)';
+              ctx.fillRect(subject.x ?? 0, subject.y ?? 0, subject.w ?? 100, subject.h ?? 100);
+            }
+          }
+        }
+      }
+
+      document.getElementById('reload-btn').addEventListener('click', loadDeck);
+      document.getElementById('deck-picker').addEventListener('change', loadDeck);
+      loadDeck();
+    </script>
+  </body>
+</html>

--- a/sdf-js/examples/scaffold-pipeline/slidedata/deck.json
+++ b/sdf-js/examples/scaffold-pipeline/slidedata/deck.json
@@ -1,0 +1,154 @@
+{
+  "deckName": "slidedata",
+  "sourceFile": "sdf-js/examples/pdf-demo/slidedata.json",
+  "scaffold": {
+    "id": "company-overview",
+    "label": "Company Overview",
+    "description": "Intro deck for prospects, partners, or recruits",
+    "pickScore": 0,
+    "pickSignals": [],
+    "fallback": true
+  },
+  "theme": {
+    "id": "editorial-navy",
+    "label": "Editorial · Navy",
+    "macroCluster": "editorial",
+    "bg": [248, 246, 240],
+    "accent": [38, 70, 130],
+    "colors": [
+      [38, 70, 130],
+      [110, 95, 75],
+      [165, 130, 90],
+      [200, 195, 180]
+    ],
+    "font": {
+      "heading": "Georgia, \"Source Serif Pro\", serif",
+      "body": "Inter, system-ui, sans-serif"
+    }
+  },
+  "slots": [
+    {
+      "slotIdx": 0,
+      "slotName": "cover",
+      "slotTitle": "Title",
+      "slotPurpose": "Company name + tagline",
+      "sourceSlideIdx": 0,
+      "sourceSlideTitle": "3D SPHERES",
+      "mappingScore": 0,
+      "mappingFallback": true,
+      "mappingEmpty": false,
+      "liftFile": null,
+      "cached": false,
+      "dryRun": true,
+      "error": null,
+      "subjectTypes": []
+    },
+    {
+      "slotIdx": 1,
+      "slotName": "mission",
+      "slotTitle": "Mission",
+      "slotPurpose": "Why we exist",
+      "sourceSlideIdx": 1,
+      "sourceSlideTitle": "3D SPHERES",
+      "mappingScore": 0,
+      "mappingFallback": true,
+      "mappingEmpty": false,
+      "liftFile": null,
+      "cached": false,
+      "dryRun": true,
+      "error": null,
+      "subjectTypes": []
+    },
+    {
+      "slotIdx": 2,
+      "slotName": "what-we-do",
+      "slotTitle": "What We Do",
+      "slotPurpose": "Products + service overview",
+      "sourceSlideIdx": 2,
+      "sourceSlideTitle": "3D SPHERES",
+      "mappingScore": 0,
+      "mappingFallback": true,
+      "mappingEmpty": false,
+      "liftFile": null,
+      "cached": false,
+      "dryRun": true,
+      "error": null,
+      "subjectTypes": []
+    },
+    {
+      "slotIdx": 3,
+      "slotName": "products",
+      "slotTitle": "Products",
+      "slotPurpose": "Feature lineup",
+      "sourceSlideIdx": 3,
+      "sourceSlideTitle": "3D SPHERES",
+      "mappingScore": 0,
+      "mappingFallback": true,
+      "mappingEmpty": false,
+      "liftFile": null,
+      "cached": false,
+      "dryRun": true,
+      "error": null,
+      "subjectTypes": []
+    },
+    {
+      "slotIdx": 4,
+      "slotName": "market",
+      "slotTitle": "Market",
+      "slotPurpose": "Where we play",
+      "sourceSlideIdx": 4,
+      "sourceSlideTitle": "3D SPHERES",
+      "mappingScore": 0,
+      "mappingFallback": true,
+      "mappingEmpty": false,
+      "liftFile": null,
+      "cached": false,
+      "dryRun": true,
+      "error": null,
+      "subjectTypes": []
+    },
+    {
+      "slotIdx": 5,
+      "slotName": "team",
+      "slotTitle": "Team",
+      "slotPurpose": "Leadership and culture",
+      "sourceSlideIdx": 5,
+      "sourceSlideTitle": "3D SPHERES",
+      "mappingScore": 0,
+      "mappingFallback": true,
+      "mappingEmpty": false,
+      "liftFile": null,
+      "cached": false,
+      "dryRun": true,
+      "error": null,
+      "subjectTypes": []
+    },
+    {
+      "slotIdx": 6,
+      "slotName": "contact",
+      "slotTitle": "Get in Touch",
+      "slotPurpose": "Contact + CTA",
+      "sourceSlideIdx": 6,
+      "sourceSlideTitle": "3D SPHERES",
+      "mappingScore": 0,
+      "mappingFallback": true,
+      "mappingEmpty": false,
+      "liftFile": null,
+      "cached": false,
+      "dryRun": true,
+      "error": null,
+      "subjectTypes": []
+    }
+  ],
+  "totals": {
+    "slotsBaked": 7,
+    "slotsEmpty": 0,
+    "slotsErrored": 0,
+    "totalCostUSD": 0
+  },
+  "meta": {
+    "generatedAt": "2026-06-22T15:00:43.060Z",
+    "model": "claude-sonnet-4-5-20250929",
+    "pipelineVersion": "sprint-16-v1"
+  }
+}

--- a/sdf-js/examples/scaffold-pipeline/vc-pitch/deck.json
+++ b/sdf-js/examples/scaffold-pipeline/vc-pitch/deck.json
@@ -1,0 +1,192 @@
+{
+  "deckName": "vc-pitch",
+  "sourceFile": "sdf-js/scripts/scaffold-pipeline-fixtures/vc-pitch.json",
+  "scaffold": {
+    "id": "pitch-deck-vc",
+    "label": "VC Pitch Deck",
+    "description": "Seed/Series A fundraise pitch (Sequoia / YC structure)",
+    "pickScore": 17,
+    "pickSignals": [
+      "title-match:VC Pitch Deck",
+      "keyword:pitch",
+      "keyword:fundraise",
+      "keyword:series",
+      "keyword:ask"
+    ],
+    "fallback": false
+  },
+  "theme": {
+    "id": "pitch-cobalt-orange",
+    "label": "Pitch · Cobalt Orange",
+    "macroCluster": "pitch",
+    "bg": [255, 255, 255],
+    "accent": [255, 120, 40],
+    "colors": [
+      [255, 120, 40],
+      [20, 60, 180],
+      [220, 220, 235],
+      [60, 65, 90]
+    ],
+    "font": {
+      "heading": "\"Inter Display\", Inter, system-ui, sans-serif",
+      "body": "Inter, system-ui, sans-serif"
+    }
+  },
+  "slots": [
+    {
+      "slotIdx": 0,
+      "slotName": "cover",
+      "slotTitle": "Title",
+      "slotPurpose": "Company name + one-line tagline + author/date",
+      "sourceSlideIdx": 0,
+      "sourceSlideTitle": "Atlas Series A Pitch",
+      "mappingScore": 0,
+      "mappingFallback": true,
+      "mappingEmpty": false,
+      "liftFile": "slots/slot-00-cover.json",
+      "cached": false,
+      "dryRun": false,
+      "error": null,
+      "subjectTypes": ["cover"]
+    },
+    {
+      "slotIdx": 1,
+      "slotName": "problem",
+      "slotTitle": "Problem",
+      "slotPurpose": "Pain point — who hurts and how much",
+      "sourceSlideIdx": 1,
+      "sourceSlideTitle": "The Problem",
+      "mappingScore": 2,
+      "mappingFallback": false,
+      "mappingEmpty": false,
+      "liftFile": "slots/slot-01-problem.json",
+      "cached": false,
+      "dryRun": false,
+      "error": null,
+      "subjectTypes": ["bullet-list", "kpi-card", "icon-badge", "icon-badge"]
+    },
+    {
+      "slotIdx": 2,
+      "slotName": "market-size",
+      "slotTitle": "Market Size",
+      "slotPurpose": "TAM/SAM/SOM with numbers",
+      "sourceSlideIdx": 2,
+      "sourceSlideTitle": "Total Addressable Market",
+      "mappingScore": 1,
+      "mappingFallback": false,
+      "mappingEmpty": false,
+      "liftFile": "slots/slot-02-market-size.json",
+      "cached": false,
+      "dryRun": false,
+      "error": null,
+      "subjectTypes": ["pyramid", "kpi-card", "kpi-card", "kpi-card"]
+    },
+    {
+      "slotIdx": 3,
+      "slotName": "solution",
+      "slotTitle": "Our Solution",
+      "slotPurpose": "Product overview + value prop",
+      "sourceSlideIdx": 3,
+      "sourceSlideTitle": "Our Solution",
+      "mappingScore": 1,
+      "mappingFallback": false,
+      "mappingEmpty": false,
+      "liftFile": "slots/slot-03-solution.json",
+      "cached": false,
+      "dryRun": false,
+      "error": null,
+      "subjectTypes": ["flow-chart", "icon-badge", "icon-badge", "icon-badge", "icon-badge"]
+    },
+    {
+      "slotIdx": 4,
+      "slotName": "product",
+      "slotTitle": "Product Demo",
+      "slotPurpose": "Screenshot mockup or feature highlight",
+      "sourceSlideIdx": 4,
+      "sourceSlideTitle": "Product Demo",
+      "mappingScore": 2,
+      "mappingFallback": false,
+      "mappingEmpty": false,
+      "liftFile": "slots/slot-04-product.json",
+      "cached": false,
+      "dryRun": false,
+      "error": null,
+      "subjectTypes": ["device-mockup-frame", "bullet-list"]
+    },
+    {
+      "slotIdx": 5,
+      "slotName": "traction",
+      "slotTitle": "Traction",
+      "slotPurpose": "Revenue / users / growth charts",
+      "sourceSlideIdx": 5,
+      "sourceSlideTitle": "Traction",
+      "mappingScore": 1,
+      "mappingFallback": false,
+      "mappingEmpty": false,
+      "liftFile": "slots/slot-05-traction.json",
+      "cached": false,
+      "dryRun": false,
+      "error": null,
+      "subjectTypes": ["line", "kpi-card", "kpi-card"]
+    },
+    {
+      "slotIdx": 6,
+      "slotName": "business-model",
+      "slotTitle": "Business Model",
+      "slotPurpose": "How we make money — unit economics",
+      "sourceSlideIdx": 6,
+      "sourceSlideTitle": "Business Model",
+      "mappingScore": 2,
+      "mappingFallback": false,
+      "mappingEmpty": false,
+      "liftFile": "slots/slot-06-business-model.json",
+      "cached": false,
+      "dryRun": false,
+      "error": null,
+      "subjectTypes": ["break-even", "kpi-card", "bullet-list"]
+    },
+    {
+      "slotIdx": 7,
+      "slotName": "team",
+      "slotTitle": "Team",
+      "slotPurpose": "Founders + key hires with credentials",
+      "sourceSlideIdx": 7,
+      "sourceSlideTitle": "The Team",
+      "mappingScore": 1,
+      "mappingFallback": false,
+      "mappingEmpty": false,
+      "liftFile": "slots/slot-07-team.json",
+      "cached": false,
+      "dryRun": false,
+      "error": null,
+      "subjectTypes": ["circle-image-hub-spoke", "kpi-card", "kpi-card", "icon-badge", "icon-badge"]
+    },
+    {
+      "slotIdx": 8,
+      "slotName": "ask",
+      "slotTitle": "The Ask",
+      "slotPurpose": "Funding amount + use of funds + milestones",
+      "sourceSlideIdx": 8,
+      "sourceSlideTitle": "The Ask",
+      "mappingScore": 0,
+      "mappingFallback": true,
+      "mappingEmpty": false,
+      "liftFile": "slots/slot-08-ask.json",
+      "cached": false,
+      "dryRun": false,
+      "error": null,
+      "subjectTypes": ["kpi-card", "pie", "bullet-list"]
+    }
+  ],
+  "totals": {
+    "slotsBaked": 9,
+    "slotsEmpty": 0,
+    "slotsErrored": 0,
+    "totalCostUSD": 0.6318434999999999
+  },
+  "meta": {
+    "generatedAt": "2026-06-22T15:02:44.083Z",
+    "model": "claude-sonnet-4-5-20250929",
+    "pipelineVersion": "sprint-16-v1"
+  }
+}

--- a/sdf-js/examples/scaffold-pipeline/vc-pitch/slots/slot-00-cover.json
+++ b/sdf-js/examples/scaffold-pipeline/vc-pitch/slots/slot-00-cover.json
@@ -1,0 +1,49 @@
+{
+  "slotIdx": 0,
+  "slotName": "cover",
+  "slotTitle": "Title",
+  "slotPurpose": "Company name + one-line tagline + author/date",
+  "sourceSlideIdx": 0,
+  "sourceSlideTitle": "Atlas Series A Pitch",
+  "sceneData": {
+    "name": "pitch-deck-vc/cover",
+    "layout": "cover",
+    "subjects": [
+      {
+        "type": "cover",
+        "x": 0,
+        "y": 0,
+        "w": 1280,
+        "h": 720,
+        "args": {
+          "title": "Atlas",
+          "subtitle": "LLM-native illustration platform",
+          "author": "Series A fundraise · 2026-Q3",
+          "date": "$15M to scale supply + distribution"
+        }
+      }
+    ]
+  },
+  "meta": {
+    "scaffold": "pitch-deck-vc",
+    "theme": "pitch-cobalt-orange",
+    "recommendedAtoms": ["cover"],
+    "forbiddenAtoms": [],
+    "tokenUsage": {
+      "input_tokens": 590,
+      "cache_creation_input_tokens": 89490,
+      "cache_read_input_tokens": 0,
+      "cache_creation": {
+        "ephemeral_5m_input_tokens": 89490,
+        "ephemeral_1h_input_tokens": 0
+      },
+      "output_tokens": 153,
+      "service_tier": "standard",
+      "inference_geo": "not_available"
+    },
+    "costUSD": 0.33965249999999997,
+    "elapsedSec": 5,
+    "generatedAt": "2026-06-22T15:01:39.006Z",
+    "model": "claude-sonnet-4-5-20250929"
+  }
+}

--- a/sdf-js/examples/scaffold-pipeline/vc-pitch/slots/slot-01-problem.json
+++ b/sdf-js/examples/scaffold-pipeline/vc-pitch/slots/slot-01-problem.json
@@ -1,0 +1,102 @@
+{
+  "slotIdx": 1,
+  "slotName": "problem",
+  "slotTitle": "Problem",
+  "slotPurpose": "Pain point — who hurts and how much",
+  "sourceSlideIdx": 1,
+  "sourceSlideTitle": "The Problem",
+  "sceneData": {
+    "name": "pitch-deck-vc/problem",
+    "layout": "grid",
+    "subjects": [
+      {
+        "type": "bullet-list",
+        "x": 80,
+        "y": 120,
+        "w": 520,
+        "h": 480,
+        "args": {
+          "items": [
+            {
+              "label": "Presentation visuals are stuck in 2008",
+              "sublabel": "PowerPoint icons + clipart + Lottie GIFs",
+              "status": "highlight"
+            },
+            {
+              "label": "AI-PPT tools fixed the text — visuals still dead",
+              "sublabel": "Copy improved, but graphics remain templated"
+            },
+            {
+              "label": "Designers spend 60% of their time on layout busywork",
+              "sublabel": "Manual alignment, resizing, and formatting overhead"
+            }
+          ],
+          "title": "The Problem",
+          "numbered": false,
+          "highlight": 0
+        }
+      },
+      {
+        "type": "kpi-card",
+        "x": 680,
+        "y": 200,
+        "w": 480,
+        "h": 280,
+        "args": {
+          "value": "60%",
+          "label": "Designer Time Wasted",
+          "sublabel": "on layout busywork instead of creativity",
+          "trend": "down",
+          "trendValue": "should be 0%",
+          "icon": "users"
+        }
+      },
+      {
+        "type": "icon-badge",
+        "x": 760,
+        "y": 520,
+        "w": 120,
+        "h": 120,
+        "args": {
+          "name": "warning-circle",
+          "label": "Outdated",
+          "color": [255, 120, 40]
+        }
+      },
+      {
+        "type": "icon-badge",
+        "x": 920,
+        "y": 520,
+        "w": 120,
+        "h": 120,
+        "args": {
+          "name": "clock",
+          "label": "Time Drain",
+          "color": [20, 60, 180]
+        }
+      }
+    ]
+  },
+  "meta": {
+    "scaffold": "pitch-deck-vc",
+    "theme": "pitch-cobalt-orange",
+    "recommendedAtoms": ["bullet-list", "kpi-card", "icon-badge"],
+    "forbiddenAtoms": ["org-chart", "gantt"],
+    "tokenUsage": {
+      "input_tokens": 664,
+      "cache_creation_input_tokens": 0,
+      "cache_read_input_tokens": 89490,
+      "cache_creation": {
+        "ephemeral_5m_input_tokens": 0,
+        "ephemeral_1h_input_tokens": 0
+      },
+      "output_tokens": 576,
+      "service_tier": "standard",
+      "inference_geo": "not_available"
+    },
+    "costUSD": 0.037479,
+    "elapsedSec": 8.5,
+    "generatedAt": "2026-06-22T15:01:47.560Z",
+    "model": "claude-sonnet-4-5-20250929"
+  }
+}

--- a/sdf-js/examples/scaffold-pipeline/vc-pitch/slots/slot-02-market-size.json
+++ b/sdf-js/examples/scaffold-pipeline/vc-pitch/slots/slot-02-market-size.json
@@ -1,0 +1,106 @@
+{
+  "slotIdx": 2,
+  "slotName": "market-size",
+  "slotTitle": "Market Size",
+  "slotPurpose": "TAM/SAM/SOM with numbers",
+  "sourceSlideIdx": 2,
+  "sourceSlideTitle": "Total Addressable Market",
+  "sceneData": {
+    "name": "pitch-deck-vc/market-size",
+    "layout": "hierarchy",
+    "subjects": [
+      {
+        "type": "pyramid",
+        "x": 80,
+        "y": 120,
+        "w": 520,
+        "h": 520,
+        "args": {
+          "layers": [
+            {
+              "label": "AI-augmented productivity",
+              "sublabel": "$48B by 2028",
+              "value": 48
+            },
+            {
+              "label": "PPT/Keynote/Google Slides",
+              "sublabel": "$4.8B annually",
+              "value": 4.8
+            },
+            {
+              "label": "Editorial illustration + infographic",
+              "sublabel": "$2.1B",
+              "value": 2.1
+            }
+          ],
+          "title": "Total Addressable Market",
+          "inverted": false
+        }
+      },
+      {
+        "type": "kpi-card",
+        "x": 680,
+        "y": 180,
+        "w": 520,
+        "h": 180,
+        "args": {
+          "value": "18M",
+          "label": "Knowledge Workers",
+          "sublabel": "making decks weekly",
+          "icon": "users",
+          "color": [255, 120, 40]
+        }
+      },
+      {
+        "type": "kpi-card",
+        "x": 680,
+        "y": 400,
+        "w": 250,
+        "h": 160,
+        "args": {
+          "value": "$4.8B",
+          "label": "Core Market",
+          "sublabel": "Presentation tools",
+          "icon": "chart-bar",
+          "color": [20, 60, 180]
+        }
+      },
+      {
+        "type": "kpi-card",
+        "x": 950,
+        "y": 400,
+        "w": 250,
+        "h": 160,
+        "args": {
+          "value": "$48B",
+          "label": "TAM 2028",
+          "sublabel": "AI productivity",
+          "icon": "lightning",
+          "color": [255, 120, 40]
+        }
+      }
+    ]
+  },
+  "meta": {
+    "scaffold": "pitch-deck-vc",
+    "theme": "pitch-cobalt-orange",
+    "recommendedAtoms": ["pyramid", "kpi-card", "sphere-fill", "bar"],
+    "forbiddenAtoms": [],
+    "tokenUsage": {
+      "input_tokens": 650,
+      "cache_creation_input_tokens": 0,
+      "cache_read_input_tokens": 89490,
+      "cache_creation": {
+        "ephemeral_5m_input_tokens": 0,
+        "ephemeral_1h_input_tokens": 0
+      },
+      "output_tokens": 585,
+      "service_tier": "standard",
+      "inference_geo": "not_available"
+    },
+    "costUSD": 0.037572,
+    "elapsedSec": 7.5,
+    "generatedAt": "2026-06-22T15:01:55.027Z",
+    "model": "claude-sonnet-4-5-20250929"
+  }
+}

--- a/sdf-js/examples/scaffold-pipeline/vc-pitch/slots/slot-03-solution.json
+++ b/sdf-js/examples/scaffold-pipeline/vc-pitch/slots/slot-03-solution.json
@@ -1,0 +1,102 @@
+{
+  "slotIdx": 3,
+  "slotName": "solution",
+  "slotTitle": "Our Solution",
+  "slotPurpose": "Product overview + value prop",
+  "sourceSlideIdx": 3,
+  "sourceSlideTitle": "Our Solution",
+  "sceneData": {
+    "name": "pitch-deck-vc/solution",
+    "layout": "row",
+    "subjects": [
+      {
+        "type": "flow-chart",
+        "x": 80,
+        "y": 120,
+        "w": 1120,
+        "h": 520,
+        "args": {
+          "steps": [
+            "LLM writes structured intent",
+            "Atlas runtime renders illustration",
+            "4 renderer variants (silhouette/3D/lines/crayon)",
+            "Editable: tweak intent → regenerate visual"
+          ],
+          "orientation": "horizontal",
+          "title": "Our Solution",
+          "highlight": 0
+        }
+      },
+      {
+        "type": "icon-badge",
+        "x": 140,
+        "y": 200,
+        "w": 80,
+        "h": 80,
+        "args": {
+          "name": "file",
+          "label": "Intent",
+          "color": [255, 120, 40]
+        }
+      },
+      {
+        "type": "icon-badge",
+        "x": 420,
+        "y": 200,
+        "w": 80,
+        "h": 80,
+        "args": {
+          "name": "cpu",
+          "label": "Runtime",
+          "color": [20, 60, 180]
+        }
+      },
+      {
+        "type": "icon-badge",
+        "x": 700,
+        "y": 200,
+        "w": 80,
+        "h": 80,
+        "args": {
+          "name": "graphics-card",
+          "label": "Renderers",
+          "color": [255, 120, 40]
+        }
+      },
+      {
+        "type": "icon-badge",
+        "x": 980,
+        "y": 200,
+        "w": 80,
+        "h": 80,
+        "args": {
+          "name": "refresh",
+          "label": "Editable",
+          "color": [20, 60, 180]
+        }
+      }
+    ]
+  },
+  "meta": {
+    "scaffold": "pitch-deck-vc",
+    "theme": "pitch-cobalt-orange",
+    "recommendedAtoms": ["bullet-list", "flow-chart", "icon-badge"],
+    "forbiddenAtoms": [],
+    "tokenUsage": {
+      "input_tokens": 623,
+      "cache_creation_input_tokens": 0,
+      "cache_read_input_tokens": 89490,
+      "cache_creation": {
+        "ephemeral_5m_input_tokens": 0,
+        "ephemeral_1h_input_tokens": 0
+      },
+      "output_tokens": 541,
+      "service_tier": "standard",
+      "inference_geo": "not_available"
+    },
+    "costUSD": 0.036831,
+    "elapsedSec": 6.9,
+    "generatedAt": "2026-06-22T15:02:01.935Z",
+    "model": "claude-sonnet-4-5-20250929"
+  }
+}

--- a/sdf-js/examples/scaffold-pipeline/vc-pitch/slots/slot-04-product.json
+++ b/sdf-js/examples/scaffold-pipeline/vc-pitch/slots/slot-04-product.json
@@ -1,0 +1,77 @@
+{
+  "slotIdx": 4,
+  "slotName": "product",
+  "slotTitle": "Product Demo",
+  "slotPurpose": "Screenshot mockup or feature highlight",
+  "sourceSlideIdx": 4,
+  "sourceSlideTitle": "Product Demo",
+  "sceneData": {
+    "name": "pitch-deck-vc/product",
+    "layout": "row",
+    "subjects": [
+      {
+        "type": "device-mockup-frame",
+        "x": 80,
+        "y": 100,
+        "w": 480,
+        "h": 520,
+        "args": {
+          "device": "laptop",
+          "title": "Atlas Present Editor",
+          "content": "Live 3D deck canvas with LLM-assisted editing",
+          "color": [255, 120, 40]
+        }
+      },
+      {
+        "type": "bullet-list",
+        "x": 620,
+        "y": 120,
+        "w": 580,
+        "h": 480,
+        "args": {
+          "title": "Key Features",
+          "items": [
+            {
+              "label": "Upload PDF, get a scaffolded 3D deck",
+              "status": "done"
+            },
+            {
+              "label": "Inline ⚡ paragraph trigger for any text",
+              "status": "highlight"
+            },
+            {
+              "label": "Live-edit canvas with the LLM in the loop",
+              "status": "done"
+            },
+            {
+              "label": "Export to PPT/PDF/MP4 (forthcoming)",
+              "status": "todo"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  "meta": {
+    "scaffold": "pitch-deck-vc",
+    "theme": "pitch-cobalt-orange",
+    "recommendedAtoms": ["device-mockup-frame", "device-mockup-row", "bullet-list"],
+    "forbiddenAtoms": [],
+    "tokenUsage": {
+      "input_tokens": 635,
+      "cache_creation_input_tokens": 0,
+      "cache_read_input_tokens": 89490,
+      "cache_creation": {
+        "ephemeral_5m_input_tokens": 0,
+        "ephemeral_1h_input_tokens": 0
+      },
+      "output_tokens": 363,
+      "service_tier": "standard",
+      "inference_geo": "not_available"
+    },
+    "costUSD": 0.034197,
+    "elapsedSec": 5.5,
+    "generatedAt": "2026-06-22T15:02:07.392Z",
+    "model": "claude-sonnet-4-5-20250929"
+  }
+}

--- a/sdf-js/examples/scaffold-pipeline/vc-pitch/slots/slot-05-traction.json
+++ b/sdf-js/examples/scaffold-pipeline/vc-pitch/slots/slot-05-traction.json
@@ -1,0 +1,87 @@
+{
+  "slotIdx": 5,
+  "slotName": "traction",
+  "slotTitle": "Traction",
+  "slotPurpose": "Revenue / users / growth charts",
+  "sourceSlideIdx": 5,
+  "sourceSlideTitle": "Traction",
+  "sceneData": {
+    "name": "pitch-deck-vc/traction",
+    "layout": "row",
+    "subjects": [
+      {
+        "type": "line",
+        "x": 80,
+        "y": 120,
+        "w": 1120,
+        "h": 420,
+        "args": {
+          "values": [0, 120, 740, 2400],
+          "labels": ["Q1 2026", "Q2 2026", "Q3 2026", "Q4 2026 (forecast)"],
+          "format": "currency",
+          "title": "ARR Growth Trajectory",
+          "showPoints": true,
+          "annotations": [
+            {
+              "index": 1,
+              "text": "10 design teams"
+            },
+            {
+              "index": 2,
+              "text": "47 teams + 3 agencies"
+            }
+          ]
+        }
+      },
+      {
+        "type": "kpi-card",
+        "x": 120,
+        "y": 560,
+        "w": 480,
+        "h": 120,
+        "args": {
+          "value": "$2.4M",
+          "label": "Q4 2026 ARR Forecast",
+          "icon": "chart-bar",
+          "trend": "up"
+        }
+      },
+      {
+        "type": "kpi-card",
+        "x": 680,
+        "y": 560,
+        "w": 480,
+        "h": 120,
+        "args": {
+          "value": "110%",
+          "label": "Net Retention",
+          "sublabel": "Q4 2026",
+          "icon": "users",
+          "trend": "up"
+        }
+      }
+    ]
+  },
+  "meta": {
+    "scaffold": "pitch-deck-vc",
+    "theme": "pitch-cobalt-orange",
+    "recommendedAtoms": ["line", "bar", "kpi-card", "dashboard-multi-kpi-composite"],
+    "forbiddenAtoms": ["mindmap", "venn"],
+    "tokenUsage": {
+      "input_tokens": 689,
+      "cache_creation_input_tokens": 0,
+      "cache_read_input_tokens": 89490,
+      "cache_creation": {
+        "ephemeral_5m_input_tokens": 0,
+        "ephemeral_1h_input_tokens": 0
+      },
+      "output_tokens": 456,
+      "service_tier": "standard",
+      "inference_geo": "not_available"
+    },
+    "costUSD": 0.035754,
+    "elapsedSec": 13.4,
+    "generatedAt": "2026-06-22T15:02:20.798Z",
+    "model": "claude-sonnet-4-5-20250929"
+  }
+}

--- a/sdf-js/examples/scaffold-pipeline/vc-pitch/slots/slot-06-business-model.json
+++ b/sdf-js/examples/scaffold-pipeline/vc-pitch/slots/slot-06-business-model.json
@@ -1,0 +1,91 @@
+{
+  "slotIdx": 6,
+  "slotName": "business-model",
+  "slotTitle": "Business Model",
+  "slotPurpose": "How we make money — unit economics",
+  "sourceSlideIdx": 6,
+  "sourceSlideTitle": "Business Model",
+  "sceneData": {
+    "name": "pitch-deck-vc/business-model",
+    "layout": "row",
+    "subjects": [
+      {
+        "type": "break-even",
+        "x": 80,
+        "y": 140,
+        "w": 560,
+        "h": 480,
+        "args": {
+          "fixedCost": 180000,
+          "variableCostPerUnit": 8,
+          "pricePerUnit": 30,
+          "maxUnits": 12000,
+          "title": "Unit Economics",
+          "currency": "USD",
+          "color": [255, 120, 40]
+        }
+      },
+      {
+        "type": "kpi-card",
+        "x": 700,
+        "y": 140,
+        "w": 500,
+        "h": 140,
+        "args": {
+          "value": "$3M",
+          "label": "Break-Even ARR",
+          "sublabel": "Projected Q3 2027",
+          "icon": "chart-bar",
+          "color": [255, 120, 40]
+        }
+      },
+      {
+        "type": "bullet-list",
+        "x": 700,
+        "y": 320,
+        "w": 500,
+        "h": 300,
+        "args": {
+          "items": [
+            {
+              "label": "Pro: $30/user/month",
+              "sublabel": "Knowledge workers",
+              "status": "highlight"
+            },
+            {
+              "label": "Team: $200/seat/month",
+              "sublabel": "Design teams (10+ seats)"
+            },
+            {
+              "label": "Studio: $50K/year",
+              "sublabel": "Agencies + enterprise (custom themes)"
+            }
+          ],
+          "title": "Pricing Tiers"
+        }
+      }
+    ]
+  },
+  "meta": {
+    "scaffold": "pitch-deck-vc",
+    "theme": "pitch-cobalt-orange",
+    "recommendedAtoms": ["break-even", "waterfall", "kpi-card", "pie"],
+    "forbiddenAtoms": [],
+    "tokenUsage": {
+      "input_tokens": 647,
+      "cache_creation_input_tokens": 0,
+      "cache_read_input_tokens": 89490,
+      "cache_creation": {
+        "ephemeral_5m_input_tokens": 0,
+        "ephemeral_1h_input_tokens": 0
+      },
+      "output_tokens": 485,
+      "service_tier": "standard",
+      "inference_geo": "not_available"
+    },
+    "costUSD": 0.036063,
+    "elapsedSec": 8.2,
+    "generatedAt": "2026-06-22T15:02:28.963Z",
+    "model": "claude-sonnet-4-5-20250929"
+  }
+}

--- a/sdf-js/examples/scaffold-pipeline/vc-pitch/slots/slot-07-team.json
+++ b/sdf-js/examples/scaffold-pipeline/vc-pitch/slots/slot-07-team.json
@@ -1,0 +1,113 @@
+{
+  "slotIdx": 7,
+  "slotName": "team",
+  "slotTitle": "Team",
+  "slotPurpose": "Founders + key hires with credentials",
+  "sourceSlideIdx": 7,
+  "sourceSlideTitle": "The Team",
+  "sceneData": {
+    "name": "pitch-deck-vc/team",
+    "layout": "hierarchy",
+    "subjects": [
+      {
+        "type": "circle-image-hub-spoke",
+        "x": 80,
+        "y": 120,
+        "w": 520,
+        "h": 520,
+        "args": {
+          "center": {
+            "label": "Leadership",
+            "color": [255, 120, 40]
+          },
+          "satellites": [
+            {
+              "label": "Sarah Chen\nCEO\nex-Figma design infra",
+              "color": [20, 60, 180]
+            },
+            {
+              "label": "Alex Wu\nCTO\nex-Anthropic research",
+              "color": [20, 60, 180]
+            },
+            {
+              "label": "Diana Liu\nHead of Design\nex-Apple Keynote",
+              "color": [20, 60, 180]
+            }
+          ]
+        }
+      },
+      {
+        "type": "kpi-card",
+        "x": 680,
+        "y": 180,
+        "w": 520,
+        "h": 160,
+        "args": {
+          "value": "20",
+          "label": "Engineers",
+          "sublabel": "Building the future of design tools",
+          "icon": "users"
+        }
+      },
+      {
+        "type": "kpi-card",
+        "x": 680,
+        "y": 380,
+        "w": 520,
+        "h": 160,
+        "args": {
+          "value": "5",
+          "label": "Designers",
+          "sublabel": "Crafting world-class UX",
+          "icon": "palette"
+        }
+      },
+      {
+        "type": "icon-badge",
+        "x": 720,
+        "y": 580,
+        "w": 80,
+        "h": 80,
+        "args": {
+          "name": "buildings",
+          "label": "NYC HQ",
+          "color": [60, 65, 90]
+        }
+      },
+      {
+        "type": "icon-badge",
+        "x": 880,
+        "y": 580,
+        "w": 80,
+        "h": 80,
+        "args": {
+          "name": "globe",
+          "label": "Remote",
+          "color": [60, 65, 90]
+        }
+      }
+    ]
+  },
+  "meta": {
+    "scaffold": "pitch-deck-vc",
+    "theme": "pitch-cobalt-orange",
+    "recommendedAtoms": ["circle-image-hub-spoke", "isotype-stat-comparison", "bullet-list"],
+    "forbiddenAtoms": [],
+    "tokenUsage": {
+      "input_tokens": 641,
+      "cache_creation_input_tokens": 0,
+      "cache_read_input_tokens": 89490,
+      "cache_creation": {
+        "ephemeral_5m_input_tokens": 0,
+        "ephemeral_1h_input_tokens": 0
+      },
+      "output_tokens": 642,
+      "service_tier": "standard",
+      "inference_geo": "not_available"
+    },
+    "costUSD": 0.038400000000000004,
+    "elapsedSec": 8.1,
+    "generatedAt": "2026-06-22T15:02:37.103Z",
+    "model": "claude-sonnet-4-5-20250929"
+  }
+}

--- a/sdf-js/examples/scaffold-pipeline/vc-pitch/slots/slot-08-ask.json
+++ b/sdf-js/examples/scaffold-pipeline/vc-pitch/slots/slot-08-ask.json
@@ -1,0 +1,89 @@
+{
+  "slotIdx": 8,
+  "slotName": "ask",
+  "slotTitle": "The Ask",
+  "slotPurpose": "Funding amount + use of funds + milestones",
+  "sourceSlideIdx": 8,
+  "sourceSlideTitle": "The Ask",
+  "sceneData": {
+    "name": "pitch-deck-vc/ask",
+    "layout": "grid",
+    "subjects": [
+      {
+        "type": "kpi-card",
+        "x": 80,
+        "y": 100,
+        "w": 520,
+        "h": 240,
+        "args": {
+          "value": "$15M",
+          "label": "Series A Raise",
+          "sublabel": "18-month runway to $10M ARR",
+          "icon": "currency-dollar",
+          "color": [255, 120, 40]
+        }
+      },
+      {
+        "type": "pie",
+        "x": 680,
+        "y": 100,
+        "w": 520,
+        "h": 240,
+        "args": {
+          "values": [60, 25, 15],
+          "labels": ["Engineering", "Sales + Community", "Reserve"],
+          "format": "percent",
+          "title": "Use of Funds",
+          "donutRatio": 0.55,
+          "centerLabel": "Allocation"
+        }
+      },
+      {
+        "type": "bullet-list",
+        "x": 80,
+        "y": 380,
+        "w": 1120,
+        "h": 280,
+        "args": {
+          "items": [
+            {
+              "label": "Engineering (60%)",
+              "sublabel": "Scaling 2D+3D atom library to 200 atoms"
+            },
+            {
+              "label": "Sales + Community (25%)",
+              "sublabel": "Agency partner program"
+            },
+            {
+              "label": "Reserve (15%)",
+              "sublabel": "18-month runway · next milestone: $10M ARR"
+            }
+          ],
+          "title": "Fund Deployment"
+        }
+      }
+    ]
+  },
+  "meta": {
+    "scaffold": "pitch-deck-vc",
+    "theme": "pitch-cobalt-orange",
+    "recommendedAtoms": ["kpi-card", "pie", "progression", "timeline"],
+    "forbiddenAtoms": [],
+    "tokenUsage": {
+      "input_tokens": 641,
+      "cache_creation_input_tokens": 0,
+      "cache_read_input_tokens": 89490,
+      "cache_creation": {
+        "ephemeral_5m_input_tokens": 0,
+        "ephemeral_1h_input_tokens": 0
+      },
+      "output_tokens": 475,
+      "service_tier": "standard",
+      "inference_geo": "not_available"
+    },
+    "costUSD": 0.035895,
+    "elapsedSec": 7,
+    "generatedAt": "2026-06-22T15:02:44.082Z",
+    "model": "claude-sonnet-4-5-20250929"
+  }
+}

--- a/sdf-js/scripts/bake-scaffold-pipeline.mjs
+++ b/sdf-js/scripts/bake-scaffold-pipeline.mjs
@@ -1,0 +1,440 @@
+#!/usr/bin/env node
+// =============================================================================
+// bake-scaffold-pipeline.mjs — 2-call scaffold pipeline E2E baker
+// -----------------------------------------------------------------------------
+// Sprint 16 — End-to-end PDF → scaffolded deck.
+//
+// Stage 0: Pick scaffold (deterministic v1 from text content)
+// Stage 1: Map source slides → scaffold slots (heuristic by purpose-keyword match)
+// Stage 2: For each slot, call lift LLM with slot context injected:
+//          - slot purpose
+//          - recommended atoms (positive constraint)
+//          - forbidden atoms (negative constraint)
+//          - theme (bg / accent / colors[])
+//
+// Output: screens/scaffold-pipeline/<deck>/deck.json + per-slot lift JSONs
+//
+// Usage:
+//   ANTHROPIC_API_KEY=sk-... node sdf-js/scripts/bake-scaffold-pipeline.mjs
+//   --slidedata PATH      source slidedata.json (default: PD sphere-fill deck)
+//   --deck-name NAME      output dir name (default: derived from slidedata)
+//   --force               re-bake existing outputs
+//   --dry-run             skip Stage 2 LLM calls (just print scaffold+slot mapping)
+//   --key-file PATH       read API key from file instead of env
+// =============================================================================
+
+import { readFileSync, writeFileSync, existsSync, mkdirSync } from 'node:fs';
+import { basename } from 'node:path';
+import { pickScaffold, distributeSources } from '../src/present/scaffolds/picker.js';
+import { getTheme } from '../src/present/themes.js';
+
+// --- args ---
+const args = process.argv.slice(2);
+function arg(name, fallback = null) {
+  const i = args.indexOf(name);
+  return i > -1 ? args[i + 1] : fallback;
+}
+const REPO = new URL('../..', import.meta.url).pathname;
+const SLIDEDATA_PATH = arg('--slidedata') || `${REPO}sdf-js/examples/pdf-demo/slidedata.json`;
+const DECK_NAME = arg('--deck-name') || basename(SLIDEDATA_PATH).replace(/\.json$/, '');
+const FORCE = args.includes('--force');
+const DRY_RUN = args.includes('--dry-run');
+const KEY_FILE = arg('--key-file', null);
+
+// --- API key ---
+let API_KEY = process.env.ANTHROPIC_API_KEY;
+if (!API_KEY && KEY_FILE && existsSync(KEY_FILE)) {
+  const raw = readFileSync(KEY_FILE, 'utf8').trim();
+  API_KEY = raw.startsWith('ANTHROPIC_API_KEY=') ? raw.slice('ANTHROPIC_API_KEY='.length) : raw;
+}
+if (!API_KEY && !DRY_RUN) {
+  console.error('ERROR: set ANTHROPIC_API_KEY or pass --key-file PATH (or use --dry-run)');
+  process.exit(2);
+}
+
+const MODEL = 'claude-sonnet-4-5-20250929';
+const SYSTEM_PROMPT_PATH = `${REPO}sdf-js/examples/compositor/system-prompt-lift-3d.md`;
+const COMPOSITOR_API_PATH = `${REPO}sdf-js/src/compositor-api.js`;
+// Output lives inside sdf-js so dev-server can serve deck.json + lifts to the
+// browser viewer. (screens/ is outside sdf-js and not web-accessible.)
+const OUT_DIR = `${REPO}sdf-js/examples/scaffold-pipeline/${DECK_NAME}`;
+mkdirSync(OUT_DIR, { recursive: true });
+mkdirSync(`${OUT_DIR}/slots`, { recursive: true });
+
+// Extract MODE_2D_ADDENDUM from compositor-api.js (same as bake-pdf-lifts-2d.mjs)
+function extractAddendum() {
+  const text = readFileSync(COMPOSITOR_API_PATH, 'utf8');
+  const start = text.indexOf('const MODE_2D_ADDENDUM = `');
+  if (start === -1) return '';
+  let i = start + 'const MODE_2D_ADDENDUM = `'.length;
+  while (i < text.length) {
+    if (text[i] === '`' && text[i - 1] !== '\\')
+      return text.slice(start + 'const MODE_2D_ADDENDUM = `'.length, i);
+    i++;
+  }
+  return '';
+}
+
+const slides = JSON.parse(readFileSync(SLIDEDATA_PATH, 'utf8'));
+const systemPromptBase = readFileSync(SYSTEM_PROMPT_PATH, 'utf8');
+const mode2dAddendum = extractAddendum();
+const systemPrompt = systemPromptBase + mode2dAddendum;
+
+console.log(
+  `\n══ Scaffold Pipeline ══\nSource: ${SLIDEDATA_PATH.replace(REPO, '')}\nSlides: ${slides.length}\nOutput: ${OUT_DIR.replace(REPO, '')}/\n`,
+);
+
+// ---------------------------------------------------------------------------
+// Stage 0 — Pick scaffold from deck-level content
+// ---------------------------------------------------------------------------
+console.log('── Stage 0: scaffold pick ──');
+
+const allTitles = slides.map((s) => s.title).filter(Boolean);
+const bodyTextsAll = [];
+for (const slide of slides) {
+  if (!slide.body) continue;
+  for (const b of slide.body) {
+    const t = typeof b === 'string' ? b : b.text || '';
+    if (t.trim()) bodyTextsAll.push(t.trim());
+  }
+}
+
+// Deck title = first slide title; body = all titles + all bodies concatenated
+const deckTitle = allTitles[0] || DECK_NAME;
+const deckCombinedBody = [...allTitles, ...bodyTextsAll];
+
+const picked = pickScaffold({
+  title: deckTitle,
+  bodyTexts: deckCombinedBody,
+});
+
+const scaffold = picked.scaffold;
+const theme = picked.theme;
+
+console.log(
+  `  picked: ${scaffold.id} (${scaffold.label})\n` +
+    `  score:  ${picked.score}${picked.fallback ? ' [FALLBACK]' : ''}\n` +
+    `  signals: ${picked.signals.slice(0, 6).join(', ')}\n` +
+    `  theme:  ${theme.id} (${theme.label})\n` +
+    `  slots:  ${scaffold.slots.length}\n`,
+);
+
+// ---------------------------------------------------------------------------
+// Stage 1 — Map source slides → scaffold slots
+//
+// Heuristic: for each slot, score each unconsumed slide by purpose-keyword
+// overlap. Pick the best match. If no slide scores > 0, leave slot empty.
+// First slide is biased toward 'cover' slot.
+// ---------------------------------------------------------------------------
+console.log('── Stage 1: slot mapping ──');
+
+function scoreSlideForSlot(slide, slot) {
+  const slideText = (
+    String(slide.title || '') +
+    ' ' +
+    (slide.body || []).map((b) => (typeof b === 'string' ? b : b.text || '')).join(' ')
+  ).toLowerCase();
+  const slotKeywords = (slot.purpose + ' ' + slot.title)
+    .toLowerCase()
+    .split(/\W+/)
+    .filter((w) => w.length >= 4); // skip short words
+  let score = 0;
+  for (const kw of slotKeywords) {
+    if (slideText.includes(kw)) score += 1;
+  }
+  return score;
+}
+
+const consumedSlides = new Set();
+const slotAssignments = scaffold.slots.map((slot, slotIdx) => {
+  let bestIdx = -1;
+  let bestScore = -1;
+
+  // Special-case slot 0 = cover → first unconsumed slide
+  if (slotIdx === 0 && slot.name === 'cover') {
+    for (let i = 0; i < slides.length; i++) {
+      if (!consumedSlides.has(i)) {
+        bestIdx = i;
+        bestScore = 0;
+        break;
+      }
+    }
+  } else {
+    for (let i = 0; i < slides.length; i++) {
+      if (consumedSlides.has(i)) continue;
+      const s = scoreSlideForSlot(slides[i], slot);
+      if (s > bestScore) {
+        bestScore = s;
+        bestIdx = i;
+      }
+    }
+  }
+
+  if (bestIdx >= 0 && bestScore > 0) {
+    consumedSlides.add(bestIdx);
+    return { slot, slotIdx, slideIdx: bestIdx, score: bestScore };
+  }
+  // Fallback: assign next unconsumed slide if any remain (so we don't skip)
+  for (let i = 0; i < slides.length; i++) {
+    if (!consumedSlides.has(i)) {
+      consumedSlides.add(i);
+      return { slot, slotIdx, slideIdx: i, score: 0, fallback: true };
+    }
+  }
+  return { slot, slotIdx, slideIdx: -1, score: 0, empty: true };
+});
+
+console.log('  slot → slide mapping:');
+for (const a of slotAssignments) {
+  const tag = a.empty ? '[EMPTY]' : a.fallback ? '[FALLBACK]' : `score ${a.score}`;
+  const slideTitle = a.slideIdx >= 0 ? slides[a.slideIdx].title || '(untitled)' : '—';
+  console.log(
+    `    ${a.slotIdx.toString().padStart(2)}. ${a.slot.name.padEnd(20)} ← slide ${a.slideIdx.toString().padStart(2)}: ${tag.padEnd(15)} ${slideTitle.slice(0, 60)}`,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Stage 2 — Lift each slot with scaffold context
+// ---------------------------------------------------------------------------
+async function callAnthropic(userMessage) {
+  const t0 = Date.now();
+  const res = await fetch('https://api.anthropic.com/v1/messages', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'x-api-key': API_KEY,
+      'anthropic-version': '2023-06-01',
+    },
+    body: JSON.stringify({
+      model: MODEL,
+      max_tokens: 16384,
+      system: [{ type: 'text', text: systemPrompt, cache_control: { type: 'ephemeral' } }],
+      messages: [{ role: 'user', content: userMessage }],
+    }),
+  });
+  const elapsed = ((Date.now() - t0) / 1000).toFixed(1);
+  if (!res.ok) throw new Error(`Anthropic ${res.status}: ${(await res.text()).slice(0, 300)}`);
+  const data = await res.json();
+  return { text: data.content[0].text, usage: data.usage, elapsed };
+}
+
+function parseSceneJson(text) {
+  const m = text.match(/```(?:json)?\s*\n([\s\S]*?)\n```/);
+  let s = m ? m[1] : text.trim();
+  if (!m && s.startsWith('{') === false) {
+    const i = s.indexOf('{');
+    const j = s.lastIndexOf('}');
+    if (i >= 0 && j > i) s = s.slice(i, j + 1);
+  }
+  return JSON.parse(s);
+}
+
+console.log('\n── Stage 2: slot lift ──');
+
+if (DRY_RUN) {
+  console.log('  [DRY RUN] skipping LLM calls');
+}
+
+const slotLifts = [];
+let totalCost = 0;
+
+for (const a of slotAssignments) {
+  if (a.empty) {
+    slotLifts.push({ slotIdx: a.slotIdx, empty: true });
+    console.log(`  slot ${a.slotIdx} (${a.slot.name}): EMPTY — no slide assigned`);
+    continue;
+  }
+
+  const slide = slides[a.slideIdx];
+  const outFile = `${OUT_DIR}/slots/slot-${String(a.slotIdx).padStart(2, '0')}-${a.slot.name}.json`;
+
+  if (!FORCE && existsSync(outFile) && !DRY_RUN) {
+    console.log(`  ↳ skip slot ${a.slotIdx} (${a.slot.name}) — exists, use --force`);
+    slotLifts.push({ slotIdx: a.slotIdx, cached: true, outFile });
+    continue;
+  }
+
+  const bodyTexts = (slide.body || [])
+    .map((b) => (typeof b === 'string' ? b : b.text || ''))
+    .filter((t) => t && t.length > 0);
+
+  const slotContext =
+    `## SCAFFOLD CONTEXT\n\n` +
+    `You are filling slot **${a.slotIdx + 1}/${scaffold.slots.length}** ` +
+    `of a **${scaffold.label}** deck.\n\n` +
+    `**Slot purpose**: ${a.slot.purpose}\n` +
+    `**Slot title**: "${a.slot.title}" (this is the section header)\n\n` +
+    `**Recommended atoms** (pick from this menu, in priority order):\n` +
+    a.slot.recommended_atoms.map((t, i) => `  ${i + 1}. \`${t}\``).join('\n') +
+    '\n\n' +
+    (a.slot.forbidden_atoms && a.slot.forbidden_atoms.length > 0
+      ? `**Forbidden atoms** (do NOT emit these in this slot):\n` +
+        a.slot.forbidden_atoms.map((t) => `  - \`${t}\``).join('\n') +
+        '\n\n'
+      : '') +
+    `**Theme** (use these colors):\n` +
+    `  - bg: rgb(${theme.bg.join(', ')})\n` +
+    `  - silhouetteColor: rgb(${theme.silhouetteColor.join(', ')})\n` +
+    `  - accent: rgb(${theme.accent.join(', ')})\n` +
+    `  - colors[]: ${theme.colors.map((c) => `rgb(${c.join(',')})`).join(' / ')}\n\n`;
+
+  const userMessage =
+    slotContext +
+    `## SOURCE MATERIAL (slide ${a.slideIdx} from input deck)\n\n` +
+    `**Title**: ${slide.title || '(untitled)'}\n\n` +
+    `**Body**:\n` +
+    bodyTexts.map((t) => `  - "${t}"`).join('\n') +
+    '\n\n' +
+    `## OUTPUT\n\n` +
+    `Canvas: **1280×720**. Emit SceneData JSON for ONE slot:\n\n` +
+    '```json\n' +
+    `{\n` +
+    `  "name": "${scaffold.id}/${a.slot.name}",\n` +
+    `  "layout": "row|grid|hierarchy|stage|cover",\n` +
+    `  "subjects": [\n` +
+    `    { "type": "<atom-name>", "x": <px>, "y": <px>, "w": <px>, "h": <px>, "args": { ... } }\n` +
+    `  ]\n` +
+    `}\n` +
+    '```\n\n' +
+    `Rules:\n` +
+    `0. **CANVAS BOUNDS**: every subject's \`x + w ≤ 1240\` AND \`y + h ≤ 700\`.\n` +
+    `1. **EVERY subject MUST have explicit \`x\`, \`y\`, \`w\`, \`h\`** in canvas pixels.\n` +
+    `2. **Atom selection**: pick ONLY from the recommended_atoms menu above. If none fit, fall back to \`cover\` + \`bullet-list\` as universal escape.\n` +
+    `3. **Slot 0 (cover)** is special — emit a SINGLE cover atom filling x=0, y=0, w=1280, h=720 (or h=360 for half-cover at top of deck).\n` +
+    `4. **Theme**: pass \`color\` args as the theme accent or palette colors[]. Don't invent unrelated colors.\n` +
+    `5. **Preserve body text**: every body line should appear as an atom label/caption/item — don't discard.\n`;
+
+  if (DRY_RUN) {
+    slotLifts.push({
+      slotIdx: a.slotIdx,
+      slotName: a.slot.name,
+      slideIdx: a.slideIdx,
+      dryRun: true,
+      promptChars: userMessage.length,
+    });
+    console.log(
+      `  slot ${a.slotIdx} (${a.slot.name}): [DRY] prompt ${userMessage.length} chars, recommends ${a.slot.recommended_atoms.length} atoms`,
+    );
+    continue;
+  }
+
+  console.log(`  slot ${a.slotIdx} (${a.slot.name}): lifting from slide ${a.slideIdx}...`);
+  try {
+    const { text, usage, elapsed } = await callAnthropic(userMessage);
+    const sceneData = parseSceneJson(text);
+    const inCost = (usage.input_tokens * 3) / 1_000_000;
+    const cacheCreateCost = ((usage.cache_creation_input_tokens || 0) * 3.75) / 1_000_000;
+    const cacheReadCost = ((usage.cache_read_input_tokens || 0) * 0.3) / 1_000_000;
+    const outCost = (usage.output_tokens * 15) / 1_000_000;
+    const costUSD = inCost + cacheCreateCost + cacheReadCost + outCost;
+    totalCost += costUSD;
+
+    const entry = {
+      slotIdx: a.slotIdx,
+      slotName: a.slot.name,
+      slotTitle: a.slot.title,
+      slotPurpose: a.slot.purpose,
+      sourceSlideIdx: a.slideIdx,
+      sourceSlideTitle: slide.title || '',
+      sceneData,
+      meta: {
+        scaffold: scaffold.id,
+        theme: theme.id,
+        recommendedAtoms: a.slot.recommended_atoms,
+        forbiddenAtoms: a.slot.forbidden_atoms || [],
+        tokenUsage: usage,
+        costUSD,
+        elapsedSec: parseFloat(elapsed),
+        generatedAt: new Date().toISOString(),
+        model: MODEL,
+      },
+    };
+    writeFileSync(outFile, JSON.stringify(entry, null, 2));
+
+    const subjectTypes = (sceneData.subjects || []).map((s) => s.type);
+    console.log(`    ✓ ${elapsed}s $${costUSD.toFixed(4)} subjects=[${subjectTypes.join(', ')}]`);
+    slotLifts.push({
+      slotIdx: a.slotIdx,
+      slotName: a.slot.name,
+      sceneData,
+      subjectTypes,
+      costUSD,
+      outFile,
+    });
+  } catch (e) {
+    console.error(`    ✗ failed: ${e.message}`);
+    slotLifts.push({ slotIdx: a.slotIdx, error: e.message });
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Write deck.json manifest
+// ---------------------------------------------------------------------------
+const deckManifest = {
+  deckName: DECK_NAME,
+  sourceFile: SLIDEDATA_PATH.replace(REPO, ''),
+  scaffold: {
+    id: scaffold.id,
+    label: scaffold.label,
+    description: scaffold.description,
+    pickScore: picked.score,
+    pickSignals: picked.signals,
+    fallback: picked.fallback,
+  },
+  theme: {
+    id: theme.id,
+    label: theme.label,
+    macroCluster: theme.macroCluster,
+    bg: theme.bg,
+    accent: theme.accent,
+    colors: theme.colors,
+    font: theme.font,
+  },
+  slots: slotAssignments.map((a) => {
+    const lift = slotLifts.find((l) => l.slotIdx === a.slotIdx) || {};
+    return {
+      slotIdx: a.slotIdx,
+      slotName: a.slot.name,
+      slotTitle: a.slot.title,
+      slotPurpose: a.slot.purpose,
+      sourceSlideIdx: a.slideIdx,
+      sourceSlideTitle: a.slideIdx >= 0 ? slides[a.slideIdx].title || '' : null,
+      mappingScore: a.score,
+      mappingFallback: !!a.fallback,
+      mappingEmpty: !!a.empty,
+      liftFile: lift.outFile ? lift.outFile.replace(`${OUT_DIR}/`, '') : null,
+      cached: !!lift.cached,
+      dryRun: !!lift.dryRun,
+      error: lift.error || null,
+      subjectTypes: lift.subjectTypes || [],
+    };
+  }),
+  totals: {
+    slotsBaked: slotLifts.filter((l) => l.sceneData || l.cached || l.dryRun).length,
+    slotsEmpty: slotLifts.filter((l) => l.empty).length,
+    slotsErrored: slotLifts.filter((l) => l.error).length,
+    totalCostUSD: totalCost,
+  },
+  meta: {
+    generatedAt: new Date().toISOString(),
+    model: MODEL,
+    pipelineVersion: 'sprint-16-v1',
+  },
+};
+
+writeFileSync(`${OUT_DIR}/deck.json`, JSON.stringify(deckManifest, null, 2));
+
+console.log(`\n══ Summary ══`);
+console.log(`  Scaffold: ${scaffold.id}`);
+console.log(`  Theme: ${theme.id}`);
+console.log(`  Slots baked: ${deckManifest.totals.slotsBaked}/${scaffold.slots.length}`);
+console.log(`  Slots empty: ${deckManifest.totals.slotsEmpty}`);
+console.log(`  Errors: ${deckManifest.totals.slotsErrored}`);
+console.log(`  Total cost: $${totalCost.toFixed(4)}`);
+console.log(`  Manifest: ${OUT_DIR.replace(REPO, '')}/deck.json`);
+
+// Helper for getTheme — silence unused-import lint
+void getTheme;
+void distributeSources;
+
+process.exit(deckManifest.totals.slotsErrored > 0 ? 1 : 0);

--- a/sdf-js/scripts/scaffold-pipeline-fixtures/vc-pitch.json
+++ b/sdf-js/scripts/scaffold-pipeline-fixtures/vc-pitch.json
@@ -1,0 +1,82 @@
+[
+  {
+    "title": "Atlas Series A Pitch",
+    "body": [
+      "Atlas — LLM-native illustration platform",
+      "Series A fundraise · 2026-Q3",
+      "$15M to scale supply + distribution"
+    ]
+  },
+  {
+    "title": "The Problem",
+    "body": [
+      "Presentation visuals are stuck in 2008",
+      "PowerPoint icons + clipart + Lottie GIFs",
+      "AI-PPT tools fixed the text — visuals still dead",
+      "Designers spend 60% of their time on layout busywork"
+    ]
+  },
+  {
+    "title": "Total Addressable Market",
+    "body": [
+      "PPT/Keynote/Google Slides market: $4.8B annually",
+      "Editorial illustration + infographic: $2.1B",
+      "AI-augmented productivity: $48B by 2028",
+      "Initial wedge: 18M knowledge workers making decks weekly"
+    ]
+  },
+  {
+    "title": "Our Solution",
+    "body": [
+      "LLM writes structured intent",
+      "Atlas runtime renders illustration deterministically",
+      "Same content × {silhouette, 3D, lines, crayon} renderers",
+      "Editable: tweak the intent, regenerate the visual"
+    ]
+  },
+  {
+    "title": "Product Demo",
+    "body": [
+      "Upload PDF, get a scaffolded 3D deck",
+      "Inline ⚡ paragraph trigger for any text",
+      "Live-edit canvas with the LLM in the loop",
+      "Export to PPT/PDF/MP4 (forthcoming)"
+    ]
+  },
+  {
+    "title": "Traction",
+    "body": [
+      "Q1 2026: $0",
+      "Q2 2026: $120K ARR (10 design teams)",
+      "Q3 2026: $740K ARR (47 teams + 3 design agencies)",
+      "Q4 2026 forecast: $2.4M ARR · 110% net retention"
+    ]
+  },
+  {
+    "title": "Business Model",
+    "body": [
+      "Pro: $30/user/month — knowledge workers",
+      "Team: $200/seat/month — design teams (10+ seats)",
+      "Studio: $50K/year — agencies + enterprise (custom themes)",
+      "Break-even at ~$3M ARR · projected Q3 2027"
+    ]
+  },
+  {
+    "title": "The Team",
+    "body": [
+      "Sarah Chen — CEO, ex-Figma design infra lead",
+      "Alex Wu — CTO, ex-Anthropic research engineer",
+      "Diana Liu — Head of Design, ex-Apple Keynote team",
+      "20 engineers + 5 designers · NYC + remote"
+    ]
+  },
+  {
+    "title": "The Ask",
+    "body": [
+      "Raising $15M Series A",
+      "60% engineering · scaling 2D+3D atom library to 200 atoms",
+      "25% sales + community · agency partner program",
+      "15% reserve · 18-month runway · next milestone: $10M ARR"
+    ]
+  }
+]


### PR DESCRIPTION
## Summary

End-to-end wiring of Sprint 15E scaffold registry into a real text-to-deck pipeline. Sprint 15 shipped the components (atoms / themes / scaffolds); this PR connects them. The 3 layers compose into a complete deck for the first time.

## 3-stage pipeline

**Stage 0 — Pick scaffold** (deterministic, no LLM)
`pickScaffold()` on concatenated deck title + body. Returns the best-fit scaffold + top-affinity theme.

**Stage 1 — Map slides to slots** (heuristic)
For each scaffold slot, score every source slide by purpose-keyword overlap. Pick the best match per slot. Cover slot always gets slide 0. Trailing slots get fallback assignments so no source is dropped.

**Stage 2 — Per-slot lift** (Claude Sonnet 4.5)
For each slot, build a slot-aware prompt injecting:
- slot purpose
- recommended atoms (priority-ordered positive constraint)
- forbidden atoms (negative constraint)
- theme (bg / accent / colors[] / font)
- source slide title + body

LLM emits SceneData JSON per slot. Writes to `examples/scaffold-pipeline/<deck>/slots/slot-NN-<name>.json` + a top-level `deck.json` manifest.

## Test fixture

Synthetic `sdf-js/scripts/scaffold-pipeline-fixtures/vc-pitch.json` (9-slide Atlas Series A pitch). Used to validate Stage 0 picks a real scaffold (vs falling back on the PD sphere-fill deck which has no business keywords).

| Slot | Source slide | Mapping score | Atoms LLM picked |
|---|---|---|---|
| cover | Atlas Series A Pitch | fallback | cover |
| problem | The Problem | 2 | bullet-list / kpi-card / icon-badge × 2 |
| market-size | Total Addressable Market | 1 | pyramid / kpi-card × 3 |
| solution | Our Solution | 1 | flow-chart / icon-badge × 4 |
| product | Product Demo | 2 | device-mockup-frame / bullet-list |
| traction | Traction | 1 | line / kpi-card × 2 |
| business-model | Business Model | 2 | break-even / kpi-card / bullet-list |
| team | The Team | 1 | circle-image-hub-spoke / kpi-card × 2 / icon-badge × 2 |
| ask | The Ask | fallback | kpi-card / pie / bullet-list |

**9/9 slots baked, $0.63 total.** Every LLM-picked atom is from its slot's `recommended_atoms[]` menu — the constraint works.

## Browser viewer

`sdf-js/examples/atoms-2d-demo/scaffold-deck-viewer.html` — loads `deck.json` + per-slot lifts, renders each slot to 1280×720 canvas under the theme. Deck picker for both fixtures.

Screenshot: `screens/scaffold-pipeline/vc-pitch-full.png` — all 9 slots stacked, showing cover (cobalt-orange theme) → problem KPI hero → market pyramid+KPIs → solution flow → product mockup → traction line chart → break-even → team hub+spoke → $15M ask.

## What this validates

Sprint 15 thesis works end-to-end: **scaffold gives shape, atoms give visual vocabulary, theme gives coherence** — all 3 layers compose into a deck better than any single layer alone. Previously separate validation moments (atoms render OK / themes apply / scaffolds pick) are now stitched into one flow.

## Follow-up backlog

- **v2 LLM-wrapped scaffold-picker** for fuzzy inputs the deterministic v1 falls back on
- **Better slot↔slide mapping** (LLM judge or embedding similarity)
- **Export to deck format** (PPTX / HTML / video)
- **Wire into visual-panel UI** for in-browser PDF upload flow

Per CLAUDE.md: DO NOT merge. Awaiting user review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)