### PR TITLE
fix(compile): preserve per-leaf tags on single-leaf atoms under transform

### DIFF
--- a/sdf-js/scenes/cover-fill-spheres.json
+++ b/sdf-js/scenes/cover-fill-spheres.json
@@ -1,0 +1,42 @@
+{
+  "v": 1,
+  "name": "kpi-hero: 3D Spheres — Fill Levels (cover)",
+  "subjects": [
+    {
+      "id": "green-20",
+      "type": "sphere-fill-3d",
+      "args": { "levels": [0.2], "radius": 0.55, "spacing": 0 },
+      "transform": { "translate": [-2.3, 1.05, -1.3] },
+      "material": { "hue": 0.30, "sat": 0.72, "value": 0.60, "kind": "fill", "roughness": 0.3, "clearcoat": 0.5 }
+    },
+    {
+      "id": "red-40",
+      "type": "sphere-fill-3d",
+      "args": { "levels": [0.4], "radius": 0.72, "spacing": 0 },
+      "transform": { "translate": [-0.45, 1.05, -0.4] },
+      "material": { "hue": 0.99, "sat": 0.85, "value": 0.50, "kind": "fill", "roughness": 0.3, "clearcoat": 0.5 }
+    },
+    {
+      "id": "blue-80",
+      "type": "sphere-fill-3d",
+      "args": { "levels": [0.8], "radius": 1.02, "spacing": 0 },
+      "transform": { "translate": [1.9, 1.05, 0.7] },
+      "material": { "hue": 0.58, "sat": 0.82, "value": 0.66, "kind": "fill", "roughness": 0.3, "clearcoat": 0.5 }
+    }
+  ],
+  "cameraSequence": {
+    "loop": false,
+    "shots": [
+      {
+        "duration": 8,
+        "pos": [0, 1.6, 8.5],
+        "target": [0, 1.0, -0.2],
+        "fov": 44,
+        "aperture": 0,
+        "focalDistance": 8.5,
+        "ease": "smooth"
+      }
+    ]
+  },
+  "defaults": { "stage": { "size": [16, 6, 11] } }
+}

--- a/sdf-js/src/scene/compile.js
+++ b/sdf-js/src/scene/compile.js
@@ -1402,6 +1402,15 @@ function compilePrimitive(subj, defaultRegion, subjectInfos) {
   if (!factory) throw new Error(`compile: no factory for primitive "${subj.type}"`);
   let sdf = factory(resolvedArgs);
 
+  // A single-leaf atom can carry its per-leaf tags on the factory SDF itself
+  // (e.g. sphere-fill-3d with ONE sphere returns the bare sphere with its fill
+  // fraction on _subjectPattern). The non-union applyTransform branch below wraps
+  // the SDF and drops those tags (same as the union branch, which re-attaches per
+  // child) — capture them now so we can re-attach after transform. Without this a
+  // lone fill gauge loses its fill and renders as plain glass (fill=0).
+  const factoryMat = sdf?._subjectMaterial;
+  const factoryPat = sdf?._subjectPattern;
+
   // 3. Apply transform. If the factory returned a UNION (a multi-leaf atom such
   // as sphere-fill-3d, where each leaf carries its own _subjectMaterial /
   // _subjectPattern), push the transform DOWN onto each union child instead of
@@ -1425,6 +1434,10 @@ function compilePrimitive(subj, defaultRegion, subjectInfos) {
     sdf = k != null ? union(...kids, { k }) : union(...kids);
   } else {
     sdf = applyTransform(sdf, subj.transform, subj.animation);
+    // Re-attach leaf tags the applyTransform wrapper dropped (mirrors the union
+    // branch above). Subject-level material/pattern in step 4 still overrides.
+    if (factoryMat !== undefined) sdf._subjectMaterial = factoryMat;
+    if (factoryPat !== undefined) sdf._subjectPattern = factoryPat;
   }
 
   // 4. Attach material/pattern at leaf level. Required when a primitive is


### PR DESCRIPTION
## 症状

一排 sphere-fill 水位计,如果**每个球做成独立 subject**(为了给每球不同液体颜色/尺寸),会渲染成**纯白实心球** —— 没有液体、没有水位线。这正是「玻璃球里没有水」的失败态(`fill=0` = 全玻璃),也就是 fill-gauge 取巧法(#134,material kind `fill`=9)本来要避免的东西。多球同色单 subject(demo `sphere-fill-gauge.json`)不受影响。

## 根因(`src/scene/compile.js` `compilePrimitive`)

单叶原子可以把 per-leaf tag 挂在 factory SDF 自身上(`sphere-fill-3d` 单球返回裸 sphere,fill 分数挂在 `_subjectPattern`)。但:

- 非 union 的 `applyTransform` 分支**包裹 SDF 时丢掉 leaf tag**(注释自己写了)。union 分支会逐 child 重新挂回(L1421-1422),**单叶分支漏了**。
- step 4 只在 `subj.pattern != null` 时重挂,而每球颜色走 `subj.material`、fill 走组件的 `_subjectPattern`(subject 级没设 pattern)→ fill 永久丢失 → fill=0 → 全玻璃。

## 修复

镜像已有的 union 分支重挂逻辑(和 `compilePseudoPrimitive` 的 source 继承):transform **前**捕获 factory tag,**后**重新挂回。step 4 的 subject 级 material/pattern 仍然 override。**数学等价 —— 只恢复 wrapper 丢掉的 per-leaf 数据。**

## 影响

解锁「N 个单球 subject = per-sphere 颜色/水位/尺寸」(handoff §7 #3)。

## 验证

- `npm test` **89/89 通过**(无变化),`node --check` clean。
- Demo `scenes/cover-fill-spheres.json` 复刻 PresentationLoad D0961 封面(蓝 80% / 红 40% / 绿 20%,三个单球 subject 各自颜色+水位+半径)。
- **视觉验证(studio headed WebGL2)**:修复前 = 三个纯白球;修复后 = 三个正确的两色水位计。

🤖 Generated with [Claude Code](https://claude.com/claude-code)