### PR TITLE
feat(studio): glass material kind + rebuild sphere-fill on a waterline split

### DIFF
--- a/sdf-js/scripts/test-sphere-fill-3d.mjs
+++ b/sdf-js/scripts/test-sphere-fill-3d.mjs
@@ -1,9 +1,13 @@
 // =============================================================================
 // L1 unit tests for the sphere-fill-3d atom.
 // -----------------------------------------------------------------------------
-// sphere-fill-3d renders a row of "fill level" spheres: each sphere is a glass
-// container (3-ring wireframe cage) holding a liquid fill cap (cutSphere) whose
-// height encodes a 0..1 fill fraction. Pure geometry — readable without color.
+// sphere-fill-3d renders a row of "fill level" spheres. Each sphere is a SOLID
+// sphere split at a waterline (height = 0..1 fill fraction) into two caps:
+//   - liquid cap (below waterline)  → part:'liquid'
+//   - glass  cap (above waterline)  → part:'glass'
+//   - part:'both' (default) unions them → a full solid sphere.
+// Pure geometry; the colored/light two-tone read is materialed at the scene/
+// shader level (see the atom's KNOWN LIMITATION note).
 //
 // PresentationLoad reference: "3D Spheres Fill Levels" (deck use case, P0).
 // =============================================================================
@@ -27,7 +31,7 @@ function ok(cond, name) {
 console.log('=== sphere-fill-3d unit test ===\n');
 
 // ---- Test group 1: defaults --------------------------------------------------
-console.log('Test group 1: defaults (4 spheres, last fully filled)');
+console.log('Test group 1: defaults (4 spheres, part:both → solid)');
 {
   const sdf = sphereFill3dSDF();
   ok(sdf != null, 'default sdf is non-null');
@@ -38,41 +42,58 @@ console.log('Test group 1: defaults (4 spheres, last fully filled)');
   ok(sdf.f([100, 0, 0]) > 0, 'far point is outside');
 }
 
-// ---- Test group 2: fill fraction discrimination ------------------------------
-console.log('\nTest group 2: fill fraction (cage off, isolate liquid)');
+// ---- Test group 2: part:'both' is a solid sphere at any fill -----------------
+console.log("\nTest group 2: part:'both' → solid sphere (both caps)");
+{
+  // Single half-full sphere at origin (waterline at y=0). Union of caps = solid.
+  const sdf = sphereFill3dSDF({ levels: [0.5], radius: 0.6 });
+  ok(sdf.f([0, -0.3, 0]) < 0, 'both: below waterline inside (liquid cap)');
+  ok(sdf.f([0, 0.3, 0]) < 0, 'both: above waterline inside (glass cap)');
+  ok(sdf.f([0, 0.9, 0]) > 0, 'both: outside the sphere radius');
+}
+
+// ---- Test group 3: part:'liquid' isolates the bottom cap ---------------------
+console.log("\nTest group 3: part:'liquid' (colored bottom cap)");
 {
   // Two spheres: empty + full. stride=1.5, offset=0.75 → x = -0.75, +0.75.
-  const sdf = sphereFill3dSDF({ levels: [0.0, 1.0], cage: false });
-  ok(sdf.f([0.75, 0, 0]) < 0, 'full sphere (fill=1.0) center inside');
-  ok(sdf.f([-0.75, 0, 0]) > 0, 'empty sphere (fill=0.0) center outside (no liquid, no cage)');
+  const sdf = sphereFill3dSDF({ levels: [0.0, 1.0], part: 'liquid' });
+  ok(sdf.f([0.75, 0, 0]) < 0, 'full (fill=1.0) liquid center inside');
+  ok(sdf.f([-0.75, 0, 0]) > 0, 'empty (fill=0.0) → no liquid, center outside');
 }
 {
-  // Single half-full sphere at origin, cage off. Liquid fills bottom half.
-  const sdf = sphereFill3dSDF({ levels: [0.5], cage: false });
-  ok(sdf.f([0, -0.3, 0]) < 0, 'half-fill: point below waterline is inside (liquid)');
-  ok(sdf.f([0, 0.3, 0]) > 0, 'half-fill: point above waterline is outside (air)');
+  // Single half-full sphere, liquid only: fills the bottom, air above.
+  const sdf = sphereFill3dSDF({ levels: [0.5], part: 'liquid' });
+  ok(sdf.f([0, -0.3, 0]) < 0, 'half liquid: below waterline inside');
+  ok(sdf.f([0, 0.3, 0]) > 0, 'half liquid: above waterline outside (no top cap)');
 }
 
-// ---- Test group 3: cage container -------------------------------------------
-console.log('\nTest group 3: wireframe cage container');
+// ---- Test group 4: part:'glass' isolates the top cap ------------------------
+console.log("\nTest group 4: part:'glass' (light top cap)");
 {
-  // Empty sphere with cage on: center hollow, but equator ring present.
-  const sdf = sphereFill3dSDF({ levels: [0.0], radius: 0.6, cage: true, cageThickness: 0.06 });
-  ok(sdf.f([0, 0, 0]) > 0, 'empty+cage: center is hollow (outside)');
-  ok(sdf.f([0.6, 0, 0]) < 0, 'empty+cage: equator ring at radius is inside');
+  // Single half-full sphere, glass only: fills the top, empty below.
+  const sdf = sphereFill3dSDF({ levels: [0.5], part: 'glass' });
+  ok(sdf.f([0, 0.3, 0]) < 0, 'half glass: above waterline inside');
+  ok(sdf.f([0, -0.3, 0]) > 0, 'half glass: below waterline outside (no bottom cap)');
+}
+{
+  // Brim-full → no empty top → glass-only emits nothing → null.
+  ok(
+    sphereFill3dSDF({ levels: [1.0], part: 'glass' }) === null,
+    'glass at fill=1.0 → null (no empty top)',
+  );
 }
 
-// ---- Test group 4: edge cases -----------------------------------------------
-console.log('\nTest group 4: edge cases');
+// ---- Test group 5: edge cases -----------------------------------------------
+console.log('\nTest group 5: edge cases');
 {
   ok(sphereFill3dSDF({ count: 0 }) === null, 'count=0 returns null');
   ok(sphereFill3dSDF({ levels: [], count: 0 }) === null, 'no spheres returns null');
-  const single = sphereFill3dSDF({ levels: [1.0], cage: false });
+  const single = sphereFill3dSDF({ levels: [1.0] });
   ok(single != null && single.f([0, 0, 0]) < 0, 'single full sphere at origin inside');
 }
 
-// ---- Test group 5: scene compile + GLSL emit ---------------------------------
-console.log('\nTest group 5: SceneData → compile → GLSL emit');
+// ---- Test group 6: scene compile + GLSL emit ---------------------------------
+console.log('\nTest group 6: SceneData → compile → GLSL emit');
 {
   const scene = {
     v: 1,
@@ -110,8 +131,7 @@ console.log('\nTest group 5: SceneData → compile → GLSL emit');
     }
     if (glsl) {
       const exprStr = typeof glsl === 'string' ? glsl : glsl.expr || JSON.stringify(glsl);
-      ok(exprStr.includes('sdCutSphere'), 'GLSL emit contains sdCutSphere (liquid fill)');
-      ok(exprStr.includes('sdTorus'), 'GLSL emit contains sdTorus (cage rings)');
+      ok(exprStr.includes('sdCutSphere'), 'GLSL emit contains sdCutSphere (waterline caps)');
     }
   }
 }

--- a/sdf-js/src/render/studio.js
+++ b/sdf-js/src/render/studio.js
@@ -796,12 +796,16 @@ void main() {
     bool isSnowy = false;       // material.kind == 'snowy'       (tone.y ~ 5)
     bool isBuilding = false;    // material.kind == 'building'    (tone.y ~ 6)
     bool isEroded = false;      // material.kind == 'eroded-terrain' (tone.y ~ 7)
+    bool isGlass = false;       // material.kind == 'glass'           (tone.y ~ 8)
     vec4 leafMat, leafTone, leafPat;
     if (matId > 1.5) {
       fetchLeafData(hitIdx, leafMat, leafTone, leafPat);
       // Route by material kind. tone.y carries an integer-encoded kind.
       // Check higher kinds first (7 > 6 > 5 > 4 > 3 > 2 > 1 > 0).
-      if (leafTone.y > 6.5) {
+      if (leafTone.y > 7.5) {
+        isGlass = true;
+        base = hsv2rgb(vec3(leafMat.x, leafMat.y, leafTone.x));
+      } else if (leafTone.y > 6.5) {
         isEroded = true;
         base = hsv2rgb(vec3(leafMat.x, leafMat.y, leafTone.x));
       } else if (leafTone.y > 5.5) {
@@ -950,6 +954,42 @@ void main() {
                + backlight;
       float tFog = atmosphereDensity(p, t);
       col = mix(lit, vec3(0.85, 0.87, 0.90), tFog);
+    } else if (isGlass) {
+      // ---- Glass material kind (real single-refraction) --------------------
+      // The view ray refracts into the (thin, hollow) shell; a secondary march
+      // SEES THROUGH to whatever is inside/behind (coloured liquid, or the
+      // distorted background). That transmission is blended with a Fresnel env
+      // reflection (strong at grazing edges) + a sharp sun glint + a cool
+      // fresnel rim. ior 1.45. base = glass tint (white = clear glass).
+      float ndv = max(dot(n, -rd), 0.0);
+      float fres = 0.04 + 0.96 * pow(1.0 - ndv, 5.0);
+      // Fresnel env reflection (edges)
+      vec3 Rfl = reflect(rd, n);
+      vec3 rsR = raymarchShort(p + n * 0.02, Rfl, 16.0);
+      vec3 reflCol = (rsR.y > 0.5)
+        ? shadeReflection(p + Rfl * rsR.x, Rfl, rsR.y, rsR.z, sunDir)
+        : sky(Rfl, sunDir);
+      // Refraction — bend the view ray by Snell's law (ior ~1.45) and march the
+      // interior so we SEE THROUGH the glass. Start a touch past the thin shell
+      // wall so the secondary march travels interior air (sphere-trace can't
+      // march solids → glass shapes must be thin hollow shells). NOTE: this is a
+      // DECORATIVE transparent-glass capability — do NOT use it for fill gauges
+      // (sphere-fill), where refraction magnifies/fills the level and destroys
+      // the readable waterline; use a waterline material split there instead.
+      vec3 Rr = refract(rd, n, 1.0 / 1.45);
+      vec3 refrCol;
+      vec3 rs = raymarchShort(p + Rr * 0.07 - n * 0.015, Rr, 12.0);
+      if (rs.y > 0.5) {
+        refrCol = shadeReflection(p + Rr * rs.x, Rr, rs.y, rs.z, sunDir);
+      } else {
+        refrCol = sky(Rr, sunDir);
+      }
+      refrCol *= mix(vec3(1.0), base, 0.5); // tint by glass colour (white = clear)
+      vec3 gcol = mix(refrCol, reflCol, fres);
+      vec3 Hg = normalize(toLight + (-rd));
+      gcol += vec3(1.0) * pow(max(dot(n, Hg), 0.0), 140.0) * shadowK * 1.2; // sharp glint
+      gcol += vec3(0.75, 0.85, 1.0) * pow(1.0 - ndv, 3.0) * 0.35;           // cool fresnel edge
+      col = gcol;
     } else if (isSnowy) {
       // ---- Snowy material kind (IQ Snow Bridge recipe-only port) -----------
       // Standard Lambert with the underlying base color, then blend snow on top

--- a/sdf-js/src/scene/components/shapes/sphere-fill-3d.js
+++ b/sdf-js/src/scene/components/shapes/sphere-fill-3d.js
@@ -1,57 +1,66 @@
 // =============================================================================
 // sphere-fill-3d.js — "fill level" spheres (Atlas Shape atom, Sprint 2).
 // -----------------------------------------------------------------------------
-// A row of glass spheres, each holding a liquid fill cap whose height encodes a
-// 0..1 fraction. Covers PresentationLoad "3D Spheres Fill Levels" (deck P0 use
-// case). Pure geometry — readable without per-part color:
-//   - container: 3 great-circle wireframe rings (tori) → recognizable "globe"
-//   - liquid:    cutSphere cap, filled from the bottom up to the waterline
+// A row of spheres, each split at a waterline into a coloured LIQUID bottom cap
+// and a light GLASS top cap. Faithful 3D twin of PresentationLoad "3D Spheres
+// Fill Levels" (stun-demo fixture D0961).
 //
-// Reuses shipped primitives (all GLSL-emit registered 2026-06-19):
-//   - sphere/cut-sphere (d3.js, sdf3.compile.js:313/566)
-//   - torus             (d3.js:73,  sdf3.compile.js:328)
-//   - union             (dn.js:37,  sdf3.compile.js:224)
+// Design note (2026-06-22): the PresentationLoad look is NOT a transparent shell
+// holding a separate liquid volume — real glass refraction magnifies/fills the
+// level and destroys the readable waterline (the gauge's whole purpose). It is a
+// SOLID sphere cut at the waterline into two opaque-but-glossy materials:
+//   - liquid (below waterline): the coloured fill — opaque, glossy + clearcoat
+//   - glass  (above waterline): light/clear — light glossy material
+// The seam between the two caps IS the waterline ellipse → the fill level reads
+// at a glance. Both caps carry a glassy sheen via the standard PBR material
+// (clearcoat + reflection), so it looks like glass without losing the data.
 //
-// Spec: docs/superpowers/specs/2026-06-20-sphere-atoms-design.md
+// `part` lets each cap carry its own material: 'liquid' (colored bottom),
+// 'glass' (light top), or 'both' (default — single material, a plain sphere).
+//
+// KNOWN LIMITATION (2026-06-22): you cannot get the two-tone gauge by overlaying
+// two instances (one part:'liquid' + one part:'glass') in one scene. Both caps
+// are cut from the SAME radius sphere, so their outer surfaces COINCIDE; the
+// studio raymarch can't tell which cap's material to use at a shared surface
+// point and the first subject's material wins for the whole sphere (verified by
+// order-swap: glass-first → all light, liquid-first → all blue). part:'liquid'
+// and part:'glass' are therefore usable as standalone building blocks, but the
+// full single-atom two-tone fill gauge awaits a SHADER waterline split (color by
+// height vs a per-sphere waterline within one solid-sphere subject). Real glass
+// refraction (studio material kind 'glass') was rejected for this atom: it
+// magnifies/fills the level and destroys the readable waterline.
 // =============================================================================
 
-import { sphere, cutSphere, torus } from '../../../sdf/d3.js';
+import { sphere, cutSphere } from '../../../sdf/d3.js';
 import { union } from '../../../sdf/dn.js';
 
 const clamp01 = (x) => (x < 0 ? 0 : x > 1 ? 1 : x);
 
 /**
- * Build a wireframe "globe cage": 3 orthogonal great-circle rings.
- * @param {number} r          ring radius (= sphere radius)
- * @param {number} thickness  tube radius
- * @returns {SDF3}
- */
-function cageRings(r, thickness) {
-  const equator = torus(r, thickness); // ring in XZ plane (axis Y)
-  const meridianA = torus(r, thickness).rotate(Math.PI / 2, [1, 0, 0]); // XY plane
-  const meridianB = torus(r, thickness).rotate(Math.PI / 2, [0, 0, 1]); // YZ plane
-  return union(equator, meridianA, meridianB);
-}
-
-/**
- * Liquid fill cap for one sphere. Fills from the bottom (−Y) up to a waterline
- * set by the fill fraction. Returns null for an empty (fraction ≤ 0) sphere.
- *
- * cutSphere(r, h) keeps the y ≥ h portion; we mirror it (rotate π about X) so
- * the kept cap is the y ≤ waterline bottom portion.
- *
- * @param {number} r  liquid radius (slightly inset inside the cage)
- * @param {number} f  fill fraction (0..1)
- * @returns {SDF3|null}
+ * Coloured liquid: the sphere portion BELOW the waterline (bottom cap).
+ * cutSphere(r, h) keeps the y ≥ h portion; mirror it (rotate π about X) to keep
+ * the bottom (y ≤ waterline) portion.
+ * @returns {SDF3|null} null when empty (f ≤ 0)
  */
 function liquidCap(r, f) {
   const frac = clamp01(f);
   if (frac <= 0) return null;
-  // A full tank is a plain sphere. cutSphere(r, ±r) is degenerate (w → 0), so
-  // route the brim-full case to the exact primitive instead of the cut cap.
-  if (frac >= 1) return sphere(r);
-  const waterline = r * (2 * frac - 1); // open interval (−r, +r)
+  if (frac >= 1) return sphere(r); // brim-full → whole sphere is liquid
+  const waterline = r * (2 * frac - 1); // ∈ (−r, +r)
   return cutSphere(r, -waterline).rotate(Math.PI, [1, 0, 0]);
+}
+
+/**
+ * Glass: the sphere portion ABOVE the waterline (top cap, the "empty" part).
+ * cutSphere(r, waterline) keeps the y ≥ waterline portion directly.
+ * @returns {SDF3|null} null when full (f ≥ 1 → no empty top)
+ */
+function glassCap(r, f) {
+  const frac = clamp01(f);
+  if (frac >= 1) return null;
+  if (frac <= 0) return sphere(r); // empty → whole sphere is glass
+  const waterline = r * (2 * frac - 1);
+  return cutSphere(r, waterline);
 }
 
 /**
@@ -62,9 +71,7 @@ function liquidCap(r, f) {
  * @param {number|null} [opts.count=null]  number of spheres (defaults to levels.length)
  * @param {number} [opts.radius=0.6]       sphere radius
  * @param {number} [opts.spacing=0.3]      gap between spheres
- * @param {boolean} [opts.cage=true]       draw the wireframe container cage
- * @param {number} [opts.cageThickness=0.025]  cage ring tube radius
- * @param {number} [opts.fillScale=0.92]   liquid radius as a fraction of sphere radius
+ * @param {'both'|'liquid'|'glass'} [opts.part='both']  which cap to emit (composite materials them separately)
  * @returns {SDF3|null}
  */
 export function sphereFill3dSDF({
@@ -72,29 +79,33 @@ export function sphereFill3dSDF({
   count = null,
   radius = 0.6,
   spacing = 0.3,
-  cage = true,
-  cageThickness = 0.025,
-  fillScale = 0.92,
+  part = 'both',
 } = {}) {
   const N = count != null ? Math.floor(count) : levels.length;
   if (N <= 0) return null;
 
   const stride = 2 * radius + spacing;
   const offset = ((N - 1) / 2) * stride;
-  const fillR = radius * fillScale;
+  const wantLiquid = part === 'both' || part === 'liquid';
+  const wantGlass = part === 'both' || part === 'glass';
 
   const parts = [];
   for (let i = 0; i < N; i++) {
     const f = levels[i] != null ? levels[i] : (levels[levels.length - 1] ?? 0.5);
     const cx = i * stride - offset;
 
-    const sphereParts = [];
-    if (cage) sphereParts.push(cageRings(radius, cageThickness));
-    const liquid = liquidCap(fillR, f);
-    if (liquid) sphereParts.push(liquid);
+    const capParts = [];
+    if (wantLiquid) {
+      const liquid = liquidCap(radius, f);
+      if (liquid) capParts.push(liquid);
+    }
+    if (wantGlass) {
+      const glass = glassCap(radius, f);
+      if (glass) capParts.push(glass);
+    }
 
-    if (sphereParts.length === 0) continue; // empty + no cage → nothing
-    const group = sphereParts.length === 1 ? sphereParts[0] : union(...sphereParts);
+    if (capParts.length === 0) continue;
+    const group = capParts.length === 1 ? capParts[0] : union(...capParts);
     parts.push(group.translate([cx, 0, 0]));
   }
 
@@ -116,20 +127,22 @@ export const sphereFill3dSpec = {
     count: { type: 'number', default: null, doc: 'Number of spheres (defaults to levels.length)' },
     radius: { type: 'number', default: 0.6, doc: 'Sphere radius' },
     spacing: { type: 'number', default: 0.3, doc: 'Gap between spheres' },
-    cage: { type: 'boolean', default: true, doc: 'Draw the wireframe container cage' },
-    cageThickness: { type: 'number', default: 0.025, doc: 'Cage ring tube radius' },
-    fillScale: { type: 'number', default: 0.92, doc: 'Liquid radius as fraction of sphere radius' },
+    part: {
+      type: 'string',
+      default: 'both',
+      doc: "Which cap: 'both' | 'liquid' (colored bottom) | 'glass' (light top)",
+    },
   },
   examples: [
     { name: 'Quartile progress', args: { levels: [0.25, 0.5, 0.75, 1.0] } },
     { name: 'Capacity gauges', args: { levels: [0.9, 0.6, 0.3], radius: 0.7 } },
-    { name: 'Single tank', args: { levels: [0.65], cage: true } },
+    { name: 'Liquid only', args: { levels: [0.5], part: 'liquid' } },
   ],
-  description: 'Row of glass spheres with liquid fill levels (0..1) for capacity / progress',
+  description: 'Row of fill-level spheres (waterline split: colored liquid bottom + glass top)',
   source: {
     author: 'Atlas',
     builtAt: '2026-06-20',
-    builder: 'Sprint 2 sphere atom #1 — taxonomy shapes/',
+    builder: 'Sprint 2 sphere atom #1 — taxonomy shapes/ (waterline-split rebuild 2026-06-22)',
     license: 'PolyForm Noncommercial 1.0.0',
   },
 };

--- a/sdf-js/src/scene/spec.js
+++ b/sdf-js/src/scene/spec.js
@@ -579,6 +579,14 @@ export const MATERIAL_KIND_INDEX = {
   // treeAmount channel > threshold, drainage darkening along ridgeMap creases.
   // Only valid on terrain-eroded-rune primitive (which uploads the texture).
   'eroded-terrain': 7,
+  // 8 = glass: real single-refraction transparent glass. The view ray refracts
+  // (Snell, ior ~1.45) and a secondary march SEES THROUGH to whatever is behind
+  // (e.g. coloured liquid inside a glass shell, or the distorted background),
+  // blended with a Fresnel-weighted env reflection + a sharp sun glint + a cool
+  // fresnel edge. Designed for thin hollow shells (so the refracted ray travels
+  // air, not solid — sphere-tracing can't march inside solids). Used by
+  // sphere-fill-3d's glass container (PresentationLoad "3D Spheres" look).
+  glass: 8,
 };
 
 // =============================================================================


### PR DESCRIPTION
## What

Wrap-up commit for the sphere-fill glass exploration (option: keep the validated pieces, park the full gauge look).

**1. New `glass` material kind (studio renderer)** — `MATERIAL_KIND_INDEX['glass'] = 8`. Single-refraction transparent glass: view ray refracts (ior 1.45) + a secondary short march sees through to the interior/background, blended with a Fresnel env reflection + sharp glint + cool rim. A general decorative transparent-glass capability (use thin hollow shells — sphere-trace can't march solids). Validated by headless render.

**2. `sphere-fill-3d` rebuilt on a waterline split** — replaces the rejected wireframe-cage globe. Each sphere is a SOLID sphere cut at the fill waterline into a liquid bottom cap + a glass top cap. New `part` arg (`both` | `liquid` | `glass`); `both` (default) unions to a solid sphere. Drops the cage + the fillScale inset.

## Why this shape (the design fork)

The PresentationLoad "fill level" read is a 2D illusion (clear top + crisp waterline). Real glass refraction (kind `glass`) reproduces a pretty glass marble but **destroys the level read** — refraction magnifies/fills the interior and smears the waterline. A fill gauge's whole job is to communicate the level, so the gauge needs a stylized waterline split, not real refraction. The `glass` kind is kept as a standalone decorative capability.

## Known limitation (documented in-file)

The full two-tone gauge can't be had by overlaying a `part:'liquid'` + `part:'glass'` instance: both caps share the same outer sphere surface, so the raymarch can't disambiguate the material at a shared hit and the **first subject's material wins for the whole sphere** (verified by order-swap: glass-first → all light, liquid-first → all blue). `part:'liquid'`/`'glass'` are usable standalone; the single-atom gauge awaits a **shader waterline split** (color by height vs a per-sphere waterline within one solid-sphere subject) — the planned next step.

## Tests

- `test-sphere-fill-3d.mjs` rewritten to the new contract — **20/20**.
- Full suite **88/88**. My 4 files lint clean.
- (Repo-wide `npm run lint` is red on a pre-existing **untracked** `src/scene/primitives/factories.js` parse error — not part of this PR.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)