### PR TITLE
feat(chart-labels): sphere-fill % auto-labels (radii-aware, on-liquid, camera-facing)

### DIFF
--- a/sdf-js/scripts/test-chart-labels.mjs
+++ b/sdf-js/scripts/test-chart-labels.mjs
@@ -1,4 +1,4 @@
-import { expandChartLabels, barAnchors } from '../src/scene/chart-labels.js';
+import { expandChartLabels, barAnchors, sphereFillAnchors } from '../src/scene/chart-labels.js';
 
 let pass = 0,
   fail = 0;
@@ -89,7 +89,13 @@ console.log('=== chart-labels (expandChartLabels connector) ===\n');
   );
   // middle sphere centred at x=0 (N=3 symmetric)
   ok(Math.abs(added[1].transform.translate[0]) < 1e-9, 'sphere-fill middle label at x=0');
-  ok(added[0].transform.translate[2] < 0, 'sphere-fill label on −z (camera-facing) front');
+  // +z = near side (camera at +z): label sits in FRONT of the sphere, not behind
+  // it (occluded). Mirrored via rotate 180°/Y so the pipe glyph reads correctly.
+  ok(added[0].transform.translate[2] > 0, 'sphere-fill label on +z near face (not occluded)');
+  ok(
+    Math.abs((added[0].transform.rotate || [0, 0, 0])[1] - Math.PI) < 1e-9,
+    'sphere-fill label mirrored (rotate 180°/Y) to face the +z camera',
+  );
 }
 
 // matrix-grid-3d: row-major flat array, row 0 on top
@@ -140,6 +146,33 @@ console.log('=== chart-labels (expandChartLabels connector) ===\n');
   };
   ok(expandChartLabels(notChart).subjects.length === 1, 'non-chart type with labels → no-op');
   ok(expandChartLabels({ v: 1, subjects: [] }).subjects.length === 0, 'empty scene → no-op');
+}
+
+// sphere-fill gauge: % auto-defaults from levels; radii-aware anchors
+{
+  // No args.labels → gauge auto-labels each sphere with its level as a %.
+  const scene = {
+    v: 1,
+    subjects: [{ id: 'g', type: 'sphere-fill-3d', args: { levels: [0.8, 0.4, 0.2] } }],
+  };
+  const labels = expandChartLabels(scene).subjects.filter((s) => s.type === 'text-3d-pipe');
+  ok(labels.length === 3, 'sphere-fill auto-labels 3 spheres from levels');
+  ok(labels[0].args.text === '80%', 'level 0.8 → "80%"');
+  ok(labels[2].args.text === '20%', 'level 0.2 → "20%"');
+
+  // Explicit args.labels:[] suppresses the auto-default.
+  const suppressed = {
+    v: 1,
+    subjects: [{ id: 'g', type: 'sphere-fill-3d', args: { levels: [0.5], labels: [] } }],
+  };
+  ok(expandChartLabels(suppressed).subjects.length === 1, 'args.labels:[] suppresses auto %');
+
+  // radii-aware anchors: surfaces stay `spacing` apart, row centred. radii
+  // [1.0,0.5] spacing 0.3 → centres at -0.9 / +0.9 (matches the atom layout).
+  const an = sphereFillAnchors({ levels: [0.5, 0.5], radii: [1.0, 0.5], spacing: 0.3 });
+  ok(Math.abs(an[0].x - -0.9) < 1e-6, 'radii anchor 0 at x=-0.9');
+  ok(Math.abs(an[1].x - 0.9) < 1e-6, 'radii anchor 1 at x=+0.9');
+  ok(Math.abs(an[0].z - 1.1) < 1e-6, 'radii anchor 0 z = +(1.0+0.1) (near side, not occluded)');
 }
 
 console.log(`\n=== Result: ${pass} passed, ${fail} failed ===`);

--- a/sdf-js/src/scene/chart-labels.js
+++ b/sdf-js/src/scene/chart-labels.js
@@ -86,21 +86,42 @@ export function pieAnchors(
 
 // sphere-fill-3d: row of spheres along +X (labels parallel to `levels`). anchor
 // = just in front of each sphere's front face (−z), centred at sphere height.
+// Mirrors the atom's own layout (sphere-fill-3d.js) including per-sphere radii[]:
+// surfaces stay `spacing` apart and the row stays centred, so labels land on the
+// spheres even when sizes differ. Uniform radii reproduce the old even row.
 export function sphereFillAnchors({
   levels = [],
   count,
   radius = 0.6,
   spacing = 0.3,
+  radii = null,
   margin = 0.1,
 } = {}) {
   const N = count != null ? Math.floor(count) : levels.length;
-  const stride = 2 * radius + spacing;
-  const offset = ((N - 1) / 2) * stride;
-  return Array.from({ length: N }, (_, i) => ({
-    x: i * stride - offset,
-    y: 0,
-    z: -(radius + margin),
-  }));
+  if (N <= 0) return [];
+  const radiusFor = (i) => (radii && radii[i] != null ? radii[i] : radius);
+  const xs = [];
+  let cx = 0;
+  for (let i = 0; i < N; i++) {
+    if (i > 0) cx += radiusFor(i - 1) + spacing + radiusFor(i);
+    xs.push(cx);
+  }
+  const mid = (xs[0] + xs[N - 1]) / 2;
+  const lvl = (i) => (i < levels.length && levels[i] != null ? levels[i] : (levels[levels.length - 1] ?? 0.5));
+  return Array.from({ length: N }, (_, i) => {
+    const r = radiusFor(i);
+    // Sit the % in the MIDDLE of the coloured liquid (not at the centre/waterline):
+    // on a sphere the liquid spans n.y∈[-1, 2f-1], so its mid is n.y=f-1 → world
+    // y = r*(f-1). White label on the coloured liquid stays legible on any
+    // background (a centre label half-lands on the bright glass top). Scaled 0.85
+    // to keep the glyph body inside the sphere for low fills.
+    const f = clampFrac(lvl(i));
+    // +z is the near side (the studio camera sits at +z looking toward −z), so
+    // the label sits JUST IN FRONT of the sphere's front face — not behind it,
+    // where the sphere would occlude it (the old −z anchor was never visually
+    // tested; sphere-fill labels are new on the studio path).
+    return { x: xs[i] - mid, y: r * (f - 1) * 0.85, z: r + margin };
+  });
 }
 
 // matrix-grid-3d: R×C card grid, ROW-MAJOR with row 0 on TOP (matches the atom:
@@ -152,7 +173,22 @@ const ANCHORS_FROM_ARGS = {
   'matrix-grid-3d': (a) => matrixAnchors(a),
 };
 
+// internal: type → (args) → default label strings, used when the subject did NOT
+// carry an explicit args.labels. For a fill gauge the % IS the datum, so a gauge
+// auto-labels each sphere from its level (the data label belongs to the geometry
+// → in-scene SDF, per the locked text policy). Pass args.labels (incl. []) to
+// override or suppress.
+const clampFrac = (x) => (x < 0 ? 0 : x > 1 ? 1 : x);
+const DEFAULT_LABELS = {
+  'sphere-fill-3d': (a) =>
+    (Array.isArray(a.levels) ? a.levels : []).map((l) => `${Math.round(clampFrac(l) * 100)}%`),
+};
+
 // turn anchors + label strings into camera-facing text-3d-pipe subjects.
+// mirror=true reflects each glyph in x (transform scale [-1,1,1]) so a label that
+// sits on the camera-NEAR (+z) face of an object reads correctly: the pipe glyph
+// is depth-symmetric, so seen from +z it would otherwise read mirrored. Labels
+// that float at −z (bar/line, above their geometry) don't need it.
 export function placeLabels(
   anchors,
   labels,
@@ -162,16 +198,23 @@ export function placeLabels(
     material = LABEL_MAT,
     idPrefix = 'lbl',
     align = 'center',
+    mirror = false,
   } = {},
 ) {
   return anchors.map((a, i) => ({
     id: `${idPrefix}${i}`,
     type: 'text-3d-pipe',
     args: { text: String(labels[i] ?? ''), height, pipeRadius, align },
-    transform: { translate: [a.x, a.y, a.z] },
+    transform: mirror
+      ? { translate: [a.x, a.y, a.z], rotate: [0, Math.PI, 0] }
+      : { translate: [a.x, a.y, a.z] },
     material,
   }));
 }
+
+// Label subjects that sit ON their geometry's near (+z) face need their glyphs
+// mirrored to read correctly (see placeLabels). sphere-fill % sits on the liquid.
+const MIRROR_LABELS = new Set(['sphere-fill-3d']);
 
 // Deterministic SceneData→SceneData: for every chart subject carrying
 // args.labels (parallel to args.values), append text-3d-pipe label subjects
@@ -183,7 +226,14 @@ export function expandChartLabels(sceneData) {
   sceneData.subjects.forEach((s, si) => {
     const fn = ANCHORS_FROM_ARGS[s && s.type];
     const args = s && s.args;
-    const labels = args && Array.isArray(args.labels) ? args.labels : null;
+    // Explicit args.labels wins (incl. [] = suppress); otherwise a per-type
+    // default may synthesise labels (e.g. gauge % from levels).
+    const labels =
+      args && Array.isArray(args.labels)
+        ? args.labels
+        : DEFAULT_LABELS[s && s.type]
+          ? DEFAULT_LABELS[s.type](args || {})
+          : null;
     if (!fn || !labels || !labels.length) return;
     const anchors = fn(args);
     if (!anchors || !anchors.length) return;
@@ -192,7 +242,10 @@ export function expandChartLabels(sceneData) {
     // only label the elements that actually have a label string
     const n = Math.min(off.length, labels.length);
     extra.push(
-      ...placeLabels(off.slice(0, n), labels.slice(0, n), { idPrefix: `lbl_${s.id ?? si}_` }),
+      ...placeLabels(off.slice(0, n), labels.slice(0, n), {
+        idPrefix: `lbl_${s.id ?? si}_`,
+        mirror: MIRROR_LABELS.has(s.type),
+      }),
     );
   });
   if (!extra.length) return sceneData;


### PR DESCRIPTION
## 背景(follow-up 2/4)

fill gauge 的 **%** 是绑几何的数据标签 → 按 locked 文字策略归 **in-scene SDF**(不是 overlay)。`expandChartLabels` 早有 sphere-fill 钩子,但:(a) 要显式 `args.labels`;(b) 用旧统一半径布局;(c) 锚在**远侧 −z**(球背面、被遮挡)且从没视觉测过。本 PR 把 % 做成真正可读的 SDF 标签。

## 改动(`src/scene/chart-labels.js`)

1. **自动 %**:gauge 无 `args.labels` 时,每球用其 level 自动标 `%`(% 就是数据)。`args.labels`(含 `[]`)可覆盖/抑制。
2. **radii-aware anchors**:`sphereFillAnchors` 镜像 atom 的 per-sphere `radii[]` 布局(表面隔 spacing、整排居中),大小不同也对齐。
3. **落在液体上**:anchor `y = r*(level−1)*0.85` 把 % 放到彩色液体中部(白字可读;放球心会半压到亮玻璃顶而糊掉)。
4. **朝向相机**:anchor 移到**近侧 +z**(否则被球挡住);pipe 字形**旋转 180°/Y 镜像**,从 +z 相机读正。(`scale[-1,1,1]` 能编译但 raymarch 时翻转 SDF → 空白,所以用旋转。)

## 验证

- **视觉(studio headed WebGL2)**:`scenes/sphere-fill-cover.json` 显示 "80%"/"40%"/"20%" 白字落在各球液体上、正立、不镜像。
- `npm test` **91/91**。

## 注意

- **行为变化**:gauge 现在**自动显示 %**(`args.labels:[]` 可关)。
- 镜像仅对 sphere-fill(`MIRROR_LABELS`);bar/line 标签浮在 −z 不受影响。

🤖 Generated with [Claude Code](https://claude.com/claude-code)