### PR TITLE
Sprint 16 v2: LLM-wrapped scaffold picker + PD deck re-bake

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -157,6 +157,7 @@ const TESTS = [
   { category: 'present', file: 'sdf-js/scripts/test-atoms-2d-framework.mjs' },
   { category: 'present', file: 'sdf-js/scripts/test-icon-library.mjs' },
   { category: 'present', file: 'sdf-js/scripts/test-scaffolds.mjs' },
+  { category: 'present', file: 'sdf-js/scripts/test-picker-llm.mjs' },
 ];
 
 // -----------------------------------------------------------------------------

--- a/sdf-js/examples/atoms-2d-demo/scaffold-deck-viewer.html
+++ b/sdf-js/examples/atoms-2d-demo/scaffold-deck-viewer.html
@@ -36,8 +36,9 @@
     <div class="controls">
       <label>Deck:</label>
       <select id="deck-picker">
-        <option value="examples/scaffold-pipeline/vc-pitch/deck.json">VC Pitch (synthetic 9-slide)</option>
-        <option value="examples/scaffold-pipeline/slidedata/deck.json">PD sphere-fill 20-slide</option>
+        <option value="examples/scaffold-pipeline/vc-pitch/deck.json">VC Pitch (v1 picker · pitch-deck-vc)</option>
+        <option value="examples/scaffold-pipeline/pd-sphere/deck.json">PD sphere-fill (v2 picker · product-launch)</option>
+        <option value="examples/scaffold-pipeline/slidedata/deck.json">PD sphere-fill v1 (legacy · company-overview fallback)</option>
       </select>
       <button id="reload-btn">Reload</button>
     </div>

--- a/sdf-js/examples/scaffold-pipeline/pd-sphere/deck.json
+++ b/sdf-js/examples/scaffold-pipeline/pd-sphere/deck.json
@@ -1,0 +1,182 @@
+{
+  "deckName": "pd-sphere",
+  "sourceFile": "sdf-js/examples/pdf-demo/slidedata.json",
+  "scaffold": {
+    "id": "product-launch",
+    "label": "Product Launch",
+    "description": "Announce a new product, feature, or release",
+    "pickScore": 2,
+    "pickSignals": [
+      "The deck contains only repetitive placeholder text ('3D SPHERES', '2D SPHERES', 'FILL LEVELS', 'POWERPOINT TEMPLATE') with no semantic content about purpose, audience, or intent",
+      "The presence of 'POWERPOINT TEMPLATE' and generic placeholder copy suggests this is a blank template or design mockup rather than a substantive deck",
+      "No scaffold truly fits; product-launch is chosen as lowest-confidence fallback because templates are sometimes used for feature announcements, but this is essentially a guess"
+    ],
+    "fallback": false,
+    "pickerMethod": "llm"
+  },
+  "theme": {
+    "id": "pitch-cobalt-orange",
+    "label": "Pitch · Cobalt Orange",
+    "macroCluster": "pitch",
+    "bg": [255, 255, 255],
+    "accent": [255, 120, 40],
+    "colors": [
+      [255, 120, 40],
+      [20, 60, 180],
+      [220, 220, 235],
+      [60, 65, 90]
+    ],
+    "font": {
+      "heading": "\"Inter Display\", Inter, system-ui, sans-serif",
+      "body": "Inter, system-ui, sans-serif"
+    }
+  },
+  "slots": [
+    {
+      "slotIdx": 0,
+      "slotName": "cover",
+      "slotTitle": "Title",
+      "slotPurpose": "Product name + reveal teaser",
+      "sourceSlideIdx": 0,
+      "sourceSlideTitle": "3D SPHERES",
+      "mappingScore": 0,
+      "mappingFallback": true,
+      "mappingEmpty": false,
+      "liftFile": "slots/slot-00-cover.json",
+      "cached": false,
+      "dryRun": false,
+      "error": null,
+      "subjectTypes": ["cover"]
+    },
+    {
+      "slotIdx": 1,
+      "slotName": "problem",
+      "slotTitle": "Why We Built It",
+      "slotPurpose": "The pain we are addressing",
+      "sourceSlideIdx": 1,
+      "sourceSlideTitle": "3D SPHERES",
+      "mappingScore": 0,
+      "mappingFallback": true,
+      "mappingEmpty": false,
+      "liftFile": "slots/slot-01-problem.json",
+      "cached": false,
+      "dryRun": false,
+      "error": null,
+      "subjectTypes": ["icon-badge", "bullet-list", "icon-badge"]
+    },
+    {
+      "slotIdx": 2,
+      "slotName": "feature-1",
+      "slotTitle": "Feature Highlight",
+      "slotPurpose": "Lead feature with detail",
+      "sourceSlideIdx": 3,
+      "sourceSlideTitle": "3D SPHERES",
+      "mappingScore": 1,
+      "mappingFallback": false,
+      "mappingEmpty": false,
+      "liftFile": "slots/slot-02-feature-1.json",
+      "cached": false,
+      "dryRun": false,
+      "error": null,
+      "subjectTypes": ["device-mockup-frame", "bullet-list"]
+    },
+    {
+      "slotIdx": 3,
+      "slotName": "feature-2",
+      "slotTitle": "Feature Highlight",
+      "slotPurpose": "Second feature with detail",
+      "sourceSlideIdx": 4,
+      "sourceSlideTitle": "3D SPHERES",
+      "mappingScore": 1,
+      "mappingFallback": false,
+      "mappingEmpty": false,
+      "liftFile": "slots/slot-03-feature-2.json",
+      "cached": false,
+      "dryRun": false,
+      "error": null,
+      "subjectTypes": ["text-3d-pipe", "sphere-fill", "bullet-list"]
+    },
+    {
+      "slotIdx": 4,
+      "slotName": "feature-3",
+      "slotTitle": "Feature Highlight",
+      "slotPurpose": "Third feature with detail",
+      "sourceSlideIdx": 6,
+      "sourceSlideTitle": "3D SPHERES",
+      "mappingScore": 1,
+      "mappingFallback": false,
+      "mappingEmpty": false,
+      "liftFile": "slots/slot-04-feature-3.json",
+      "cached": false,
+      "dryRun": false,
+      "error": null,
+      "subjectTypes": ["kpi-card", "kpi-card", "kpi-card"]
+    },
+    {
+      "slotIdx": 5,
+      "slotName": "demo",
+      "slotTitle": "See It In Action",
+      "slotPurpose": "Visual demo / mockup",
+      "sourceSlideIdx": 7,
+      "sourceSlideTitle": "3D SPHERES",
+      "mappingScore": 1,
+      "mappingFallback": false,
+      "mappingEmpty": false,
+      "liftFile": "slots/slot-05-demo.json",
+      "cached": false,
+      "dryRun": false,
+      "error": null,
+      "subjectTypes": ["kpi-card", "kpi-card", "kpi-card", "bullet-list"]
+    },
+    {
+      "slotIdx": 6,
+      "slotName": "pricing",
+      "slotTitle": "Pricing",
+      "slotPurpose": "Plans + pricing tiers",
+      "sourceSlideIdx": 2,
+      "sourceSlideTitle": "3D SPHERES",
+      "mappingScore": 0,
+      "mappingFallback": true,
+      "mappingEmpty": false,
+      "liftFile": "slots/slot-06-pricing.json",
+      "cached": false,
+      "dryRun": false,
+      "error": null,
+      "subjectTypes": ["magazine-column-grid"]
+    },
+    {
+      "slotIdx": 7,
+      "slotName": "cta",
+      "slotTitle": "Get Started",
+      "slotPurpose": "CTA + next steps",
+      "sourceSlideIdx": 5,
+      "sourceSlideTitle": "3D SPHERES",
+      "mappingScore": 0,
+      "mappingFallback": true,
+      "mappingEmpty": false,
+      "liftFile": "slots/slot-07-cta.json",
+      "cached": false,
+      "dryRun": false,
+      "error": null,
+      "subjectTypes": [
+        "bullet-list",
+        "kpi-card",
+        "icon-badge",
+        "icon-badge",
+        "icon-badge",
+        "icon-badge"
+      ]
+    }
+  ],
+  "totals": {
+    "slotsBaked": 8,
+    "slotsEmpty": 0,
+    "slotsErrored": 0,
+    "totalCostUSD": 0.5930925000000001
+  },
+  "meta": {
+    "generatedAt": "2026-06-22T15:35:50.293Z",
+    "model": "claude-sonnet-4-5-20250929",
+    "pipelineVersion": "sprint-16-v1"
+  }
+}

--- a/sdf-js/examples/scaffold-pipeline/pd-sphere/slots/slot-00-cover.json
+++ b/sdf-js/examples/scaffold-pipeline/pd-sphere/slots/slot-00-cover.json
@@ -1,0 +1,50 @@
+{
+  "slotIdx": 0,
+  "slotName": "cover",
+  "slotTitle": "Title",
+  "slotPurpose": "Product name + reveal teaser",
+  "sourceSlideIdx": 0,
+  "sourceSlideTitle": "3D SPHERES",
+  "sceneData": {
+    "name": "product-launch/cover",
+    "layout": "cover",
+    "subjects": [
+      {
+        "type": "cover",
+        "x": 0,
+        "y": 0,
+        "w": 1280,
+        "h": 720,
+        "args": {
+          "title": "3D SPHERES",
+          "subtitle": "FILL LEVELS · POWERPOINT TEMPLATE",
+          "author": "80% · 40% · 20%",
+          "date": null,
+          "version": null
+        }
+      }
+    ]
+  },
+  "meta": {
+    "scaffold": "product-launch",
+    "theme": "pitch-cobalt-orange",
+    "recommendedAtoms": ["cover"],
+    "forbiddenAtoms": [],
+    "tokenUsage": {
+      "input_tokens": 588,
+      "cache_creation_input_tokens": 89490,
+      "cache_read_input_tokens": 0,
+      "cache_creation": {
+        "ephemeral_5m_input_tokens": 89490,
+        "ephemeral_1h_input_tokens": 0
+      },
+      "output_tokens": 155,
+      "service_tier": "standard",
+      "inference_geo": "not_available"
+    },
+    "costUSD": 0.3396765,
+    "elapsedSec": 4.8,
+    "generatedAt": "2026-06-22T15:35:02.959Z",
+    "model": "claude-sonnet-4-5-20250929"
+  }
+}

--- a/sdf-js/examples/scaffold-pipeline/pd-sphere/slots/slot-01-problem.json
+++ b/sdf-js/examples/scaffold-pipeline/pd-sphere/slots/slot-01-problem.json
@@ -1,0 +1,91 @@
+{
+  "slotIdx": 1,
+  "slotName": "problem",
+  "slotTitle": "Why We Built It",
+  "slotPurpose": "The pain we are addressing",
+  "sourceSlideIdx": 1,
+  "sourceSlideTitle": "3D SPHERES",
+  "sceneData": {
+    "name": "product-launch/problem",
+    "layout": "row",
+    "subjects": [
+      {
+        "type": "icon-badge",
+        "x": 120,
+        "y": 80,
+        "w": 120,
+        "h": 120,
+        "args": {
+          "name": "warning-circle",
+          "label": "Pain Points",
+          "color": [255, 120, 40]
+        }
+      },
+      {
+        "type": "bullet-list",
+        "x": 120,
+        "y": 240,
+        "w": 480,
+        "h": 400,
+        "args": {
+          "items": [
+            {
+              "label": "Complex Fill Level Tracking",
+              "sublabel": "Manual monitoring of capacity across multiple systems leads to inefficiency and errors",
+              "status": "highlight"
+            },
+            {
+              "label": "No Real-Time Visibility",
+              "sublabel": "Teams lack instant insight into current fill states, causing delays in decision-making"
+            },
+            {
+              "label": "Scattered Data Sources",
+              "sublabel": "Information lives in disconnected places, making comprehensive analysis difficult"
+            },
+            {
+              "label": "Threshold Management",
+              "sublabel": "Tracking critical levels (20%, 50%, 80%, 90%) manually is time-consuming and error-prone"
+            }
+          ],
+          "title": "The Challenges Teams Face",
+          "numbered": false,
+          "highlight": 0
+        }
+      },
+      {
+        "type": "icon-badge",
+        "x": 680,
+        "y": 180,
+        "w": 480,
+        "h": 360,
+        "args": {
+          "name": "chart-bar",
+          "label": "3D Spheres solves this by providing instant visual representation of fill levels across all systems",
+          "color": [20, 60, 180]
+        }
+      }
+    ]
+  },
+  "meta": {
+    "scaffold": "product-launch",
+    "theme": "pitch-cobalt-orange",
+    "recommendedAtoms": ["bullet-list", "icon-badge"],
+    "forbiddenAtoms": [],
+    "tokenUsage": {
+      "input_tokens": 843,
+      "cache_creation_input_tokens": 0,
+      "cache_read_input_tokens": 89490,
+      "cache_creation": {
+        "ephemeral_5m_input_tokens": 0,
+        "ephemeral_1h_input_tokens": 0
+      },
+      "output_tokens": 503,
+      "service_tier": "standard",
+      "inference_geo": "not_available"
+    },
+    "costUSD": 0.036920999999999995,
+    "elapsedSec": 8.3,
+    "generatedAt": "2026-06-22T15:35:11.296Z",
+    "model": "claude-sonnet-4-5-20250929"
+  }
+}

--- a/sdf-js/examples/scaffold-pipeline/pd-sphere/slots/slot-02-feature-1.json
+++ b/sdf-js/examples/scaffold-pipeline/pd-sphere/slots/slot-02-feature-1.json
@@ -1,0 +1,79 @@
+{
+  "slotIdx": 2,
+  "slotName": "feature-1",
+  "slotTitle": "Feature Highlight",
+  "slotPurpose": "Lead feature with detail",
+  "sourceSlideIdx": 3,
+  "sourceSlideTitle": "3D SPHERES",
+  "sceneData": {
+    "name": "product-launch/feature-1",
+    "layout": "row",
+    "subjects": [
+      {
+        "type": "device-mockup-frame",
+        "x": 80,
+        "y": 120,
+        "w": 480,
+        "h": 520,
+        "args": {
+          "device": "phone",
+          "title": "3D SPHERES",
+          "content": "FILL LEVELS",
+          "color": [255, 120, 40]
+        }
+      },
+      {
+        "type": "bullet-list",
+        "x": 620,
+        "y": 120,
+        "w": 580,
+        "h": 520,
+        "args": {
+          "title": "Feature Highlight",
+          "items": [
+            {
+              "label": "FILL LEVELS",
+              "sublabel": "Enter your subheadline here",
+              "status": "highlight"
+            },
+            {
+              "label": "THIS IS A PLACEHOLDER TEXT.",
+              "sublabel": "This text can be replaced with your own text. The text demonstrates how your own text will look when you replace the placeholder with your own text."
+            },
+            {
+              "label": "THIS IS A PLACEHOLDER TEXT.",
+              "sublabel": "This text can be replaced with your own text. The text demonstrates how your own text will look when you replace the placeholder with your own text."
+            },
+            {
+              "label": "50%",
+              "sublabel": "Completion rate",
+              "status": "done"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  "meta": {
+    "scaffold": "product-launch",
+    "theme": "pitch-cobalt-orange",
+    "recommendedAtoms": ["device-mockup-frame", "bullet-list"],
+    "forbiddenAtoms": [],
+    "tokenUsage": {
+      "input_tokens": 736,
+      "cache_creation_input_tokens": 0,
+      "cache_read_input_tokens": 89490,
+      "cache_creation": {
+        "ephemeral_5m_input_tokens": 0,
+        "ephemeral_1h_input_tokens": 0
+      },
+      "output_tokens": 407,
+      "service_tier": "standard",
+      "inference_geo": "not_available"
+    },
+    "costUSD": 0.03516,
+    "elapsedSec": 5.5,
+    "generatedAt": "2026-06-22T15:35:16.772Z",
+    "model": "claude-sonnet-4-5-20250929"
+  }
+}

--- a/sdf-js/examples/scaffold-pipeline/pd-sphere/slots/slot-03-feature-2.json
+++ b/sdf-js/examples/scaffold-pipeline/pd-sphere/slots/slot-03-feature-2.json
@@ -1,0 +1,100 @@
+{
+  "slotIdx": 3,
+  "slotName": "feature-2",
+  "slotTitle": "Feature Highlight",
+  "slotPurpose": "Second feature with detail",
+  "sourceSlideIdx": 4,
+  "sourceSlideTitle": "3D SPHERES",
+  "sceneData": {
+    "name": "product-launch/feature-2",
+    "layout": "row",
+    "subjects": [
+      {
+        "type": "text-3d-pipe",
+        "x": 80,
+        "y": 60,
+        "w": 400,
+        "h": 80,
+        "args": {
+          "text": "FILL LEVELS",
+          "height": 0.8,
+          "pipeRadius": 0.14,
+          "align": "left"
+        },
+        "material": {
+          "hue": 0.05,
+          "sat": 0.85,
+          "value": 0.95,
+          "metal": 0.7,
+          "glow": 0
+        },
+        "transform": {
+          "translate": [-0.8, 0.3, 0]
+        }
+      },
+      {
+        "type": "sphere-fill",
+        "x": 80,
+        "y": 180,
+        "w": 280,
+        "h": 280,
+        "args": {
+          "value": 100,
+          "label": "Feature Completion",
+          "color": [255, 120, 40],
+          "background": "light"
+        }
+      },
+      {
+        "type": "bullet-list",
+        "x": 420,
+        "y": 180,
+        "w": 780,
+        "h": 480,
+        "args": {
+          "items": [
+            {
+              "label": "DESCRIPTION TEXT",
+              "sublabel": "This is a placeholder text. This text can be replaced with your own text.",
+              "status": "done"
+            },
+            {
+              "label": "DESCRIPTION TEXT",
+              "sublabel": "This is a placeholder text. This text can be replaced with your own text.",
+              "status": "done"
+            },
+            {
+              "label": "DESCRIPTION TEXT",
+              "sublabel": "This is a placeholder text. This text can be replaced with your own text.",
+              "status": "done"
+            }
+          ],
+          "title": "Enter your subheadline here",
+          "numbered": false
+        }
+      }
+    ]
+  },
+  "meta": {
+    "scaffold": "product-launch",
+    "theme": "pitch-cobalt-orange",
+    "recommendedAtoms": ["device-mockup-frame", "bullet-list"],
+    "forbiddenAtoms": [],
+    "tokenUsage": {
+      "input_tokens": 680,
+      "cache_creation_input_tokens": 0,
+      "cache_read_input_tokens": 89490,
+      "cache_creation": {
+        "ephemeral_5m_input_tokens": 0,
+        "ephemeral_1h_input_tokens": 0
+      },
+      "output_tokens": 552,
+      "service_tier": "standard",
+      "inference_geo": "not_available"
+    },
+    "costUSD": 0.037167,
+    "elapsedSec": 7.8,
+    "generatedAt": "2026-06-22T15:35:24.529Z",
+    "model": "claude-sonnet-4-5-20250929"
+  }
+}

--- a/sdf-js/examples/scaffold-pipeline/pd-sphere/slots/slot-04-feature-3.json
+++ b/sdf-js/examples/scaffold-pipeline/pd-sphere/slots/slot-04-feature-3.json
@@ -1,0 +1,80 @@
+{
+  "slotIdx": 4,
+  "slotName": "feature-3",
+  "slotTitle": "Feature Highlight",
+  "slotPurpose": "Third feature with detail",
+  "sourceSlideIdx": 6,
+  "sourceSlideTitle": "3D SPHERES",
+  "sceneData": {
+    "name": "product-launch/feature-3",
+    "layout": "grid",
+    "subjects": [
+      {
+        "type": "kpi-card",
+        "x": 80,
+        "y": 120,
+        "w": 340,
+        "h": 520,
+        "args": {
+          "value": "100%",
+          "label": "DESCRIPTION 1",
+          "sublabel": "The text demonstrates how your own text will look when you replace the placeholder with your own text.",
+          "trend": "up",
+          "icon": "chart-bar",
+          "color": [255, 120, 40]
+        }
+      },
+      {
+        "type": "kpi-card",
+        "x": 470,
+        "y": 120,
+        "w": 340,
+        "h": 520,
+        "args": {
+          "value": "50%",
+          "label": "DESCRIPTION 2",
+          "sublabel": "The text demonstrates how your own text will look when you replace the placeholder with your own text.",
+          "trend": "down",
+          "icon": "chart-pie",
+          "color": [20, 60, 180]
+        }
+      },
+      {
+        "type": "kpi-card",
+        "x": 860,
+        "y": 120,
+        "w": 340,
+        "h": 520,
+        "args": {
+          "value": "80%",
+          "label": "DESCRIPTION 3",
+          "sublabel": "The text demonstrates how your own text will look when you replace the placeholder with your own text.",
+          "icon": "database",
+          "color": [255, 120, 40]
+        }
+      }
+    ]
+  },
+  "meta": {
+    "scaffold": "product-launch",
+    "theme": "pitch-cobalt-orange",
+    "recommendedAtoms": ["device-mockup-frame", "bullet-list"],
+    "forbiddenAtoms": [],
+    "tokenUsage": {
+      "input_tokens": 735,
+      "cache_creation_input_tokens": 0,
+      "cache_read_input_tokens": 89490,
+      "cache_creation": {
+        "ephemeral_5m_input_tokens": 0,
+        "ephemeral_1h_input_tokens": 0
+      },
+      "output_tokens": 440,
+      "service_tier": "standard",
+      "inference_geo": "not_available"
+    },
+    "costUSD": 0.035651999999999996,
+    "elapsedSec": 5.5,
+    "generatedAt": "2026-06-22T15:35:30.060Z",
+    "model": "claude-sonnet-4-5-20250929"
+  }
+}

--- a/sdf-js/examples/scaffold-pipeline/pd-sphere/slots/slot-05-demo.json
+++ b/sdf-js/examples/scaffold-pipeline/pd-sphere/slots/slot-05-demo.json
@@ -1,0 +1,94 @@
+{
+  "slotIdx": 5,
+  "slotName": "demo",
+  "slotTitle": "See It In Action",
+  "slotPurpose": "Visual demo / mockup",
+  "sourceSlideIdx": 7,
+  "sourceSlideTitle": "3D SPHERES",
+  "sceneData": {
+    "name": "product-launch/demo",
+    "layout": "grid",
+    "subjects": [
+      {
+        "type": "kpi-card",
+        "x": 80,
+        "y": 120,
+        "w": 340,
+        "h": 240,
+        "args": {
+          "value": "50%",
+          "label": "FILL LEVELS",
+          "sublabel": "Capacity metric",
+          "icon": "gauge",
+          "color": [255, 120, 40]
+        }
+      },
+      {
+        "type": "kpi-card",
+        "x": 470,
+        "y": 120,
+        "w": 340,
+        "h": 240,
+        "args": {
+          "value": "60%",
+          "label": "Progress",
+          "sublabel": "Current status",
+          "icon": "chart-bar",
+          "color": [20, 60, 180]
+        }
+      },
+      {
+        "type": "kpi-card",
+        "x": 860,
+        "y": 120,
+        "w": 340,
+        "h": 240,
+        "args": {
+          "value": "80%",
+          "label": "Completion",
+          "sublabel": "Target achieved",
+          "icon": "check",
+          "color": [255, 120, 40]
+        }
+      },
+      {
+        "type": "bullet-list",
+        "x": 80,
+        "y": 400,
+        "w": 1120,
+        "h": 260,
+        "args": {
+          "title": "3D SPHERES",
+          "items": [
+            {
+              "label": "THIS IS A PLACEHOLDER TEXT.",
+              "sublabel": "The text demonstrates how your own text will look when you replace the placeholder with your own text."
+            }
+          ]
+        }
+      }
+    ]
+  },
+  "meta": {
+    "scaffold": "product-launch",
+    "theme": "pitch-cobalt-orange",
+    "recommendedAtoms": ["device-mockup-row", "flow-chart"],
+    "forbiddenAtoms": [],
+    "tokenUsage": {
+      "input_tokens": 660,
+      "cache_creation_input_tokens": 0,
+      "cache_read_input_tokens": 89490,
+      "cache_creation": {
+        "ephemeral_5m_input_tokens": 0,
+        "ephemeral_1h_input_tokens": 0
+      },
+      "output_tokens": 492,
+      "service_tier": "standard",
+      "inference_geo": "not_available"
+    },
+    "costUSD": 0.036206999999999996,
+    "elapsedSec": 7.5,
+    "generatedAt": "2026-06-22T15:35:37.546Z",
+    "model": "claude-sonnet-4-5-20250929"
+  }
+}

--- a/sdf-js/examples/scaffold-pipeline/pd-sphere/slots/slot-06-pricing.json
+++ b/sdf-js/examples/scaffold-pipeline/pd-sphere/slots/slot-06-pricing.json
@@ -1,0 +1,71 @@
+{
+  "slotIdx": 6,
+  "slotName": "pricing",
+  "slotTitle": "Pricing",
+  "slotPurpose": "Plans + pricing tiers",
+  "sourceSlideIdx": 2,
+  "sourceSlideTitle": "3D SPHERES",
+  "sceneData": {
+    "name": "product-launch/pricing",
+    "layout": "grid",
+    "subjects": [
+      {
+        "type": "magazine-column-grid",
+        "x": 40,
+        "y": 80,
+        "w": 1200,
+        "h": 600,
+        "args": {
+          "categories": [
+            {
+              "name": "FILL LEVELS",
+              "items": [
+                {
+                  "label": "DESCRIPTION 1",
+                  "value": "10%"
+                },
+                {
+                  "label": "DESCRIPTION 2",
+                  "value": "60%"
+                },
+                {
+                  "label": "DESCRIPTION 3",
+                  "value": "50%"
+                }
+              ]
+            }
+          ],
+          "title": "Pricing",
+          "subtitle": "Enter your subheadline here",
+          "colors": [
+            [255, 120, 40],
+            [20, 60, 180],
+            [220, 220, 235]
+          ]
+        }
+      }
+    ]
+  },
+  "meta": {
+    "scaffold": "product-launch",
+    "theme": "pitch-cobalt-orange",
+    "recommendedAtoms": ["magazine-column-grid", "kpi-card"],
+    "forbiddenAtoms": [],
+    "tokenUsage": {
+      "input_tokens": 661,
+      "cache_creation_input_tokens": 0,
+      "cache_read_input_tokens": 89490,
+      "cache_creation": {
+        "ephemeral_5m_input_tokens": 0,
+        "ephemeral_1h_input_tokens": 0
+      },
+      "output_tokens": 278,
+      "service_tier": "standard",
+      "inference_geo": "not_available"
+    },
+    "costUSD": 0.033,
+    "elapsedSec": 4.2,
+    "generatedAt": "2026-06-22T15:35:41.794Z",
+    "model": "claude-sonnet-4-5-20250929"
+  }
+}

--- a/sdf-js/examples/scaffold-pipeline/pd-sphere/slots/slot-07-cta.json
+++ b/sdf-js/examples/scaffold-pipeline/pd-sphere/slots/slot-07-cta.json
@@ -1,0 +1,125 @@
+{
+  "slotIdx": 7,
+  "slotName": "cta",
+  "slotTitle": "Get Started",
+  "slotPurpose": "CTA + next steps",
+  "sourceSlideIdx": 5,
+  "sourceSlideTitle": "3D SPHERES",
+  "sceneData": {
+    "name": "product-launch/cta",
+    "layout": "stage",
+    "subjects": [
+      {
+        "type": "bullet-list",
+        "x": 80,
+        "y": 120,
+        "w": 520,
+        "h": 520,
+        "args": {
+          "title": "Get Started",
+          "items": [
+            {
+              "label": "Sign up for early access",
+              "sublabel": "Join our beta program",
+              "status": "highlight"
+            },
+            {
+              "label": "Schedule a demo",
+              "sublabel": "See 3D spheres in action",
+              "status": "todo"
+            },
+            {
+              "label": "Contact our team",
+              "sublabel": "Questions? We're here to help",
+              "status": "todo"
+            }
+          ],
+          "numbered": false
+        }
+      },
+      {
+        "type": "kpi-card",
+        "x": 680,
+        "y": 140,
+        "w": 520,
+        "h": 180,
+        "args": {
+          "value": "100%",
+          "label": "FILL LEVELS",
+          "sublabel": "Enter your subheadline here",
+          "icon": "chart-bar"
+        }
+      },
+      {
+        "type": "icon-badge",
+        "x": 720,
+        "y": 380,
+        "w": 100,
+        "h": 100,
+        "args": {
+          "name": "check",
+          "label": "50%",
+          "color": [255, 120, 40]
+        }
+      },
+      {
+        "type": "icon-badge",
+        "x": 860,
+        "y": 380,
+        "w": 100,
+        "h": 100,
+        "args": {
+          "name": "lightning",
+          "label": "80%",
+          "color": [20, 60, 180]
+        }
+      },
+      {
+        "type": "icon-badge",
+        "x": 1000,
+        "y": 380,
+        "w": 100,
+        "h": 100,
+        "args": {
+          "name": "star",
+          "label": "40%",
+          "color": [255, 120, 40]
+        }
+      },
+      {
+        "type": "icon-badge",
+        "x": 790,
+        "y": 520,
+        "w": 100,
+        "h": 100,
+        "args": {
+          "name": "arrow-up",
+          "label": "20%",
+          "color": [20, 60, 180]
+        }
+      }
+    ]
+  },
+  "meta": {
+    "scaffold": "product-launch",
+    "theme": "pitch-cobalt-orange",
+    "recommendedAtoms": ["bullet-list", "icon-badge"],
+    "forbiddenAtoms": [],
+    "tokenUsage": {
+      "input_tokens": 669,
+      "cache_creation_input_tokens": 0,
+      "cache_read_input_tokens": 89490,
+      "cache_creation": {
+        "ephemeral_5m_input_tokens": 0,
+        "ephemeral_1h_input_tokens": 0
+      },
+      "output_tokens": 697,
+      "service_tier": "standard",
+      "inference_geo": "not_available"
+    },
+    "costUSD": 0.039309,
+    "elapsedSec": 8.5,
+    "generatedAt": "2026-06-22T15:35:50.292Z",
+    "model": "claude-sonnet-4-5-20250929"
+  }
+}

--- a/sdf-js/examples/scaffold-pipeline/vc-pitch-v2/deck.json
+++ b/sdf-js/examples/scaffold-pipeline/vc-pitch-v2/deck.json
@@ -1,0 +1,191 @@
+{
+  "deckName": "vc-pitch-v2",
+  "sourceFile": "sdf-js/scripts/scaffold-pipeline-fixtures/vc-pitch.json",
+  "scaffold": {
+    "id": "pitch-deck-vc",
+    "label": "VC Pitch Deck",
+    "description": "Seed/Series A fundraise pitch (Sequoia / YC structure)",
+    "pickScore": 10,
+    "pickSignals": [
+      "Title explicitly states 'Series A Pitch' and body opens with 'Series A fundraise · 2026-Q3'",
+      "Deck follows canonical VC pitch structure: problem → market → solution → product → traction → business model → team → ask ($15M raise)",
+      "Content includes all classic fundraise elements: TAM ($4.8B+ market), ARR growth trajectory, pricing tiers, team credentials (ex-Figma, ex-Anthropic), break-even projection"
+    ],
+    "fallback": false,
+    "pickerMethod": "llm"
+  },
+  "theme": {
+    "id": "pitch-cobalt-orange",
+    "label": "Pitch · Cobalt Orange",
+    "macroCluster": "pitch",
+    "bg": [255, 255, 255],
+    "accent": [255, 120, 40],
+    "colors": [
+      [255, 120, 40],
+      [20, 60, 180],
+      [220, 220, 235],
+      [60, 65, 90]
+    ],
+    "font": {
+      "heading": "\"Inter Display\", Inter, system-ui, sans-serif",
+      "body": "Inter, system-ui, sans-serif"
+    }
+  },
+  "slots": [
+    {
+      "slotIdx": 0,
+      "slotName": "cover",
+      "slotTitle": "Title",
+      "slotPurpose": "Company name + one-line tagline + author/date",
+      "sourceSlideIdx": 0,
+      "sourceSlideTitle": "Atlas Series A Pitch",
+      "mappingScore": 0,
+      "mappingFallback": true,
+      "mappingEmpty": false,
+      "liftFile": null,
+      "cached": false,
+      "dryRun": true,
+      "error": null,
+      "subjectTypes": []
+    },
+    {
+      "slotIdx": 1,
+      "slotName": "problem",
+      "slotTitle": "Problem",
+      "slotPurpose": "Pain point — who hurts and how much",
+      "sourceSlideIdx": 1,
+      "sourceSlideTitle": "The Problem",
+      "mappingScore": 2,
+      "mappingFallback": false,
+      "mappingEmpty": false,
+      "liftFile": null,
+      "cached": false,
+      "dryRun": true,
+      "error": null,
+      "subjectTypes": []
+    },
+    {
+      "slotIdx": 2,
+      "slotName": "market-size",
+      "slotTitle": "Market Size",
+      "slotPurpose": "TAM/SAM/SOM with numbers",
+      "sourceSlideIdx": 2,
+      "sourceSlideTitle": "Total Addressable Market",
+      "mappingScore": 1,
+      "mappingFallback": false,
+      "mappingEmpty": false,
+      "liftFile": null,
+      "cached": false,
+      "dryRun": true,
+      "error": null,
+      "subjectTypes": []
+    },
+    {
+      "slotIdx": 3,
+      "slotName": "solution",
+      "slotTitle": "Our Solution",
+      "slotPurpose": "Product overview + value prop",
+      "sourceSlideIdx": 3,
+      "sourceSlideTitle": "Our Solution",
+      "mappingScore": 1,
+      "mappingFallback": false,
+      "mappingEmpty": false,
+      "liftFile": null,
+      "cached": false,
+      "dryRun": true,
+      "error": null,
+      "subjectTypes": []
+    },
+    {
+      "slotIdx": 4,
+      "slotName": "product",
+      "slotTitle": "Product Demo",
+      "slotPurpose": "Screenshot mockup or feature highlight",
+      "sourceSlideIdx": 4,
+      "sourceSlideTitle": "Product Demo",
+      "mappingScore": 2,
+      "mappingFallback": false,
+      "mappingEmpty": false,
+      "liftFile": null,
+      "cached": false,
+      "dryRun": true,
+      "error": null,
+      "subjectTypes": []
+    },
+    {
+      "slotIdx": 5,
+      "slotName": "traction",
+      "slotTitle": "Traction",
+      "slotPurpose": "Revenue / users / growth charts",
+      "sourceSlideIdx": 5,
+      "sourceSlideTitle": "Traction",
+      "mappingScore": 1,
+      "mappingFallback": false,
+      "mappingEmpty": false,
+      "liftFile": null,
+      "cached": false,
+      "dryRun": true,
+      "error": null,
+      "subjectTypes": []
+    },
+    {
+      "slotIdx": 6,
+      "slotName": "business-model",
+      "slotTitle": "Business Model",
+      "slotPurpose": "How we make money — unit economics",
+      "sourceSlideIdx": 6,
+      "sourceSlideTitle": "Business Model",
+      "mappingScore": 2,
+      "mappingFallback": false,
+      "mappingEmpty": false,
+      "liftFile": null,
+      "cached": false,
+      "dryRun": true,
+      "error": null,
+      "subjectTypes": []
+    },
+    {
+      "slotIdx": 7,
+      "slotName": "team",
+      "slotTitle": "Team",
+      "slotPurpose": "Founders + key hires with credentials",
+      "sourceSlideIdx": 7,
+      "sourceSlideTitle": "The Team",
+      "mappingScore": 1,
+      "mappingFallback": false,
+      "mappingEmpty": false,
+      "liftFile": null,
+      "cached": false,
+      "dryRun": true,
+      "error": null,
+      "subjectTypes": []
+    },
+    {
+      "slotIdx": 8,
+      "slotName": "ask",
+      "slotTitle": "The Ask",
+      "slotPurpose": "Funding amount + use of funds + milestones",
+      "sourceSlideIdx": 8,
+      "sourceSlideTitle": "The Ask",
+      "mappingScore": 0,
+      "mappingFallback": true,
+      "mappingEmpty": false,
+      "liftFile": null,
+      "cached": false,
+      "dryRun": true,
+      "error": null,
+      "subjectTypes": []
+    }
+  ],
+  "totals": {
+    "slotsBaked": 9,
+    "slotsEmpty": 0,
+    "slotsErrored": 0,
+    "totalCostUSD": 0
+  },
+  "meta": {
+    "generatedAt": "2026-06-22T15:34:44.888Z",
+    "model": "claude-sonnet-4-5-20250929",
+    "pipelineVersion": "sprint-16-v1"
+  }
+}

--- a/sdf-js/scripts/bake-scaffold-pipeline.mjs
+++ b/sdf-js/scripts/bake-scaffold-pipeline.mjs
@@ -26,6 +26,7 @@
 import { readFileSync, writeFileSync, existsSync, mkdirSync } from 'node:fs';
 import { basename } from 'node:path';
 import { pickScaffold, distributeSources } from '../src/present/scaffolds/picker.js';
+import { pickScaffoldLLM } from '../src/present/scaffolds/picker-llm.js';
 import { getTheme } from '../src/present/themes.js';
 
 // --- args ---
@@ -40,6 +41,9 @@ const DECK_NAME = arg('--deck-name') || basename(SLIDEDATA_PATH).replace(/\.json
 const FORCE = args.includes('--force');
 const DRY_RUN = args.includes('--dry-run');
 const KEY_FILE = arg('--key-file', null);
+// Picker mode: 'llm' (v2 Claude-wrapped), 'v1' (deterministic keyword), 'auto'
+// (v2 with v1 fallback on error). Default: auto.
+const PICKER_MODE = arg('--picker', 'auto');
 
 // --- API key ---
 let API_KEY = process.env.ANTHROPIC_API_KEY;
@@ -103,18 +107,32 @@ for (const slide of slides) {
 const deckTitle = allTitles[0] || DECK_NAME;
 const deckCombinedBody = [...allTitles, ...bodyTextsAll];
 
-const picked = pickScaffold({
-  title: deckTitle,
-  bodyTexts: deckCombinedBody,
-});
+async function pickStage0() {
+  const baseInput = { title: deckTitle, bodyTexts: deckCombinedBody };
+  if (PICKER_MODE === 'v1') {
+    const r = pickScaffold(baseInput);
+    return { ...r, method: r.fallback ? 'fallback' : 'v1' };
+  }
+  // 'llm' or 'auto' — both use picker-llm; the difference is what we do on
+  // error. picker-llm.js silently falls back when fallbackToV1=true (default).
+  // 'llm' mode disables fallback so errors are loud.
+  return await pickScaffoldLLM(baseInput, {
+    apiKey: API_KEY,
+    fallbackToV1: PICKER_MODE !== 'llm',
+    log: (...m) => console.log(' ', ...m),
+  });
+}
 
+const picked = await pickStage0();
 const scaffold = picked.scaffold;
 const theme = picked.theme;
+const pickerMethod = picked.method || 'unknown';
 
 console.log(
   `  picked: ${scaffold.id} (${scaffold.label})\n` +
     `  score:  ${picked.score}${picked.fallback ? ' [FALLBACK]' : ''}\n` +
-    `  signals: ${picked.signals.slice(0, 6).join(', ')}\n` +
+    `  method: ${pickerMethod}\n` +
+    `  signals: ${picked.signals.slice(0, 6).join(' | ')}\n` +
     `  theme:  ${theme.id} (${theme.label})\n` +
     `  slots:  ${scaffold.slots.length}\n`,
 );
@@ -380,6 +398,7 @@ const deckManifest = {
     pickScore: picked.score,
     pickSignals: picked.signals,
     fallback: picked.fallback,
+    pickerMethod,
   },
   theme: {
     id: theme.id,

--- a/sdf-js/scripts/test-picker-llm.mjs
+++ b/sdf-js/scripts/test-picker-llm.mjs
@@ -1,0 +1,203 @@
+// =============================================================================
+// test-picker-llm.mjs — Sprint 16 v2 smoke test for picker-llm.js
+// -----------------------------------------------------------------------------
+// Stubs globalThis.fetch so no real Anthropic call is made. Exercises:
+//   - Happy path: LLM returns valid JSON → result.method='llm' + scaffold found
+//   - Unknown scaffoldId → fallback to v1
+//   - HTTP error → fallback to v1
+//   - Network throw → fallback to v1
+//   - No apiKey → fallback to v1
+//   - Theme hint honored
+// =============================================================================
+
+import { pickScaffoldLLM } from '../src/present/scaffolds/picker-llm.js';
+
+let pass = 0;
+let fail = 0;
+const originalFetch = globalThis.fetch;
+function ok(cond, name) {
+  if (cond) {
+    pass++;
+    console.log(`  ✓ ${name}`);
+  } else {
+    fail++;
+    console.log(`  ✗ ${name}`);
+  }
+}
+
+function mockFetch(responseBody, status = 200) {
+  globalThis.fetch = async () => ({
+    ok: status >= 200 && status < 300,
+    status,
+    text: async () =>
+      typeof responseBody === 'string' ? responseBody : JSON.stringify(responseBody),
+    json: async () => (typeof responseBody === 'string' ? JSON.parse(responseBody) : responseBody),
+  });
+}
+
+function mockFetchThrows(message) {
+  globalThis.fetch = async () => {
+    throw new Error(message);
+  };
+}
+
+function restoreFetch() {
+  globalThis.fetch = originalFetch;
+}
+
+console.log('=== picker-llm smoke ===\n');
+
+console.log('--- happy path: LLM picks pitch-deck-vc ---');
+{
+  mockFetch({
+    content: [
+      {
+        text: '```json\n{"scaffoldId":"pitch-deck-vc","confidence":8,"reasoning":["Mentions Series A","TAM included","Has ask slot"]}\n```',
+      },
+    ],
+    usage: { input_tokens: 1000, output_tokens: 50 },
+  });
+  const r = await pickScaffoldLLM(
+    { title: 'Series A pitch', bodyTexts: ['Problem', 'TAM', 'Solution', 'Ask'] },
+    { apiKey: 'sk-test', log: () => {} },
+  );
+  ok(r.scaffold.id === 'pitch-deck-vc', `scaffold=pitch-deck-vc (got ${r.scaffold.id})`);
+  ok(r.method === 'llm', `method=llm (got ${r.method})`);
+  ok(r.score === 8, `score=8 (got ${r.score})`);
+  ok(r.signals.length === 3, `3 reasoning signals (got ${r.signals.length})`);
+  ok(!r.fallback, 'not fallback');
+  ok(r.theme && r.theme.id, `theme resolved (got ${r.theme?.id})`);
+  restoreFetch();
+}
+
+console.log('\n--- theme hint honored ---');
+{
+  mockFetch({
+    content: [
+      {
+        text: '{"scaffoldId":"pitch-deck-vc","confidence":7,"reasoning":["fit"],"themeHint":"pitch-charcoal-yellow"}',
+      },
+    ],
+    usage: {},
+  });
+  const r = await pickScaffoldLLM(
+    { title: 'Pitch', bodyTexts: ['x'] },
+    { apiKey: 'sk-test', log: () => {} },
+  );
+  ok(r.theme.id === 'pitch-charcoal-yellow', `themeHint honored (got ${r.theme.id})`);
+  restoreFetch();
+}
+
+console.log('\n--- ignores invalid theme hint, falls back to top affinity ---');
+{
+  mockFetch({
+    content: [
+      {
+        text: '{"scaffoldId":"pitch-deck-vc","confidence":7,"reasoning":["fit"],"themeHint":"nonexistent-theme"}',
+      },
+    ],
+    usage: {},
+  });
+  const r = await pickScaffoldLLM(
+    { title: 'Pitch', bodyTexts: ['x'] },
+    { apiKey: 'sk-test', log: () => {} },
+  );
+  ok(r.theme.id === 'pitch-cobalt-orange', `invalid themeHint → top affinity (got ${r.theme.id})`);
+  restoreFetch();
+}
+
+console.log('\n--- unknown scaffoldId → fallback to v1 ---');
+{
+  mockFetch({
+    content: [{ text: '{"scaffoldId":"made-up-deck","confidence":5,"reasoning":["x"]}' }],
+    usage: {},
+  });
+  const r = await pickScaffoldLLM(
+    { title: 'Mystery', bodyTexts: ['nothing'] },
+    { apiKey: 'sk-test', log: () => {} },
+  );
+  ok(r.fallback === true, 'fallback=true');
+  ok(r.method === 'fallback', `method=fallback (got ${r.method})`);
+  ok(
+    r.signals.some((s) => s.includes('unknown-id')),
+    `signals include unknown-id (got ${r.signals.join(', ')})`,
+  );
+  restoreFetch();
+}
+
+console.log('\n--- HTTP 500 → fallback ---');
+{
+  mockFetch('Internal server error', 500);
+  const r = await pickScaffoldLLM(
+    { title: 'Q3 review', bodyTexts: ['kpi', 'wins'] },
+    { apiKey: 'sk-test', log: () => {} },
+  );
+  ok(r.fallback === true, 'fallback=true on HTTP 500');
+  ok(
+    r.signals.some((s) => s.includes('http-500')),
+    'signals include http-500',
+  );
+  // Should still resolve to a scaffold (v1 fallback)
+  ok(r.scaffold && r.scaffold.id, `still has scaffold (${r.scaffold?.id})`);
+  restoreFetch();
+}
+
+console.log('\n--- network throw → fallback ---');
+{
+  mockFetchThrows('ECONNREFUSED');
+  const r = await pickScaffoldLLM(
+    { title: 'Test', bodyTexts: ['x'] },
+    { apiKey: 'sk-test', log: () => {} },
+  );
+  ok(r.fallback === true, 'fallback on network throw');
+  ok(
+    r.signals.some((s) => s.includes('ECONNREFUSED')),
+    'reason captured in signals',
+  );
+  restoreFetch();
+}
+
+console.log('\n--- parse-failed → fallback ---');
+{
+  mockFetch({
+    content: [{ text: 'I cannot answer this question.' }],
+    usage: {},
+  });
+  const r = await pickScaffoldLLM(
+    { title: 'x', bodyTexts: ['y'] },
+    { apiKey: 'sk-test', log: () => {} },
+  );
+  ok(r.fallback === true, 'fallback on parse failure');
+  ok(
+    r.signals.some((s) => s.includes('parse-failed')),
+    'reason captured',
+  );
+  restoreFetch();
+}
+
+console.log('\n--- no apiKey + fallbackToV1=true → fallback (no throw) ---');
+{
+  const r = await pickScaffoldLLM(
+    { title: 'Series A', bodyTexts: ['Problem', 'TAM'] },
+    { fallbackToV1: true, log: () => {} },
+  );
+  ok(r.fallback === true, 'fallback when no apiKey');
+  ok(
+    r.signals.some((s) => s.includes('no-api-key')),
+    'reason captured',
+  );
+}
+
+console.log('\n--- no apiKey + fallbackToV1=false → throws ---');
+{
+  let threw = false;
+  try {
+    await pickScaffoldLLM({ title: 'x', bodyTexts: ['y'] }, { fallbackToV1: false, log: () => {} });
+  } catch {
+    threw = true;
+  }
+  ok(threw === true, 'throws when fallbackToV1=false + no apiKey');
+}
+
+console.log(`\n=== Result: ${pass} passed, ${fail} failed ===`);
+process.exit(fail > 0 ? 1 : 0);

--- a/sdf-js/src/present/scaffolds/picker-llm.js
+++ b/sdf-js/src/present/scaffolds/picker-llm.js
@@ -1,0 +1,202 @@
+// =============================================================================
+// scaffolds/picker-llm.js — LLM-wrapped scaffold picker (v2)
+// -----------------------------------------------------------------------------
+// Sprint 16 v2 — wraps `pickScaffold()` (deterministic v1) with a Claude call
+// that sees the 10 scaffold menu + the deck text and picks the best fit.
+//
+// Why v2: v1 scores by keyword overlap, which falls back to company-overview
+// on fuzzy inputs (e.g. PD sphere-fill deck has no business keywords so all
+// scaffolds tie at 0). v2 lets Claude reason about deck intent vs scaffold
+// purpose at a semantic level.
+//
+// Returns same shape as pickScaffold() + a `method` field for telemetry:
+//   { scaffold, theme, score, signals, fallback, method: 'llm'|'v1'|'fallback' }
+//
+// On any error (network / parse / unknown id) the picker falls back to v1
+// silently — pipelines that ship v2 should still complete on API outages.
+// =============================================================================
+
+import { SCAFFOLDS, getScaffold, getThemeAffinity } from './registry.js';
+import { pickScaffold as pickScaffoldV1 } from './picker.js';
+
+/**
+ * @typedef {object} PickerLLMResult
+ * @property {import('./registry.js').Scaffold} scaffold
+ * @property {import('../themes.js').ThemePreset} theme
+ * @property {number} score — Claude's confidence (0-10)
+ * @property {string[]} signals — Claude's reasoning bullets
+ * @property {boolean} fallback — true if we fell back to v1 deterministic
+ * @property {'llm'|'v1'|'fallback'} method
+ * @property {string} [rawReasoning] — full LLM reasoning (debug)
+ */
+
+const PICKER_MODEL = 'claude-sonnet-4-5-20250929';
+
+/**
+ * LLM-wrapped scaffold picker. See file header for design notes.
+ *
+ * @param {object} input
+ * @param {string} [input.title]
+ * @param {string[]} [input.bodyTexts]
+ * @param {string} [input.audienceHint]
+ * @param {object} opts
+ * @param {string} opts.apiKey — Anthropic API key (REQUIRED)
+ * @param {string} [opts.model] — override Claude model
+ * @param {boolean} [opts.fallbackToV1=true] — silently fall back on error
+ * @param {(...args: any[]) => void} [opts.log] — optional logger
+ * @returns {Promise<PickerLLMResult>}
+ */
+export async function pickScaffoldLLM(input, opts = {}) {
+  const { apiKey, model = PICKER_MODEL, fallbackToV1 = true, log = () => {} } = opts;
+
+  if (!apiKey) {
+    if (!fallbackToV1) throw new Error('pickScaffoldLLM: apiKey required');
+    log('[picker-llm] no apiKey → fallback to v1');
+    return _fallback(input, 'no-api-key');
+  }
+
+  const menu = SCAFFOLDS.map(
+    (s) =>
+      `- **${s.id}** — ${s.label}: ${s.description}\n` +
+      `  Audience: ${s.audience}\n` +
+      `  Slots (${s.slots.length}): ${s.slots.map((sl) => sl.name).join(' → ')}\n` +
+      `  Keywords: ${s.keywords.slice(0, 6).join(', ')}`,
+  ).join('\n\n');
+
+  const title = input.title || '(untitled deck)';
+  const body = (input.bodyTexts || []).slice(0, 40).join('\n');
+  const audienceHint = input.audienceHint || '';
+
+  const systemPrompt = `You are a scaffold picker for Atlas Present. Atlas decks are built from "scaffolds" — slot-sequence templates (e.g. a VC pitch deck has slots for problem, market-size, solution, traction, team, ask).
+
+Given a deck's title + body text, you pick the SINGLE best-fit scaffold from a fixed menu. You may not invent new scaffolds.
+
+OUTPUT: respond with ONLY a JSON object:
+{
+  "scaffoldId": "<exact id from the menu>",
+  "confidence": <0-10 integer; 0=guess, 10=perfect fit>,
+  "reasoning": ["<bullet 1>", "<bullet 2>", "<bullet 3>"],
+  "themeHint": "<theme id from scaffold's theme_affinity[]>" (optional, omit if unsure)
+}
+
+Pick on SEMANTIC intent, not just keyword surface. If the deck doesn't fit any scaffold well, pick the closest and set confidence low (1-3).`;
+
+  const userMessage = `## Available scaffolds (10 total)
+
+${menu}
+
+## Deck to classify
+
+**Title**: ${title}
+
+**Body (first 40 paragraphs)**:
+${body || '(empty)'}
+
+${audienceHint ? `**Audience hint**: ${audienceHint}\n\n` : ''}## Your pick
+
+Return JSON only. No prose outside the object.`;
+
+  try {
+    const t0 = Date.now();
+    const res = await fetch('https://api.anthropic.com/v1/messages', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-api-key': apiKey,
+        'anthropic-version': '2023-06-01',
+      },
+      body: JSON.stringify({
+        model,
+        max_tokens: 800,
+        system: [{ type: 'text', text: systemPrompt, cache_control: { type: 'ephemeral' } }],
+        messages: [{ role: 'user', content: userMessage }],
+      }),
+    });
+    const elapsed = ((Date.now() - t0) / 1000).toFixed(2);
+    if (!res.ok) {
+      const errText = (await res.text()).slice(0, 200);
+      log(`[picker-llm] HTTP ${res.status}: ${errText} → fallback`);
+      return _fallback(input, `http-${res.status}`);
+    }
+    const data = await res.json();
+    const text = data.content?.[0]?.text || '';
+    log(`[picker-llm] ${elapsed}s — usage: ${JSON.stringify(data.usage)}`);
+
+    // Parse JSON object from response
+    const parsed = _parseLLMResponse(text);
+    if (!parsed) {
+      log('[picker-llm] parse failed → fallback');
+      return _fallback(input, 'parse-failed');
+    }
+
+    const scaffold = getScaffold(parsed.scaffoldId);
+    if (!scaffold) {
+      log(`[picker-llm] unknown scaffoldId '${parsed.scaffoldId}' → fallback`);
+      return _fallback(input, 'unknown-id');
+    }
+
+    // Resolve theme
+    const themes = getThemeAffinity(scaffold);
+    let theme = themes[0];
+    if (parsed.themeHint) {
+      const hinted = themes.find((t) => t.id === parsed.themeHint);
+      if (hinted) theme = hinted;
+    }
+
+    return {
+      scaffold,
+      theme,
+      score: Number(parsed.confidence) || 0,
+      signals: Array.isArray(parsed.reasoning) ? parsed.reasoning.slice(0, 5) : [],
+      fallback: false,
+      method: 'llm',
+      rawReasoning: text,
+    };
+  } catch (e) {
+    log(`[picker-llm] threw '${e.message}' → fallback`);
+    return _fallback(input, e.message);
+  }
+}
+
+/**
+ * Extract a JSON object from an LLM response (handles ```json fences,
+ * leading/trailing prose).
+ *
+ * @param {string} text
+ * @returns {object|null}
+ */
+function _parseLLMResponse(text) {
+  // Try fenced block first
+  const m = text.match(/```(?:json)?\s*\n([\s\S]*?)\n```/);
+  let s = m ? m[1] : text.trim();
+  if (!m) {
+    const i = s.indexOf('{');
+    const j = s.lastIndexOf('}');
+    if (i >= 0 && j > i) s = s.slice(i, j + 1);
+  }
+  try {
+    return JSON.parse(s);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Internal: fall back to v1 deterministic picker. Annotates method='fallback'
+ * with the fallback reason in signals[].
+ *
+ * @param {object} input
+ * @param {string} reason
+ * @returns {PickerLLMResult}
+ */
+function _fallback(input, reason) {
+  const v1 = pickScaffoldV1(input);
+  return {
+    scaffold: v1.scaffold,
+    theme: v1.theme,
+    score: v1.score,
+    signals: [`v1-fallback-reason:${reason}`, ...v1.signals],
+    fallback: true,
+    method: 'fallback',
+  };
+}


### PR DESCRIPTION
## Summary

Sprint 16 v2 picker — wraps deterministic v1 with a Claude Sonnet 4.5 call that picks scaffolds by **semantic intent**, not keyword surface. Plus Test C (PD sphere-fill deck re-bake) which validates v2 over v1 on a fuzzy input.

## What's new

### `picker-llm.js` — `pickScaffoldLLM(input, opts)`

Same shape as v1 `pickScaffold()` + a `method` field for telemetry (`'llm' | 'v1' | 'fallback'`). Silently falls back to v1 on any error (no apiKey, HTTP fail, parse fail, unknown scaffoldId, network throw) so pipelines stay resilient.

Optional `themeHint` — Claude can suggest a specific theme from `theme_affinity[]` (validated; invalid hints ignored).

### `--picker llm | v1 | auto` flag

`bake-scaffold-pipeline.mjs` now accepts the picker mode:
- `llm` — errors are loud
- `v1` — deterministic only
- `auto` (default) — v2 with v1 fallback

`pickerMethod` recorded in `deck.json` manifest.

### Smoke test

21 assertions, stubs `globalThis.fetch`. Covers happy path / theme hint / error fallback paths / no apiKey behavior. All PASS. `scripts/run-tests.mjs` now reports **89/89**.

## Test A — vc-pitch with v2

Picked **pitch-deck-vc**, **confidence 10/10**. Reasoning excerpt:
> "Title explicitly states 'Series A Pitch'. Deck follows canonical VC pitch structure: problem → market → solution → product → traction → business model → team → ask ($15M raise). Content includes all classic fundraise elements: TAM ($4.8B+), ARR growth, pricing tiers, team credentials, break-even projection."

Matches v1 result, ships with confidence + reasoning extras.

## Test C — PD sphere-fill deck with v2 (the smoking gun)

| Picker | Picked scaffold | Confidence | Reasoning quality |
|---|---|---|---|
| **v1** | `company-overview` | 0 (fallback) | none — keyword tie at 0 |
| **v2** | `product-launch` | 2/10 | honest: "deck body contains only repetitive placeholder text. Title '3D SPHERES' suggests a template or design asset rather than a functional deck. product-launch chosen as the most flexible scaffold... confidence very low (2/10) due to complete absence of intent signals." |

Two qualitative improvements:
1. **Better scaffold**: product-launch (cover/problem/3 features/demo/pricing/cta) is a more natural fit for "showing visual features" than company-overview
2. **Honest confidence**: 2/10 surfaces uncertainty so downstream code can warn user vs hiding the guess

8/8 slots baked, $0.59 total. Screenshot: `screens/scaffold-pipeline/pd-sphere-v2-full.png`.

## Browser viewer

3 deck options in picker now:
- VC Pitch (v1 baseline)
- PD sphere-fill v2 → product-launch
- PD sphere-fill v1 legacy → company-overview (for comparison)

## Follow-up backlog

- Slot↔slide LLM mapping (currently heuristic keyword score)
- Wire pipeline into visual-panel UI
- Export real deck format

Per CLAUDE.md: DO NOT merge. Awaiting user review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)