### PR TITLE
chore: gitignore .playwright-mcp/ (Playwright MCP scratch artifacts)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ node_modules/
 # 产物
 *.stl
 .gstack/
+.playwright-mcp/
 
 # Test fixtures: real-world PDFs/PPTXs may be copyrighted templates — kept
 # local only. Pre-parsed baked JSON (e.g. pdf-mapping-data.json) ships in the


### PR DESCRIPTION
Playwright MCP writes page snapshots / console logs / screenshots into `.playwright-mcp/` at the repo root — ignore them. Playwright is now the studio visual-verification path (its Chromium has WebGL2, unlike the gstack headless daemon which rendered blank).

🤖 Generated with [Claude Code](https://claude.com/claude-code)