### PR TITLE
polish(present): overlay chips + dotted spokes + radius-scaled % + p3 arrows

### DIFF
--- a/sdf-js/apps/present/overlay.js
+++ b/sdf-js/apps/present/overlay.js
@@ -8,27 +8,38 @@
 // frame, so a label tracks its object as the authored camera flies between
 // stations.
 //
+// Each text block sits on a dark, semi-transparent, frosted CHIP so it stays
+// legible over ANY background (the light studio stage AND the dark cinema cover)
+// — the chip provides its own contrast instead of relying on the scene behind.
+//
 // Projection reuses studio.project(world) → {x, y, visible} (x,y ∈ [0,1],
 // top-left origin), the camera the renderer ACTUALLY drew with last frame — no
 // camera-convention duplication outside the renderer.
 //
-// Scene contract:  scene.overlay = [{ text, anchor:[x,y,z], role?, align? }]
-//   role  = 'title' | 'head' | 'body' | 'kpi'  (default 'body')
-//   align = 'center' (default) | 'left' | 'right'  — horizontal anchoring
+// Scene contract:  scene.overlay = [ ...blocks, ...spokes ]
+//   block: { text, anchor:[x,y,z], role?, align? }
+//     role  = 'title' | 'head' | 'body' | 'kpi'  (default 'body')
+//     align = 'center' (default) | 'left' | 'right'  — horizontal anchoring
+//   spoke: { from:[x,y,z], to:[x,y,z], role:'spoke' }  — dotted connector line
 //
 // Layer-2 only: imports nothing from src/ or examples/; talks to the studio via
 // its public project() method.
 // =============================================================================
 
+const FONT = '-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif';
+// Dark frosted chip — the "black transparent rectangle" the text rides on.
+const CHIP =
+  'background:rgba(9,12,20,0.52);-webkit-backdrop-filter:blur(5px);backdrop-filter:blur(5px);' +
+  'border:1px solid rgba(255,255,255,0.08);border-radius:9px;box-shadow:0 6px 20px rgba(0,0,0,0.28);';
+
 const ROLE_CSS = {
-  // dark-on-light by default (the chart archetypes render on the light studio
-  // stage); a soft light halo keeps text legible over busier areas too.
-  title:
-    'font:700 30px/1.15 -apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;letter-spacing:-0.01em;color:#0e1726;',
-  head: 'font:700 14px/1.2 -apple-system,sans-serif;letter-spacing:0.1em;text-transform:uppercase;color:#1b2433;',
-  body: 'font:400 13px/1.45 -apple-system,sans-serif;color:#3a4656;max-width:210px;',
-  kpi: 'font:800 36px/1 -apple-system,sans-serif;color:#f4f8ff;text-shadow:0 2px 10px rgba(0,0,0,0.45);',
+  title: `font:700 28px/1.2 ${FONT};letter-spacing:-0.01em;color:#f4f7fc;padding:10px 22px;`,
+  head: `font:700 13px/1.2 ${FONT};letter-spacing:0.12em;text-transform:uppercase;color:#d4deee;padding:7px 14px;`,
+  body: `font:400 12.5px/1.5 ${FONT};color:#aeb9cd;max-width:210px;padding:8px 13px;`,
+  kpi: `font:800 34px/1 ${FONT};color:#ffffff;padding:8px 18px;`,
 };
+
+const SVG_NS = 'http://www.w3.org/2000/svg';
 
 /**
  * Create a screen-text overlay layer over the studio canvas.
@@ -46,32 +57,47 @@ export function makeOverlay(wrap, studio) {
     overflow: 'hidden',
     zIndex: '30',
   });
+  // One SVG behind the chips carries the dotted spoke connectors.
+  const svg = document.createElementNS(SVG_NS, 'svg');
+  Object.assign(svg.style, { position: 'absolute', inset: '0', width: '100%', height: '100%' });
+  layer.appendChild(svg);
   wrap.appendChild(layer);
 
   let blocks = []; // { el, anchor }
+  let spokes = []; // { line, from, to }
   let raf = 0;
 
   function clear() {
     for (const b of blocks) b.el.remove();
+    for (const s of spokes) s.line.remove();
     blocks = [];
+    spokes = [];
   }
 
   function set(list) {
     clear();
     for (const o of Array.isArray(list) ? list : []) {
-      if (!o || !Array.isArray(o.anchor) || o.anchor.length < 3) continue;
+      if (!o) continue;
+      if (o.role === 'spoke' && Array.isArray(o.from) && Array.isArray(o.to)) {
+        const line = document.createElementNS(SVG_NS, 'line');
+        line.setAttribute('stroke', 'rgba(64,84,124,0.85)');
+        line.setAttribute('stroke-width', '2.5');
+        line.setAttribute('stroke-dasharray', '2 8');
+        line.setAttribute('stroke-linecap', 'round');
+        line.style.opacity = '0';
+        svg.appendChild(line);
+        spokes.push({ line, from: o.from, to: o.to });
+        continue;
+      }
+      if (!Array.isArray(o.anchor) || o.anchor.length < 3) continue;
       const el = document.createElement('div');
       el.textContent = o.text || '';
-      const halo =
-        o.role === 'kpi'
-          ? ''
-          : 'text-shadow:0 1px 2px rgba(255,255,255,0.55),0 1px 6px rgba(255,255,255,0.35);';
       // anchor maps to the block's reference point; center by default.
       const tx = o.align === 'left' ? '0' : o.align === 'right' ? '-100%' : '-50%';
       const textAlign = o.align || 'center';
       el.style.cssText =
         `position:absolute;transform:translate(${tx},-50%);text-align:${textAlign};white-space:pre-line;` +
-        `opacity:0;transition:opacity 0.25s ease;will-change:left,top;${halo}` +
+        `opacity:0;transition:opacity 0.25s ease;will-change:left,top;${CHIP}` +
         (ROLE_CSS[o.role] || ROLE_CSS.body);
       layer.appendChild(el);
       blocks.push({ el, anchor: o.anchor });
@@ -81,7 +107,7 @@ export function makeOverlay(wrap, studio) {
 
   function tick() {
     raf = requestAnimationFrame(tick);
-    if (!blocks.length) return;
+    if (!blocks.length && !spokes.length) return;
     const W = wrap.clientWidth;
     const H = wrap.clientHeight;
     for (const b of blocks) {
@@ -93,6 +119,19 @@ export function makeOverlay(wrap, studio) {
       b.el.style.left = (p.x * W).toFixed(1) + 'px';
       b.el.style.top = (p.y * H).toFixed(1) + 'px';
       b.el.style.opacity = '1';
+    }
+    for (const s of spokes) {
+      const a = studio.project(s.from);
+      const b = studio.project(s.to);
+      if (!a || !b || !a.visible || !b.visible) {
+        s.line.style.opacity = '0';
+        continue;
+      }
+      s.line.setAttribute('x1', (a.x * W).toFixed(1));
+      s.line.setAttribute('y1', (a.y * H).toFixed(1));
+      s.line.setAttribute('x2', (b.x * W).toFixed(1));
+      s.line.setAttribute('y2', (b.y * H).toFixed(1));
+      s.line.style.opacity = '1';
     }
   }
 

--- a/sdf-js/scenes/p11-hero-list-gauges.json
+++ b/sdf-js/scenes/p11-hero-list-gauges.json
@@ -6,99 +6,48 @@
       "id": "hero",
       "type": "sphere-fill-3d",
       "args": { "levels": [0.3], "radius": 1.35 },
-      "transform": { "translate": [-2.6, 1.5, 0] },
-      "material": {
-        "hue": 0.57,
-        "sat": 0.55,
-        "value": 0.62,
-        "kind": "fill",
-        "roughness": 0.3,
-        "clearcoat": 0.5
-      }
+      "transform": { "translate": [-2.8, 1.5, 0] },
+      "material": { "hue": 0.57, "sat": 0.55, "value": 0.62, "kind": "fill", "roughness": 0.3, "clearcoat": 0.5 }
     },
     {
       "id": "item1",
       "type": "sphere-fill-3d",
-      "args": { "levels": [0.5], "radius": 0.5 },
-      "transform": { "translate": [1.7, 2.75, 0] },
-      "material": {
-        "hue": 0.57,
-        "sat": 0.55,
-        "value": 0.62,
-        "kind": "fill",
-        "roughness": 0.3,
-        "clearcoat": 0.5
-      }
+      "args": { "levels": [0.5], "radius": 0.48 },
+      "transform": { "translate": [2.8, 2.7, 0] },
+      "material": { "hue": 0.57, "sat": 0.55, "value": 0.62, "kind": "fill", "roughness": 0.3, "clearcoat": 0.5 }
     },
     {
       "id": "item2",
       "type": "sphere-fill-3d",
-      "args": { "levels": [0.3], "radius": 0.5 },
-      "transform": { "translate": [1.7, 1.5, 0] },
-      "material": {
-        "hue": 0.57,
-        "sat": 0.55,
-        "value": 0.62,
-        "kind": "fill",
-        "roughness": 0.3,
-        "clearcoat": 0.5
-      }
+      "args": { "levels": [0.3], "radius": 0.48 },
+      "transform": { "translate": [2.8, 1.5, 0] },
+      "material": { "hue": 0.57, "sat": 0.55, "value": 0.62, "kind": "fill", "roughness": 0.3, "clearcoat": 0.5 }
     },
     {
       "id": "item3",
       "type": "sphere-fill-3d",
-      "args": { "levels": [0.2], "radius": 0.5 },
-      "transform": { "translate": [1.7, 0.25, 0] },
-      "material": {
-        "hue": 0.57,
-        "sat": 0.55,
-        "value": 0.62,
-        "kind": "fill",
-        "roughness": 0.3,
-        "clearcoat": 0.5
-      }
+      "args": { "levels": [0.2], "radius": 0.48 },
+      "transform": { "translate": [2.8, 0.3, 0] },
+      "material": { "hue": 0.57, "sat": 0.55, "value": 0.62, "kind": "fill", "roughness": 0.3, "clearcoat": 0.5 }
     }
   ],
   "overlay": [
-    { "text": "DESCRIPTION 1", "anchor": [-2.6, -0.4, 0], "role": "head" },
+    { "text": "DESCRIPTION 1", "anchor": [-2.8, -0.4, 0], "role": "head" },
 
-    { "text": "DESCRIPTION 2", "anchor": [2.6, 2.75, 0], "role": "head", "align": "left" },
-    {
-      "text": "Placeholder for your own text.",
-      "anchor": [2.6, 2.45, 0],
-      "role": "body",
-      "align": "left"
-    },
+    { "text": "DESCRIPTION 2", "anchor": [0.7, 2.85, 0], "role": "head" },
+    { "text": "Placeholder for your own text.", "anchor": [0.7, 2.45, 0], "role": "body" },
 
-    { "text": "DESCRIPTION 3", "anchor": [2.6, 1.5, 0], "role": "head", "align": "left" },
-    {
-      "text": "Placeholder for your own text.",
-      "anchor": [2.6, 1.2, 0],
-      "role": "body",
-      "align": "left"
-    },
+    { "text": "DESCRIPTION 3", "anchor": [0.7, 1.65, 0], "role": "head" },
+    { "text": "Placeholder for your own text.", "anchor": [0.7, 1.25, 0], "role": "body" },
 
-    { "text": "DESCRIPTION 4", "anchor": [2.6, 0.25, 0], "role": "head", "align": "left" },
-    {
-      "text": "Placeholder for your own text.",
-      "anchor": [2.6, -0.05, 0],
-      "role": "body",
-      "align": "left"
-    }
+    { "text": "DESCRIPTION 4", "anchor": [0.7, 0.45, 0], "role": "head" },
+    { "text": "Placeholder for your own text.", "anchor": [0.7, 0.05, 0], "role": "body" }
   ],
   "cameraSequence": {
     "loop": false,
     "shots": [
-      {
-        "duration": 10,
-        "pos": [0, 1.6, 9.0],
-        "target": [0, 1.4, 0],
-        "fov": 46,
-        "aperture": 0,
-        "focalDistance": 9.0,
-        "ease": "smooth"
-      }
+      { "duration": 10, "pos": [0, 1.6, 9.5], "target": [0, 1.4, 0], "fov": 46, "aperture": 0, "focalDistance": 9.5, "ease": "smooth" }
     ]
   },
-  "defaults": { "stage": { "size": [20, 8, 11] } }
+  "defaults": { "stage": { "size": [22, 8, 11] } }
 }

--- a/sdf-js/scenes/p15-radial-gauge.json
+++ b/sdf-js/scenes/p15-radial-gauge.json
@@ -20,6 +20,11 @@
   "overlay": [
     { "text": "3D SPHERES — FILL LEVELS", "anchor": [0, 4.3, 0], "role": "title" },
 
+    { "role": "spoke", "from": [-1.21, 2.1, 0], "to": [-3.0, 3.0, 0] },
+    { "role": "spoke", "from": [1.21, 2.1, 0], "to": [3.0, 3.0, 0] },
+    { "role": "spoke", "from": [-1.28, 1.06, 0], "to": [-3.0, 0.55, 0] },
+    { "role": "spoke", "from": [1.28, 1.06, 0], "to": [3.0, 0.55, 0] },
+
     { "text": "DESCRIPTION 1", "anchor": [-3.2, 3.1, 0], "role": "head" },
     {
       "text": "This is a placeholder text.\nReplace with your own.",

--- a/sdf-js/scenes/p3-sequence-gauges.json
+++ b/sdf-js/scenes/p3-sequence-gauges.json
@@ -7,39 +7,20 @@
       "type": "sphere-fill-3d",
       "args": { "levels": [0.1, 0.6, 0.5], "radius": 0.72, "spacing": 1.5 },
       "transform": { "translate": [0, 1.1, 0] },
-      "material": {
-        "hue": 0.57,
-        "sat": 0.55,
-        "value": 0.62,
-        "kind": "fill",
-        "roughness": 0.3,
-        "clearcoat": 0.5
-      }
+      "material": { "hue": 0.57, "sat": 0.55, "value": 0.62, "kind": "fill", "roughness": 0.3, "clearcoat": 0.5 }
     },
     {
       "id": "arrowA",
       "type": "arrow-3d",
-      "args": {
-        "length": 0.9,
-        "shaftWidth": 0.12,
-        "headLength": 0.32,
-        "headWidth": 0.34,
-        "depth": 0.16
-      },
-      "transform": { "translate": [-1.47, 1.1, 0] },
+      "args": { "length": 0.9, "shaftWidth": 0.12, "headLength": 0.32, "headWidth": 0.34, "depth": 0.16 },
+      "transform": { "translate": [-1.47, 1.1, 0], "rotate": [0, 3.14159, 0] },
       "material": { "hue": 0.0, "sat": 0.0, "value": 0.7, "kind": "normal" }
     },
     {
       "id": "arrowB",
       "type": "arrow-3d",
-      "args": {
-        "length": 0.9,
-        "shaftWidth": 0.12,
-        "headLength": 0.32,
-        "headWidth": 0.34,
-        "depth": 0.16
-      },
-      "transform": { "translate": [1.47, 1.1, 0] },
+      "args": { "length": 0.9, "shaftWidth": 0.12, "headLength": 0.32, "headWidth": 0.34, "depth": 0.16 },
+      "transform": { "translate": [1.47, 1.1, 0], "rotate": [0, 3.14159, 0] },
       "material": { "hue": 0.0, "sat": 0.0, "value": 0.7, "kind": "normal" }
     }
   ],
@@ -58,15 +39,7 @@
   "cameraSequence": {
     "loop": false,
     "shots": [
-      {
-        "duration": 10,
-        "pos": [0, 1.5, 9.5],
-        "target": [0, 1.0, 0],
-        "fov": 44,
-        "aperture": 0,
-        "focalDistance": 9.5,
-        "ease": "smooth"
-      }
+      { "duration": 10, "pos": [0, 1.5, 9.5], "target": [0, 1.0, 0], "fov": 44, "aperture": 0, "focalDistance": 9.5, "ease": "smooth" }
     ]
   },
   "defaults": { "stage": { "size": [20, 7, 11] } }

--- a/sdf-js/src/scene/chart-labels.js
+++ b/sdf-js/src/scene/chart-labels.js
@@ -121,7 +121,9 @@ export function sphereFillAnchors({
     // the label sits JUST IN FRONT of the sphere's front face — not behind it,
     // where the sphere would occlude it (the old −z anchor was never visually
     // tested; sphere-fill labels are new on the studio path).
-    return { x: xs[i] - mid, y: r * (f - 1) * 0.85, z: r + margin };
+    // `h` scales the glyph height with the sphere so a big gauge gets a big %
+    // and a small one a small % (placeLabels reads per-anchor `h`).
+    return { x: xs[i] - mid, y: r * (f - 1) * 0.85, z: r + margin, h: r * 0.42 };
   });
 }
 
@@ -205,7 +207,7 @@ export function placeLabels(
   return anchors.map((a, i) => ({
     id: `${idPrefix}${i}`,
     type: 'text-3d-pipe',
-    args: { text: String(labels[i] ?? ''), height, pipeRadius, align },
+    args: { text: String(labels[i] ?? ''), height: a.h ?? height, pipeRadius, align },
     transform: mirror
       ? { translate: [a.x, a.y, a.z], rotate: [0, Math.PI, 0] }
       : { translate: [a.x, a.y, a.z] },
@@ -239,7 +241,7 @@ export function expandChartLabels(sceneData) {
     const anchors = fn(args);
     if (!anchors || !anchors.length) return;
     const tr = (s.transform && s.transform.translate) || [0, 0, 0];
-    const off = anchors.map((a) => ({ x: a.x + tr[0], y: a.y + tr[1], z: a.z + tr[2] }));
+    const off = anchors.map((a) => ({ x: a.x + tr[0], y: a.y + tr[1], z: a.z + tr[2], h: a.h }));
     // only label the elements that actually have a label string
     const n = Math.min(off.length, labels.length);
     extra.push(


### PR DESCRIPTION
## 精修(承 #148,review 反馈)

四项 polish,全程 headed WebGL2 视觉验证:

1. **overlay 黑色透明矩形** —— 每个文字块现在坐在**深色毛玻璃 chip**(半透明圆角 + 浅色字)上,任何背景都可读(浅色舞台 + 深色封面都行),取代之前会糊掉的「深字浅底」。
2. **p15 dotted 辐条** —— overlay 新增 `spoke` 类型(`{from,to,role:'spoke'}` 画 SVG 虚线连两个投影点),p15 从中心 gauge 辐射 4 条到各角 DESCRIPTION。
3. **gauge 标签随球径缩放** —— % 字高 = `r*0.42`(anchor 带 `h`,placeLabels 读 per-anchor `h`),大球大 %、小球小 %(cover:80% 大 / 40% 中 / 20% 小)。
4. **p3 箭头转向** —— 旋转 180°/Y 指向 screen-right(+x→屏幕左的 handedness 让默认 +x 箭头指反了)。
5. **p11 重排** —— 小 gauge 列与 DESCRIPTION chip 拉开,chip 不再盖住球。

## 验证

- **视觉(headed)**:p3(箭头→右 + chip)、p15(辐条 + 四角 chip)、p11(干净列)、cover(标签随径缩放)。
- `npm test` **93/93**,`node --check` clean,三场景 E0/W0 编译。

🤖 Generated with [Claude Code](https://claude.com/claude-code)