### PR TITLE
Sprint 17 quality: bullet-list/kpi-card/agenda-list/cover + lift prompt v3

### DIFF
--- a/sdf-js/examples/atoms-2d-demo/scaffold-deck-viewer.html
+++ b/sdf-js/examples/atoms-2d-demo/scaffold-deck-viewer.html
@@ -36,6 +36,7 @@
     <div class="controls">
       <label>Deck:</label>
       <select id="deck-picker">
+        <option value="examples/scaffold-pipeline/antfun-stress-test/deck.json">⚡ ANTFUN stress test (Sprint 17 atom fixes)</option>
         <option value="examples/scaffold-pipeline/vc-pitch/deck.json">VC Pitch (v1 picker · pitch-deck-vc)</option>
         <option value="examples/scaffold-pipeline/pd-sphere/deck.json">PD sphere-fill (v2 picker · product-launch)</option>
         <option value="examples/scaffold-pipeline/slidedata/deck.json">PD sphere-fill v1 (legacy · company-overview fallback)</option>

--- a/sdf-js/examples/atoms-2d-demo/test-agenda-showcase.html
+++ b/sdf-js/examples/atoms-2d-demo/test-agenda-showcase.html
@@ -28,4 +28,12 @@ const items4 = items6.slice(0, 4);
 await renderAtom(document.getElementById('c1').getContext('2d'), 'agenda-list', {items: items6, title: 'Agenda', subtitle: 'Q3 board review'}, 'pseudo3d', {x:0,y:0,w:1100,h:500,palette:theme});
 await renderAtom(document.getElementById('c2').getContext('2d'), 'agenda-list', {items: items4, title: 'Agenda'}, 'pseudo3d', {x:0,y:0,w:900,h:420,palette:theme});
 await renderAtom(document.getElementById('c3').getContext('2d'), 'agenda-list', {items: items4, title: 'Agenda'}, 'pseudo3d', {x:0,y:0,w:480,h:320,palette:theme});
+
+// Cover section-style test (PL slide 31 pattern)
+const sec = document.createElement('div');
+sec.innerHTML = `<div class="label" style="margin-top:24px;">Cover · style: section — PL section-divider</div><canvas id="c4" width="1280" height="500"></canvas><div class="label">Cover · style: gradient (default)</div><canvas id="c5" width="1280" height="500"></canvas>`;
+document.body.appendChild(sec);
+const navyTheme = {bg:[248,246,240], silhouetteColor:[22,35,70], accent:[38,70,130], colors:[[38,70,130]]};
+await renderAtom(document.getElementById('c4').getContext('2d'), 'cover', {title: 'OUR VISION', subtitle: 'Where we are going next.', style:'section'}, 'pseudo3d', {x:0,y:0,w:1280,h:500,palette:navyTheme});
+await renderAtom(document.getElementById('c5').getContext('2d'), 'cover', {title: 'OUR VISION', subtitle: 'Where we are going next.'}, 'pseudo3d', {x:0,y:0,w:1280,h:500,palette:navyTheme});
 </script></body></html>

--- a/sdf-js/examples/atoms-2d-demo/test-agenda-showcase.html
+++ b/sdf-js/examples/atoms-2d-demo/test-agenda-showcase.html
@@ -1,0 +1,31 @@
+<!doctype html>
+<html><head><meta charset="utf-8"><title>agenda showcase test</title>
+<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;900&family=Inter+Display:wght@900&display=swap">
+<style>body { background: #f8f7f4; padding: 40px; font-family: Inter; }
+canvas { background: white; border: 1px solid #d0cec3; display: block; margin-bottom: 24px; box-shadow: 0 4px 12px rgba(0,0,0,0.08); }
+.label { font-family: 'IBM Plex Mono', monospace; font-size: 11px; background: #1e1b1e; color: white; padding: 4px 10px; display: inline-block; }
+</style></head>
+<body>
+<h2>Agenda showcase mode test</h2>
+<div class="label">6 items, 1100x500 — should be 2-col PL-style</div>
+<canvas id="c1" width="1100" height="500"></canvas>
+<div class="label">4 items, 900x420 — should be 1-col showcase (w≥800)</div>
+<canvas id="c2" width="900" height="420"></canvas>
+<div class="label">4 items, 480x320 — compact fallback</div>
+<canvas id="c3" width="480" height="320"></canvas>
+<script type="module">
+import { renderAtom } from '/src/present/atoms-2d/registry.js';
+const theme = {bg:[248,246,240], silhouetteColor:[22,35,70], accent:[255,120,40], colors:[[255,120,40]]};
+const items6 = [
+  {label:'Recap last quarter', sublabel:'5 min'},
+  {label:'KPI dashboard review', sublabel:'15 min'},
+  {label:'Wins and losses', sublabel:'20 min'},
+  {label:'Challenges and risks', sublabel:'15 min'},
+  {label:'Next-quarter plan', sublabel:'20 min'},
+  {label:'Q&A and next steps', sublabel:'10 min'},
+];
+const items4 = items6.slice(0, 4);
+await renderAtom(document.getElementById('c1').getContext('2d'), 'agenda-list', {items: items6, title: 'Agenda', subtitle: 'Q3 board review'}, 'pseudo3d', {x:0,y:0,w:1100,h:500,palette:theme});
+await renderAtom(document.getElementById('c2').getContext('2d'), 'agenda-list', {items: items4, title: 'Agenda'}, 'pseudo3d', {x:0,y:0,w:900,h:420,palette:theme});
+await renderAtom(document.getElementById('c3').getContext('2d'), 'agenda-list', {items: items4, title: 'Agenda'}, 'pseudo3d', {x:0,y:0,w:480,h:320,palette:theme});
+</script></body></html>

--- a/sdf-js/examples/scaffold-pipeline/antfun-stress-test/deck.json
+++ b/sdf-js/examples/scaffold-pipeline/antfun-stress-test/deck.json
@@ -1,0 +1,100 @@
+{
+  "deckName": "antfun-stress-test",
+  "sourceFile": "synthetic stress test reproducing observed LLM patterns",
+  "scaffold": {
+    "id": "company-overview",
+    "label": "Company Overview",
+    "description": "Reproduces ANTFUN export quality issues for atom-level regression testing",
+    "pickScore": 0,
+    "pickSignals": ["synthetic"],
+    "fallback": false,
+    "pickerMethod": "synthetic"
+  },
+  "theme": {
+    "id": "pitch-cobalt-orange",
+    "label": "Pitch · Cobalt Orange",
+    "macroCluster": "pitch",
+    "bg": [255, 255, 255],
+    "accent": [255, 120, 40],
+    "colors": [
+      [255, 120, 40],
+      [20, 60, 180],
+      [220, 220, 235],
+      [60, 65, 90]
+    ],
+    "font": {
+      "heading": "\"Inter Display\", Inter, system-ui, sans-serif",
+      "body": "Inter, system-ui, sans-serif"
+    }
+  },
+  "slots": [
+    {
+      "slotIdx": 0,
+      "slotName": "cover",
+      "slotTitle": "Title",
+      "slotPurpose": "Company name + tagline",
+      "sourceSlideIdx": 0,
+      "sourceSlideTitle": "ANTFUN",
+      "mappingScore": 0,
+      "mappingFallback": false,
+      "mappingEmpty": false,
+      "liftFile": "slots/slot-00-cover.json",
+      "cached": false,
+      "dryRun": false,
+      "error": null,
+      "subjectTypes": ["cover"]
+    },
+    {
+      "slotIdx": 1,
+      "slotName": "mission",
+      "slotTitle": "Mission",
+      "slotPurpose": "Why we exist",
+      "sourceSlideIdx": 1,
+      "sourceSlideTitle": "Our Mission",
+      "mappingScore": 2,
+      "mappingFallback": false,
+      "mappingEmpty": false,
+      "liftFile": "slots/slot-01-mission.json",
+      "cached": false,
+      "dryRun": false,
+      "error": null,
+      "subjectTypes": ["bullet-list"]
+    },
+    {
+      "slotIdx": 2,
+      "slotName": "kpi-stress",
+      "slotTitle": "Strategic KPIs",
+      "slotPurpose": "Stress-test long kpi values",
+      "sourceSlideIdx": 2,
+      "sourceSlideTitle": "Strategic Position",
+      "mappingScore": 2,
+      "mappingFallback": false,
+      "mappingEmpty": false,
+      "liftFile": "slots/slot-02-kpi-stress.json",
+      "cached": false,
+      "dryRun": false,
+      "error": null,
+      "subjectTypes": [
+        "kpi-card",
+        "kpi-card",
+        "kpi-card",
+        "kpi-card",
+        "kpi-card",
+        "kpi-card",
+        "kpi-card",
+        "kpi-card"
+      ]
+    }
+  ],
+  "totals": {
+    "slotsBaked": 3,
+    "slotsEmpty": 0,
+    "slotsErrored": 0,
+    "totalCostUSD": 0
+  },
+  "meta": {
+    "generatedAt": "2026-06-22T00:00:00Z",
+    "model": "synthetic",
+    "pipelineVersion": "sprint-17-stress-v1"
+  }
+}

--- a/sdf-js/examples/scaffold-pipeline/antfun-stress-test/slots/slot-00-cover.json
+++ b/sdf-js/examples/scaffold-pipeline/antfun-stress-test/slots/slot-00-cover.json
@@ -1,0 +1,22 @@
+{
+  "slotIdx": 0,
+  "slotName": "cover",
+  "sceneData": {
+    "name": "company-overview/cover",
+    "layout": "cover",
+    "subjects": [
+      {
+        "type": "cover",
+        "x": 0,
+        "y": 0,
+        "w": 1280,
+        "h": 720,
+        "args": {
+          "title": "ANTFUN",
+          "subtitle": "On-Chain Trading Super App",
+          "author": "Company Overview · 2026-Q3"
+        }
+      }
+    ]
+  }
+}

--- a/sdf-js/examples/scaffold-pipeline/antfun-stress-test/slots/slot-01-mission.json
+++ b/sdf-js/examples/scaffold-pipeline/antfun-stress-test/slots/slot-01-mission.json
@@ -1,0 +1,66 @@
+{
+  "slotIdx": 1,
+  "slotName": "mission",
+  "sceneData": {
+    "name": "company-overview/mission",
+    "layout": "row",
+    "subjects": [
+      {
+        "type": "cover",
+        "x": 0,
+        "y": 0,
+        "w": 1280,
+        "h": 120,
+        "args": { "title": "Our Mission · Team · Focus", "subtitle": "Why we exist + who we are" }
+      },
+      {
+        "type": "bullet-list",
+        "x": 40,
+        "y": 160,
+        "w": 400,
+        "h": 480,
+        "args": {
+          "title": "Our Mission",
+          "items": [
+            { "text": "Make on-chain trading as natural as messaging" },
+            { "name": "Replace centralized exchanges with self-custodial UX" },
+            "Lower the barrier to DeFi for the next 100 million users"
+          ]
+        }
+      },
+      {
+        "type": "bullet-list",
+        "x": 460,
+        "y": 160,
+        "w": 400,
+        "h": 480,
+        "args": {
+          "title": "Team Heritage",
+          "items": [
+            { "label": "Built by ex-Binance + ex-Coinbase engineers" },
+            { "label": "5 years of crypto-native product experience" },
+            { "label": "Previously shipped wallets serving 10M+ users" },
+            { "label": "Backed by Sequoia, Paradigm, and Multicoin" },
+            { "label": "Based across NYC, Singapore, and Lisbon" }
+          ]
+        }
+      },
+      {
+        "type": "bullet-list",
+        "x": 880,
+        "y": 160,
+        "w": 360,
+        "h": 480,
+        "args": {
+          "title": "Our Focus",
+          "items": [
+            { "title": "Mobile-first wallet with embedded trading" },
+            { "title": "AI co-pilot for portfolio decisions" },
+            { "title": "Privacy by default, zero-knowledge architecture" },
+            { "title": "Cross-chain liquidity aggregation" }
+          ]
+        }
+      }
+    ]
+  }
+}

--- a/sdf-js/examples/scaffold-pipeline/antfun-stress-test/slots/slot-02-kpi-stress.json
+++ b/sdf-js/examples/scaffold-pipeline/antfun-stress-test/slots/slot-02-kpi-stress.json
@@ -1,0 +1,97 @@
+{
+  "slotIdx": 2,
+  "slotName": "kpi-stress",
+  "sceneData": {
+    "name": "company-overview/kpi-stress",
+    "layout": "grid",
+    "subjects": [
+      {
+        "type": "kpi-card",
+        "x": 30,
+        "y": 30,
+        "w": 400,
+        "h": 200,
+        "args": {
+          "value": "User Persona",
+          "label": "Competitive Position",
+          "sublabel": "Mass-market trader"
+        }
+      },
+      {
+        "type": "kpi-card",
+        "x": 440,
+        "y": 30,
+        "w": 400,
+        "h": 200,
+        "args": {
+          "value": "Beyond Forex",
+          "label": "Market Gap",
+          "sublabel": "Underserved opportunity"
+        }
+      },
+      {
+        "type": "kpi-card",
+        "x": 850,
+        "y": 30,
+        "w": 400,
+        "h": 200,
+        "args": { "value": "1-2 Months", "label": "Timeline", "sublabel": "Launch window" }
+      },
+      {
+        "type": "kpi-card",
+        "x": 30,
+        "y": 250,
+        "w": 400,
+        "h": 200,
+        "args": { "value": "OpenClaw", "label": "AI Integration", "sublabel": "Inference layer" }
+      },
+      {
+        "type": "kpi-card",
+        "x": 440,
+        "y": 250,
+        "w": 400,
+        "h": 200,
+        "args": {
+          "value": "Agent Mentions",
+          "label": "Community Features",
+          "sublabel": "Telegram bot adoption"
+        }
+      },
+      {
+        "type": "kpi-card",
+        "x": 850,
+        "y": 250,
+        "w": 400,
+        "h": 200,
+        "args": { "value": "4 Weeks", "label": "Perp DEX Launch", "sublabel": "Time to MVP" }
+      },
+      {
+        "type": "kpi-card",
+        "x": 30,
+        "y": 470,
+        "w": 605,
+        "h": 220,
+        "args": {
+          "value": "$300K Daily",
+          "label": "Self-built Perp DEX",
+          "sublabel": "Trading volume week 4",
+          "trend": "up",
+          "trendValue": "+47%"
+        }
+      },
+      {
+        "type": "kpi-card",
+        "x": 645,
+        "y": 470,
+        "w": 605,
+        "h": 220,
+        "args": {
+          "value": "Prototype Ready",
+          "label": "Smart Money System",
+          "sublabel": "50K wallets labeled in real-time",
+          "trend": "neutral"
+        }
+      }
+    ]
+  }
+}

--- a/sdf-js/scripts/bake-scaffold-pipeline.mjs
+++ b/sdf-js/scripts/bake-scaffold-pipeline.mjs
@@ -314,13 +314,19 @@ for (const a of slotAssignments) {
     `  ]\n` +
     `}\n` +
     '```\n\n' +
-    `Rules:\n` +
-    `0. **CANVAS BOUNDS**: every subject's \`x + w ≤ 1240\` AND \`y + h ≤ 700\`.\n` +
-    `1. **EVERY subject MUST have explicit \`x\`, \`y\`, \`w\`, \`h\`** in canvas pixels.\n` +
-    `2. **Atom selection**: pick ONLY from the recommended_atoms menu above. If none fit, fall back to \`cover\` + \`bullet-list\` as universal escape.\n` +
-    `3. **Slot 0 (cover)** is special — emit a SINGLE cover atom filling x=0, y=0, w=1280, h=720 (or h=360 for half-cover at top of deck).\n` +
-    `4. **Theme**: pass \`color\` args as the theme accent or palette colors[]. Don't invent unrelated colors.\n` +
-    `5. **Preserve body text**: every body line should appear as an atom label/caption/item — don't discard.\n`;
+    `Rules (Sprint 17 polish — read CAREFULLY):\n` +
+    `0. **Canvas bounds**: Every subject: x+w ≤ 1240, y+h ≤ 700.\n` +
+    `1. **EVERY subject MUST have explicit x/y/w/h** in canvas pixels.\n` +
+    `2. **Atom selection**: pick ONLY from the recommended_atoms menu (priority order). Fall back to cover+bullet-list ONLY if no recommended atom fits.\n` +
+    `3. **Density — fill the canvas, don't leave 60% empty**. Aim for 3-6 subjects per slot (not 1). If source has 3 description blocks → emit 3 bullet-list / kpi-card / icon-badge atoms. If only 1, pair it with a cover top-strip + supporting context.\n` +
+    `4. **Slot 0 (cover)** = single cover atom, h=720 full (deck cover, not used mid-deck).\n` +
+    `5. **Cover atom when used mid-deck** (e.g. section header): h=120 TOP STRIP (x=0, y=0, w=1280). NEVER full-canvas cover unless slot 0.\n` +
+    `6. **Theme**: pass \`color\` args as theme accent or colors[]. Don't invent colors.\n` +
+    `7. **Body text preservation**: every body line lands in an atom's args. Acceptable shapes:\n` +
+    `   - \`bullet-list\` args.items = \`[{label: "body line 1"}, {label: "body line 2"}]\` — use \`label\` key explicitly, NOT \`text\` or plain strings.\n` +
+    `   - \`kpi-card\` args = \`{value: "HEADLINE", label: "Subtitle", sublabel: "Context"}\`. Keep value 1-3 words (e.g. "$3M", "1-2 Months", "Prototype Ready"); long phrases → .label or .sublabel.\n` +
+    `   - \`icon-badge\` args = \`{name: "<phosphor-name>", label: "Caption"}\`. Pick semantic icon: briefcase / chart-bar / users / shield / lightning / globe / mail / phone / calendar / target / trophy / brain / building / wallet / chat-circle / device-mobile / wrench / rocket. NEVER default to "star".\n` +
+    `8. **Empty bullets are a bug** — if items list is empty or only \`[{}]\` objects, you've failed. Populate every items[].label with actual text from source body.\n`;
 
   if (DRY_RUN) {
     slotLifts.push({

--- a/sdf-js/scripts/bake-scaffold-pipeline.mjs
+++ b/sdf-js/scripts/bake-scaffold-pipeline.mjs
@@ -319,8 +319,10 @@ for (const a of slotAssignments) {
     `1. **EVERY subject MUST have explicit x/y/w/h** in canvas pixels.\n` +
     `2. **Atom selection**: pick ONLY from the recommended_atoms menu (priority order). Fall back to cover+bullet-list ONLY if no recommended atom fits.\n` +
     `3. **Density — fill the canvas, don't leave 60% empty**. Aim for 3-6 subjects per slot (not 1). If source has 3 description blocks → emit 3 bullet-list / kpi-card / icon-badge atoms. If only 1, pair it with a cover top-strip + supporting context.\n` +
-    `4. **Slot 0 (cover)** = single cover atom, h=720 full (deck cover, not used mid-deck).\n` +
-    `5. **Cover atom when used mid-deck** (e.g. section header): h=120 TOP STRIP (x=0, y=0, w=1280). NEVER full-canvas cover unless slot 0.\n` +
+    `4. **Slot 0 (cover)** = single cover atom, h=720 full. style: 'gradient' default; pass title + subtitle + optional author.\n` +
+    `5. **Cover atom when used mid-deck**:\n` +
+    `   - For in-slide TITLE STRIP (e.g. "Section 2 — Products" band): h=120 TOP STRIP (x=0, y=0, w=1280). Default 'gradient' style.\n` +
+    `   - For SECTION DIVIDER slot (Vision / Mission / Values transition where entire slot is title hero): h=720 full canvas + \`args.style: "section"\` (PL-style deep accent + box-behind-title).\n` +
     `6. **Theme**: pass \`color\` args as theme accent or colors[]. Don't invent colors.\n` +
     `7. **Body text preservation**: every body line lands in an atom's args. Acceptable shapes:\n` +
     `   - \`bullet-list\` args.items = \`[{label: "body line 1"}, {label: "body line 2"}]\` — use \`label\` key explicitly, NOT \`text\` or plain strings.\n` +

--- a/sdf-js/scripts/scaffold-pipeline-fixtures/antfun-company.json
+++ b/sdf-js/scripts/scaffold-pipeline-fixtures/antfun-company.json
@@ -1,0 +1,107 @@
+[
+  {
+    "title": "ANTFUN",
+    "body": ["On-Chain Trading Super App", "Company Overview", "2026-Q3"]
+  },
+  {
+    "title": "Our Mission",
+    "body": [
+      "Make on-chain trading as natural as messaging",
+      "Replace centralized exchanges with self-custodial UX",
+      "Lower the barrier to DeFi for the next 100 million users",
+      "Team Heritage",
+      "Built by ex-Binance + ex-Coinbase engineers",
+      "5 years of crypto-native product experience",
+      "Previously shipped wallets serving 10M+ users",
+      "Backed by Sequoia, Paradigm, and Multicoin",
+      "Based across NYC, Singapore, and Lisbon",
+      "Our Focus",
+      "Mobile-first wallet with embedded trading",
+      "AI co-pilot for portfolio decisions",
+      "Privacy by default, zero-knowledge architecture",
+      "Cross-chain liquidity aggregation"
+    ]
+  },
+  {
+    "title": "Market Opportunity",
+    "body": [
+      "Potential User Groups",
+      "Crypto-native traders frustrated by slow wallets",
+      "DeFi power users looking for unified UX",
+      "Mainstream users wanting wallet + trading combined",
+      "Smart-money traders following on-chain alpha",
+      "Core Differentiators",
+      "Sub-second order execution on aggregated DEXs",
+      "AI agents for strategy automation",
+      "Self-custodial without compromising speed",
+      "Embedded chat groups for community alpha-sharing",
+      "Built-in audio rooms for live trading sessions",
+      "Open API for developer ecosystem"
+    ]
+  },
+  {
+    "title": "Product Suite",
+    "body": [
+      "Lightweight Wallet — mobile-first self-custodial",
+      "Chat Module — embedded social and alpha-sharing",
+      "Trading Acceleration — aggregated DEX routing",
+      "Competitive Advantages",
+      "Sub-second execution beats every existing wallet",
+      "Self-custodial without UX compromises",
+      "AI-native — agents not just chatbots",
+      "Network effects from embedded social",
+      "Open ecosystem for plugin developers",
+      "Top-tier security audited by Trail of Bits",
+      "Growth Metrics",
+      "$300K daily trading volume after 4 weeks",
+      "12K monthly active wallets",
+      "47% week-over-week growth",
+      "92% user retention at day 30",
+      "Average session: 8 minutes, 3x industry norm",
+      "NPS score 72 (top quartile crypto product)"
+    ]
+  },
+  {
+    "title": "Strategic Position",
+    "body": [
+      "User Persona — Competitive Position",
+      "Beyond For — Market Gap",
+      "1-2 Months — Timeline",
+      "OpenClaw — AI Integration",
+      "Agent Mentions — Community Features",
+      "4 Weeks — Perp DEX Launch",
+      "$300K Daily — Self-built Perp DEX",
+      "Prototype Ready — Smart Money System"
+    ]
+  },
+  {
+    "title": "Technology Stack",
+    "body": [
+      "Self-Custodial Strategy — Browser-side key management with hardware-wallet integration",
+      "Multi-chain bridge layer — Ethereum + Solana + Base + Arbitrum",
+      "OpenClaw AI inference — on-device for privacy, server for heavy lift",
+      "Chat encryption — end-to-end via Signal protocol",
+      "Order routing — proprietary DEX aggregator with MEV protection",
+      "Smart Money tracker — labels 50K wallets in real-time"
+    ]
+  },
+  {
+    "title": "Get in Touch",
+    "body": [
+      "Connect with ANTFUN",
+      "Email — team@antfun.io",
+      "Website — antfun.io",
+      "Chat & Group — Telegram + Discord",
+      "Audio/Video — Twitter Spaces every Friday",
+      "Community — 12K members across channels",
+      "AI Agent — talk to @antfun-bot on Telegram",
+      "Why Connect With Us",
+      "We ship weekly and listen to feedback",
+      "Direct access to founders via Discord",
+      "Beta access for power users",
+      "Revenue share for community contributors",
+      "Open-source SDK for developers",
+      "Real-time on-chain analytics dashboard"
+    ]
+  }
+]

--- a/sdf-js/src/present/atoms-2d/charts/agenda/agenda-list.js
+++ b/sdf-js/src/present/atoms-2d/charts/agenda/agenda-list.js
@@ -33,6 +33,11 @@ export const spec = {
     title: { type: 'string?', example: 'Today’s Agenda' },
     numbered: { type: 'boolean', default: true, example: true },
     highlight: { type: 'integer?', example: 2 },
+    style: {
+      type: "'compact'|'showcase'?",
+      default: "'auto' — showcase when w≥800 or items≥5",
+      example: 'showcase',
+    },
   },
 };
 
@@ -47,11 +52,40 @@ export function drawPseudo3D(ctx, args, opts = {}) {
   const fg = palette.silhouetteColor || [30, 27, 30];
   const accent = palette.colors?.[0] || [60, 130, 200];
 
-  const items = Array.isArray(args.items) ? args.items.slice(0, 12) : [];
+  // Tolerate LLM-emitted alternate item shapes (plain strings / text/name/title keys)
+  // — Sprint 17 quality fix mirrors bullet-list.
+  const rawItems = Array.isArray(args.items) ? args.items.slice(0, 12) : [];
+  const items = rawItems.map((it) => {
+    if (typeof it === 'string') return { label: it };
+    if (!it || typeof it !== 'object') return { label: '' };
+    return {
+      ...it,
+      label: it.label || it.text || it.name || it.title || it.value || '',
+      sublabel: it.sublabel || it.subtitle || it.caption || it.description || it.duration || '',
+    };
+  });
   const N = items.length;
   if (N === 0) return;
   const numbered = args.numbered !== false;
   const highlight = typeof args.highlight === 'number' ? args.highlight - 1 : -1;
+
+  // Sprint 17: PL-style showcase mode (HUGE light-gray numbers + bold label).
+  // Auto-pick when explicit style not set: showcase when canvas is wide
+  // (w ≥ 800) OR there are 5+ items. Showcase becomes 2-col when items ≥ 6.
+  const styleArg = args.style;
+  const isShowcase = styleArg === 'showcase' || (styleArg !== 'compact' && (w >= 800 || N >= 5));
+  if (isShowcase) {
+    return drawShowcase(ctx, items, args, opts, palette, {
+      fg,
+      accent,
+      x,
+      y,
+      w,
+      h,
+      numbered,
+      highlight,
+    });
+  }
 
   let plotTop = y + PAD;
   if (args.title) {
@@ -134,6 +168,105 @@ export function drawPseudo3D(ctx, args, opts = {}) {
       ctx.restore();
     }
   }
+}
+
+// Sprint 17: PL-style showcase layout — HUGE numbers + bold label + optional sublabel.
+// 2-col grid when items ≥ 6, else single column.
+function drawShowcase(
+  ctx,
+  items,
+  args,
+  _opts,
+  _palette,
+  { fg, accent, x, y, w, h, numbered, highlight },
+) {
+  const N = items.length;
+  const PAD = 28;
+
+  let plotTop = y + PAD;
+  if (args.title) {
+    ctx.fillStyle = rgbCss(fg);
+    ctx.font = `700 ${Math.round(h * 0.085)}px Inter, system-ui, sans-serif`;
+    ctx.textAlign = 'left';
+    ctx.textBaseline = 'top';
+    ctx.fillText(String(args.title).toUpperCase(), x + PAD, y + PAD);
+    plotTop = y + PAD + Math.round(h * 0.085) + 8;
+
+    if (args.subtitle) {
+      ctx.fillStyle = rgbaCss(fg, 0.55);
+      ctx.font = `400 ${Math.round(h * 0.045)}px Inter, system-ui, sans-serif`;
+      ctx.fillText(String(args.subtitle), x + PAD, plotTop);
+      plotTop += Math.round(h * 0.045) + 12;
+    } else {
+      plotTop += 6;
+    }
+  }
+
+  const useTwoCol = N >= 6 && w >= 700;
+  const cols = useTwoCol ? 2 : 1;
+  const rows = Math.ceil(N / cols);
+  const colW = (w - PAD * 2) / cols;
+  const rowH = (y + h - plotTop - PAD) / rows;
+
+  const numSize = Math.min(rowH * 0.55, (w / cols) * 0.16, 88);
+  const labelSize = Math.min(rowH * 0.22, 28);
+  const subSize = Math.min(rowH * 0.16, 18);
+
+  for (let i = 0; i < N; i++) {
+    const it = items[i] || {};
+    const col = useTwoCol ? Math.floor(i / rows) : 0;
+    const row = useTwoCol ? i % rows : i;
+    const cellX = x + PAD + col * colW;
+    const cellY = plotTop + row * rowH;
+    const isHi = i === highlight;
+
+    // Big number (PL signature)
+    if (numbered) {
+      ctx.fillStyle = isHi ? rgbCss(accent) : rgbaCss(fg, 0.18);
+      ctx.font = `900 ${Math.round(numSize)}px "Inter Display", Inter, system-ui, sans-serif`;
+      ctx.textAlign = 'left';
+      ctx.textBaseline = 'top';
+      const numText = String(i + 1).padStart(2, '0');
+      ctx.fillText(numText, cellX, cellY);
+    }
+
+    // Label position: right of number (compute number width)
+    ctx.font = `900 ${Math.round(numSize)}px "Inter Display", Inter, system-ui, sans-serif`;
+    const numW = numbered ? ctx.measureText(String(i + 1).padStart(2, '0')).width + 16 : 0;
+    const labelX = cellX + numW;
+    const labelMaxW = colW - numW - 12;
+
+    // Item label (bold, dark)
+    if (it.label) {
+      ctx.fillStyle = isHi ? rgbCss(accent) : rgbCss(fg);
+      ctx.font = `700 ${Math.round(labelSize)}px Inter, system-ui, sans-serif`;
+      ctx.textBaseline = 'top';
+      ctx.fillText(
+        fitText(ctx, String(it.label), labelMaxW),
+        labelX,
+        cellY + Math.round(numSize * 0.18),
+      );
+    }
+
+    // Sublabel below label
+    if (it.sublabel) {
+      ctx.fillStyle = rgbaCss(fg, 0.55);
+      ctx.font = `400 ${Math.round(subSize)}px Inter, system-ui, sans-serif`;
+      ctx.textBaseline = 'top';
+      ctx.fillText(
+        fitText(ctx, String(it.sublabel), labelMaxW),
+        labelX,
+        cellY + Math.round(numSize * 0.18) + Math.round(labelSize) + 4,
+      );
+    }
+  }
+}
+
+function fitText(ctx, text, maxW) {
+  if (ctx.measureText(text).width <= maxW) return text;
+  let s = text;
+  while (s.length > 1 && ctx.measureText(s + '…').width > maxW) s = s.slice(0, -1);
+  return s + '…';
 }
 
 function roundRect(ctx, x, y, w, h, r) {

--- a/sdf-js/src/present/atoms-2d/charts/data/kpi-card.js
+++ b/sdf-js/src/present/atoms-2d/charts/data/kpi-card.js
@@ -64,7 +64,8 @@ export function drawPseudo3D(ctx, args, opts = {}) {
   const palette = opts.palette || {};
   const fg = palette.silhouetteColor || [30, 27, 30];
   const bg = palette.bg || [247, 244, 224];
-  const accent = palette.colors?.[0] || [60, 100, 200];
+  const _accent = palette.colors?.[0] || [60, 100, 200];
+  void _accent;
 
   // ---- Drop shadow (softer: 10px blur, alpha 0.12) ----
   ctx.save();
@@ -106,26 +107,56 @@ export function drawPseudo3D(ctx, args, opts = {}) {
     drawIconStub(ctx, args.icon, x + 22, y + 26, 22, rgbCss(bg));
   }
 
-  // ---- Hero value (weight 900, generous left padding) ----
+  // ---- Hero value (weight 900, auto-scale to fit width) ----
+  // Sprint 17 quality fix: long values like "User Persona" / "1-2 Months"
+  // were getting truncated mid-word. Now we measure + scale down to fit.
   ctx.fillStyle = rgbCss(bg);
   ctx.textAlign = 'left';
   ctx.textBaseline = 'alphabetic';
-  const valueSize = Math.round(h * 0.34);
+  const availW = w - 44; // 22px padding each side
+  const valueText = String(args.value ?? '');
+  let valueSize = Math.round(h * 0.34);
+  const minValueSize = Math.round(h * 0.14);
   ctx.font = `900 ${valueSize}px Inter, system-ui, sans-serif`;
+  while (ctx.measureText(valueText).width > availW && valueSize > minValueSize) {
+    valueSize -= 2;
+    ctx.font = `900 ${valueSize}px Inter, system-ui, sans-serif`;
+  }
   const valueY = y + h * 0.56;
-  ctx.fillText(String(args.value ?? ''), x + 22, valueY);
+  ctx.fillText(valueText, x + 22, valueY);
 
-  // ---- Label (Inter 700 for stronger hierarchy) ----
+  // ---- Label (Inter 700 for stronger hierarchy, auto-scale + ellipsis fallback) ----
   ctx.fillStyle = rgbaCss(bg, 0.85);
-  ctx.font = `700 ${Math.round(h * 0.11)}px Inter, system-ui, sans-serif`;
-  ctx.fillText(String(args.label ?? ''), x + 22, valueY + Math.round(h * 0.17));
+  let labelSize = Math.round(h * 0.11);
+  const minLabelSize = Math.round(h * 0.07);
+  const labelText = String(args.label ?? '');
+  ctx.font = `700 ${labelSize}px Inter, system-ui, sans-serif`;
+  while (ctx.measureText(labelText).width > availW && labelSize > minLabelSize) {
+    labelSize -= 1;
+    ctx.font = `700 ${labelSize}px Inter, system-ui, sans-serif`;
+  }
+  ctx.fillText(fitText(ctx, labelText, availW), x + 22, valueY + Math.round(h * 0.17));
 
   // ---- Sublabel (Inter 400, faded, proper breathing room) ----
   if (args.sublabel) {
     ctx.fillStyle = rgbaCss(bg, 0.55);
     ctx.font = `400 ${Math.round(h * 0.085)}px Inter, system-ui, sans-serif`;
-    ctx.fillText(String(args.sublabel), x + 22, valueY + Math.round(h * 0.29));
+    ctx.fillText(
+      fitText(ctx, String(args.sublabel), availW),
+      x + 22,
+      valueY + Math.round(h * 0.29),
+    );
   }
+}
+
+// Truncate with ellipsis if even after font-scale it overflows.
+function fitText(ctx, text, maxW) {
+  if (ctx.measureText(text).width <= maxW) return text;
+  let s = text;
+  while (s.length > 1 && ctx.measureText(s + '…').width > maxW) {
+    s = s.slice(0, -1);
+  }
+  return s + '…';
 }
 
 // ============================================================================

--- a/sdf-js/src/present/atoms-2d/charts/lists/bullet-list.js
+++ b/sdf-js/src/present/atoms-2d/charts/lists/bullet-list.js
@@ -44,7 +44,20 @@ export function drawPseudo3D(ctx, args, opts = {}) {
   const fg = palette.silhouetteColor || [30, 27, 30];
   const accent = palette.colors?.[0] || [60, 130, 200];
 
-  const items = Array.isArray(args.items) ? args.items.slice(0, 12) : [];
+  // Normalize items: tolerate LLM emitting plain strings OR objects with
+  // alternate label keys (text / name / title / value) instead of the spec's
+  // canonical `label`. Sprint 17 quality fix — was 50% of slots rendered
+  // empty bullets when LLM picked the wrong key.
+  const rawItems = Array.isArray(args.items) ? args.items.slice(0, 12) : [];
+  const items = rawItems.map((it) => {
+    if (typeof it === 'string') return { label: it };
+    if (!it || typeof it !== 'object') return { label: '' };
+    return {
+      ...it,
+      label: it.label || it.text || it.name || it.title || it.value || '',
+      sublabel: it.sublabel || it.subtitle || it.caption || it.description || '',
+    };
+  });
   const N = items.length;
   if (N === 0) return;
 

--- a/sdf-js/src/present/atoms-2d/presentation/cover.js
+++ b/sdf-js/src/present/atoms-2d/presentation/cover.js
@@ -36,6 +36,11 @@ export const spec = {
     author: { type: 'string?', example: 'Sarah Chen, CEO' },
     date: { type: 'string?', example: 'November 2025' },
     version: { type: 'string?', example: 'v1.0' },
+    style: {
+      type: "'gradient'|'section'?",
+      default: "'gradient'",
+      example: 'section',
+    },
   },
 };
 
@@ -58,14 +63,21 @@ export function drawPseudo3D(ctx, args, opts = {}) {
   const author = args.author;
   const date = args.date;
   const version = args.version;
+  const style = args.style || 'gradient';
 
-  // ---- Subtle diagonal gradient backdrop ----
-  // accent at top-left → lighten(accent, 0.20) bottom-right. Capped saturation.
-  const bgGrad = ctx.createLinearGradient(x, y, x + w, y + h);
-  bgGrad.addColorStop(0, rgbCss(darken(accent, 0.05)));
-  bgGrad.addColorStop(1, rgbCss(lighten(accent, 0.2)));
-  ctx.fillStyle = bgGrad;
-  ctx.fillRect(x, y, w, h);
+  // ---- Backdrop: gradient (default) or section (deep accent + accent box behind title) ----
+  if (style === 'section') {
+    // Deep solid backdrop + decorative title-box behind text (PL D3180/031 pattern)
+    ctx.fillStyle = rgbCss(darken(accent, 0.32));
+    ctx.fillRect(x, y, w, h);
+  } else {
+    // Default: subtle diagonal gradient — accent → lighten(accent, 0.20)
+    const bgGrad = ctx.createLinearGradient(x, y, x + w, y + h);
+    bgGrad.addColorStop(0, rgbCss(darken(accent, 0.05)));
+    bgGrad.addColorStop(1, rgbCss(lighten(accent, 0.2)));
+    ctx.fillStyle = bgGrad;
+    ctx.fillRect(x, y, w, h);
+  }
 
   // ---- Thin top-band hairline (stage-strip feel) ----
   ctx.save();
@@ -85,7 +97,19 @@ export function drawPseudo3D(ctx, args, opts = {}) {
   const blockH = titleSize + (subtitle ? subtitleSize + 8 : 0);
   const blockTop = y + (h - blockH) / 2 - (h > 160 ? 10 : 0);
 
-  // Title
+  // Title — for section style, draw accent box behind title (PL signature)
+  if (style === 'section') {
+    ctx.font = `900 ${titleSize}px "Inter Display", Inter, system-ui, sans-serif`;
+    const titleW = ctx.measureText(String(title)).width;
+    const boxX = titleX - 14;
+    const boxY = blockTop - 6;
+    const boxW = titleW + 28;
+    const boxH = titleSize + 14;
+    ctx.fillStyle = `rgba(${lighten(accent, 0.15)
+      .map((c) => Math.round(c))
+      .join(',')},0.85)`;
+    ctx.fillRect(boxX, boxY, boxW, boxH);
+  }
   ctx.fillStyle = 'rgba(255,255,255,0.97)';
   ctx.font = `900 ${titleSize}px Inter, system-ui, sans-serif`;
   ctx.textAlign = 'left';

--- a/sdf-js/src/present/scaffold-view.js
+++ b/sdf-js/src/present/scaffold-view.js
@@ -294,12 +294,20 @@ export async function mountScaffoldView(target, deckId) {
       '/' +
       assignment.slot.name +
       '",\n  "layout": "row|grid|hierarchy|stage|cover",\n  "subjects": [\n    { "type": "<atom>", "x": <px>, "y": <px>, "w": <px>, "h": <px>, "args": { ... } }\n  ]\n}\n```\n\n' +
-      `Rules:\n0. Every subject: x+w ≤ 1240, y+h ≤ 700.\n` +
-      `1. EVERY subject MUST have explicit x/y/w/h.\n` +
-      `2. Pick ONLY from recommended_atoms menu; fall back to cover+bullet-list if needed.\n` +
-      `3. Slot 0 (cover) emits single cover atom (h=360 strip or h=720 full).\n` +
-      `4. Theme: pass color args as theme accent/colors[]. Don't invent colors.\n` +
-      `5. Preserve body text — every body line appears as atom label/caption/item.\n`;
+      `Rules (Sprint 17 polish — read CAREFULLY):\n` +
+      `0. **Canvas bounds**: Every subject: x+w ≤ 1240, y+h ≤ 700.\n` +
+      `1. **EVERY subject MUST have explicit x/y/w/h** in canvas pixels.\n` +
+      `2. **Atom selection**: pick ONLY from recommended_atoms menu (priority order). Fall back to cover+bullet-list ONLY if no recommended atom fits.\n` +
+      `3. **Density — fill the canvas, don't leave 60% empty**. Aim for 3-6 subjects per slot (not 1). If source has 3 description blocks → emit 3 bullet-list / kpi-card / icon-badge atoms. If only 1, pair it with a cover top-strip + supporting context.\n` +
+      `4. **Slot 0 (cover)** = single cover atom, h=720 full (deck cover, not used here mid-deck).\n` +
+      `5. **Cover atom when used mid-deck** (e.g. section header): h=120 TOP STRIP (x=0, y=0, w=1280). NEVER full-canvas cover unless slot 0.\n` +
+      `6. **Theme**: pass \`color\` args as theme accent or colors[]. Don't invent colors.\n` +
+      `7. **Body text preservation**: every body line should land in an atom's args. Acceptable shapes:\n` +
+      `   - \`bullet-list\` args.items = \`[{label: "body line 1"}, {label: "body line 2"}]\` (NOT [{text:...}] or plain strings; use \`label\` key explicitly)\n` +
+      `   - \`kpi-card\` args = \`{value: "HEADLINE TEXT", label: "Subtitle", sublabel: "Context"}\`\n` +
+      `   - \`icon-badge\` args = \`{name: "<phosphor-icon-name>", label: "Caption"}\`. Pick semantic icon: briefcase / chart-bar / users / star / shield / lightning / globe / mail / phone / calendar / target / trophy / brain / building. NEVER default to "star" — pick by meaning.\n` +
+      `8. **Empty bullets are a bug** — if items list is empty or only has \`{}\` objects, you've failed. Always populate items[].label with actual text from the source body.\n` +
+      `9. **Don't truncate** — for kpi-card.value, prefer 1-3 word headlines (e.g. "$3M", "User Persona", "1-2 Months", "Prototype Ready"). Long phrases go to .label or .sublabel.\n`;
 
     const systemPrompt = `You are the Atlas Present scaffold-mode lift LLM. Emit a single JSON SceneData object inside a \`\`\`json fence with no prose. Atoms are 2D Canvas primitives — no 3D, no text-3d-pipe.`;
 

--- a/sdf-js/src/present/scaffold-view.js
+++ b/sdf-js/src/present/scaffold-view.js
@@ -299,8 +299,10 @@ export async function mountScaffoldView(target, deckId) {
       `1. **EVERY subject MUST have explicit x/y/w/h** in canvas pixels.\n` +
       `2. **Atom selection**: pick ONLY from recommended_atoms menu (priority order). Fall back to cover+bullet-list ONLY if no recommended atom fits.\n` +
       `3. **Density — fill the canvas, don't leave 60% empty**. Aim for 3-6 subjects per slot (not 1). If source has 3 description blocks → emit 3 bullet-list / kpi-card / icon-badge atoms. If only 1, pair it with a cover top-strip + supporting context.\n` +
-      `4. **Slot 0 (cover)** = single cover atom, h=720 full (deck cover, not used here mid-deck).\n` +
-      `5. **Cover atom when used mid-deck** (e.g. section header): h=120 TOP STRIP (x=0, y=0, w=1280). NEVER full-canvas cover unless slot 0.\n` +
+      `4. **Slot 0 (cover)** = single cover atom, h=720 full. style: 'gradient' (default) is fine; pass title + subtitle + optional author.\n` +
+      `5. **Cover atom when used mid-deck**:\n` +
+      `   - For an in-slide TITLE STRIP (e.g. "Section 2 — Products" header band): h=120 TOP STRIP (x=0, y=0, w=1280). Default 'gradient' style.\n` +
+      `   - For a SECTION DIVIDER slot (Vision / Mission / Values transition page where the entire slot is just a title hero): use h=720 full canvas + \`args.style: "section"\` (PL-style deep accent + box-behind-title).\n` +
       `6. **Theme**: pass \`color\` args as theme accent or colors[]. Don't invent colors.\n` +
       `7. **Body text preservation**: every body line should land in an atom's args. Acceptable shapes:\n` +
       `   - \`bullet-list\` args.items = \`[{label: "body line 1"}, {label: "body line 2"}]\` (NOT [{text:...}] or plain strings; use \`label\` key explicitly)\n` +


### PR DESCRIPTION
## Summary

Triggered by user's ANTFUN PDF end-to-end test: visible quality gaps vs PL company-presentation refs (D3180/001-264). Two waves of fixes shipped.

User direction: 自主迭代，跟 PL 视觉效果对比 https://www.presentationload.com/company-presentation.html。

## Wave 1 — atom + prompt fixes

### `bullet-list.js` — multi-key tolerance
Was: strict `it.label`. LLM emitting `{text:...}` / `{name:...}` / `{title:...}` / plain strings rendered empty open-rings. **~50% of slots in user's ANTFUN export.**
Now: accept `label || text || name || title || value || plain string`.

### `kpi-card.js` — auto-scale value + label
Was: fixed valueSize, "User Persona" / "1-2 Months" truncated mid-word. **Slide 5 of ANTFUN broken.**
Now: measureText loop scales down to min h*0.14, ellipsis fallback for labels that still don't fit.

### `agenda-list.js` — PL-style showcase mode
Was: compact mode only (small chips + label).
Now: auto-pick **showcase** when w≥800 OR items≥5. Huge light-gray 01/02 numbers + bold black label + light sublabel. Auto 2-col grid when items≥6. Matches PL slide 015 nearly identically (sans photo block).

### Lift prompt v2 — both `scaffold-view.js` + `bake-scaffold-pipeline.mjs`
- Density: aim 3-6 subjects/slot, not 1 (was emitting sparse slot 6 in ANTFUN)
- bullet-list items MUST use `label` key explicitly
- kpi-card value 1-3 words (long phrases → .label/.sublabel)
- icon-badge MUST pick semantic Phosphor name (briefcase / chart-bar / users / shield / rocket / wallet / chat-circle / mail / target / trophy / brain / building / device-mobile / wrench) — NEVER default `star`

## Wave 2 — cover section variant + prompt v3

### `cover.js` — `style: 'section'` variant (PL D3180/031)
New optional style. Deep accent backdrop + light accent box behind title. For Vision/Mission/Values section-divider slots where the whole slot is a title hero.

### Lift prompt v3 — cover usage clarified
- Slot 0 (deck cover) → style: 'gradient' h=720 full
- Mid-deck title strip → h=120 TOP STRIP
- SECTION DIVIDER slot → h=720 full + `style: 'section'`

## Visual evidence

| | PL reference | Atlas |
|---|---|---|
| Agenda showcase 2-col 6-item | D3180/015 | `test-agenda-showcase.html` row 1 — near-identical (sans photo) |
| Section divider | D3180/031 | `cover-section-test.png` — deep navy + accent box behind "OUR VISION" |
| Bullet labels render | n/a | `stress-test-after-fixes.png` row 2 — 3 cols all show text via fallback chain |
| KPI auto-scale | n/a | `stress-test-after-fixes.png` row 3 — 8 long values all fit |

Screenshots: `screens/sprint17-quality/` + `screens/pl-reference/`.

## Stress test fixture

`sdf-js/examples/scaffold-pipeline/antfun-stress-test/` — synthetic 3-slot deck reproducing observed LLM failure patterns (mixed item keys + long KPI values). Loadable in `scaffold-deck-viewer.html` → "ANTFUN stress test". Regression test without API key.

## Validation: ask user to re-bake their ANTFUN PDF after merge

Atom-level fixes are immediately verified via stress fixture. Prompt v3 improvements (density / icon / cover-section) need a live re-bake to verify. After merging, user can re-import the same ANTFUN PDF in scaffold mode and compare against their original PDF.

## Tests

- npm test: 89/89 PASS unchanged
- Visual smoke: agenda-list showcase, cover section, stress test deck — all pass

## Known remaining gaps (out of scope this PR)

- Photography integration — PL leans heavily; structural feature needed
- LLM-side mapping (Stage 1) — heuristic, fuzzy inputs misroute
- Atom density on long-tail prompts — partly addressed by prompt v3, may need more

Per CLAUDE.md: DO NOT merge. Awaiting user review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)