### PR TITLE
feat(present): screen-text overlay anchored to 3D points (locked text policy)

### DIFF
--- a/sdf-js/apps/present/overlay.js
+++ b/sdf-js/apps/present/overlay.js
@@ -1,0 +1,106 @@
+// =============================================================================
+// overlay.js — Layer-2 screen-text overlay (Atlas Present).
+// -----------------------------------------------------------------------------
+// Implements the locked text policy (see deck-player.js): narrative / title /
+// descriptive text → DOM overlay; only data labels bound to geometry → in-scene
+// SDF. This is the overlay half: flat DOM text blocks that DON'T live in the SDF
+// tree but ARE anchored to 3D world points and PROJECTED to the screen each
+// frame, so a label tracks its object as the authored camera flies between
+// stations.
+//
+// Projection reuses studio.project(world) → {x, y, visible} (x,y ∈ [0,1],
+// top-left origin), the camera the renderer ACTUALLY drew with last frame — no
+// camera-convention duplication outside the renderer.
+//
+// Scene contract:  scene.overlay = [{ text, anchor:[x,y,z], role?, align? }]
+//   role  = 'title' | 'head' | 'body' | 'kpi'  (default 'body')
+//   align = 'center' (default) | 'left' | 'right'  — horizontal anchoring
+//
+// Layer-2 only: imports nothing from src/ or examples/; talks to the studio via
+// its public project() method.
+// =============================================================================
+
+const ROLE_CSS = {
+  // dark-on-light by default (the chart archetypes render on the light studio
+  // stage); a soft light halo keeps text legible over busier areas too.
+  title:
+    'font:700 30px/1.15 -apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;letter-spacing:-0.01em;color:#0e1726;',
+  head: 'font:700 14px/1.2 -apple-system,sans-serif;letter-spacing:0.1em;text-transform:uppercase;color:#1b2433;',
+  body: 'font:400 13px/1.45 -apple-system,sans-serif;color:#3a4656;max-width:210px;',
+  kpi: 'font:800 36px/1 -apple-system,sans-serif;color:#f4f8ff;text-shadow:0 2px 10px rgba(0,0,0,0.45);',
+};
+
+/**
+ * Create a screen-text overlay layer over the studio canvas.
+ * @param {HTMLElement} wrap   the canvas wrapper (positioned container)
+ * @param {{project:(w:number[])=>{x:number,y:number,visible:boolean}}} studio
+ * @returns {{ set:(list:object[])=>void, clear:()=>void, destroy:()=>void }}
+ */
+export function makeOverlay(wrap, studio) {
+  if (getComputedStyle(wrap).position === 'static') wrap.style.position = 'relative';
+  const layer = document.createElement('div');
+  Object.assign(layer.style, {
+    position: 'absolute',
+    inset: '0',
+    pointerEvents: 'none',
+    overflow: 'hidden',
+    zIndex: '30',
+  });
+  wrap.appendChild(layer);
+
+  let blocks = []; // { el, anchor }
+  let raf = 0;
+
+  function clear() {
+    for (const b of blocks) b.el.remove();
+    blocks = [];
+  }
+
+  function set(list) {
+    clear();
+    for (const o of Array.isArray(list) ? list : []) {
+      if (!o || !Array.isArray(o.anchor) || o.anchor.length < 3) continue;
+      const el = document.createElement('div');
+      el.textContent = o.text || '';
+      const halo =
+        o.role === 'kpi' ? '' : 'text-shadow:0 1px 2px rgba(255,255,255,0.55),0 1px 6px rgba(255,255,255,0.35);';
+      // anchor maps to the block's reference point; center by default.
+      const tx = o.align === 'left' ? '0' : o.align === 'right' ? '-100%' : '-50%';
+      const textAlign = o.align || 'center';
+      el.style.cssText =
+        `position:absolute;transform:translate(${tx},-50%);text-align:${textAlign};white-space:pre-line;` +
+        `opacity:0;transition:opacity 0.25s ease;will-change:left,top;${halo}` +
+        (ROLE_CSS[o.role] || ROLE_CSS.body);
+      layer.appendChild(el);
+      blocks.push({ el, anchor: o.anchor });
+    }
+    if (!raf) tick();
+  }
+
+  function tick() {
+    raf = requestAnimationFrame(tick);
+    if (!blocks.length) return;
+    const W = wrap.clientWidth;
+    const H = wrap.clientHeight;
+    for (const b of blocks) {
+      const p = studio.project(b.anchor);
+      if (!p || !p.visible) {
+        b.el.style.opacity = '0';
+        continue;
+      }
+      b.el.style.left = (p.x * W).toFixed(1) + 'px';
+      b.el.style.top = (p.y * H).toFixed(1) + 'px';
+      b.el.style.opacity = '1';
+    }
+  }
+
+  return {
+    set,
+    clear,
+    destroy() {
+      if (raf) cancelAnimationFrame(raf);
+      raf = 0;
+      layer.remove();
+    },
+  };
+}

--- a/sdf-js/apps/present/present.js
+++ b/sdf-js/apps/present/present.js
@@ -12,6 +12,7 @@
 
 import { createStudioRenderer } from '../../src/render/studio.js';
 import { applyStudioScene } from '../../src/runtime/apply-studio-scene.js';
+import { makeOverlay } from './overlay.js';
 
 const SCENES = '../../scenes'; // shared scene/deck JSON dir (also read by the playground later)
 
@@ -45,6 +46,10 @@ const getControls = () => ({
 
 const studio = createStudioRenderer({ canvas, getControls, onFps: () => {} });
 
+// Screen-text overlay (locked text policy: narrative/title/descriptive text →
+// DOM overlay anchored to 3D points; only geometry-bound data labels → SDF).
+const overlay = makeOverlay(wrap, studio);
+
 window.addEventListener('resize', () => {
   sizeCanvas();
   if (studio.requestRender) studio.requestRender(); // next frame reallocates the FBO + redraws
@@ -53,9 +58,14 @@ window.addEventListener('resize', () => {
 export const present = {
   studio,
   wrap,
+  overlay,
   /** Render a parsed SceneData (the inner v1 scene) into the studio. */
   show(sceneData) {
-    return applyStudioScene(studio, sceneData);
+    const r = applyStudioScene(studio, sceneData);
+    // Narrative/descriptive text rides on scene.overlay[] (projected DOM blocks),
+    // never in the SDF tree. Empty/absent → overlay clears.
+    overlay.set(sceneData && sceneData.overlay);
+    return r;
   },
   /** Fetch a scene/deck-segment file from scenes/ and render its sceneData. */
   async load(file) {

--- a/sdf-js/scenes/p7-stage-gauges.json
+++ b/sdf-js/scenes/p7-stage-gauges.json
@@ -1,0 +1,32 @@
+{
+  "v": 1,
+  "name": "sequence: 3D Spheres Fill Levels — stage (p7)",
+  "subjects": [
+    {
+      "id": "gauges",
+      "type": "sphere-fill-3d",
+      "args": { "levels": [0.8, 1.0, 0.5], "radii": [0.85, 1.05, 0.7], "spacing": 0.6 },
+      "transform": { "translate": [0, 1.1, 0] },
+      "material": { "hue": 0.57, "sat": 0.55, "value": 0.62, "kind": "fill", "roughness": 0.3, "clearcoat": 0.5 }
+    }
+  ],
+  "overlay": [
+    { "text": "3D SPHERES — FILL LEVELS", "anchor": [0, 4.15, 0], "role": "title" },
+
+    { "text": "DESCRIPTION 1", "anchor": [2.425, 3.2, 0], "role": "head" },
+    { "text": "The text demonstrates how\nyour own text will look here.", "anchor": [2.425, 2.5, 0], "role": "body" },
+
+    { "text": "DESCRIPTION 2", "anchor": [0.075, 3.55, 0], "role": "head" },
+    { "text": "The text demonstrates how\nyour own text will look here.", "anchor": [0.075, 2.85, 0], "role": "body" },
+
+    { "text": "DESCRIPTION 3", "anchor": [-2.425, 3.35, 0], "role": "head" },
+    { "text": "The text demonstrates how\nyour own text will look here.", "anchor": [-2.425, 2.65, 0], "role": "body" }
+  ],
+  "cameraSequence": {
+    "loop": false,
+    "shots": [
+      { "duration": 10, "pos": [0, 1.6, 8.5], "target": [0, 1.0, 0], "fov": 44, "aperture": 0, "focalDistance": 8.5, "ease": "smooth" }
+    ]
+  },
+  "defaults": { "stage": { "size": [18, 7, 11] } }
+}


### PR DESCRIPTION
## 背景

text-heavy 图表 slide(PresentationLoad p3/p7/p11/p15:DESCRIPTION 表头 + 正文段落分布在各物体周围)**不能全做成 3D SDF 文字**。LOCKED 文字策略(deck-player.js line 17):**叙事/标题/描述文字 → DOM 浮层;只有绑几何的数据标签 → in-scene SDF**。本 PR 为单场景 present host 实现浮层那一半。

## 改动

1. **`apps/present/overlay.js`** — 一层 DOM 文字块,每块锚定一个 **3D 世界点**,每帧用 `studio.project()`(渲染器实际用的相机,无相机约定重复)投影到屏幕。**相机飞越时文字跟着物体走**。role:title/head/body/kpi。**场景契约**:`scene.overlay = [{ text, anchor:[x,y,z], role?, align? }]`(2026-06-24 与 user 定)。
2. **present.js** — 创建一次 overlay,每次 `show()` 从 `scene.overlay` 刷新;无/空 → 清空。Layer-2 only(除 `studio.project()` 外不耦合 src/ 或 examples/)。
3. **Demo `scenes/p7-stage-gauges.json`** — p7「stage」archetype:三个不同大小蓝 gauge(radii)+ DESCRIPTION 1/2/3 表头 + 正文作为投影浮层落在各球上方 + 居中标题。

## 验证

- **视觉验证(studio headed WebGL2)**:三个 gauge + 标题 + 三组 DESCRIPTION/body 精确落在各球上方;文字是平的 DOM(浅色舞台上深色字),gauge 是 3D SDF —— **策略分工在屏幕上成立**。
- `npm test` **91/91**,`node --check` clean。

## 后续

- 教 lift prompt 认 `scene.overlay` 契约 + SDF-vs-overlay 判断(v3.37)。
- deck-player 多段 deck 也接 overlay。
- 球上的 **%** 是数据标签 → 正确归宿是 SDF chart-label(不是浮层),单独做。

🤖 Generated with [Claude Code](https://claude.com/claude-code)