### PR TITLE
feat(sphere-fill): per-sphere radius via radii[] (one subject reproduces the cover)

### DIFF
--- a/sdf-js/scenes/sphere-fill-cover.json
+++ b/sdf-js/scenes/sphere-fill-cover.json
@@ -1,0 +1,29 @@
+{
+  "v": 1,
+  "name": "kpi-hero: 3D Spheres Fill Levels cover (one subject)",
+  "subjects": [
+    {
+      "id": "gauges",
+      "type": "sphere-fill-3d",
+      "args": {
+        "levels": [0.8, 0.4, 0.2],
+        "radii": [1.0, 0.72, 0.55],
+        "spacing": 0.5,
+        "colors": [
+          { "hue": 0.58, "sat": 0.82, "value": 0.66 },
+          { "hue": 0.99, "sat": 0.85, "value": 0.5 },
+          { "hue": 0.3, "sat": 0.72, "value": 0.6 }
+        ]
+      },
+      "transform": { "translate": [0, 1.1, 0] },
+      "material": { "hue": 0.58, "sat": 0.82, "value": 0.62, "kind": "fill", "roughness": 0.3, "clearcoat": 0.5 }
+    }
+  ],
+  "cameraSequence": {
+    "loop": false,
+    "shots": [
+      { "duration": 8, "pos": [0, 1.6, 8.5], "target": [0, 1.0, 0], "fov": 44, "aperture": 0, "focalDistance": 8.5, "ease": "smooth" }
+    ]
+  },
+  "defaults": { "stage": { "size": [16, 6, 11] } }
+}

--- a/sdf-js/scripts/test-sphere-fill-3d.mjs
+++ b/sdf-js/scripts/test-sphere-fill-3d.mjs
@@ -158,5 +158,31 @@ console.log('\nTest group 6: per-sphere colours via colors[]');
   ok(Math.abs(single?._subjectMaterial?.hue - 0.3) < 1e-6, 'single coloured sphere hue = 0.3');
 }
 
+// ---- Test group 7: per-sphere radius (radii[]) -------------------------------
+console.log('\nTest group 7: per-sphere radius via radii[]');
+{
+  // radii [1.0, 0.5], spacing 0.3 → centres at x = -0.9 and +0.9 (row centred).
+  // f(centre_i) = -radius_i (distance to own surface), proving per-sphere size.
+  const sdf = sphereFill3dSDF({ levels: [0.5, 0.5], radii: [1.0, 0.5], spacing: 0.3 });
+  ok(Math.abs(sdf.f([-0.9, 0, 0]) - -1.0) < 1e-6, 'sphere 0 radius 1.0 at x=-0.9');
+  ok(Math.abs(sdf.f([0.9, 0, 0]) - -0.5) < 1e-6, 'sphere 1 radius 0.5 at x=+0.9');
+}
+{
+  // radii null reproduces the old uniform row exactly (radius 0.6, N=2 →
+  // centres at -0.75 / +0.75; same as stride 1.5, offset 0.75).
+  const sdf = sphereFill3dSDF({ levels: [0.5, 0.5], radius: 0.6 });
+  ok(Math.abs(sdf.f([-0.75, 0, 0]) - -0.6) < 1e-6, 'uniform layout unchanged (sphere 0 at -0.75)');
+  ok(Math.abs(sdf.f([0.75, 0, 0]) - -0.6) < 1e-6, 'uniform layout unchanged (sphere 1 at +0.75)');
+}
+{
+  // Spheres past radii.length fall back to the uniform radius.
+  const sdf = sphereFill3dSDF({ levels: [0.5, 0.5, 0.5], radii: [1.0], radius: 0.4, spacing: 0.2 });
+  const kids = sdf.ast?.children ?? [];
+  ok(kids.length === 3, 'three spheres');
+  // Sphere 0 radius 1.0, spheres 1+2 radius 0.4. Centres: 0, then +1.0+0.2+0.4=1.6,
+  // then +0.4+0.2+0.4=1.0 → 2.6. mid=1.3. So centre 0 at x=-1.3.
+  ok(Math.abs(sdf.f([-1.3, 0, 0]) - -1.0) < 1e-6, 'sphere 0 uses radii[0]=1.0');
+}
+
 console.log(`\n=== Result: ${pass} passed, ${fail} failed ===`);
 process.exit(fail > 0 ? 1 : 0);

--- a/sdf-js/src/scene/compile.js
+++ b/sdf-js/src/scene/compile.js
@@ -462,6 +462,7 @@ const PRIMITIVE_FACTORIES = {
       radius: a.radius ?? 0.6,
       spacing: a.spacing ?? a.gap ?? 0.3,
       colors: a.colors ?? null,
+      radii: a.radii ?? null,
       cage: a.cage ?? true,
       cageThickness: a.cageThickness ?? 0.025,
       fillScale: a.fillScale ?? 0.92,

--- a/sdf-js/src/scene/components/shapes/sphere-fill-3d.js
+++ b/sdf-js/src/scene/components/shapes/sphere-fill-3d.js
@@ -47,6 +47,10 @@ const FILL_KIND = MATERIAL_KIND_INDEX.fill;
  *        (preset name or {hue,sat,value} object); kind is forced to 'fill' so
  *        the gauge shading is kept and only the liquid hue varies. Spheres past
  *        colors.length fall back to the subject's material (uniform colour).
+ * @param {number[]|null} [opts.radii=null]  optional per-sphere radius, parallel
+ *        to levels[]. Spheres past radii.length use the uniform `radius`. The row
+ *        is laid out so neighbouring surfaces stay `spacing` apart and stays
+ *        centred on the origin (uniform radii reproduce the old even row exactly).
  * @returns {SDF3|null}
  */
 export function sphereFill3dSDF({
@@ -55,18 +59,29 @@ export function sphereFill3dSDF({
   radius = 0.6,
   spacing = 0.3,
   colors = null,
+  radii = null,
 } = {}) {
   const N = count != null ? Math.floor(count) : levels.length;
   if (N <= 0) return null;
 
-  const stride = 2 * radius + spacing;
-  const offset = ((N - 1) / 2) * stride;
+  const radiusFor = (i) => (radii && radii[i] != null ? radii[i] : radius);
+
+  // Lay out centres left→right so neighbouring SURFACES stay `spacing` apart
+  // (step = prevRadius + spacing + thisRadius), then shift the whole row so it
+  // is centred on x=0. With uniform radii this collapses to the old even grid
+  // (step = 2*radius + spacing, offset = ((N-1)/2)*step).
+  const xs = [];
+  let cx = 0;
+  for (let i = 0; i < N; i++) {
+    if (i > 0) cx += radiusFor(i - 1) + spacing + radiusFor(i);
+    xs.push(cx);
+  }
+  const mid = (xs[0] + xs[N - 1]) / 2;
 
   const parts = [];
   for (let i = 0; i < N; i++) {
     const f = clamp01(levels[i] != null ? levels[i] : (levels[levels.length - 1] ?? 0.5));
-    const cx = i * stride - offset;
-    const s = sphere(radius).translate([cx, 0, 0]);
+    const s = sphere(radiusFor(i)).translate([xs[i] - mid, 0, 0]);
     // Per-sphere fill rides in the pattern LUT slot [3]. The 'fill' material kind
     // (set on the subject) reads u_leafPattern.w as the waterline height.
     s._subjectPattern = { code: 0, scale: 0, strength: 0, fill: f };
@@ -106,6 +121,11 @@ export const sphereFill3dSpec = {
       default: null,
       doc: 'Optional per-sphere liquid colour, parallel to levels[]. Each entry mirrors material (preset name or {hue,sat,value}); kind is forced to "fill". Spheres past colors.length use the subject material.',
     },
+    radii: {
+      type: 'array',
+      default: null,
+      doc: 'Optional per-sphere radius, parallel to levels[]. Spheres past radii.length use the uniform radius. The row stays centred and neighbouring surfaces stay `spacing` apart.',
+    },
   },
   examples: [
     { name: 'Quartile progress', args: { levels: [0.25, 0.5, 0.75, 1.0] } },
@@ -117,9 +137,17 @@ export const sphereFill3dSpec = {
         colors: [{ hue: 0.58, sat: 0.82, value: 0.66 }, 'fruit-red', { hue: 0.3, sat: 0.72, value: 0.6 }],
       },
     },
+    {
+      name: 'Cover (per-sphere colour + size)',
+      args: {
+        levels: [0.8, 0.4, 0.2],
+        radii: [1.0, 0.72, 0.55],
+        colors: [{ hue: 0.58, sat: 0.82, value: 0.66 }, { hue: 0.99, sat: 0.85, value: 0.5 }, { hue: 0.3, sat: 0.72, value: 0.6 }],
+      },
+    },
   ],
   description:
-    'Row of fill-level gauge spheres (liquid bottom + glass top split at a waterline). Set the subject material.kind to "fill" with a liquid hue/sat/value for the gauge look. Pass colors[] (parallel to levels[]) to give each sphere its own liquid colour.',
+    'Row of fill-level gauge spheres (liquid bottom + glass top split at a waterline). Set the subject material.kind to "fill" with a liquid hue/sat/value for the gauge look. Pass colors[] (parallel to levels[]) for per-sphere liquid colour, and radii[] for per-sphere size.',
   source: {
     author: 'Atlas',
     builtAt: '2026-06-20',


### PR DESCRIPTION
## 背景

接续 #141(per-sphere 颜色)。PresentationLoad D0961 封面除了多色,**每球大小也不同**(绿 20% 小 / 红 40% 中 / 蓝 80% 大)。此前 radius 是 subject 级统一。本 PR 把 per-sphere 半径做成一等 arg —— 至此「一个 subject 复刻封面」所需的全部维度(水位 + 颜色 + 大小)齐了。

## 改动

1. **组件** — 新增 `radii[]`(与 levels[] 平行)。布局让相邻**表面**保持 `spacing` 间距(step = prevR + spacing + thisR),整排居中于 x=0。**统一半径时退化成旧的等距网格(向后兼容)**。`radii.length` 不足的球用统一 `radius`。
2. **compile.js** — curated `PRIMITIVE_FACTORIES` wrapper 转发 `radii`(第二道关卡,与 #141 colors[] 同一个静默丢弃点 —— [[atlas-add-atom-arg-two-gatekeepers]] 铁律)。
3. **测试组 7** — per-sphere 半径生效(f(中心_i) = -radius_i)、统一布局不变、radii.length 回退。
4. **Demo** `scenes/sphere-fill-cover.json` — 一个 subject,levels [0.8,0.4,0.2] + radii [1.0,0.72,0.55] + colors [蓝,红,绿] = 完整封面。

## 验证

- `npm test` **91/91**,`node --check` clean。
- **视觉验证(studio headed WebGL2)**:一个 subject → 绿小 / 红中 / 蓝大 三个 gauge,对齐 PDF 封面 p1。

至此 per-sphere 颜色 + 大小都是一等能力,多色多尺寸 gauge 不再需要手拼多 subject。

🤖 Generated with [Claude Code](https://claude.com/claude-code)