### PR TITLE
Sprint 17: PPTX + PDF export — assembled deck → shareable file

### DIFF
--- a/sdf-js/examples/atoms-2d-demo/scaffold-deck-viewer.html
+++ b/sdf-js/examples/atoms-2d-demo/scaffold-deck-viewer.html
@@ -41,12 +41,62 @@
         <option value="examples/scaffold-pipeline/slidedata/deck.json">PD sphere-fill v1 (legacy · company-overview fallback)</option>
       </select>
       <button id="reload-btn">Reload</button>
+      <button id="export-pptx-btn" style="background:#1e1b1e;color:white;">⬇ PPTX</button>
+      <button id="export-pdf-btn" style="background:white;color:#1e1b1e;border:1px solid #1e1b1e;">⬇ PDF</button>
+      <span id="export-status" style="font-size:11px;color:#666;margin-left:8px;"></span>
     </div>
 
     <div id="root"></div>
 
     <script type="module">
       import { renderAtom } from '/src/present/atoms-2d/registry.js';
+      import { exportDeckToPPTX } from '/src/present/exporters/pptx.js';
+      import { exportDeckToPDF } from '/src/present/exporters/pdf.js';
+
+      let currentManifest = null;
+      let currentSlotLifts = new Map(); // slotIdx → lift JSON
+
+      async function handleExport(format) {
+        if (!currentManifest) return;
+        const status = document.getElementById('export-status');
+        status.textContent = `Loading slot lifts...`;
+        const slots = [];
+        for (const slotRef of currentManifest.slots) {
+          if (!slotRef.liftFile) continue;
+          let lift = currentSlotLifts.get(slotRef.slotIdx);
+          if (!lift) {
+            const r = await fetch(`/examples/scaffold-pipeline/${currentManifest.deckName}/${slotRef.liftFile}`);
+            lift = await r.json();
+            currentSlotLifts.set(slotRef.slotIdx, lift);
+          }
+          slots.push({
+            slotIdx: slotRef.slotIdx,
+            slotName: slotRef.slotName,
+            slotTitle: slotRef.slotTitle,
+            slotPurpose: slotRef.slotPurpose,
+            sceneData: lift.sceneData,
+          });
+        }
+        const deck = {
+          title: currentManifest.deckName,
+          theme: currentManifest.theme,
+          scaffold: currentManifest.scaffold,
+          slots,
+        };
+        const fn = format === 'pptx' ? exportDeckToPPTX : exportDeckToPDF;
+        try {
+          const result = await fn(deck, {
+            onProgress: (msg, pct) => { status.textContent = `${msg} (${Math.round(pct)}%)`; },
+          });
+          status.textContent = `✓ Downloaded ${result.filename}`;
+        } catch (e) {
+          status.textContent = `✗ Export failed: ${e.message}`;
+          console.error(e);
+        }
+      }
+
+      document.getElementById('export-pptx-btn').addEventListener('click', () => handleExport('pptx'));
+      document.getElementById('export-pdf-btn').addEventListener('click', () => handleExport('pdf'));
 
       async function loadDeck() {
         const url = document.getElementById('deck-picker').value;
@@ -64,6 +114,8 @@
         }
 
         root.innerHTML = '';
+        currentManifest = manifest;
+        currentSlotLifts = new Map();
 
         // Deck-level meta
         const meta = document.createElement('div');

--- a/sdf-js/src/present/exporters/pdf.js
+++ b/sdf-js/src/present/exporters/pdf.js
@@ -1,0 +1,103 @@
+// =============================================================================
+// exporters/pdf.js — Export assembled deck → PDF file
+// -----------------------------------------------------------------------------
+// Sprint 17 — Lighter-weight sibling of pptx.js. Each baked slot becomes one
+// PDF page in landscape orientation. Image-embed approach (canvas PNG) — same
+// rationale as pptx.js.
+//
+// PDF is for distribution / archival / printing. PPTX is for editing.
+// Both share the same canvas-render pipeline from atoms-2d.
+// =============================================================================
+
+import { renderAtom } from '../atoms-2d/registry.js';
+
+const JSPDF_CDN = 'https://esm.sh/jspdf@2.5.2';
+let jsPDF = null;
+
+async function loadJsPDF() {
+  if (jsPDF) return jsPDF;
+  const mod = await import(/* @vite-ignore */ JSPDF_CDN);
+  jsPDF = mod.jsPDF || mod.default?.jsPDF || mod.default;
+  if (!jsPDF) throw new Error('jspdf module did not expose jsPDF constructor');
+  return jsPDF;
+}
+
+/**
+ * Export the assembled deck to a PDF file and trigger browser download.
+ * Same input shape as exportDeckToPPTX.
+ *
+ * @param {import('./pptx.js').ExportDeckInput} deck
+ * @param {object} [opts]
+ * @param {string} [opts.filename]
+ * @param {(msg: string, pct: number) => void} [opts.onProgress]
+ * @returns {Promise<{filename: string, pageCount: number, bytes: number}>}
+ */
+export async function exportDeckToPDF(deck, opts = {}) {
+  const onProgress = opts.onProgress || (() => {});
+  const JsPDF = await loadJsPDF();
+  onProgress('jspdf loaded', 5);
+
+  // Landscape A4-ish at 1280:720 aspect (16:9). Use mm units.
+  // 280mm × 157.5mm matches 16:9 nicely and fits Letter/A4 landscape.
+  const PAGE_W_MM = 280;
+  const PAGE_H_MM = 157.5;
+
+  const pdf = new JsPDF({
+    orientation: 'landscape',
+    unit: 'mm',
+    format: [PAGE_W_MM, PAGE_H_MM],
+    compress: true,
+  });
+  pdf.setProperties({
+    title: deck.title,
+    author: 'Atlas Present',
+    creator: 'Atlas',
+    subject: deck.scaffold?.label || 'deck',
+  });
+
+  const total = deck.slots.length;
+  for (let i = 0; i < total; i++) {
+    const slot = deck.slots[i];
+    onProgress(`Rendering page ${i + 1}/${total} (${slot.slotName})`, 5 + (i / total) * 90);
+
+    const canvas = document.createElement('canvas');
+    canvas.width = 1280;
+    canvas.height = 720;
+    const ctx = canvas.getContext('2d');
+    ctx.fillStyle = `rgb(${deck.theme.bg.join(',')})`;
+    ctx.fillRect(0, 0, canvas.width, canvas.height);
+
+    if (slot.sceneData?.subjects) {
+      for (const subj of slot.sceneData.subjects) {
+        try {
+          await renderAtom(ctx, subj.type, subj.args, 'pseudo3d', {
+            x: subj.x ?? 0,
+            y: subj.y ?? 0,
+            w: subj.w ?? 320,
+            h: subj.h ?? 240,
+            palette: deck.theme,
+          });
+        } catch (e) {
+          console.error(`[pdf] renderAtom ${subj.type} failed:`, e);
+        }
+      }
+    }
+
+    const pngDataURL = canvas.toDataURL('image/png');
+
+    if (i > 0) pdf.addPage([PAGE_W_MM, PAGE_H_MM], 'landscape');
+    pdf.addImage(pngDataURL, 'PNG', 0, 0, PAGE_W_MM, PAGE_H_MM, undefined, 'FAST');
+  }
+
+  onProgress('Encoding PDF...', 96);
+  const filename = opts.filename || `${deck.scaffold?.id || 'atlas-deck'}-${todayIsoDate()}.pdf`;
+  pdf.save(filename);
+
+  onProgress('Done', 100);
+  return { filename, pageCount: total, bytes: -1 };
+}
+
+function todayIsoDate() {
+  const d = new Date();
+  return `${d.getFullYear()}${String(d.getMonth() + 1).padStart(2, '0')}${String(d.getDate()).padStart(2, '0')}`;
+}

--- a/sdf-js/src/present/exporters/pptx.js
+++ b/sdf-js/src/present/exporters/pptx.js
@@ -1,0 +1,146 @@
+// =============================================================================
+// exporters/pptx.js — Export assembled deck → PPTX file
+// -----------------------------------------------------------------------------
+// Sprint 17 — Atlas Present's canonical export path. Each baked slot becomes
+// a 16:9 PPTX slide with the rendered atom canvas embedded as a full-bleed
+// PNG. Slide title taken from scaffold slot. Speaker notes optional.
+//
+// Why image embed (not native PPTX shapes):
+//   1. Atoms-2d are dense Canvas2D renders (gradient + specular + drop
+//      shadow + text wrapping). Translating each atom 1:1 to PPTX
+//      shapes would lose visual parity and balloon the file
+//   2. Image embed is portable across PowerPoint / Keynote / Google Slides
+//   3. Atlas is the spatial visual PRESENTER — the PPTX is the deliverable
+//      to share / present; downstream editability is not a goal
+//
+// Architectural note: the 3D side consumes a SCAFFOLD-PIPELINE deck.json,
+// NOT this PPTX. PPTX is for human delivery; deck.json is for 3D translator.
+// =============================================================================
+
+import { renderAtom } from '../atoms-2d/registry.js';
+
+// pptxgenjs loaded from esm.sh on first call (matches pdfjs CDN pattern in
+// src/parser/pdf.js — no build step / bundler required).
+const PPTXGEN_CDN = 'https://esm.sh/pptxgenjs@3.12.0';
+let PptxGenJS = null;
+
+async function loadPptxGen() {
+  if (PptxGenJS) return PptxGenJS;
+  const mod = await import(/* @vite-ignore */ PPTXGEN_CDN);
+  PptxGenJS = mod.default || mod.PptxGenJS || mod;
+  return PptxGenJS;
+}
+
+/**
+ * @typedef {object} ExportSlotInput
+ * @property {number} slotIdx
+ * @property {string} slotName
+ * @property {string} slotTitle
+ * @property {object} sceneData — {subjects: [{type, x, y, w, h, args}]}
+ */
+
+/**
+ * @typedef {object} ExportDeckInput
+ * @property {string} title — deck display title
+ * @property {import('../themes.js').ThemePreset} theme
+ * @property {{id: string, label: string}} scaffold
+ * @property {ExportSlotInput[]} slots — in display order
+ */
+
+/**
+ * Export the assembled deck to a PPTX file and trigger browser download.
+ *
+ * @param {ExportDeckInput} deck
+ * @param {object} [opts]
+ * @param {string} [opts.filename] — overrides default `<scaffold>-<date>.pptx`
+ * @param {(msg: string, pct: number) => void} [opts.onProgress]
+ * @returns {Promise<{filename: string, slideCount: number, bytes: number}>}
+ */
+export async function exportDeckToPPTX(deck, opts = {}) {
+  const onProgress = opts.onProgress || (() => {});
+  const Pptx = await loadPptxGen();
+  onProgress('pptxgenjs loaded', 5);
+
+  const pres = new Pptx();
+  pres.layout = 'LAYOUT_WIDE'; // 13.333×7.5 inches (16:9)
+  pres.title = deck.title;
+  pres.author = 'Atlas Present';
+  pres.company = 'Atlas';
+
+  const SLIDE_W_IN = 13.333;
+  const SLIDE_H_IN = 7.5;
+
+  const total = deck.slots.length;
+  for (let i = 0; i < total; i++) {
+    const slot = deck.slots[i];
+    onProgress(`Rendering slot ${i + 1}/${total} (${slot.slotName})`, 5 + (i / total) * 90);
+
+    // Render slot to offscreen canvas → PNG dataURL
+    const canvas = document.createElement('canvas');
+    canvas.width = 1280;
+    canvas.height = 720;
+    const ctx = canvas.getContext('2d');
+    ctx.fillStyle = `rgb(${deck.theme.bg.join(',')})`;
+    ctx.fillRect(0, 0, canvas.width, canvas.height);
+
+    if (slot.sceneData?.subjects) {
+      for (const subj of slot.sceneData.subjects) {
+        try {
+          await renderAtom(ctx, subj.type, subj.args, 'pseudo3d', {
+            x: subj.x ?? 0,
+            y: subj.y ?? 0,
+            w: subj.w ?? 320,
+            h: subj.h ?? 240,
+            palette: deck.theme,
+          });
+        } catch (e) {
+          console.error(`[pptx] renderAtom ${subj.type} failed:`, e);
+        }
+      }
+    }
+
+    const pngDataURL = canvas.toDataURL('image/png');
+    const slide = pres.addSlide();
+    slide.background = { color: rgbToHex(deck.theme.bg) };
+    // Full-bleed image
+    slide.addImage({
+      data: pngDataURL,
+      x: 0,
+      y: 0,
+      w: SLIDE_W_IN,
+      h: SLIDE_H_IN,
+    });
+    // Speaker notes: slot purpose for the presenter
+    if (slot.slotTitle || slot.slotName) {
+      slide.addNotes(
+        `${slot.slotTitle || slot.slotName}\n\n${slot.slotPurpose || ''}\n\nAtoms: ${
+          (slot.sceneData?.subjects || []).map((s) => s.type).join(', ') || '—'
+        }`,
+      );
+    }
+  }
+
+  onProgress('Encoding PPTX...', 96);
+  const filename = opts.filename || `${deck.scaffold?.id || 'atlas-deck'}-${todayIsoDate()}.pptx`;
+
+  // pptxgenjs writeFile in browser triggers download
+  await pres.writeFile({ fileName: filename });
+
+  onProgress('Done', 100);
+  return { filename, slideCount: total, bytes: -1 };
+}
+
+function rgbToHex(rgb) {
+  return rgb
+    .map((c) =>
+      Math.max(0, Math.min(255, Math.round(c)))
+        .toString(16)
+        .padStart(2, '0'),
+    )
+    .join('');
+}
+
+function todayIsoDate() {
+  const d = new Date();
+  return `${d.getFullYear()}${String(d.getMonth() + 1).padStart(2, '0')}${String(d.getDate()).padStart(2, '0')}`;
+}

--- a/sdf-js/src/present/scaffold-view.js
+++ b/sdf-js/src/present/scaffold-view.js
@@ -21,6 +21,8 @@ import { pickScaffold, distributeSources } from './scaffolds/picker.js';
 import { pickScaffoldLLM } from './scaffolds/picker-llm.js';
 import { getTheme } from './themes.js';
 import { renderAtom } from './atoms-2d/registry.js';
+import { exportDeckToPPTX } from './exporters/pptx.js';
+import { exportDeckToPDF } from './exporters/pdf.js';
 
 const ANTHROPIC_KEY_STORAGE = 'atlas-anthropic-key';
 const MODEL = 'claude-sonnet-4-5-20250929';
@@ -53,6 +55,7 @@ export async function mountScaffoldView(target, deckId) {
     slotLifts: null, // array of {slotIdx, status, sceneData?, costUSD?, error?}
     totalCost: 0,
     apiKey: localStorage.getItem(ANTHROPIC_KEY_STORAGE) || '',
+    export: { active: false, format: null, progress: 0, msg: '', error: null },
   };
 
   function render() {
@@ -66,6 +69,7 @@ export async function mountScaffoldView(target, deckId) {
         ${renderStage0(state)}
         ${state.pickerResult ? renderStage1(state) : ''}
         ${state.slotAssignments ? renderStage2(state) : ''}
+        ${state.stage === 'done' ? renderStage3Export(state) : ''}
         ${state.slotLifts ? renderDeckPreview(state) : ''}
       </div>
     `;
@@ -86,6 +90,54 @@ export async function mountScaffoldView(target, deckId) {
     document.getElementById('btn-confirm-scaffold')?.addEventListener('click', onConfirmScaffold);
     document.getElementById('btn-generate')?.addEventListener('click', onGenerateAll);
     document.getElementById('btn-set-key')?.addEventListener('click', onSetKey);
+    document.getElementById('btn-export-pptx')?.addEventListener('click', () => onExport('pptx'));
+    document.getElementById('btn-export-pdf')?.addEventListener('click', () => onExport('pdf'));
+  }
+
+  async function onExport(format) {
+    if (state.export.active) return;
+    state.export = { active: true, format, progress: 0, msg: 'Starting…', error: null };
+    render();
+
+    const exportInput = {
+      title: deck.title,
+      theme: state.pickerResult.theme,
+      scaffold: {
+        id: state.pickerResult.scaffold.id,
+        label: state.pickerResult.scaffold.label,
+      },
+      slots: state.slotLifts
+        .filter((l) => l.status === 'done' && l.sceneData)
+        .map((l) => {
+          const assignment = state.slotAssignments.find((a) => a.slotIdx === l.slotIdx);
+          return {
+            slotIdx: l.slotIdx,
+            slotName: l.slotName,
+            slotTitle: assignment?.slot?.title || l.slotName,
+            slotPurpose: assignment?.slot?.purpose || '',
+            sceneData: l.sceneData,
+          };
+        }),
+    };
+
+    const onProgress = (msg, pct) => {
+      state.export.msg = msg;
+      state.export.progress = pct;
+      render();
+    };
+
+    try {
+      const fn = format === 'pptx' ? exportDeckToPPTX : exportDeckToPDF;
+      const result = await fn(exportInput, { onProgress });
+      state.export.msg = `Downloaded: ${result.filename}`;
+      state.export.progress = 100;
+    } catch (e) {
+      state.export.error = e.message;
+      console.error(`[scaffold-view] export ${format} failed:`, e);
+    } finally {
+      state.export.active = false;
+      render();
+    }
   }
 
   function onSetKey() {
@@ -498,6 +550,37 @@ function renderStage2(state) {
           })
           .join('')}
       </div>
+    </section>
+  `;
+}
+
+function renderStage3Export(state) {
+  const liftsOK = state.slotLifts.filter((l) => l.status === 'done').length;
+  if (liftsOK === 0) return '';
+  const ex = state.export;
+  return `
+    <section style="border:1px solid #d0cec3; border-radius:6px; padding:18px; margin-bottom:16px; background:white;">
+      <h3 style="margin:0 0 8px; font-size:16px;">Stage 3 — Export</h3>
+      <div style="font-size:12px; color:#666; margin-bottom:12px;">
+        Atlas Present is the spatial visual <strong>presenter</strong>. PPTX = editable / shareable; PDF = archival / print. 3D handoff uses the underlying <code>deck.json</code>, not these.
+      </div>
+      <div style="display:flex; gap:10px; align-items:center;">
+        <button id="btn-export-pptx" ${ex.active ? 'disabled' : ''} style="padding:10px 16px; background:#1e1b1e; color:white; border:none; border-radius:4px; cursor:pointer; font-weight:600;">
+          ${ex.active && ex.format === 'pptx' ? '⏳ Exporting PPTX…' : '⬇ Download PPTX'}
+        </button>
+        <button id="btn-export-pdf" ${ex.active ? 'disabled' : ''} style="padding:10px 16px; background:white; color:#1e1b1e; border:1px solid #1e1b1e; border-radius:4px; cursor:pointer; font-weight:600;">
+          ${ex.active && ex.format === 'pdf' ? '⏳ Exporting PDF…' : '⬇ Download PDF'}
+        </button>
+        <span style="font-size:12px; color:#888;">${liftsOK} slot${liftsOK !== 1 ? 's' : ''} baked</span>
+      </div>
+      ${
+        ex.active || ex.error || (ex.msg && ex.progress === 100)
+          ? `<div style="margin-top:12px; font-size:12px; ${ex.error ? 'color:#a00;' : 'color:#444;'}">
+              ${ex.error ? `ERROR: ${escapeHtml(ex.error)}` : `${escapeHtml(ex.msg)} (${Math.round(ex.progress)}%)`}
+              ${ex.active ? `<div style="margin-top:6px; background:#eee; height:4px; border-radius:2px; overflow:hidden;"><div style="background:#2a8; height:100%; width:${ex.progress}%; transition:width 0.2s;"></div></div>` : ''}
+            </div>`
+          : ''
+      }
     </section>
   `;
 }


### PR DESCRIPTION
## Summary

User lock 2026-06-22: Atlas 定位 **空间视觉演示器** (spatial visual presenter). Two ends:
- **2D end (this PR)**: text → pseudo-3D PL-style deck → PPTX/PDF export for humans
- **3D end (separate)**: consumes `deck.json` to translate into real 3D scenes

This PR ships the 2D end's export path. PPTX/PDF is the **human deliverable**; `deck.json` remains the **machine contract** between 2D and 3D ends.

## New modules

### `sdf-js/src/present/exporters/pptx.js`

`exportDeckToPPTX(deck, opts)` → triggers browser download.
- pptxgenjs from esm.sh CDN (matches existing pdfjs CDN pattern)
- 16:9 LAYOUT_WIDE (13.333×7.5 in)
- Each slot rendered to offscreen 1280×720 canvas → PNG → full-bleed image
- Speaker notes carry slot title + purpose + emitted atom list
- Filename: `<scaffoldId>-YYYYMMDD.pptx`

### `sdf-js/src/present/exporters/pdf.js`

`exportDeckToPDF(deck, opts)` → triggers browser download.
- jspdf from esm.sh CDN
- Landscape 280×157.5 mm (16:9, fits Letter/A4 landscape)
- Each slot = 1 PDF page
- PDF metadata with title / author=Atlas Present / subject=scaffold label

## Why image-embed (not native PPTX shapes)

1. **Fidelity**: atoms-2d are dense Canvas2D renders (gradient + specular + drop shadow + text wrapping). Translating each atom 1:1 to PPTX shapes would balloon file + lose visual parity.
2. **Portability**: image embed works in PowerPoint / Keynote / Google Slides identically.
3. **Editing not a goal**: Atlas is the PRESENTER — the source of truth lives in `deck.json` for the 3D translator; PPTX is for distribution.

## UI integration

### `scaffold-view.js` (Sprint 17 B in-browser pipeline UI)

New "Stage 3 — Export" appears when `state.stage === 'done'`:
- Two buttons: **Download PPTX** (primary, dark) + **Download PDF** (secondary, outlined)
- Live progress bar during export with per-slot messages

### `scaffold-deck-viewer.html` (pre-baked deck viewer)

Toolbar now has PPTX + PDF buttons. **Lets you export ANY existing baked deck without re-baking** (no API key needed for testing).

## Smoke test

Loaded VC pitch deck (9 baked slots) in viewer:
- ✓ pptxgenjs loaded from CDN
- ✓ 9 canvases rendered offscreen
- ✓ PPTX downloaded as `pitch-deck-vc-20260622.pptx` (no errors)
- ✓ PDF downloaded as `pitch-deck-vc-20260622.pdf` (no errors)

Screenshot: `screens/export/viewer-export-success.png`

## Follow-up backlog

- Save baked deck back to deck-model so scaffold lifts persist
- Cache exported file in IndexedDB for re-download
- Higher-res rendering (2× or 3× canvas) for print quality PDF
- Native PPTX shape translation for top atoms (kpi-card, bullet-list, bar) — keeps editability for simple slides
- Wire export buttons into deck-view "Play" mode

Per CLAUDE.md: DO NOT merge. Awaiting user review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)