### PR TITLE
feat(present): reproduce p3/p11/p15 archetypes + document deck overlay layers

### DIFF
--- a/sdf-js/apps/present/deck-player.js
+++ b/sdf-js/apps/present/deck-player.js
@@ -14,8 +14,12 @@
 //   • progress dots (click to jump) + keyboard: → / Space next, ← prev,
 //     P pause/resume auto-advance, R restart segment.
 //
-// Text policy (locked): narrative/title text → overlay (this file). Only data
-// labels bound to geometry → in-scene SDF. Launch: ?deck=<deckId>.
+// Text policy (locked): narrative/title text → overlay; only data labels bound
+// to geometry → in-scene SDF. Two overlay layers: (1) the per-segment CAPTION
+// here (deck title + station titles, bottom-centre); (2) per-segment SLIDE text
+// via scene.overlay[] — projected DOM blocks anchored to 3D points — which
+// present.load()→present.show() sets automatically per segment (overlay.js).
+// Launch: ?deck=<deckId>.
 //
 // Atlas Present host version: drives the studio via window.present.load() (the
 // thin present.js host) — NOT the compositor playground. Reads decks/segments

--- a/sdf-js/scenes/p11-hero-list-gauges.json
+++ b/sdf-js/scenes/p11-hero-list-gauges.json
@@ -1,0 +1,53 @@
+{
+  "v": 1,
+  "name": "kpi-hero: 3D Spheres Fill Levels — hero + list (p11)",
+  "subjects": [
+    {
+      "id": "hero",
+      "type": "sphere-fill-3d",
+      "args": { "levels": [0.3], "radius": 1.35 },
+      "transform": { "translate": [-2.6, 1.5, 0] },
+      "material": { "hue": 0.57, "sat": 0.55, "value": 0.62, "kind": "fill", "roughness": 0.3, "clearcoat": 0.5 }
+    },
+    {
+      "id": "item1",
+      "type": "sphere-fill-3d",
+      "args": { "levels": [0.5], "radius": 0.5 },
+      "transform": { "translate": [1.7, 2.75, 0] },
+      "material": { "hue": 0.57, "sat": 0.55, "value": 0.62, "kind": "fill", "roughness": 0.3, "clearcoat": 0.5 }
+    },
+    {
+      "id": "item2",
+      "type": "sphere-fill-3d",
+      "args": { "levels": [0.3], "radius": 0.5 },
+      "transform": { "translate": [1.7, 1.5, 0] },
+      "material": { "hue": 0.57, "sat": 0.55, "value": 0.62, "kind": "fill", "roughness": 0.3, "clearcoat": 0.5 }
+    },
+    {
+      "id": "item3",
+      "type": "sphere-fill-3d",
+      "args": { "levels": [0.2], "radius": 0.5 },
+      "transform": { "translate": [1.7, 0.25, 0] },
+      "material": { "hue": 0.57, "sat": 0.55, "value": 0.62, "kind": "fill", "roughness": 0.3, "clearcoat": 0.5 }
+    }
+  ],
+  "overlay": [
+    { "text": "DESCRIPTION 1", "anchor": [-2.6, -0.4, 0], "role": "head" },
+
+    { "text": "DESCRIPTION 2", "anchor": [2.6, 2.75, 0], "role": "head", "align": "left" },
+    { "text": "Placeholder for your own text.", "anchor": [2.6, 2.45, 0], "role": "body", "align": "left" },
+
+    { "text": "DESCRIPTION 3", "anchor": [2.6, 1.5, 0], "role": "head", "align": "left" },
+    { "text": "Placeholder for your own text.", "anchor": [2.6, 1.2, 0], "role": "body", "align": "left" },
+
+    { "text": "DESCRIPTION 4", "anchor": [2.6, 0.25, 0], "role": "head", "align": "left" },
+    { "text": "Placeholder for your own text.", "anchor": [2.6, -0.05, 0], "role": "body", "align": "left" }
+  ],
+  "cameraSequence": {
+    "loop": false,
+    "shots": [
+      { "duration": 10, "pos": [0, 1.6, 9.0], "target": [0, 1.4, 0], "fov": 46, "aperture": 0, "focalDistance": 9.0, "ease": "smooth" }
+    ]
+  },
+  "defaults": { "stage": { "size": [20, 8, 11] } }
+}

--- a/sdf-js/scenes/p15-radial-gauge.json
+++ b/sdf-js/scenes/p15-radial-gauge.json
@@ -1,0 +1,35 @@
+{
+  "v": 1,
+  "name": "relation: 3D Spheres Fill Levels — radial spoke (p15)",
+  "subjects": [
+    {
+      "id": "hub",
+      "type": "sphere-fill-3d",
+      "args": { "levels": [1.0], "radius": 1.25 },
+      "transform": { "translate": [0, 1.5, 0] },
+      "material": { "hue": 0.57, "sat": 0.55, "value": 0.62, "kind": "fill", "roughness": 0.3, "clearcoat": 0.5 }
+    }
+  ],
+  "overlay": [
+    { "text": "3D SPHERES — FILL LEVELS", "anchor": [0, 4.3, 0], "role": "title" },
+
+    { "text": "DESCRIPTION 1", "anchor": [-3.2, 3.1, 0], "role": "head" },
+    { "text": "This is a placeholder text.\nReplace with your own.", "anchor": [-3.2, 2.55, 0], "role": "body" },
+
+    { "text": "DESCRIPTION 2", "anchor": [3.2, 3.1, 0], "role": "head" },
+    { "text": "This is a placeholder text.\nReplace with your own.", "anchor": [3.2, 2.55, 0], "role": "body" },
+
+    { "text": "DESCRIPTION 3", "anchor": [-3.2, 0.4, 0], "role": "head" },
+    { "text": "This is a placeholder text.\nReplace with your own.", "anchor": [-3.2, -0.15, 0], "role": "body" },
+
+    { "text": "DESCRIPTION 4", "anchor": [3.2, 0.4, 0], "role": "head" },
+    { "text": "This is a placeholder text.\nReplace with your own.", "anchor": [3.2, -0.15, 0], "role": "body" }
+  ],
+  "cameraSequence": {
+    "loop": false,
+    "shots": [
+      { "duration": 10, "pos": [0, 1.7, 9.0], "target": [0, 1.4, 0], "fov": 46, "aperture": 0, "focalDistance": 9.0, "ease": "smooth" }
+    ]
+  },
+  "defaults": { "stage": { "size": [20, 8, 11] } }
+}

--- a/sdf-js/scenes/p3-sequence-gauges.json
+++ b/sdf-js/scenes/p3-sequence-gauges.json
@@ -1,0 +1,46 @@
+{
+  "v": 1,
+  "name": "sequence: 3D Spheres Fill Levels — flow (p3)",
+  "subjects": [
+    {
+      "id": "gauges",
+      "type": "sphere-fill-3d",
+      "args": { "levels": [0.1, 0.6, 0.5], "radius": 0.72, "spacing": 1.5 },
+      "transform": { "translate": [0, 1.1, 0] },
+      "material": { "hue": 0.57, "sat": 0.55, "value": 0.62, "kind": "fill", "roughness": 0.3, "clearcoat": 0.5 }
+    },
+    {
+      "id": "arrowA",
+      "type": "arrow-3d",
+      "args": { "length": 0.9, "shaftWidth": 0.12, "headLength": 0.32, "headWidth": 0.34, "depth": 0.16 },
+      "transform": { "translate": [-1.47, 1.1, 0] },
+      "material": { "hue": 0.0, "sat": 0.0, "value": 0.7, "kind": "normal" }
+    },
+    {
+      "id": "arrowB",
+      "type": "arrow-3d",
+      "args": { "length": 0.9, "shaftWidth": 0.12, "headLength": 0.32, "headWidth": 0.34, "depth": 0.16 },
+      "transform": { "translate": [1.47, 1.1, 0] },
+      "material": { "hue": 0.0, "sat": 0.0, "value": 0.7, "kind": "normal" }
+    }
+  ],
+  "overlay": [
+    { "text": "3D SPHERES — FILL LEVELS", "anchor": [0, 4.0, 0], "role": "title" },
+
+    { "text": "DESCRIPTION 1", "anchor": [2.94, 2.5, 0], "role": "head" },
+    { "text": "Placeholder for your text.", "anchor": [2.94, -0.15, 0], "role": "body" },
+
+    { "text": "DESCRIPTION 2", "anchor": [0, 2.5, 0], "role": "head" },
+    { "text": "Placeholder for your text.", "anchor": [0, -0.15, 0], "role": "body" },
+
+    { "text": "DESCRIPTION 3", "anchor": [-2.94, 2.5, 0], "role": "head" },
+    { "text": "Placeholder for your text.", "anchor": [-2.94, -0.15, 0], "role": "body" }
+  ],
+  "cameraSequence": {
+    "loop": false,
+    "shots": [
+      { "duration": 10, "pos": [0, 1.5, 9.5], "target": [0, 1.0, 0], "fov": 44, "aperture": 0, "focalDistance": 9.5, "ease": "smooth" }
+    ]
+  },
+  "defaults": { "stage": { "size": [20, 7, 11] } }
+}


### PR DESCRIPTION
## follow-ups 3 & 4

overlay 运行时(#144)+ gauge % SDF 标签(#146)进 main 后,剩下的 text-heavy「3D Spheres Fill Levels」archetype 全部复刻成:**gauge(3D SDF + 自动 % 数据标签)+ `scene.overlay[]`(DESCRIPTION 表头/正文/标题的投影 DOM)** —— locked 两套文字系统分工,在屏幕上成立。

## ④ 三个 archetype demo

- **p3 sequence** `scenes/p3-sequence-gauges.json` —— 3 gauge 横排 + `arrow-3d` 连接 + DESCRIPTION 1/2/3 + 正文浮层。
- **p15 radial-spoke** `scenes/p15-radial-gauge.json` —— 1 中心 100% gauge + 四角 DESCRIPTION。
- **p11 hero+list** `scenes/p11-hero-list-gauges.json` —— 1 大 hero gauge + 3 小 gauge 竖列,各带 DESCRIPTION。
- (相机 handedness 使左右镜像于 PDF,结构忠实。)

## ③ deck-player overlay

**无需改代码** —— deck-player `present.load → present.show → overlay.set` 让每段 deck 自动获得投影 overlay 层(与底部 caption 并存)。仅加注释点明。

## 验证

- **视觉(studio headed WebGL2)**:三个 archetype —— gauge 带液体上 % + DESCRIPTION/正文/标题浮层,每块精确落在对应物体上。
- `npm test` **92/92**,`node --check` clean。

🤖 Generated with [Claude Code](https://claude.com/claude-code)