### PR TITLE
Sprint 18 Tier 3 A.1: atom-spec catalog in lift prompt

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -12,6 +12,9 @@ sdf-js/scripts/regression/results/
 # Scaffold pipeline auto-generated decks (LLM bake outputs)
 sdf-js/examples/scaffold-pipeline/antfun-*/
 sdf-js/examples/scaffold-pipeline/pd-*/
+sdf-js/examples/scaffold-pipeline/vcpitch-*/
+sdf-js/examples/scaffold-pipeline/qbr-*/
+sdf-js/examples/scaffold-pipeline/pdsphere-*/
 
 # Smoke test baselines (binary/visual diff artifacts)
 sdf-js/tests/smoke/baselines/

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -161,6 +161,7 @@ const TESTS = [
   { category: 'present', file: 'sdf-js/scripts/test-mapper-llm.mjs' },
   { category: 'present', file: 'sdf-js/scripts/test-icon-library-expanded.mjs' },
   { category: 'present', file: 'sdf-js/scripts/test-atoms-icons.mjs' },
+  { category: 'present', file: 'sdf-js/scripts/test-atom-catalog.mjs' },
 ];
 
 // -----------------------------------------------------------------------------

--- a/sdf-js/scenes/p11-hero-list-gauges.json
+++ b/sdf-js/scenes/p11-hero-list-gauges.json
@@ -7,46 +7,97 @@
       "type": "sphere-fill-3d",
       "args": { "levels": [0.3], "radius": 1.35 },
       "transform": { "translate": [-2.6, 1.5, 0] },
-      "material": { "hue": 0.57, "sat": 0.55, "value": 0.62, "kind": "fill", "roughness": 0.3, "clearcoat": 0.5 }
+      "material": {
+        "hue": 0.57,
+        "sat": 0.55,
+        "value": 0.62,
+        "kind": "fill",
+        "roughness": 0.3,
+        "clearcoat": 0.5
+      }
     },
     {
       "id": "item1",
       "type": "sphere-fill-3d",
       "args": { "levels": [0.5], "radius": 0.5 },
       "transform": { "translate": [1.7, 2.75, 0] },
-      "material": { "hue": 0.57, "sat": 0.55, "value": 0.62, "kind": "fill", "roughness": 0.3, "clearcoat": 0.5 }
+      "material": {
+        "hue": 0.57,
+        "sat": 0.55,
+        "value": 0.62,
+        "kind": "fill",
+        "roughness": 0.3,
+        "clearcoat": 0.5
+      }
     },
     {
       "id": "item2",
       "type": "sphere-fill-3d",
       "args": { "levels": [0.3], "radius": 0.5 },
       "transform": { "translate": [1.7, 1.5, 0] },
-      "material": { "hue": 0.57, "sat": 0.55, "value": 0.62, "kind": "fill", "roughness": 0.3, "clearcoat": 0.5 }
+      "material": {
+        "hue": 0.57,
+        "sat": 0.55,
+        "value": 0.62,
+        "kind": "fill",
+        "roughness": 0.3,
+        "clearcoat": 0.5
+      }
     },
     {
       "id": "item3",
       "type": "sphere-fill-3d",
       "args": { "levels": [0.2], "radius": 0.5 },
       "transform": { "translate": [1.7, 0.25, 0] },
-      "material": { "hue": 0.57, "sat": 0.55, "value": 0.62, "kind": "fill", "roughness": 0.3, "clearcoat": 0.5 }
+      "material": {
+        "hue": 0.57,
+        "sat": 0.55,
+        "value": 0.62,
+        "kind": "fill",
+        "roughness": 0.3,
+        "clearcoat": 0.5
+      }
     }
   ],
   "overlay": [
     { "text": "DESCRIPTION 1", "anchor": [-2.6, -0.4, 0], "role": "head" },
 
     { "text": "DESCRIPTION 2", "anchor": [2.6, 2.75, 0], "role": "head", "align": "left" },
-    { "text": "Placeholder for your own text.", "anchor": [2.6, 2.45, 0], "role": "body", "align": "left" },
+    {
+      "text": "Placeholder for your own text.",
+      "anchor": [2.6, 2.45, 0],
+      "role": "body",
+      "align": "left"
+    },
 
     { "text": "DESCRIPTION 3", "anchor": [2.6, 1.5, 0], "role": "head", "align": "left" },
-    { "text": "Placeholder for your own text.", "anchor": [2.6, 1.2, 0], "role": "body", "align": "left" },
+    {
+      "text": "Placeholder for your own text.",
+      "anchor": [2.6, 1.2, 0],
+      "role": "body",
+      "align": "left"
+    },
 
     { "text": "DESCRIPTION 4", "anchor": [2.6, 0.25, 0], "role": "head", "align": "left" },
-    { "text": "Placeholder for your own text.", "anchor": [2.6, -0.05, 0], "role": "body", "align": "left" }
+    {
+      "text": "Placeholder for your own text.",
+      "anchor": [2.6, -0.05, 0],
+      "role": "body",
+      "align": "left"
+    }
   ],
   "cameraSequence": {
     "loop": false,
     "shots": [
-      { "duration": 10, "pos": [0, 1.6, 9.0], "target": [0, 1.4, 0], "fov": 46, "aperture": 0, "focalDistance": 9.0, "ease": "smooth" }
+      {
+        "duration": 10,
+        "pos": [0, 1.6, 9.0],
+        "target": [0, 1.4, 0],
+        "fov": 46,
+        "aperture": 0,
+        "focalDistance": 9.0,
+        "ease": "smooth"
+      }
     ]
   },
   "defaults": { "stage": { "size": [20, 8, 11] } }

--- a/sdf-js/scenes/p15-radial-gauge.json
+++ b/sdf-js/scenes/p15-radial-gauge.json
@@ -7,28 +7,59 @@
       "type": "sphere-fill-3d",
       "args": { "levels": [1.0], "radius": 1.25 },
       "transform": { "translate": [0, 1.5, 0] },
-      "material": { "hue": 0.57, "sat": 0.55, "value": 0.62, "kind": "fill", "roughness": 0.3, "clearcoat": 0.5 }
+      "material": {
+        "hue": 0.57,
+        "sat": 0.55,
+        "value": 0.62,
+        "kind": "fill",
+        "roughness": 0.3,
+        "clearcoat": 0.5
+      }
     }
   ],
   "overlay": [
     { "text": "3D SPHERES — FILL LEVELS", "anchor": [0, 4.3, 0], "role": "title" },
 
     { "text": "DESCRIPTION 1", "anchor": [-3.2, 3.1, 0], "role": "head" },
-    { "text": "This is a placeholder text.\nReplace with your own.", "anchor": [-3.2, 2.55, 0], "role": "body" },
+    {
+      "text": "This is a placeholder text.\nReplace with your own.",
+      "anchor": [-3.2, 2.55, 0],
+      "role": "body"
+    },
 
     { "text": "DESCRIPTION 2", "anchor": [3.2, 3.1, 0], "role": "head" },
-    { "text": "This is a placeholder text.\nReplace with your own.", "anchor": [3.2, 2.55, 0], "role": "body" },
+    {
+      "text": "This is a placeholder text.\nReplace with your own.",
+      "anchor": [3.2, 2.55, 0],
+      "role": "body"
+    },
 
     { "text": "DESCRIPTION 3", "anchor": [-3.2, 0.4, 0], "role": "head" },
-    { "text": "This is a placeholder text.\nReplace with your own.", "anchor": [-3.2, -0.15, 0], "role": "body" },
+    {
+      "text": "This is a placeholder text.\nReplace with your own.",
+      "anchor": [-3.2, -0.15, 0],
+      "role": "body"
+    },
 
     { "text": "DESCRIPTION 4", "anchor": [3.2, 0.4, 0], "role": "head" },
-    { "text": "This is a placeholder text.\nReplace with your own.", "anchor": [3.2, -0.15, 0], "role": "body" }
+    {
+      "text": "This is a placeholder text.\nReplace with your own.",
+      "anchor": [3.2, -0.15, 0],
+      "role": "body"
+    }
   ],
   "cameraSequence": {
     "loop": false,
     "shots": [
-      { "duration": 10, "pos": [0, 1.7, 9.0], "target": [0, 1.4, 0], "fov": 46, "aperture": 0, "focalDistance": 9.0, "ease": "smooth" }
+      {
+        "duration": 10,
+        "pos": [0, 1.7, 9.0],
+        "target": [0, 1.4, 0],
+        "fov": 46,
+        "aperture": 0,
+        "focalDistance": 9.0,
+        "ease": "smooth"
+      }
     ]
   },
   "defaults": { "stage": { "size": [20, 8, 11] } }

--- a/sdf-js/scenes/p3-sequence-gauges.json
+++ b/sdf-js/scenes/p3-sequence-gauges.json
@@ -7,19 +7,38 @@
       "type": "sphere-fill-3d",
       "args": { "levels": [0.1, 0.6, 0.5], "radius": 0.72, "spacing": 1.5 },
       "transform": { "translate": [0, 1.1, 0] },
-      "material": { "hue": 0.57, "sat": 0.55, "value": 0.62, "kind": "fill", "roughness": 0.3, "clearcoat": 0.5 }
+      "material": {
+        "hue": 0.57,
+        "sat": 0.55,
+        "value": 0.62,
+        "kind": "fill",
+        "roughness": 0.3,
+        "clearcoat": 0.5
+      }
     },
     {
       "id": "arrowA",
       "type": "arrow-3d",
-      "args": { "length": 0.9, "shaftWidth": 0.12, "headLength": 0.32, "headWidth": 0.34, "depth": 0.16 },
+      "args": {
+        "length": 0.9,
+        "shaftWidth": 0.12,
+        "headLength": 0.32,
+        "headWidth": 0.34,
+        "depth": 0.16
+      },
       "transform": { "translate": [-1.47, 1.1, 0] },
       "material": { "hue": 0.0, "sat": 0.0, "value": 0.7, "kind": "normal" }
     },
     {
       "id": "arrowB",
       "type": "arrow-3d",
-      "args": { "length": 0.9, "shaftWidth": 0.12, "headLength": 0.32, "headWidth": 0.34, "depth": 0.16 },
+      "args": {
+        "length": 0.9,
+        "shaftWidth": 0.12,
+        "headLength": 0.32,
+        "headWidth": 0.34,
+        "depth": 0.16
+      },
       "transform": { "translate": [1.47, 1.1, 0] },
       "material": { "hue": 0.0, "sat": 0.0, "value": 0.7, "kind": "normal" }
     }
@@ -39,7 +58,15 @@
   "cameraSequence": {
     "loop": false,
     "shots": [
-      { "duration": 10, "pos": [0, 1.5, 9.5], "target": [0, 1.0, 0], "fov": 44, "aperture": 0, "focalDistance": 9.5, "ease": "smooth" }
+      {
+        "duration": 10,
+        "pos": [0, 1.5, 9.5],
+        "target": [0, 1.0, 0],
+        "fov": 44,
+        "aperture": 0,
+        "focalDistance": 9.5,
+        "ease": "smooth"
+      }
     ]
   },
   "defaults": { "stage": { "size": [20, 7, 11] } }

--- a/sdf-js/scripts/bake-scaffold-pipeline.mjs
+++ b/sdf-js/scripts/bake-scaffold-pipeline.mjs
@@ -31,6 +31,7 @@ import { pickScaffoldLLM } from '../src/present/scaffolds/picker-llm.js';
 import { mapSlidesToSlotsLLM } from '../src/present/scaffolds/mapper-llm.js';
 import { getTheme } from '../src/present/themes.js';
 import { buildIconCatalogString } from '../src/icons/index.js';
+import { buildAtomCatalogString } from '../src/present/atoms-2d/catalog.js';
 
 // --- args ---
 const args = process.argv.slice(2);
@@ -78,6 +79,8 @@ const systemPrompt =
   `# CORE GOAL: Atlas decks are 3D theatrical presentations. TEXT MUST BE MINIMAL. ` +
   `Use icons + charts to replace verbose phrases. Audience reads a slide in ` +
   `≤3 seconds; long prose disappears in 3D space.\n\n` +
+  (await buildAtomCatalogString()) +
+  '\n\n' +
   buildIconCatalogString();
 
 console.log(

--- a/sdf-js/scripts/scaffold-pipeline-fixtures/qbr-q3-2026.json
+++ b/sdf-js/scripts/scaffold-pipeline-fixtures/qbr-q3-2026.json
@@ -1,0 +1,65 @@
+[
+  {
+    "title": "Q3 2026 Quarterly Business Review",
+    "body": ["ANTFUN team review · 2026-09-30", "Operations + Product + GTM"]
+  },
+  {
+    "title": "Executive Summary",
+    "body": [
+      "Q3 ARR reached $740K — up 117% QoQ",
+      "Active wallets crossed 12,500 daily users",
+      "Insurance policy launched in week 8",
+      "Perp DEX prototype shipped end of quarter",
+      "3 strategic risks identified — see risks slide"
+    ]
+  },
+  {
+    "title": "KPI Dashboard",
+    "body": [
+      "ARR: $740K (target $600K, +23%)",
+      "DAU: 12,500 (target 8,000, +56%)",
+      "Trading volume: $4.2M daily (target $3M, +40%)",
+      "Retention D30: 92% (target 85%, +7pt)",
+      "NPS: 72 (target 60, +12pt)",
+      "Burn: $180K/mo (budget $250K, under by $70K)"
+    ]
+  },
+  {
+    "title": "Wins",
+    "body": [
+      "Self-custodial UX received Web3 Product Award",
+      "Sequoia follow-on $25M signed",
+      "Talent: hired 4 engineers from Coinbase + 2 from Anthropic",
+      "Press: TechCrunch / Bloomberg coverage 3 stories",
+      "Community: Discord crossed 24K members"
+    ]
+  },
+  {
+    "title": "Challenges",
+    "body": [
+      "Bridge integration delayed — third-party API instability",
+      "Perp DEX latency higher than target (2s vs 800ms goal)",
+      "Asia GTM slower due to regulatory uncertainty",
+      "Customer support response time avg 8h vs 2h SLA"
+    ]
+  },
+  {
+    "title": "Q4 Outlook",
+    "body": [
+      "ARR target $2.4M (3.2× Q3)",
+      "Launch Perp DEX with sub-second matching",
+      "Insurance policy expansion to 10 tokens",
+      "Asia regulatory clearance — Singapore + HK",
+      "Series B exploratory conversations"
+    ]
+  },
+  {
+    "title": "Next Steps",
+    "body": [
+      "Action: ship Perp DEX matching engine — Owner: Eng — Due: 2026-10-15",
+      "Action: insurance API beta — Owner: Product — Due: 2026-10-30",
+      "Action: Asia compliance docs — Owner: Legal — Due: 2026-11-10",
+      "Action: B-round pitch deck v1 — Owner: CEO — Due: 2026-11-30"
+    ]
+  }
+]

--- a/sdf-js/scripts/test-atom-catalog.mjs
+++ b/sdf-js/scripts/test-atom-catalog.mjs
@@ -1,0 +1,55 @@
+#!/usr/bin/env node
+// Smoke test for buildAtomCatalogString — Sprint 18 Tier 3 A.1
+import { buildAtomCatalogString, _resetCatalogCache } from '../src/present/atoms-2d/catalog.js';
+
+let pass = 0;
+let fail = 0;
+
+function ok(label, cond) {
+  if (cond) {
+    pass++;
+    console.log('  ✓ ' + label);
+  } else {
+    fail++;
+    console.log('  ✗ ' + label);
+  }
+}
+
+console.log('=== atom-catalog smoke ===');
+
+_resetCatalogCache();
+const s = await buildAtomCatalogString();
+
+ok('returns non-empty string', typeof s === 'string' && s.length > 1000);
+ok('has header', s.includes('Atlas Atom Catalog'));
+ok('has HARD RULE warning about exact keys', s.includes('HARD RULE'));
+
+// Atoms previously emitted with WRONG args (the bug this fixes)
+ok('fishbone entry present', s.includes('`fishbone`'));
+ok(
+  'fishbone has correct args (effect + branches)',
+  /fishbone[\s\S]{0,200}effect[\s\S]{0,200}branches/.test(s),
+);
+ok('timeline entry present', s.includes('`timeline`'));
+ok('timeline has correct args (events not milestones)', /timeline[\s\S]{0,200}events:/.test(s));
+
+// Atoms emitted correctly should also be in catalog
+ok('kpi-card present', s.includes('`kpi-card`'));
+ok('icon-row present', s.includes('`icon-row`'));
+ok('dashboard-multi-kpi-composite present', s.includes('`dashboard-multi-kpi-composite`'));
+ok('cover present', s.includes('`cover`'));
+
+// Categories should be present
+ok('charts/data category present', s.includes('### charts/data'));
+ok('icons category present', s.includes('### icons'));
+ok('presentation category present', s.includes('### presentation'));
+
+// Cache: 2nd call returns identical
+const s2 = await buildAtomCatalogString();
+ok('cached: second call returns same string', s === s2);
+
+// Size sanity: < 50KB so it fits cache budget
+ok('size < 50KB (' + s.length + ' chars)', s.length < 50000);
+
+console.log(`\n=== Result: ${pass} passed, ${fail} failed ===`);
+if (fail > 0) process.exit(1);

--- a/sdf-js/src/present/atoms-2d/catalog.js
+++ b/sdf-js/src/present/atoms-2d/catalog.js
@@ -1,0 +1,93 @@
+// =============================================================================
+// atoms-2d/catalog.js — atom spec catalog string for lift LLM prompt injection
+// -----------------------------------------------------------------------------
+// Sprint 18 Tier 3 A.1 — fixes "LLM guesses wrong arg keys" bug observed in
+// QBR bake (fishbone got `problem`/`categories` vs spec `effect`/`branches`;
+// timeline got `milestones` vs `events` → atoms rendered empty).
+//
+// Outputs a compact, cache-friendly catalog of every registered atom + its
+// args schema, suitable for `cache_control: ephemeral` injection into the
+// scaffold-pipeline lift system prompt.
+//
+// Usage:
+//   import { buildAtomCatalogString } from '.../atoms-2d/catalog.js';
+//   systemPrompt = base + buildAtomCatalogString() + buildIconCatalogString();
+// =============================================================================
+
+import { listAtomTypes, getAtomSpec } from './registry.js';
+
+// In-memory cache so we don't re-load all atom modules on every bake run.
+let _cached = null;
+
+function fmtArg(name, def) {
+  // def: { type, required, default, example, ... }
+  const t = def?.type || 'any';
+  const req = def?.required ? '' : '?';
+  return `${name}${req}: ${t}`;
+}
+
+function fmtArgsBlock(specArgs) {
+  if (!specArgs || typeof specArgs !== 'object') return '';
+  const entries = Object.entries(specArgs);
+  if (entries.length === 0) return '';
+  return entries.map(([k, v]) => fmtArg(k, v)).join(', ');
+}
+
+/**
+ * Build the prompt-injection catalog.
+ *
+ * Format per entry:
+ *   - `atom-type` (category) — description
+ *     args: argName: type, argName?: type, ...
+ *
+ * Atoms grouped by category. Cache result on first call.
+ *
+ * @returns {Promise<string>}
+ */
+export async function buildAtomCatalogString() {
+  if (_cached !== null) return _cached;
+
+  const types = listAtomTypes();
+  const byCategory = new Map();
+
+  for (const type of types) {
+    try {
+      const spec = await getAtomSpec(type);
+      const cat = spec?.category || 'misc';
+      if (!byCategory.has(cat)) byCategory.set(cat, []);
+      byCategory.get(cat).push({ type, spec });
+    } catch (e) {
+      // Skip atoms that fail to load — don't break the prompt builder
+      continue;
+    }
+  }
+
+  const lines = [
+    '## Atlas Atom Catalog — every emit-able atom + its exact args',
+    '',
+    '**HARD RULE**: Use the EXACT arg key names below. Atoms silently render',
+    'empty if you pass wrong keys (e.g. `problem` instead of `effect`).',
+    '',
+  ];
+
+  const sortedCats = [...byCategory.keys()].sort();
+  for (const cat of sortedCats) {
+    lines.push(`### ${cat}`);
+    const items = byCategory.get(cat).sort((a, b) => a.type.localeCompare(b.type));
+    for (const { type, spec } of items) {
+      const desc = (spec.description || '').slice(0, 120);
+      const argsBlock = fmtArgsBlock(spec.args);
+      lines.push(`- \`${type}\` — ${desc}`);
+      if (argsBlock) lines.push(`  args: ${argsBlock}`);
+    }
+    lines.push('');
+  }
+
+  _cached = lines.join('\n');
+  return _cached;
+}
+
+// Test-only reset (called by smoke test to verify rebuild)
+export function _resetCatalogCache() {
+  _cached = null;
+}

--- a/sdf-js/src/present/scaffold-view.js
+++ b/sdf-js/src/present/scaffold-view.js
@@ -25,6 +25,7 @@ import { renderAtom } from './atoms-2d/registry.js';
 import { exportDeckToPPTX } from './exporters/pptx.js';
 import { exportDeckToPDF } from './exporters/pdf.js';
 import { buildIconCatalogString } from '../icons/index.js';
+import { buildAtomCatalogString } from './atoms-2d/catalog.js';
 
 const ANTHROPIC_KEY_STORAGE = 'atlas-anthropic-key';
 const MODEL = 'claude-sonnet-4-5-20250929';
@@ -411,6 +412,8 @@ export async function mountScaffoldView(target, deckId) {
       `# CORE GOAL: Atlas decks are 3D theatrical presentations. TEXT MUST BE MINIMAL. ` +
       `Use icons + charts to replace verbose phrases. Audience reads a slide in ` +
       `≤3 seconds; long prose disappears in 3D space.\n\n` +
+      (await buildAtomCatalogString()) +
+      '\n\n' +
       buildIconCatalogString();
 
     const t0 = Date.now();

--- a/sdf-js/src/scene/chart-labels.js
+++ b/sdf-js/src/scene/chart-labels.js
@@ -107,7 +107,8 @@ export function sphereFillAnchors({
     xs.push(cx);
   }
   const mid = (xs[0] + xs[N - 1]) / 2;
-  const lvl = (i) => (i < levels.length && levels[i] != null ? levels[i] : (levels[levels.length - 1] ?? 0.5));
+  const lvl = (i) =>
+    i < levels.length && levels[i] != null ? levels[i] : (levels[levels.length - 1] ?? 0.5);
   return Array.from({ length: N }, (_, i) => {
     const r = radiusFor(i);
     // Sit the % in the MIDDLE of the coloured liquid (not at the centre/waterline):


### PR DESCRIPTION
## Summary

Sprint 18 Tier 3 A multi-scaffold validation surfaced a real bug: LLM was guessing arg keys for atoms it had never seen specs for. This caused `fishbone` (LLM emitted `problem`/`categories` vs spec `effect`/`branches`) and `timeline` (`milestones` vs `events`) to render as empty white rectangles in the QBR bake — the data was correct semantically, just keyed wrong.

Root cause: lift system prompt only contained `buildIconCatalogString()` (icon names) but had no atom spec catalog. LLM was inventing key names from atom name semantics.

## Fix

New module: `sdf-js/src/present/atoms-2d/catalog.js` exports `buildAtomCatalogString()`:
- Walks the atom registry (`listAtomTypes()`)
- Loads each spec (`getAtomSpec()`)
- Outputs compact 14KB catalog grouped by category, with HARD RULE warning + exact arg keys per atom
- In-memory cached after first call

Wired into both:
- `sdf-js/scripts/bake-scaffold-pipeline.mjs` (CLI bake)
- `sdf-js/src/present/scaffold-view.js` (in-browser flow)

## Validation: re-bake QBR

| | Tier 1+2 FINAL | Tier 3 A.1 (this PR) |
|---|---|---|
| Slots baked | 7/7 | 7/7 |
| Slots that **render** with visible content | **4/7** | **7/7** |
| timeline arg key | `milestones` (wrong → empty) | `events` ✅ |
| timeline.events[0] | n/a | `{date: 'Oct 15', label: 'Perp DEX Matching Engine', sublabel: 'Owner: Eng'}` |
| fishbone | wrong keys → empty | LLM swapped to bullet-list (acceptable safe fallback) |

Visual: `screens/tier3-validation/qbr-tier3a1.png` — all 7 slots now have visible content; previously slots 1, 4, 6 rendered empty white rectangles.

## Tests

- `test-atom-catalog.mjs`: 16 assertions covering fishbone+timeline correct args, cache behavior, size sanity (<50KB)
- npm test: **93/93 PASS**

## Cost impact

- Adds ~14KB to system prompt (~3.5K tokens)
- All `cache_control: ephemeral` so amortized across slot calls within a bake
- Per-deck cost rose marginally: $0.12 → $0.16 (QBR), still well under $0.20

## Out of scope

- LLM dropped fishbone for bullet-list on Challenges this round — could add explicit "use fishbone for cause-analysis slots" guidance in next prompt iteration, not blocking
- `text` atom hallucination still occurs sporadically (1 in 4 bakes) — separate prompt fix

Per CLAUDE.md: DO NOT merge. Awaiting user review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)