### PR TITLE
feat(sphere-fill): per-sphere liquid colour via colors[] (one subject, N colours)

### DIFF
--- a/sdf-js/scenes/sphere-fill-multicolor.json
+++ b/sdf-js/scenes/sphere-fill-multicolor.json
@@ -1,0 +1,29 @@
+{
+  "v": 1,
+  "name": "kpi-hero: multi-colour fill levels (one subject)",
+  "subjects": [
+    {
+      "id": "gauges",
+      "type": "sphere-fill-3d",
+      "args": {
+        "levels": [0.8, 0.4, 0.2],
+        "radius": 0.8,
+        "spacing": 0.5,
+        "colors": [
+          { "hue": 0.58, "sat": 0.82, "value": 0.66 },
+          { "hue": 0.99, "sat": 0.85, "value": 0.5 },
+          { "hue": 0.3, "sat": 0.72, "value": 0.6 }
+        ]
+      },
+      "transform": { "translate": [0, 1.0, 0] },
+      "material": { "hue": 0.58, "sat": 0.82, "value": 0.62, "kind": "fill", "roughness": 0.3, "clearcoat": 0.5 }
+    }
+  ],
+  "cameraSequence": {
+    "loop": false,
+    "shots": [
+      { "duration": 8, "pos": [0, 1.5, 7.5], "target": [0, 1.0, 0], "fov": 46, "aperture": 0, "focalDistance": 7.5, "ease": "smooth" }
+    ]
+  },
+  "defaults": { "stage": { "size": [14, 5.5, 10] } }
+}

--- a/sdf-js/scripts/test-sphere-fill-3d.mjs
+++ b/sdf-js/scripts/test-sphere-fill-3d.mjs
@@ -128,5 +128,35 @@ console.log('\nTest group 5: SceneData → compile → GLSL emit');
   }
 }
 
+// ---- Test group 6: per-sphere colours (colors[]) -----------------------------
+console.log('\nTest group 6: per-sphere colours via colors[]');
+{
+  // Mix object HSV + preset string; one sphere left uncoloured (falls back).
+  const sdf = sphereFill3dSDF({
+    levels: [0.8, 0.4, 0.2],
+    colors: [{ hue: 0.58, sat: 0.82, value: 0.66 }, 'fruit-red'],
+  });
+  const kids = sdf.ast?.children ?? [];
+  ok(kids.length === 3, 'three sphere leaves');
+  // Sphere 0: object colour → per-leaf material, kind forced to fill (9).
+  ok(kids[0]?._subjectMaterial != null, 'sphere 0 has per-leaf material');
+  ok(kids[0]?._subjectMaterial?.kind === 9, 'sphere 0 material kind forced to fill (9)');
+  ok(Math.abs(kids[0]?._subjectMaterial?.hue - 0.58) < 1e-6, 'sphere 0 hue = 0.58 (blue)');
+  ok(kids[0]?._subjectMaterial?.roughness === 0.3, 'sphere 0 gets gauge roughness default 0.3');
+  // Sphere 1: preset 'fruit-red' resolves, kind still forced to fill.
+  ok(kids[1]?._subjectMaterial?.kind === 9, 'sphere 1 (preset) kind forced to fill');
+  ok(kids[1]?._subjectMaterial?.hue === 0.0, "sphere 1 preset 'fruit-red' hue = 0");
+  // Sphere 2: no colour → no per-leaf material → falls back to subject material.
+  ok(kids[2]?._subjectMaterial === undefined, 'sphere 2 (no colour) falls back to subject material');
+  // Fill fractions still independent of colour.
+  ok(kids[0]?._subjectPattern?.fill === 0.8, 'sphere 0 keeps its fill 0.8');
+}
+{
+  // Single coloured sphere: leaf returned directly, still carries its material.
+  const single = sphereFill3dSDF({ levels: [0.5], colors: [{ hue: 0.3, sat: 0.7, value: 0.6 }] });
+  ok(single?._subjectMaterial?.kind === 9, 'single coloured sphere kind = fill');
+  ok(Math.abs(single?._subjectMaterial?.hue - 0.3) < 1e-6, 'single coloured sphere hue = 0.3');
+}
+
 console.log(`\n=== Result: ${pass} passed, ${fail} failed ===`);
 process.exit(fail > 0 ? 1 : 0);

--- a/sdf-js/src/scene/compile.js
+++ b/sdf-js/src/scene/compile.js
@@ -461,6 +461,7 @@ const PRIMITIVE_FACTORIES = {
       count: a.count ?? null,
       radius: a.radius ?? 0.6,
       spacing: a.spacing ?? a.gap ?? 0.3,
+      colors: a.colors ?? null,
       cage: a.cage ?? true,
       cageThickness: a.cageThickness ?? 0.025,
       fillScale: a.fillScale ?? 0.92,

--- a/sdf-js/src/scene/components/shapes/sphere-fill-3d.js
+++ b/sdf-js/src/scene/components/shapes/sphere-fill-3d.js
@@ -20,12 +20,19 @@
 // attached here per leaf. The LIQUID COLOUR comes from the subject's material
 // (hue/sat/value); set the subject `material.kind = "fill"` to get the gauge look
 // (without it the spheres render as plain solid spheres — a safe fallback).
+//
+// Per-sphere colour: pass `colors[]` (parallel to levels[]) to give each sphere
+// its own liquid hue — each entry mirrors `material` (preset name or {hue,sat,
+// value}) and is attached as a per-leaf material with kind forced to 'fill', so
+// flattenUnion's child-overrides-parent rule lets one subject carry N colours.
 // =============================================================================
 
 import { sphere } from '../../../sdf/d3.js';
 import { union } from '../../../sdf/dn.js';
+import { resolveMaterial, MATERIAL_KIND_INDEX } from '../../spec.js';
 
 const clamp01 = (x) => (x < 0 ? 0 : x > 1 ? 1 : x);
+const FILL_KIND = MATERIAL_KIND_INDEX.fill;
 
 /**
  * sphere-fill-3d SDF — a row of solid gauge spheres.
@@ -35,6 +42,11 @@ const clamp01 = (x) => (x < 0 ? 0 : x > 1 ? 1 : x);
  * @param {number|null} [opts.count=null]  number of spheres (defaults to levels.length)
  * @param {number} [opts.radius=0.6]       sphere radius
  * @param {number} [opts.spacing=0.3]      gap between spheres
+ * @param {Array<string|object>|null} [opts.colors=null]  optional per-sphere
+ *        liquid colour, parallel to levels[]. Each entry mirrors `material`
+ *        (preset name or {hue,sat,value} object); kind is forced to 'fill' so
+ *        the gauge shading is kept and only the liquid hue varies. Spheres past
+ *        colors.length fall back to the subject's material (uniform colour).
  * @returns {SDF3|null}
  */
 export function sphereFill3dSDF({
@@ -42,6 +54,7 @@ export function sphereFill3dSDF({
   count = null,
   radius = 0.6,
   spacing = 0.3,
+  colors = null,
 } = {}) {
   const N = count != null ? Math.floor(count) : levels.length;
   if (N <= 0) return null;
@@ -57,6 +70,16 @@ export function sphereFill3dSDF({
     // Per-sphere fill rides in the pattern LUT slot [3]. The 'fill' material kind
     // (set on the subject) reads u_leafPattern.w as the waterline height.
     s._subjectPattern = { code: 0, scale: 0, strength: 0, fill: f };
+    // Optional per-sphere liquid colour → per-leaf material (child overrides the
+    // subject's material in flattenUnion). Force kind:'fill' so each sphere keeps
+    // the gauge waterline look and only the hue changes; default a soft gauge
+    // roughness when the colour entry doesn't specify one.
+    if (colors && colors[i] != null) {
+      const m = resolveMaterial(colors[i]);
+      if (m) {
+        s._subjectMaterial = { ...m, kind: FILL_KIND, roughness: m.roughness < 0 ? 0.3 : m.roughness };
+      }
+    }
     parts.push(s);
   }
 
@@ -78,13 +101,25 @@ export const sphereFill3dSpec = {
     count: { type: 'number', default: null, doc: 'Number of spheres (defaults to levels.length)' },
     radius: { type: 'number', default: 0.6, doc: 'Sphere radius' },
     spacing: { type: 'number', default: 0.3, doc: 'Gap between spheres' },
+    colors: {
+      type: 'array',
+      default: null,
+      doc: 'Optional per-sphere liquid colour, parallel to levels[]. Each entry mirrors material (preset name or {hue,sat,value}); kind is forced to "fill". Spheres past colors.length use the subject material.',
+    },
   },
   examples: [
     { name: 'Quartile progress', args: { levels: [0.25, 0.5, 0.75, 1.0] } },
     { name: 'Capacity gauges', args: { levels: [0.9, 0.6, 0.3], radius: 0.7 } },
+    {
+      name: 'Multi-colour fill levels',
+      args: {
+        levels: [0.8, 0.4, 0.2],
+        colors: [{ hue: 0.58, sat: 0.82, value: 0.66 }, 'fruit-red', { hue: 0.3, sat: 0.72, value: 0.6 }],
+      },
+    },
   ],
   description:
-    'Row of fill-level gauge spheres (liquid bottom + glass top split at a waterline). Set the subject material.kind to "fill" with a liquid hue/sat/value for the gauge look.',
+    'Row of fill-level gauge spheres (liquid bottom + glass top split at a waterline). Set the subject material.kind to "fill" with a liquid hue/sat/value for the gauge look. Pass colors[] (parallel to levels[]) to give each sphere its own liquid colour.',
   source: {
     author: 'Atlas',
     builtAt: '2026-06-20',


### PR DESCRIPTION
## 背景

PresentationLoad D0961 封面的 fill gauge 是**多色液体**(绿 20% / 红 40% / 蓝 80%)。此前 `sphere-fill-3d` 一个 subject 只有一种液体色(subject material),多色得靠 N 个单球 subject 拼。本 PR 把 per-sphere 颜色做成**一等原子能力**。

## 改动

1. **组件** — 新增 `colors[]`,与 `levels[]` 平行。每项**镜像 `material`**(preset 名 或 `{hue,sat,value}` 对象,2026-06-24 与 user 定的契约),挂为 per-leaf `_subjectMaterial` 并**强制 kind:'fill'**,靠 flattenUnion 的 child-overrides-parent 让**一个 subject 携带 N 种颜色**。`colors.length` 不足的球回退到 subject material。未指定时给 gauge roughness 默认值。
2. **compile.js(load-bearing 修复)** — `sphere-fill-3d` 的 curated `PRIMITIVE_FACTORIES` wrapper 只转发 levels/count/radius/spacing,**没转发 colors** → 新 arg 在到达 factory 前被静默丢弃(per-leaf 材质解析成 subject 颜色)。补上转发。**没这一行,组件改动在 compile 路径上完全失效**(第一次渲染就是全蓝)。
3. **测试组 6** — colors[] 挂 per-leaf 材质(kind 9 + 正确 hue)、preset 项能解析、无色球回退、fill 与颜色独立。
4. **Demo** `scenes/sphere-fill-multicolor.json` — 一个 subject,levels [0.8,0.4,0.2] + colors [蓝,红,绿]。

## 验证

- `npm test` **91/91 通过**,`node --check` clean。
- 探编译后 `leafMaterials`:hue 0.58/0.99/0.30、全 kind 9、fill 0.8/0.4/0.2(per-leaf 正确)。
- **视觉验证(studio headed WebGL2)**:一个 subject → 三个正确的两色 gauge,各自液体色(绿/红/蓝)。

## 决策 + 后续

- `colors[]` 项镜像 `material`(preset | HSV 对象),与现有材质词表最大一致。
- **per-sphere 半径**留作后续(radius 仍 subject 级统一)。
- **lift prompt 教 LLM 用 colors[]**(v3.36)留作小后续,与本引擎能力解耦。

🤖 Generated with [Claude Code](https://claude.com/claude-code)