### PR TITLE
feat(camera): cinematic camera language — ease modes + rack focus (intra-shot DoF)

### DIFF
--- a/sdf-js/scenes/stage-showcase.json
+++ b/sdf-js/scenes/stage-showcase.json
@@ -30,26 +30,36 @@
       }
     ],
     "cameraSequence": {
-      "loop": false,
+      "loop": true,
       "shots": [
         {
-          "duration": 2.6,
-          "pos": [3.6, 3.3, 10.5],
-          "target": [0, 0.9, -0.1],
-          "fov": 44,
-          "aperture": 0,
-          "focalDistance": 10.5,
-          "ease": "smooth",
+          "duration": 4.2,
+          "pos": [5.0, 3.4, 12.0],
+          "target": [-1.1, 1.1, 0],
+          "fov": 42,
+          "aperture": 0.4,
+          "focalDistance": 12.0,
+          "ease": "out",
           "exposure": [0, 1]
         },
         {
-          "duration": 5.4,
-          "pos": [-1.8, 2.0, 8.0],
-          "target": [0, 0.82, -0.25],
-          "fov": 47,
-          "aperture": 0,
-          "focalDistance": 8.0,
+          "duration": 4.6,
+          "pos": [6.0, 1.6, 4.2],
+          "target": [0, 0.9, 0],
+          "fov": 38,
+          "aperture": 0.85,
+          "focalDistance": [5.2, 9.3],
           "ease": "smooth",
+          "transition": "blend"
+        },
+        {
+          "duration": 5.2,
+          "pos": [-1.6, 2.2, 8.6],
+          "target": [-1.0, 0.95, 0],
+          "fov": 44,
+          "aperture": 0.5,
+          "focalDistance": 8.6,
+          "ease": "out",
           "transition": "blend"
         }
       ]

--- a/sdf-js/src/scene/camera-sequence.js
+++ b/sdf-js/src/scene/camera-sequence.js
@@ -38,6 +38,31 @@ function smoothstep(t) {
   const c = Math.max(0, Math.min(1, t));
   return c * c * (3 - 2 * c);
 }
+function clamp01(t) {
+  return Math.max(0, Math.min(1, t));
+}
+// Per-shot easing vocabulary. 'smooth'/'inout' = ease-in-out (default), 'linear'
+// = constant velocity, 'in' = accelerate from rest (push-off), 'out' = decelerate
+// to a gentle SETTLE (the most cinematic arrival for a push-in/reveal).
+function applyEase(mode, t) {
+  const c = clamp01(t);
+  if (mode === 'linear') return c;
+  if (mode === 'in') return c * c;
+  if (mode === 'out') return 1 - (1 - c) * (1 - c);
+  return c * c * (3 - 2 * c); // 'smooth' | 'inout'
+}
+// DoF (aperture / focalDistance) accepts a number OR a [from, to] pair. A number
+// keeps the existing cross-shot blend; a pair ramps WITHIN the shot (rack focus —
+// the camera can hold while focus pulls from one subject to another).
+function dofSettle(v, fallback) {
+  if (typeof v === 'number') return v;
+  if (Array.isArray(v) && v.length === 2) return Number(v[1]); // settle = the 'to'
+  return fallback;
+}
+function dofValue(v, eased, blendedFallback) {
+  if (Array.isArray(v) && v.length === 2) return lerp(Number(v[0]), Number(v[1]), clamp01(eased));
+  return blendedFallback;
+}
 
 /**
  * Hash-noise for camera shake. Tiny + deterministic.
@@ -89,8 +114,8 @@ export function evaluateCameraSequence(seq, tSec, ctx) {
       pos: [...(last.pos || [0, 0, 0])],
       target: [...(last.target || [0, 0, 0])],
       fov: Number(last.fov ?? 25),
-      aperture: Number(last.aperture ?? 0),
-      focalDistance: Number(last.focalDistance ?? distance(last.pos, last.target)),
+      aperture: dofSettle(last.aperture, 0),
+      focalDistance: dofSettle(last.focalDistance, distance(last.pos, last.target)),
       shotIndex: shots.length - 1,
       shotBlend: 1.0,
     };
@@ -110,7 +135,7 @@ export function evaluateCameraSequence(seq, tSec, ctx) {
   const shotDur = Number(shot.duration) || 1;
   const shotT = (t - acc) / shotDur;
   const easeMode = shot.ease || 'smooth';
-  const blend = easeMode === 'linear' ? shotT : smoothstep(shotT);
+  const blend = applyEase(easeMode, shotT);
 
   // Sprint 4: Resolve subject motion BEFORE building start/end states so
   // relativeTo target resolution sees current frame's subject positions.
@@ -129,8 +154,8 @@ export function evaluateCameraSequence(seq, tSec, ctx) {
     pos: endPos,
     target: endTarget,
     fov: Number(shot.fov ?? 25),
-    aperture: Number(shot.aperture ?? 0),
-    focalDistance: Number(shot.focalDistance ?? distance(endPos, endTarget)),
+    aperture: dofSettle(shot.aperture, 0),
+    focalDistance: dofSettle(shot.focalDistance, distance(endPos, endTarget)),
   };
   let startState = endState;
   let startSceneState = shot.sceneState || {};
@@ -143,8 +168,8 @@ export function evaluateCameraSequence(seq, tSec, ctx) {
       pos: startPos,
       target: startTarget,
       fov: Number(prev.fov ?? 25),
-      aperture: Number(prev.aperture ?? 0),
-      focalDistance: Number(prev.focalDistance ?? distance(startPos, startTarget)),
+      aperture: dofSettle(prev.aperture, 0),
+      focalDistance: dofSettle(prev.focalDistance, distance(startPos, startTarget)),
     };
     // Sprint 5: sceneState lerps too when blending. Without this, thrusterLevel
     // jumps abruptly from 0 → 1 at shot boundary (engine bursts on instead of
@@ -181,6 +206,12 @@ export function evaluateCameraSequence(seq, tSec, ctx) {
     exposure: resolveExposure(shot, shotT),
     shotRenderer: typeof shot.renderer === 'string' ? shot.renderer : null,
   };
+
+  // Intra-shot DoF ramp (rack focus): a [from, to] focalDistance / aperture pulls
+  // focus across THIS shot while the camera can hold still — the classic focus
+  // pull from one subject to another. A plain number keeps the cross-shot blend.
+  out.aperture = dofValue(shot.aperture, blend, out.aperture);
+  out.focalDistance = dofValue(shot.focalDistance, blend, out.focalDistance);
 
   // Sprint 4: resolved shake (number OR {amount, velocityScale, scaleWith})
   const shakeAmt = resolveShake(shot.shake, subjectOffsets);

--- a/sdf-js/src/scene/spec.js
+++ b/sdf-js/src/scene/spec.js
@@ -1257,8 +1257,17 @@ function validatePostFx(pfx, errors, warnings) {
 // 'cut' is the default transition between shots (hard cut); ease='blend' opts
 // into smoothly interpolating from the prev shot's end state.
 // =============================================================================
-const SHOT_EASES = new Set(['smooth', 'linear']);
+const SHOT_EASES = new Set(['smooth', 'linear', 'in', 'out', 'inout']);
 const SHOT_TRANSITIONS = new Set(['cut', 'blend']);
+
+// DoF fields (aperture / focalDistance) accept a number OR a [from, to] pair
+// (the pair ramps within the shot → rack focus).
+function isNumberOrPair(v) {
+  return (
+    typeof v === 'number' ||
+    (Array.isArray(v) && v.length === 2 && typeof v[0] === 'number' && typeof v[1] === 'number')
+  );
+}
 
 function validateCameraSequence(seq, errors, warnings) {
   if (typeof seq !== 'object' || seq == null) {
@@ -1354,11 +1363,11 @@ function validateCameraSequence(seq, errors, warnings) {
     } else if (shot.fov < 5 || shot.fov > 90) {
       warnings.push(`${tag}.fov ${shot.fov} outside typical [5, 90]`);
     }
-    if (shot.aperture != null && typeof shot.aperture !== 'number') {
-      errors.push(`${tag}.aperture: must be a number if provided`);
+    if (shot.aperture != null && !isNumberOrPair(shot.aperture)) {
+      errors.push(`${tag}.aperture: must be a number or [from, to] pair if provided`);
     }
-    if (shot.focalDistance != null && typeof shot.focalDistance !== 'number') {
-      errors.push(`${tag}.focalDistance: must be a number if provided`);
+    if (shot.focalDistance != null && !isNumberOrPair(shot.focalDistance)) {
+      errors.push(`${tag}.focalDistance: must be a number or [from, to] pair if provided`);
     }
     if (shot.ease != null && !SHOT_EASES.has(shot.ease)) {
       errors.push(`${tag}.ease: must be one of ${[...SHOT_EASES].join(' | ')}`);


### PR DESCRIPTION
## What

`cameraSequence` polish — a richer camera-move vocabulary + true rack focus.

- **easing vocabulary**: adds `'in'` (accelerate from rest), `'out'` (decelerate to a gentle SETTLE — the cinematic arrival), and `'inout'` alongside the existing `'smooth'`/`'linear'`.
- **rack focus**: `focalDistance` / `aperture` now accept a `[from, to]` pair that ramps **within** a shot — the camera can hold still while focus pulls from one subject to another. A plain number keeps the existing cross-shot blend. Both the **evaluator** (`camera-sequence.js`) and the SceneData **validator** (`spec.js`) were updated — fully backward compatible.
- **hero `stage-showcase`** re-authored as a 3-shot cinematic sequence: ease-out establishing push-in → side-angle **rack focus** (focus pulls box→gold) → drift settle, with thirds composition.

**88/88 tests pass.** Backward compatible (number = old behaviour, `[from,to]` = new ramp; new ease modes are additive).

## Notes
- DoF strength / shot timing are all knobs in the scene data; tune per-scene.
- Composition (rule-of-thirds) is authoring-level — demonstrated on the hero, not an engine change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)