### PR TITLE
feat(studio): sphere-fill two-tone gauge via a shader waterline (material kind 'fill')

### DIFF
--- a/sdf-js/scenes/sphere-fill-gauge.json
+++ b/sdf-js/scenes/sphere-fill-gauge.json
@@ -1,0 +1,41 @@
+{
+  "id": "sphere-fill-gauge",
+  "title": "Fill-level spheres · on the studio stage",
+  "prompt": "four capacity gauges as glass spheres filling with blue liquid to different levels",
+  "code2d": "// sphere-fill-3d + material.kind:'fill' → solid spheres shaded as fill gauges (liquid below a waterline, glass above). PresentationLoad '3D Spheres Fill Levels' twin.",
+  "sceneData": {
+    "v": 1,
+    "name": "sphere fill gauges",
+    "subjects": [
+      {
+        "id": "gauges",
+        "type": "sphere-fill-3d",
+        "args": { "levels": [0.25, 0.5, 0.75, 1.0], "radius": 0.8, "spacing": 0.5 },
+        "transform": { "translate": [0, 1.0, 0] },
+        "material": {
+          "hue": 0.58,
+          "sat": 0.82,
+          "value": 0.62,
+          "kind": "fill",
+          "roughness": 0.3,
+          "clearcoat": 0.5
+        }
+      }
+    ],
+    "cameraSequence": {
+      "loop": false,
+      "shots": [
+        {
+          "duration": 8,
+          "pos": [0, 1.5, 7.5],
+          "target": [0, 1.0, 0],
+          "fov": 46,
+          "aperture": 0,
+          "focalDistance": 7.5,
+          "ease": "smooth"
+        }
+      ]
+    },
+    "defaults": { "stage": { "size": [14, 5.5, 10] } }
+  }
+}

--- a/sdf-js/scripts/test-sphere-fill-3d.mjs
+++ b/sdf-js/scripts/test-sphere-fill-3d.mjs
@@ -1,13 +1,11 @@
 // =============================================================================
 // L1 unit tests for the sphere-fill-3d atom.
 // -----------------------------------------------------------------------------
-// sphere-fill-3d renders a row of "fill level" spheres. Each sphere is a SOLID
-// sphere split at a waterline (height = 0..1 fill fraction) into two caps:
-//   - liquid cap (below waterline)  → part:'liquid'
-//   - glass  cap (above waterline)  → part:'glass'
-//   - part:'both' (default) unions them → a full solid sphere.
-// Pure geometry; the colored/light two-tone read is materialed at the scene/
-// shader level (see the atom's KNOWN LIMITATION note).
+// sphere-fill-3d renders a row of "fill level" gauge spheres. Each sphere is ONE
+// SOLID sphere; the liquid/glass two-tone split happens in the studio 'fill'
+// material kind (shader), driven by a per-sphere fill fraction carried in the
+// pattern LUT slot [3] (leaf._subjectPattern.fill). So this unit test checks the
+// geometry (solid spheres, correct layout) + that each sphere carries its fill.
 //
 // PresentationLoad reference: "3D Spheres Fill Levels" (deck use case, P0).
 // =============================================================================
@@ -31,69 +29,62 @@ function ok(cond, name) {
 console.log('=== sphere-fill-3d unit test ===\n');
 
 // ---- Test group 1: defaults --------------------------------------------------
-console.log('Test group 1: defaults (4 spheres, part:both → solid)');
+console.log('Test group 1: defaults (4 solid spheres)');
 {
   const sdf = sphereFill3dSDF();
   ok(sdf != null, 'default sdf is non-null');
   // Defaults: levels=[0.25,0.5,0.75,1.0], radius=0.6, spacing=0.3.
   // stride = 2*0.6 + 0.3 = 1.5; offset = (4-1)/2*1.5 = 2.25.
-  // Sphere index 3 (fill 1.0) center x = 3*1.5 - 2.25 = 2.25.
-  ok(sdf.f([2.25, 0, 0]) < 0, 'last sphere (fill=1.0) center is inside');
+  // Sphere index 3 center x = 3*1.5 - 2.25 = 2.25.
+  ok(sdf.f([2.25, 0, 0]) < 0, 'last sphere center is inside');
   ok(sdf.f([100, 0, 0]) > 0, 'far point is outside');
 }
 
-// ---- Test group 2: part:'both' is a solid sphere at any fill -----------------
-console.log("\nTest group 2: part:'both' → solid sphere (both caps)");
+// ---- Test group 2: each sphere is solid (geometry independent of fill) -------
+console.log('\nTest group 2: solid sphere (geometry independent of fill)');
 {
-  // Single half-full sphere at origin (waterline at y=0). Union of caps = solid.
-  const sdf = sphereFill3dSDF({ levels: [0.5], radius: 0.6 });
-  ok(sdf.f([0, -0.3, 0]) < 0, 'both: below waterline inside (liquid cap)');
-  ok(sdf.f([0, 0.3, 0]) < 0, 'both: above waterline inside (glass cap)');
-  ok(sdf.f([0, 0.9, 0]) > 0, 'both: outside the sphere radius');
+  // Single sphere at origin, low fill. Geometry is still a full solid sphere;
+  // the waterline is a shading effect, not a cut.
+  const sdf = sphereFill3dSDF({ levels: [0.2], radius: 0.6 });
+  ok(sdf.f([0, 0, 0]) < 0, 'center inside');
+  ok(sdf.f([0, 0.4, 0]) < 0, 'above-waterline point inside (solid)');
+  ok(sdf.f([0, -0.4, 0]) < 0, 'below-waterline point inside (solid)');
+  ok(sdf.f([0, 0.9, 0]) > 0, 'point beyond radius outside');
 }
 
-// ---- Test group 3: part:'liquid' isolates the bottom cap ---------------------
-console.log("\nTest group 3: part:'liquid' (colored bottom cap)");
+// ---- Test group 3: per-sphere fill carried in pattern ------------------------
+console.log('\nTest group 3: per-sphere fill in pattern slot');
 {
-  // Two spheres: empty + full. stride=1.5, offset=0.75 → x = -0.75, +0.75.
-  const sdf = sphereFill3dSDF({ levels: [0.0, 1.0], part: 'liquid' });
-  ok(sdf.f([0.75, 0, 0]) < 0, 'full (fill=1.0) liquid center inside');
-  ok(sdf.f([-0.75, 0, 0]) > 0, 'empty (fill=0.0) → no liquid, center outside');
+  const sdf = sphereFill3dSDF({ levels: [0.3, 0.7] });
+  const kids = sdf.ast?.children ?? [];
+  ok(kids.length === 2, 'two sphere leaves');
+  ok(kids[0]?._subjectPattern?.fill === 0.3, 'sphere 0 fill = 0.3');
+  ok(kids[1]?._subjectPattern?.fill === 0.7, 'sphere 1 fill = 0.7');
 }
 {
-  // Single half-full sphere, liquid only: fills the bottom, air above.
-  const sdf = sphereFill3dSDF({ levels: [0.5], part: 'liquid' });
-  ok(sdf.f([0, -0.3, 0]) < 0, 'half liquid: below waterline inside');
-  ok(sdf.f([0, 0.3, 0]) > 0, 'half liquid: above waterline outside (no top cap)');
-}
-
-// ---- Test group 4: part:'glass' isolates the top cap ------------------------
-console.log("\nTest group 4: part:'glass' (light top cap)");
-{
-  // Single half-full sphere, glass only: fills the top, empty below.
-  const sdf = sphereFill3dSDF({ levels: [0.5], part: 'glass' });
-  ok(sdf.f([0, 0.3, 0]) < 0, 'half glass: above waterline inside');
-  ok(sdf.f([0, -0.3, 0]) > 0, 'half glass: below waterline outside (no bottom cap)');
+  // Single sphere returns the leaf directly (no wrapping union).
+  const single = sphereFill3dSDF({ levels: [0.5] });
+  ok(single?._subjectPattern?.fill === 0.5, 'single sphere carries fill 0.5');
 }
 {
-  // Brim-full → no empty top → glass-only emits nothing → null.
-  ok(
-    sphereFill3dSDF({ levels: [1.0], part: 'glass' }) === null,
-    'glass at fill=1.0 → null (no empty top)',
-  );
+  // Fill fractions are clamped to 0..1.
+  const sdf = sphereFill3dSDF({ levels: [-0.5, 1.4] });
+  const kids = sdf.ast?.children ?? [];
+  ok(kids[0]?._subjectPattern?.fill === 0, 'negative fill clamped to 0');
+  ok(kids[1]?._subjectPattern?.fill === 1, 'over-1 fill clamped to 1');
 }
 
-// ---- Test group 5: edge cases -----------------------------------------------
-console.log('\nTest group 5: edge cases');
+// ---- Test group 4: edge cases -----------------------------------------------
+console.log('\nTest group 4: edge cases');
 {
   ok(sphereFill3dSDF({ count: 0 }) === null, 'count=0 returns null');
   ok(sphereFill3dSDF({ levels: [], count: 0 }) === null, 'no spheres returns null');
   const single = sphereFill3dSDF({ levels: [1.0] });
-  ok(single != null && single.f([0, 0, 0]) < 0, 'single full sphere at origin inside');
+  ok(single != null && single.f([0, 0, 0]) < 0, 'single sphere at origin inside');
 }
 
-// ---- Test group 6: scene compile + GLSL emit ---------------------------------
-console.log('\nTest group 6: SceneData → compile → GLSL emit');
+// ---- Test group 5: scene compile + GLSL emit ---------------------------------
+console.log('\nTest group 5: SceneData → compile → GLSL emit');
 {
   const scene = {
     v: 1,
@@ -106,6 +97,7 @@ console.log('\nTest group 6: SceneData → compile → GLSL emit');
         type: 'sphere-fill-3d',
         id: 'test-fill',
         args: { levels: [0.5, 1.0], radius: 0.6, spacing: 0.3 },
+        material: { hue: 0.58, sat: 0.8, value: 0.6, kind: 'fill' },
         region: 'object',
       },
     ],
@@ -120,8 +112,8 @@ console.log('\nTest group 6: SceneData → compile → GLSL emit');
   }
 
   if (compiled && compiled.sdf) {
-    // Full sphere (index 1) center x = 1*1.5 - 0.75 = 0.75.
-    ok(compiled.sdf.f([0.75, 0, 0]) < 0, 'compiled SDF: full sphere center inside');
+    // Sphere index 1 center x = 1*1.5 - 0.75 = 0.75.
+    ok(compiled.sdf.f([0.75, 0, 0]) < 0, 'compiled SDF: sphere center inside');
     let glsl;
     try {
       glsl = compileSDF3ToGLSL(compiled.sdf, { time: 'u_time' });
@@ -131,7 +123,7 @@ console.log('\nTest group 6: SceneData → compile → GLSL emit');
     }
     if (glsl) {
       const exprStr = typeof glsl === 'string' ? glsl : glsl.expr || JSON.stringify(glsl);
-      ok(exprStr.includes('sdCutSphere'), 'GLSL emit contains sdCutSphere (waterline caps)');
+      ok(exprStr.includes('sdSphere'), 'GLSL emit contains sdSphere');
     }
   }
 }

--- a/sdf-js/src/render/studio.js
+++ b/sdf-js/src/render/studio.js
@@ -797,12 +797,16 @@ void main() {
     bool isBuilding = false;    // material.kind == 'building'    (tone.y ~ 6)
     bool isEroded = false;      // material.kind == 'eroded-terrain' (tone.y ~ 7)
     bool isGlass = false;       // material.kind == 'glass'           (tone.y ~ 8)
+    bool isFill = false;        // material.kind == 'fill'            (tone.y ~ 9)
     vec4 leafMat, leafTone, leafPat;
     if (matId > 1.5) {
       fetchLeafData(hitIdx, leafMat, leafTone, leafPat);
       // Route by material kind. tone.y carries an integer-encoded kind.
-      // Check higher kinds first (7 > 6 > 5 > 4 > 3 > 2 > 1 > 0).
-      if (leafTone.y > 7.5) {
+      // Check higher kinds first (9 > 8 > 7 > ... > 1 > 0).
+      if (leafTone.y > 8.5) {
+        isFill = true;
+        base = hsv2rgb(vec3(leafMat.x, leafMat.y, leafTone.x)); // liquid colour
+      } else if (leafTone.y > 7.5) {
         isGlass = true;
         base = hsv2rgb(vec3(leafMat.x, leafMat.y, leafTone.x));
       } else if (leafTone.y > 6.5) {
@@ -990,6 +994,37 @@ void main() {
       gcol += vec3(1.0) * pow(max(dot(n, Hg), 0.0), 140.0) * shadowK * 1.2; // sharp glint
       gcol += vec3(0.75, 0.85, 1.0) * pow(1.0 - ndv, 3.0) * 0.35;           // cool fresnel edge
       col = gcol;
+    } else if (isFill) {
+      // ---- Fill-gauge material kind (waterline two-tone) -------------------
+      // A SOLID sphere read as a "fill level": coloured liquid below a waterline,
+      // light glass above, crisp meniscus between. On a sphere the surface normal
+      // y-component IS the local height fraction, so the split is transform-free
+      // and needs no center/radius — just the per-leaf fill fraction (pat.w).
+      // Stylized on purpose: real glass refraction smears the level (see kind 8),
+      // so we keep the waterline crisp and the data readable.
+      float fillFrac = clamp(leafPat.w, 0.0, 1.0);
+      float waterline = 2.0 * fillFrac - 1.0;                  // n.y at the surface
+      float below = 1.0 - smoothstep(waterline - 0.012, waterline + 0.012, n.y);
+      vec3 liquidCol = base;                                   // material hue/sat/value
+      vec3 glassCol = mix(vec3(0.93, 0.95, 0.99), base, 0.10); // light, faint liquid tint
+      vec3 albedo = mix(glassCol, liquidCol, below);
+      // FLAT-ish data-viz lighting: a strong ambient floor so the liquid colour
+      // reads even on the down-facing (sun-shadowed) bottom of the sphere — a
+      // gauge must stay legible, not go realistically dark — plus a soft key for
+      // form and a faint sky tint.
+      vec3 sunColF = vec3(1.20, 0.94, 0.72);
+      float diffF = max(dot(n, toLight), 0.0);
+      vec3 litF = albedo * (0.62 + 0.55 * diffF * shadowK) * sunColF * 0.92
+                + albedo * sky(n, sunDir) * skyL * ao * 0.12;
+      // Glossy clearcoat sheen → glass look: tight white glint + cool fresnel rim.
+      float ndvF = max(dot(n, -rd), 0.0);
+      vec3 HgF = normalize(toLight + (-rd));
+      litF += vec3(1.0) * pow(max(dot(n, HgF), 0.0), 90.0) * shadowK * 0.6;
+      litF += vec3(0.85, 0.90, 1.0) * pow(1.0 - ndvF, 4.0) * 0.18;
+      // Crisp meniscus band where liquid meets glass.
+      float band = 1.0 - smoothstep(0.0, 0.045, abs(n.y - waterline));
+      litF += vec3(0.92, 0.96, 1.0) * band * 0.22;
+      col = litF;
     } else if (isSnowy) {
       // ---- Snowy material kind (IQ Snow Bridge recipe-only port) -----------
       // Standard Lambert with the underlying base color, then blend snow on top
@@ -2150,7 +2185,8 @@ export function createStudioRenderer({
       patternLUT[i * 4 + 0] = p.code;
       patternLUT[i * 4 + 1] = p.scale;
       patternLUT[i * 4 + 2] = p.strength;
-      // [3] reserved for future use (e.g. rotation, sub-variant)
+      // [3] = fill fraction (0..1) for material kind 9 (fill-gauge); 0 otherwise.
+      patternLUT[i * 4 + 3] = p.fill ?? 0;
     }
 
     // Upload LUTs ONCE per program load. Uniforms persist on the program

--- a/sdf-js/src/scene/compile.js
+++ b/sdf-js/src/scene/compile.js
@@ -1402,8 +1402,30 @@ function compilePrimitive(subj, defaultRegion, subjectInfos) {
   if (!factory) throw new Error(`compile: no factory for primitive "${subj.type}"`);
   let sdf = factory(resolvedArgs);
 
-  // 3. Apply transform
-  sdf = applyTransform(sdf, subj.transform, subj.animation);
+  // 3. Apply transform. If the factory returned a UNION (a multi-leaf atom such
+  // as sphere-fill-3d, where each leaf carries its own _subjectMaterial /
+  // _subjectPattern), push the transform DOWN onto each union child instead of
+  // wrapping the union — otherwise applyTransform wraps the union AST in a
+  // translate/rotate/scale op node that flattenUnion (sdf3.compile) can't descend,
+  // collapsing all leaves into one and dropping their per-leaf material/pattern
+  // (same failure mode as the compileBoolean union push-down below). This is
+  // mathematically equivalent: the transform acts on the query point and min()
+  // distributes over union, so the geometry is unchanged.
+  const hasOuterTransform = subj.transform != null || hasTransformAnim(subj.animation);
+  const isUnion = sdf?.ast?.kind === 'op' && sdf.ast.name === 'union';
+  if (isUnion && hasOuterTransform) {
+    const k = sdf.ast.opts?.k;
+    const kids = sdf.ast.children.map((c) => {
+      const t = applyTransform(c, subj.transform, subj.animation);
+      // applyTransform wrappers drop leaf tags — re-attach from the inner child.
+      if (c._subjectMaterial !== undefined) t._subjectMaterial = c._subjectMaterial;
+      if (c._subjectPattern !== undefined) t._subjectPattern = c._subjectPattern;
+      return t;
+    });
+    sdf = k != null ? union(...kids, { k }) : union(...kids);
+  } else {
+    sdf = applyTransform(sdf, subj.transform, subj.animation);
+  }
 
   // 4. Attach material/pattern at leaf level. Required when a primitive is
   // nested inside DomainGroup ops (rep / curve / mirror / twist / bend) —

--- a/sdf-js/src/scene/components/shapes/sphere-fill-3d.js
+++ b/sdf-js/src/scene/components/shapes/sphere-fill-3d.js
@@ -1,77 +1,40 @@
 // =============================================================================
-// sphere-fill-3d.js — "fill level" spheres (Atlas Shape atom, Sprint 2).
+// sphere-fill-3d.js — "fill level" gauge spheres (Atlas Shape atom, Sprint 2).
 // -----------------------------------------------------------------------------
-// A row of spheres, each split at a waterline into a coloured LIQUID bottom cap
-// and a light GLASS top cap. Faithful 3D twin of PresentationLoad "3D Spheres
-// Fill Levels" (stun-demo fixture D0961).
+// A row of SOLID spheres, each read as a fill gauge: a coloured liquid bottom
+// below a waterline + a light glass top above it, with a crisp meniscus between.
+// Faithful 3D twin of PresentationLoad "3D Spheres Fill Levels" (stun-demo
+// fixture D0961).
 //
-// Design note (2026-06-22): the PresentationLoad look is NOT a transparent shell
-// holding a separate liquid volume — real glass refraction magnifies/fills the
-// level and destroys the readable waterline (the gauge's whole purpose). It is a
-// SOLID sphere cut at the waterline into two opaque-but-glossy materials:
-//   - liquid (below waterline): the coloured fill — opaque, glossy + clearcoat
-//   - glass  (above waterline): light/clear — light glossy material
-// The seam between the two caps IS the waterline ellipse → the fill level reads
-// at a glance. Both caps carry a glassy sheen via the standard PBR material
-// (clearcoat + reflection), so it looks like glass without losing the data.
+// The two-tone split happens IN THE SHADER (studio material kind 'fill', =9), not
+// in geometry. Why: the earlier two-cap geometry can't be materialed as a gauge —
+// the liquid/glass caps share the same outer sphere surface, so the raymarch can't
+// disambiguate the material at a shared hit (see
+// project_studio_coincident_surface_material_limit). And real glass refraction
+// (kind 'glass', =8) smears the waterline. So each sphere is ONE solid leaf, and
+// the 'fill' shader splits it by height: on a sphere the surface normal's
+// y-component IS the local height, so the waterline is simply `n.y < 2*fill-1` —
+// transform-invariant, no center/radius needed.
 //
-// `part` lets each cap carry its own material: 'liquid' (colored bottom),
-// 'glass' (light top), or 'both' (default — single material, a plain sphere).
-//
-// KNOWN LIMITATION (2026-06-22): you cannot get the two-tone gauge by overlaying
-// two instances (one part:'liquid' + one part:'glass') in one scene. Both caps
-// are cut from the SAME radius sphere, so their outer surfaces COINCIDE; the
-// studio raymarch can't tell which cap's material to use at a shared surface
-// point and the first subject's material wins for the whole sphere (verified by
-// order-swap: glass-first → all light, liquid-first → all blue). part:'liquid'
-// and part:'glass' are therefore usable as standalone building blocks, but the
-// full single-atom two-tone fill gauge awaits a SHADER waterline split (color by
-// height vs a per-sphere waterline within one solid-sphere subject). Real glass
-// refraction (studio material kind 'glass') was rejected for this atom: it
-// magnifies/fills the level and destroys the readable waterline.
+// Per-sphere fill fraction rides in the PATTERN LUT slot [3] (u_leafPattern.w),
+// attached here per leaf. The LIQUID COLOUR comes from the subject's material
+// (hue/sat/value); set the subject `material.kind = "fill"` to get the gauge look
+// (without it the spheres render as plain solid spheres — a safe fallback).
 // =============================================================================
 
-import { sphere, cutSphere } from '../../../sdf/d3.js';
+import { sphere } from '../../../sdf/d3.js';
 import { union } from '../../../sdf/dn.js';
 
 const clamp01 = (x) => (x < 0 ? 0 : x > 1 ? 1 : x);
 
 /**
- * Coloured liquid: the sphere portion BELOW the waterline (bottom cap).
- * cutSphere(r, h) keeps the y ≥ h portion; mirror it (rotate π about X) to keep
- * the bottom (y ≤ waterline) portion.
- * @returns {SDF3|null} null when empty (f ≤ 0)
- */
-function liquidCap(r, f) {
-  const frac = clamp01(f);
-  if (frac <= 0) return null;
-  if (frac >= 1) return sphere(r); // brim-full → whole sphere is liquid
-  const waterline = r * (2 * frac - 1); // ∈ (−r, +r)
-  return cutSphere(r, -waterline).rotate(Math.PI, [1, 0, 0]);
-}
-
-/**
- * Glass: the sphere portion ABOVE the waterline (top cap, the "empty" part).
- * cutSphere(r, waterline) keeps the y ≥ waterline portion directly.
- * @returns {SDF3|null} null when full (f ≥ 1 → no empty top)
- */
-function glassCap(r, f) {
-  const frac = clamp01(f);
-  if (frac >= 1) return null;
-  if (frac <= 0) return sphere(r); // empty → whole sphere is glass
-  const waterline = r * (2 * frac - 1);
-  return cutSphere(r, waterline);
-}
-
-/**
- * sphere-fill-3d SDF.
+ * sphere-fill-3d SDF — a row of solid gauge spheres.
  *
  * @param {object} opts
  * @param {number[]} [opts.levels=[0.25,0.5,0.75,1.0]]  per-sphere fill fraction 0..1
  * @param {number|null} [opts.count=null]  number of spheres (defaults to levels.length)
  * @param {number} [opts.radius=0.6]       sphere radius
  * @param {number} [opts.spacing=0.3]      gap between spheres
- * @param {'both'|'liquid'|'glass'} [opts.part='both']  which cap to emit (composite materials them separately)
  * @returns {SDF3|null}
  */
 export function sphereFill3dSDF({
@@ -79,34 +42,22 @@ export function sphereFill3dSDF({
   count = null,
   radius = 0.6,
   spacing = 0.3,
-  part = 'both',
 } = {}) {
   const N = count != null ? Math.floor(count) : levels.length;
   if (N <= 0) return null;
 
   const stride = 2 * radius + spacing;
   const offset = ((N - 1) / 2) * stride;
-  const wantLiquid = part === 'both' || part === 'liquid';
-  const wantGlass = part === 'both' || part === 'glass';
 
   const parts = [];
   for (let i = 0; i < N; i++) {
-    const f = levels[i] != null ? levels[i] : (levels[levels.length - 1] ?? 0.5);
+    const f = clamp01(levels[i] != null ? levels[i] : (levels[levels.length - 1] ?? 0.5));
     const cx = i * stride - offset;
-
-    const capParts = [];
-    if (wantLiquid) {
-      const liquid = liquidCap(radius, f);
-      if (liquid) capParts.push(liquid);
-    }
-    if (wantGlass) {
-      const glass = glassCap(radius, f);
-      if (glass) capParts.push(glass);
-    }
-
-    if (capParts.length === 0) continue;
-    const group = capParts.length === 1 ? capParts[0] : union(...capParts);
-    parts.push(group.translate([cx, 0, 0]));
+    const s = sphere(radius).translate([cx, 0, 0]);
+    // Per-sphere fill rides in the pattern LUT slot [3]. The 'fill' material kind
+    // (set on the subject) reads u_leafPattern.w as the waterline height.
+    s._subjectPattern = { code: 0, scale: 0, strength: 0, fill: f };
+    parts.push(s);
   }
 
   if (parts.length === 0) return null;
@@ -127,22 +78,17 @@ export const sphereFill3dSpec = {
     count: { type: 'number', default: null, doc: 'Number of spheres (defaults to levels.length)' },
     radius: { type: 'number', default: 0.6, doc: 'Sphere radius' },
     spacing: { type: 'number', default: 0.3, doc: 'Gap between spheres' },
-    part: {
-      type: 'string',
-      default: 'both',
-      doc: "Which cap: 'both' | 'liquid' (colored bottom) | 'glass' (light top)",
-    },
   },
   examples: [
     { name: 'Quartile progress', args: { levels: [0.25, 0.5, 0.75, 1.0] } },
     { name: 'Capacity gauges', args: { levels: [0.9, 0.6, 0.3], radius: 0.7 } },
-    { name: 'Liquid only', args: { levels: [0.5], part: 'liquid' } },
   ],
-  description: 'Row of fill-level spheres (waterline split: colored liquid bottom + glass top)',
+  description:
+    'Row of fill-level gauge spheres (liquid bottom + glass top split at a waterline). Set the subject material.kind to "fill" with a liquid hue/sat/value for the gauge look.',
   source: {
     author: 'Atlas',
     builtAt: '2026-06-20',
-    builder: 'Sprint 2 sphere atom #1 — taxonomy shapes/ (waterline-split rebuild 2026-06-22)',
+    builder: 'Sprint 2 sphere atom #1 — taxonomy shapes/ (shader waterline gauge 2026-06-23)',
     license: 'PolyForm Noncommercial 1.0.0',
   },
 };

--- a/sdf-js/src/scene/spec.js
+++ b/sdf-js/src/scene/spec.js
@@ -584,9 +584,18 @@ export const MATERIAL_KIND_INDEX = {
   // (e.g. coloured liquid inside a glass shell, or the distorted background),
   // blended with a Fresnel-weighted env reflection + a sharp sun glint + a cool
   // fresnel edge. Designed for thin hollow shells (so the refracted ray travels
-  // air, not solid — sphere-tracing can't march inside solids). Used by
-  // sphere-fill-3d's glass container (PresentationLoad "3D Spheres" look).
+  // air, not solid — sphere-tracing can't march inside solids). A standalone
+  // decorative transparent-glass capability (NOT used by sphere-fill — see kind 9).
   glass: 8,
+  // 9 = fill-gauge: a SOLID sphere shaded as a "fill level" gauge. The surface is
+  // split at a waterline into a coloured liquid bottom (the material's hue/sat/
+  // value) and a light glass top, with a crisp meniscus band between. The fill
+  // fraction (0..1) rides per-leaf in the PATTERN LUT slot [3] (u_leafPattern.w);
+  // on a sphere the surface normal's y-component IS the local height, so the
+  // split is `n.y < 2*fill-1` — transform-invariant, no center/radius needed.
+  // This is how sphere-fill-3d renders the readable two-tone gauge (the caps/
+  // overlay approach can't, see project_studio_coincident_surface_material_limit).
+  fill: 9,
 };
 
 // =============================================================================


### PR DESCRIPTION
## What

The full readable sphere-fill gauge — the piece parked in #133. Each sphere now shows its own fill level: coloured liquid below a waterline, light glass above, crisp meniscus between. (Plus a tiny cleanup: deleted a dead untracked `src/scene/primitives/factories.js` Cursor artifact that was breaking local lint — not a tracked file, so it is not in this diff.)

![gauge](does-not-render-but-see-description)

Left→right in the demo: levels `[0.25, 0.5, 0.75, 1.0]` (the camera renders +x on the left, so the full sphere is leftmost).

## How

**New material kind `fill` (=9).** Shades a SOLID sphere as a gauge, split by height at the waterline. On a sphere the surface normal's y-component IS the local height, so the split is simply `n.y < 2*fill-1` — transform-invariant, no center/radius needed. Liquid colour = the material hue/sat/value; glass = a light cool tint. Lit **flat** (strong ambient floor) so the liquid stays legible on the sun-shadowed underside — a gauge must read, not go realistically dark. Per-sphere fill rides in the pattern LUT slot **[3]** (`u_leafPattern.w`), previously reserved.

**`sphere-fill-3d` rewritten** to a row of plain solid spheres, each tagged with its fill via `_subjectPattern`. This sidesteps both dead ends from #133: the caps/overlay approach (couldn't be materialed — coincident surfaces) and real glass refraction (smears the waterline).

**compile.js fix (the load-bearing one).** `compilePrimitive` now pushes a subject transform DOWN onto union children — like `compileBoolean` already does — instead of wrapping the union in a transform op that `flattenUnion` can't descend. The old behaviour collapsed all leaves into one and dropped per-leaf material/pattern (here: every sphere read fill=0 → all glass). Mathematically equivalent (the transform acts on the query point; `min()` distributes over union), so geometry is unchanged. This fixes per-leaf data for **any** multi-leaf primitive atom under a transform — same class as the canal "green" material-loss bug.

## Tests

- `scenes/sphere-fill-gauge.json` — demo + lift reference, exercises kind 9.
- `test-sphere-fill-3d.mjs` rewritten to the solid-sphere + per-sphere-fill contract — **20/20**.
- Full suite **89/89**; lint **0 errors**.
- Visually verified headless (4 spheres, distinct readable levels, crisp waterline, light glass top).

## Follow-ups (not blocking)

- Lift prompt should learn: for sphere-fill set `material.kind:"fill"` + a liquid hue/sat/value.
- Per-sphere colours (PDF has multi-colour sets) — currently one liquid colour per subject.

🤖 Generated with [Claude Code](https://claude.com/claude-code)