### PR TITLE
Sprint 18 Tier 3 C: image + image-split atoms (PL hero + full-bleed)

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -162,6 +162,7 @@ const TESTS = [
   { category: 'present', file: 'sdf-js/scripts/test-icon-library-expanded.mjs' },
   { category: 'present', file: 'sdf-js/scripts/test-atoms-icons.mjs' },
   { category: 'present', file: 'sdf-js/scripts/test-atom-catalog.mjs' },
+  { category: 'present', file: 'sdf-js/scripts/test-atoms-image.mjs' },
 ];
 
 // -----------------------------------------------------------------------------

--- a/sdf-js/scripts/bake-scaffold-pipeline.mjs
+++ b/sdf-js/scripts/bake-scaffold-pipeline.mjs
@@ -463,10 +463,10 @@ for (const a of slotAssignments) {
     `    - 2-set comparison slots (Before/After / Us vs Them) → \`venn\` or side-by-side kpi-cards\n` +
     `    Specialized atoms communicate semantics in 3D theatrical playback — bullet-list reads as "they had no better atom".\n` +
     `14. **NEVER emit \`type: "text"\`** — there is NO text atom. For corner attribution (author / date / version) use cover's \`author\`/\`date\`/\`version\` args. For floating labels INSIDE a chart, set the chart atom's title/labels args. If you can't express something via an atom + its args, omit it.\n` +
-    `15. **Image atoms (Sprint 18 Tier 3 C)** — use when content describes a visual subject AND a URL is present in the source:\n` +
-    `    - Hero slot with a single dominant photo + title/body/bullets → \`image-split\` (image one side, text other side; PL hero pattern)\n` +
-    `    - Full-bleed background photo with overlay caption → \`image\` with fit:'cover'\n` +
-    `    - For src URL: ONLY use URLs that appear in slide.body (look for "image:" or "https://images." or "https://picsum." prefixes). If no URL is in source, OMIT image atoms — DO NOT fabricate URLs that will 404.\n` +
+    `15. **Image atoms (Sprint 18 Tier 3 C)** — strictly bound to images that were ALREADY embedded in the user's source document. We do NOT call image-generation models, we do NOT search the internet for stock photos:\n` +
+    `    - Use ONLY when slide.body contains an explicit src for an image the user already had (look for "image:" lines pointing to data: URIs, OR relative paths the parser emitted from embedded images).\n` +
+    `    - If no such src exists in source, OMIT image atoms entirely. NEVER fabricate URLs. NEVER add picsum / unsplash / any internet host. NEVER write "image: https://..." that isn't in the source.\n` +
+    `    - When you DO have a valid src: hero slot with one dominant image + title/body/bullets → \`image-split\`; full-bleed photo with caption → \`image\` (fit:'cover').\n` +
     `    - DO NOT use image atoms for purely numeric / list / process content — specialized atoms (kpi-card / fishbone / timeline / flow-chart) are better.\n`;
 
   if (DRY_RUN) {

--- a/sdf-js/scripts/bake-scaffold-pipeline.mjs
+++ b/sdf-js/scripts/bake-scaffold-pipeline.mjs
@@ -462,7 +462,12 @@ for (const a of slotAssignments) {
     `    - process / workflow slots (How It Works / Pipeline) → \`flow-chart\` or \`progression\`\n` +
     `    - 2-set comparison slots (Before/After / Us vs Them) → \`venn\` or side-by-side kpi-cards\n` +
     `    Specialized atoms communicate semantics in 3D theatrical playback — bullet-list reads as "they had no better atom".\n` +
-    `14. **NEVER emit \`type: "text"\`** — there is NO text atom. For corner attribution (author / date / version) use cover's \`author\`/\`date\`/\`version\` args. For floating labels INSIDE a chart, set the chart atom's title/labels args. If you can't express something via an atom + its args, omit it.\n`;
+    `14. **NEVER emit \`type: "text"\`** — there is NO text atom. For corner attribution (author / date / version) use cover's \`author\`/\`date\`/\`version\` args. For floating labels INSIDE a chart, set the chart atom's title/labels args. If you can't express something via an atom + its args, omit it.\n` +
+    `15. **Image atoms (Sprint 18 Tier 3 C)** — use when content describes a visual subject AND a URL is present in the source:\n` +
+    `    - Hero slot with a single dominant photo + title/body/bullets → \`image-split\` (image one side, text other side; PL hero pattern)\n` +
+    `    - Full-bleed background photo with overlay caption → \`image\` with fit:'cover'\n` +
+    `    - For src URL: ONLY use URLs that appear in slide.body (look for "image:" or "https://images." or "https://picsum." prefixes). If no URL is in source, OMIT image atoms — DO NOT fabricate URLs that will 404.\n` +
+    `    - DO NOT use image atoms for purely numeric / list / process content — specialized atoms (kpi-card / fishbone / timeline / flow-chart) are better.\n`;
 
   if (DRY_RUN) {
     slotLifts.push({

--- a/sdf-js/scripts/scaffold-pipeline-fixtures/yosemite-trip-2026.json
+++ b/sdf-js/scripts/scaffold-pipeline-fixtures/yosemite-trip-2026.json
@@ -4,7 +4,7 @@
     "body": [
       "5-day backcountry + valley itinerary",
       "September 2026 — group of 4",
-      "image: https://picsum.photos/seed/yosemite/1280/720"
+      "image: data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 640 360'><defs><linearGradient id='g' x1='0' y1='0' x2='0' y2='1'><stop offset='0' stop-color='%23ffa654'/><stop offset='1' stop-color='%23c44a4a'/></linearGradient></defs><rect width='640' height='360' fill='url(%23g)'/><polygon fill='%23332244' points='0,360 120,180 220,260 340,160 460,250 560,140 640,220 640,360'/><text x='320' y='340' fill='white' font-size='14' text-anchor='middle' opacity='0.6'>Yosemite valley sunrise (embedded photo placeholder)</text></svg>"
     ]
   },
   {
@@ -12,7 +12,6 @@
     "body": [
       "Spend 3 days in the high country and 2 in the valley",
       "Mix of granite peaks, alpine lakes, and big waterfalls",
-      "image: https://picsum.photos/seed/granite/1280/720",
       "Cover ~45 trail miles total at a relaxed pace"
     ]
   },
@@ -20,7 +19,7 @@
     "title": "El Capitan",
     "body": [
       "Day 2 — granite monolith on the north side of Yosemite Valley",
-      "image: https://picsum.photos/seed/elcapitan/1280/720",
+      "image: data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 640 360'><rect width='640' height='360' fill='%23b8c8d8'/><polygon fill='%23556677' points='80,360 240,40 320,360'/><polygon fill='%23445566' points='240,40 320,360 380,360'/><circle cx='500' cy='80' r='28' fill='%23ffe' opacity='0.7'/><text x='320' y='340' fill='%23223' font-size='14' text-anchor='middle' opacity='0.55'>El Capitan (embedded photo placeholder)</text></svg>",
       "Hiked the base trail (3 miles round trip)",
       "Spotted 4 climbers attempting the Nose route"
     ]
@@ -29,7 +28,6 @@
     "title": "Tuolumne Meadows",
     "body": [
       "Day 3 — alpine meadow at 8,600 ft elevation",
-      "image: https://picsum.photos/seed/meadows/1280/720",
       "Set up camp by Cathedral Lake",
       "Stargazing was incredible — Milky Way crystal clear"
     ]
@@ -38,7 +36,7 @@
     "title": "Half Dome Ascent",
     "body": [
       "Day 4 — summit climb via the cables route",
-      "image: https://picsum.photos/seed/halfdome/1280/720",
+      "image: data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 640 360'><defs><linearGradient id='sky' x1='0' y1='0' x2='0' y2='1'><stop offset='0' stop-color='%2370a0d0'/><stop offset='1' stop-color='%23ffe0a0'/></linearGradient></defs><rect width='640' height='360' fill='url(%23sky)'/><path fill='%23667780' d='M40,360 Q 140,180 260,260 Q 360,330 460,200 Q 540,140 640,260 L 640,360 Z'/><circle cx='100' cy='80' r='35' fill='%23ffeebb' opacity='0.9'/><text x='320' y='340' fill='%23223' font-size='14' text-anchor='middle' opacity='0.55'>Half Dome summit (embedded photo placeholder)</text></svg>",
       "16 miles round trip, ~10 hours total",
       "Cables were busy but manageable — early start at 4am"
     ]
@@ -57,7 +55,6 @@
     "title": "What's Next",
     "body": [
       "Plan: return spring 2027 for the waterfall season",
-      "image: https://picsum.photos/seed/waterfall/1280/720",
       "Permits open Jan 2027 — set calendar reminders",
       "Bring a real camera this time, not just phone"
     ]

--- a/sdf-js/scripts/scaffold-pipeline-fixtures/yosemite-trip-2026.json
+++ b/sdf-js/scripts/scaffold-pipeline-fixtures/yosemite-trip-2026.json
@@ -1,0 +1,65 @@
+[
+  {
+    "title": "Yosemite Trip Report",
+    "body": [
+      "5-day backcountry + valley itinerary",
+      "September 2026 — group of 4",
+      "image: https://picsum.photos/seed/yosemite/1280/720"
+    ]
+  },
+  {
+    "title": "Our Goal",
+    "body": [
+      "Spend 3 days in the high country and 2 in the valley",
+      "Mix of granite peaks, alpine lakes, and big waterfalls",
+      "image: https://picsum.photos/seed/granite/1280/720",
+      "Cover ~45 trail miles total at a relaxed pace"
+    ]
+  },
+  {
+    "title": "El Capitan",
+    "body": [
+      "Day 2 — granite monolith on the north side of Yosemite Valley",
+      "image: https://picsum.photos/seed/elcapitan/1280/720",
+      "Hiked the base trail (3 miles round trip)",
+      "Spotted 4 climbers attempting the Nose route"
+    ]
+  },
+  {
+    "title": "Tuolumne Meadows",
+    "body": [
+      "Day 3 — alpine meadow at 8,600 ft elevation",
+      "image: https://picsum.photos/seed/meadows/1280/720",
+      "Set up camp by Cathedral Lake",
+      "Stargazing was incredible — Milky Way crystal clear"
+    ]
+  },
+  {
+    "title": "Half Dome Ascent",
+    "body": [
+      "Day 4 — summit climb via the cables route",
+      "image: https://picsum.photos/seed/halfdome/1280/720",
+      "16 miles round trip, ~10 hours total",
+      "Cables were busy but manageable — early start at 4am"
+    ]
+  },
+  {
+    "title": "Trip Stats",
+    "body": [
+      "Total miles hiked: 47",
+      "Elevation gain: 11,200 ft",
+      "Photos taken: 1,432",
+      "Best day: Half Dome (no contest)",
+      "Worst moment: dropped phone at Glacier Point lookout"
+    ]
+  },
+  {
+    "title": "What's Next",
+    "body": [
+      "Plan: return spring 2027 for the waterfall season",
+      "image: https://picsum.photos/seed/waterfall/1280/720",
+      "Permits open Jan 2027 — set calendar reminders",
+      "Bring a real camera this time, not just phone"
+    ]
+  }
+]

--- a/sdf-js/scripts/test-atoms-image.mjs
+++ b/sdf-js/scripts/test-atoms-image.mjs
@@ -1,0 +1,101 @@
+#!/usr/bin/env node
+// Smoke test for image + image-split atoms (Sprint 18 Tier 3 C).
+import { isAtom2DType, getAtomSpec, renderAtom } from '../src/present/atoms-2d/registry.js';
+import { buildAtomCatalogString, _resetCatalogCache } from '../src/present/atoms-2d/catalog.js';
+
+let pass = 0;
+let fail = 0;
+
+function ok(label, cond) {
+  if (cond) {
+    pass++;
+    console.log('  ✓ ' + label);
+  } else {
+    fail++;
+    console.log('  ✗ ' + label);
+  }
+}
+
+console.log('=== atoms-image smoke ===');
+
+// Registration
+ok('image atom registered', isAtom2DType('image'));
+ok('image-split atom registered', isAtom2DType('image-split'));
+
+// Specs
+const imgSpec = await getAtomSpec('image');
+const splitSpec = await getAtomSpec('image-split');
+
+ok('image spec has src as required', imgSpec.args.src?.required === true);
+ok('image spec has fit arg', imgSpec.args.fit?.type?.includes('cover'));
+ok('image spec has caption arg', 'caption' in imgSpec.args);
+ok('image spec has borderRadius arg', 'borderRadius' in imgSpec.args);
+
+ok('image-split spec has src as required', splitSpec.args.src?.required === true);
+ok('image-split spec has title as required', splitSpec.args.title?.required === true);
+ok('image-split spec has bullets arg', 'bullets' in splitSpec.args);
+ok('image-split spec has imageSide arg', 'imageSide' in splitSpec.args);
+
+// Catalog auto-pickup
+_resetCatalogCache();
+const catalog = await buildAtomCatalogString();
+ok('atom catalog includes image entry', catalog.includes('`image`'));
+ok('atom catalog includes image-split entry', catalog.includes('`image-split`'));
+ok('atom catalog has media category', catalog.includes('### media'));
+
+// Node-env render: doesn't throw, returns promise that resolves
+const stubCtx = {
+  save() {},
+  restore() {},
+  beginPath() {},
+  moveTo() {},
+  lineTo() {},
+  quadraticCurveTo() {},
+  closePath() {},
+  clip() {},
+  fillRect() {},
+  fillText() {},
+  measureText() {
+    return { width: 50 };
+  },
+  drawImage() {},
+  createLinearGradient() {
+    return { addColorStop() {} };
+  },
+  arc() {},
+  fill() {},
+  set fillStyle(_v) {},
+  set font(_v) {},
+  set textAlign(_v) {},
+  set textBaseline(_v) {},
+};
+
+const r1 = renderAtom(
+  stubCtx,
+  'image',
+  { src: 'https://picsum.photos/seed/test/640/360' },
+  'pseudo3d',
+  { x: 0, y: 0, w: 640, h: 360 },
+);
+ok('image render returns a Promise', r1 instanceof Promise);
+await r1;
+ok('image render resolves (Node placeholder path)', true);
+
+const r2 = renderAtom(
+  stubCtx,
+  'image-split',
+  {
+    src: 'https://picsum.photos/seed/test/640/360',
+    title: 'Hello',
+    body: 'Test body',
+    bullets: ['one', 'two'],
+  },
+  'pseudo3d',
+  { x: 0, y: 0, w: 1280, h: 480, palette: { accent: [60, 100, 200] } },
+);
+ok('image-split render returns a Promise', r2 instanceof Promise);
+await r2;
+ok('image-split render resolves (Node placeholder path)', true);
+
+console.log(`\n=== Result: ${pass} passed, ${fail} failed ===`);
+if (fail > 0) process.exit(1);

--- a/sdf-js/src/present/atoms-2d/media/image-split.js
+++ b/sdf-js/src/present/atoms-2d/media/image-split.js
@@ -20,12 +20,14 @@ import { drawPseudo3D as drawImage } from './image.js';
 export const spec = {
   type: 'image-split',
   category: 'media',
-  description: 'Hero split: image on one side, text + bullets on the other. PL hero pattern.',
+  description:
+    'Hero split: image on one side, text + bullets on the other. PL hero pattern. src MUST be a data: URI or parser-emitted relative path from an embedded image in the source — never an internet URL or generated photo.',
   args: {
     src: {
-      type: 'string (URL)',
+      type: 'string (data: URI or parser-emitted relative path)',
       required: true,
-      example: 'https://images.unsplash.com/photo-1497436072909-60f360e1d4b1?w=1280',
+      example:
+        'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVQIHWNgIBb8BwABKAEBwGDOlAAAAABJRU5ErkJggg==',
     },
     title: { type: 'string', required: true, example: 'Our Mission' },
     body: { type: 'string?', example: 'Make on-chain trading natural.' },

--- a/sdf-js/src/present/atoms-2d/media/image-split.js
+++ b/sdf-js/src/present/atoms-2d/media/image-split.js
@@ -1,0 +1,137 @@
+// =============================================================================
+// atoms-2d/media/image-split.js — Hero image-text split atom (PL pattern)
+// -----------------------------------------------------------------------------
+// Sprint 18 Tier 3 C — closes structural gap vs PL D3180 reference benchmark.
+//
+// Semantic: PL hero split — image on one side, title + body + bullets on the
+// other. Used for "Our Mission" / "About Us" / "Why Now" hero slides.
+//
+// Args:
+//   src            — image URL (required)
+//   title          — heading (required)
+//   body           — optional body paragraph
+//   bullets        — optional bullets[]
+//   imageSide      — 'left'|'right' (default 'left')
+//   imageWidthPct  — 0-1 fraction of slot width for image (default 0.5)
+// =============================================================================
+
+import { drawPseudo3D as drawImage } from './image.js';
+
+export const spec = {
+  type: 'image-split',
+  category: 'media',
+  description: 'Hero split: image on one side, text + bullets on the other. PL hero pattern.',
+  args: {
+    src: {
+      type: 'string (URL)',
+      required: true,
+      example: 'https://images.unsplash.com/photo-1497436072909-60f360e1d4b1?w=1280',
+    },
+    title: { type: 'string', required: true, example: 'Our Mission' },
+    body: { type: 'string?', example: 'Make on-chain trading natural.' },
+    bullets: {
+      type: 'string[]?',
+      example: ['Self-custodial', 'Multi-chain', '24/7 support'],
+    },
+    imageSide: { type: "'left'|'right'?", default: "'left'", example: 'left' },
+    imageWidthPct: { type: 'number? (0-1)', default: 0.5, example: 0.5 },
+  },
+};
+
+const PAD = 28;
+
+function drawTextSide(ctx, x, y, w, h, args, palette) {
+  const accent = palette.accent || [60, 100, 200];
+  const accentCss = `rgb(${Math.round(accent[0])},${Math.round(accent[1])},${Math.round(accent[2])})`;
+
+  const titleSize = Math.max(20, Math.min(Math.round(h * 0.11), 44));
+  const bodySize = Math.max(12, Math.min(Math.round(h * 0.055), 18));
+  const bulletSize = Math.max(11, Math.min(Math.round(h * 0.045), 15));
+
+  let cy = y + PAD;
+
+  // Title
+  ctx.fillStyle = 'rgba(20,20,30,0.92)';
+  ctx.font = `700 ${titleSize}px "Inter Display", Inter, system-ui, sans-serif`;
+  ctx.textAlign = 'left';
+  ctx.textBaseline = 'top';
+  ctx.fillText(String(args.title || ''), x + PAD, cy);
+  cy += titleSize + 12;
+
+  // Accent rule under title
+  ctx.fillStyle = accentCss;
+  ctx.fillRect(x + PAD, cy, 48, 3);
+  cy += 14;
+
+  // Body
+  if (args.body) {
+    ctx.fillStyle = 'rgba(40,40,50,0.75)';
+    ctx.font = `500 ${bodySize}px Inter, system-ui, sans-serif`;
+    // Simple word-wrap
+    const words = String(args.body).split(/\s+/);
+    const maxW = w - PAD * 2;
+    let line = '';
+    for (const word of words) {
+      const test = line ? line + ' ' + word : word;
+      if (ctx.measureText(test).width > maxW && line) {
+        ctx.fillText(line, x + PAD, cy);
+        cy += bodySize + 4;
+        line = word;
+      } else {
+        line = test;
+      }
+    }
+    if (line) {
+      ctx.fillText(line, x + PAD, cy);
+      cy += bodySize + 4;
+    }
+    cy += 8;
+  }
+
+  // Bullets
+  if (Array.isArray(args.bullets) && args.bullets.length > 0) {
+    ctx.font = `600 ${bulletSize}px Inter, system-ui, sans-serif`;
+    const rowH = bulletSize + 10;
+    const bulletDotR = Math.max(3, bulletSize * 0.28);
+    for (const bullet of args.bullets) {
+      if (cy + rowH > y + h - PAD) break;
+      // accent dot
+      ctx.fillStyle = accentCss;
+      ctx.beginPath();
+      ctx.arc(x + PAD + bulletDotR, cy + bulletSize / 2, bulletDotR, 0, Math.PI * 2);
+      ctx.fill();
+      // label
+      ctx.fillStyle = 'rgba(30,30,40,0.88)';
+      ctx.textBaseline = 'middle';
+      ctx.fillText(String(bullet), x + PAD + bulletDotR * 2 + 10, cy + bulletSize / 2 + 1);
+      cy += rowH;
+    }
+  }
+}
+
+export async function drawPseudo3D(ctx, args, opts = {}) {
+  const x = opts.x ?? 0;
+  const y = opts.y ?? 0;
+  const w = opts.w ?? 1280;
+  const h = opts.h ?? 480;
+  const palette = opts.palette || {};
+
+  const imageSide = args.imageSide || 'left';
+  const imageWidthPct = Math.max(0.25, Math.min(0.75, args.imageWidthPct ?? 0.5));
+
+  const imgW = Math.round(w * imageWidthPct);
+  const textW = w - imgW;
+
+  const imgX = imageSide === 'left' ? x : x + textW;
+  const textX = imageSide === 'left' ? x + imgW : x;
+
+  // Text-side background (subtle off-white panel)
+  ctx.fillStyle = 'rgba(248,248,251,1)';
+  ctx.fillRect(textX, y, textW, h);
+
+  // Render image side
+  await drawImage(ctx, { src: args.src, fit: 'cover' }, { x: imgX, y, w: imgW, h, palette });
+
+  // Render text side on top of panel
+  drawTextSide(ctx, textX, y, textW, h, args, palette);
+}

--- a/sdf-js/src/present/atoms-2d/media/image.js
+++ b/sdf-js/src/present/atoms-2d/media/image.js
@@ -23,15 +23,16 @@ export const spec = {
   type: 'image',
   category: 'media',
   description:
-    'Image rendered from URL. Supports cover/contain fit modes + optional caption overlay.',
+    'Render an image already present in the source document. src MUST be a data: URI or relative path the parser emitted from embedded media. Do NOT use internet URLs or generated/stock images.',
   args: {
     src: {
-      type: 'string (URL)',
+      type: 'string (data: URI or parser-emitted relative path)',
       required: true,
-      example: 'https://images.unsplash.com/photo-1497436072909-60f360e1d4b1?w=1280',
+      example:
+        'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVQIHWNgIBb8BwABKAEBwGDOlAAAAABJRU5ErkJggg==',
     },
     fit: { type: "'cover'|'contain'|'fill'?", default: "'cover'", example: 'cover' },
-    caption: { type: 'string?', example: 'Yosemite, 2025' },
+    caption: { type: 'string?', example: 'Slide 3 photo' },
     captionPosition: { type: "'bottom'|'top'?", default: "'bottom'", example: 'bottom' },
     borderRadius: { type: 'number?', default: 0, example: 12 },
   },

--- a/sdf-js/src/present/atoms-2d/media/image.js
+++ b/sdf-js/src/present/atoms-2d/media/image.js
@@ -1,0 +1,219 @@
+// =============================================================================
+// atoms-2d/media/image.js — Image atom (URL src, cover/contain/fill fit)
+// -----------------------------------------------------------------------------
+// Sprint 18 Tier 3 C — closes structural gap vs PL D3180 reference benchmark.
+//
+// Semantic: renders an image from a URL with fit math. Supports optional caption
+// overlay and border radius. In Node (bake CLI) emits a placeholder rect — the
+// real rendering happens browser-side in the viewer.
+//
+// Args:
+//   src             — URL (required)
+//   fit             — 'cover'|'contain'|'fill' (default 'cover')
+//   caption         — optional caption string (renders as semi-opaque bar)
+//   captionPosition — 'bottom'|'top' (default 'bottom')
+//   borderRadius    — number in px (default 0)
+//
+// Render strategy:
+//   In browser: loads image via Image API, draws with fit math + caption overlay.
+//   In Node:    draws placeholder rect with "IMG" label + URL snippet (no crash).
+// =============================================================================
+
+export const spec = {
+  type: 'image',
+  category: 'media',
+  description:
+    'Image rendered from URL. Supports cover/contain fit modes + optional caption overlay.',
+  args: {
+    src: {
+      type: 'string (URL)',
+      required: true,
+      example: 'https://images.unsplash.com/photo-1497436072909-60f360e1d4b1?w=1280',
+    },
+    fit: { type: "'cover'|'contain'|'fill'?", default: "'cover'", example: 'cover' },
+    caption: { type: 'string?', example: 'Yosemite, 2025' },
+    captionPosition: { type: "'bottom'|'top'?", default: "'bottom'", example: 'bottom' },
+    borderRadius: { type: 'number?', default: 0, example: 12 },
+  },
+};
+
+// In-browser image cache: URL → HTMLImageElement (fully loaded)
+const _imgCache = new Map();
+
+/**
+ * Load an image from URL. Returns a Promise<HTMLImageElement>.
+ * Caches loaded images so re-renders are instant.
+ */
+function loadImage(url) {
+  if (_imgCache.has(url)) {
+    const cached = _imgCache.get(url);
+    if (cached.complete && cached.naturalWidth > 0) return Promise.resolve(cached);
+  }
+  return new Promise((resolve) => {
+    const img = new Image();  
+    img.crossOrigin = 'anonymous';
+    img.onload = () => {
+      _imgCache.set(url, img);
+      resolve(img);
+    };
+    img.onerror = () => {
+      // Store a sentinel so we don't retry on every frame
+      _imgCache.set(url, { failed: true, complete: true, naturalWidth: 0 });
+      resolve(null);
+    };
+    img.src = url;
+  });
+}
+
+/**
+ * Apply clipping path for borderRadius before drawing image.
+ */
+function clipRoundRect(ctx, x, y, w, h, r) {
+  if (!r || r <= 0) return;
+  ctx.beginPath();
+  ctx.moveTo(x + r, y);
+  ctx.lineTo(x + w - r, y);
+  ctx.quadraticCurveTo(x + w, y, x + w, y + r);
+  ctx.lineTo(x + w, y + h - r);
+  ctx.quadraticCurveTo(x + w, y + h, x + w - r, y + h);
+  ctx.lineTo(x + r, y + h);
+  ctx.quadraticCurveTo(x, y + h, x, y + h - r);
+  ctx.lineTo(x, y + r);
+  ctx.quadraticCurveTo(x, y, x + r, y);
+  ctx.closePath();
+  ctx.clip();
+}
+
+/**
+ * Draw placeholder rect (Node env or failed load).
+ */
+function drawPlaceholder(ctx, x, y, w, h, url) {
+  ctx.save();
+  ctx.fillStyle = 'rgba(120,120,140,0.25)';
+  ctx.fillRect(x, y, w, h);
+  ctx.fillStyle = 'rgba(80,80,100,0.5)';
+  ctx.font = `bold ${Math.min(24, h * 0.12)}px Inter, sans-serif`;
+  ctx.textAlign = 'center';
+  ctx.textBaseline = 'middle';
+  ctx.fillText('IMG', x + w / 2, y + h / 2 - 14);
+  if (url) {
+    ctx.font = `${Math.min(11, h * 0.06)}px Inter, monospace`;
+    ctx.fillStyle = 'rgba(80,80,100,0.4)';
+    const snippet = url.length > 40 ? url.slice(0, 37) + '...' : url;
+    ctx.fillText(snippet, x + w / 2, y + h / 2 + 14);
+  }
+  ctx.restore();
+}
+
+/**
+ * Draw a caption bar (semi-opaque gradient + white text).
+ */
+function drawCaption(ctx, x, y, w, h, caption, position) {
+  if (!caption) return;
+  const barH = Math.min(44, h * 0.15);
+  const barY = position === 'top' ? y : y + h - barH;
+
+  ctx.save();
+  const grad = ctx.createLinearGradient(x, barY, x, barY + barH);
+  if (position === 'top') {
+    grad.addColorStop(0, 'rgba(0,0,0,0.65)');
+    grad.addColorStop(1, 'rgba(0,0,0,0.0)');
+  } else {
+    grad.addColorStop(0, 'rgba(0,0,0,0.0)');
+    grad.addColorStop(1, 'rgba(0,0,0,0.65)');
+  }
+  ctx.fillStyle = grad;
+  ctx.fillRect(x, barY, w, barH);
+
+  ctx.fillStyle = 'rgba(255,255,255,0.92)';
+  ctx.font = `500 ${Math.max(10, Math.min(14, barH * 0.55))}px Inter, sans-serif`;
+  ctx.textAlign = 'left';
+  ctx.textBaseline = 'middle';
+  ctx.fillText(caption, x + 12, barY + barH / 2);
+  ctx.restore();
+}
+
+/**
+ * Compute drawImage params for cover/contain/fill fit.
+ */
+function fitRect(imgW, imgH, dstX, dstY, dstW, dstH, fit) {
+  if (fit === 'fill') {
+    return { sx: 0, sy: 0, sw: imgW, sh: imgH, dx: dstX, dy: dstY, dw: dstW, dh: dstH };
+  }
+  const scaleX = dstW / imgW;
+  const scaleY = dstH / imgH;
+  let scale;
+  if (fit === 'contain') {
+    scale = Math.min(scaleX, scaleY);
+  } else {
+    // cover (default)
+    scale = Math.max(scaleX, scaleY);
+  }
+  const rendW = imgW * scale;
+  const rendH = imgH * scale;
+  const offX = (dstW - rendW) / 2;
+  const offY = (dstH - rendH) / 2;
+  return {
+    sx: 0,
+    sy: 0,
+    sw: imgW,
+    sh: imgH,
+    dx: dstX + offX,
+    dy: dstY + offY,
+    dw: rendW,
+    dh: rendH,
+  };
+}
+
+/**
+ * Async render. Awaits image load in browser; in Node draws placeholder.
+ *
+ * @param {CanvasRenderingContext2D} ctx
+ * @param {object} args — see spec.args
+ * @param {object} [opts]
+ */
+export async function drawPseudo3D(ctx, args, opts = {}) {
+  const x = opts.x ?? 0;
+  const y = opts.y ?? 0;
+  const w = opts.w ?? 640;
+  const h = opts.h ?? 360;
+  const src = args.src || '';
+  const fit = args.fit || 'cover';
+  const caption = args.caption || null;
+  const captionPosition = args.captionPosition || 'bottom';
+  const borderRadius = args.borderRadius ?? 0;
+
+  ctx.save();
+
+  if (borderRadius > 0) {
+    clipRoundRect(ctx, x, y, w, h, borderRadius);
+  }
+
+  // Node env: no Image constructor → draw placeholder
+  if (typeof Image === 'undefined') {
+    if (src) console.warn(`[image atom] Node env — skipping fetch of ${src}`);
+    drawPlaceholder(ctx, x, y, w, h, src);
+    ctx.restore();
+    return;
+  }
+
+  // Browser: load + draw
+  const img = await loadImage(src);
+  if (!img || img.failed || img.naturalWidth === 0) {
+    drawPlaceholder(ctx, x, y, w, h, src);
+  } else {
+    const { sx, sy, sw, sh, dx, dy, dw, dh } = fitRect(
+      img.naturalWidth,
+      img.naturalHeight,
+      x,
+      y,
+      w,
+      h,
+      fit,
+    );
+    ctx.drawImage(img, sx, sy, sw, sh, dx, dy, dw, dh);
+  }
+
+  drawCaption(ctx, x, y, w, h, caption, captionPosition);
+  ctx.restore();
+}

--- a/sdf-js/src/present/atoms-2d/media/image.js
+++ b/sdf-js/src/present/atoms-2d/media/image.js
@@ -50,7 +50,7 @@ function loadImage(url) {
     if (cached.complete && cached.naturalWidth > 0) return Promise.resolve(cached);
   }
   return new Promise((resolve) => {
-    const img = new Image();  
+    const img = new Image();
     img.crossOrigin = 'anonymous';
     img.onload = () => {
       _imgCache.set(url, img);

--- a/sdf-js/src/present/atoms-2d/registry.js
+++ b/sdf-js/src/present/atoms-2d/registry.js
@@ -118,6 +118,10 @@ const ATOM_LOADERS = {
   'matrix-grid': () => import('./charts/matrix/matrix-grid.js'),
   'nine-field-matrix': () => import('./charts/matrix/nine-field-matrix.js'),
 
+  // Media (Sprint 18 Tier 3 C) — image rendering for PL-style hero / full-bleed slides
+  image: () => import('./media/image.js'),
+  'image-split': () => import('./media/image-split.js'),
+
   // Icons (Phase 4) — 24 atlas-icon names wrapped in pseudo-3D badge
   'icon-badge': () => import('./icons/icon-badge.js'),
   // Icons (Sprint 18) — N icons horizontally with labels (vision/values/contact)

--- a/sdf-js/src/present/scaffold-view.js
+++ b/sdf-js/src/present/scaffold-view.js
@@ -411,7 +411,12 @@ export async function mountScaffoldView(target, deckId) {
       `    - process / workflow slots (How It Works / Pipeline) → \`flow-chart\` or \`progression\`\n` +
       `    - 2-set comparison slots (Before/After / Us vs Them) → \`venn\` or side-by-side kpi-cards\n` +
       `    Specialized atoms communicate semantics in 3D theatrical playback — bullet-list reads as "they had no better atom".\n` +
-      `14. **NEVER emit \`type: "text"\`** — there is NO text atom. For corner attribution (author / date / version) use cover's \`author\`/\`date\`/\`version\` args. For floating labels INSIDE a chart, set the chart atom's title/labels args. If you can't express something via an atom + its args, omit it.\n`;
+      `14. **NEVER emit \`type: "text"\`** — there is NO text atom. For corner attribution (author / date / version) use cover's \`author\`/\`date\`/\`version\` args. For floating labels INSIDE a chart, set the chart atom's title/labels args. If you can't express something via an atom + its args, omit it.\n` +
+      `15. **Image atoms (Sprint 18 Tier 3 C)** — use when content describes a visual subject AND a URL is present in the source:\n` +
+      `    - Hero slot with a single dominant photo + title/body/bullets → \`image-split\` (image one side, text other side; PL hero pattern)\n` +
+      `    - Full-bleed background photo with overlay caption → \`image\` with fit:'cover'\n` +
+      `    - For src URL: ONLY use URLs that appear in slide.body (look for "image:" or "https://images." or "https://picsum." prefixes). If no URL is in source, OMIT image atoms — DO NOT fabricate URLs that will 404.\n` +
+      `    - DO NOT use image atoms for purely numeric / list / process content — specialized atoms (kpi-card / fishbone / timeline / flow-chart) are better.\n`;
 
     const systemPrompt =
       `You are the Atlas Present scaffold-mode lift LLM. Emit a single JSON ` +

--- a/sdf-js/src/present/scaffold-view.js
+++ b/sdf-js/src/present/scaffold-view.js
@@ -412,10 +412,10 @@ export async function mountScaffoldView(target, deckId) {
       `    - 2-set comparison slots (Before/After / Us vs Them) → \`venn\` or side-by-side kpi-cards\n` +
       `    Specialized atoms communicate semantics in 3D theatrical playback — bullet-list reads as "they had no better atom".\n` +
       `14. **NEVER emit \`type: "text"\`** — there is NO text atom. For corner attribution (author / date / version) use cover's \`author\`/\`date\`/\`version\` args. For floating labels INSIDE a chart, set the chart atom's title/labels args. If you can't express something via an atom + its args, omit it.\n` +
-      `15. **Image atoms (Sprint 18 Tier 3 C)** — use when content describes a visual subject AND a URL is present in the source:\n` +
-      `    - Hero slot with a single dominant photo + title/body/bullets → \`image-split\` (image one side, text other side; PL hero pattern)\n` +
-      `    - Full-bleed background photo with overlay caption → \`image\` with fit:'cover'\n` +
-      `    - For src URL: ONLY use URLs that appear in slide.body (look for "image:" or "https://images." or "https://picsum." prefixes). If no URL is in source, OMIT image atoms — DO NOT fabricate URLs that will 404.\n` +
+      `15. **Image atoms (Sprint 18 Tier 3 C)** — strictly bound to images that were ALREADY embedded in the user's source document. We do NOT call image-generation models, we do NOT search the internet for stock photos:\n` +
+      `    - Use ONLY when slide.body contains an explicit src for an image the user already had (look for "image:" lines pointing to data: URIs, OR relative paths the parser emitted from embedded images).\n` +
+      `    - If no such src exists in source, OMIT image atoms entirely. NEVER fabricate URLs. NEVER add picsum / unsplash / any internet host. NEVER write "image: https://..." that isn't in the source.\n` +
+      `    - When you DO have a valid src: hero slot with one dominant image + title/body/bullets → \`image-split\`; full-bleed photo with caption → \`image\` (fit:'cover').\n` +
       `    - DO NOT use image atoms for purely numeric / list / process content — specialized atoms (kpi-card / fishbone / timeline / flow-chart) are better.\n`;
 
     const systemPrompt =


### PR DESCRIPTION
## Summary

Sprint 18 Tier 3 C — MVP photo support. Closes structural gap vs PL D3180 reference.

**Scope (2026-06-25 user lock)**: Atlas image atoms consume ONLY images already embedded in the user's source document. **No internet stock photos. No image-generation models.** The atoms surface the user's own visuals — never invent new ones.

## What's new

### 2 new atoms

**`image`** ([sdf-js/src/present/atoms-2d/media/image.js](sdf-js/src/present/atoms-2d/media/image.js)) — 219 LOC
- async render via Image API + in-memory cache; failed loads cached as sentinels
- Args: `src` (required: data: URI or parser-emitted relative path), `fit`, `caption`, `captionPosition`, `borderRadius`
- Node-env safe: draws placeholder rect

**`image-split`** ([sdf-js/src/present/atoms-2d/media/image-split.js](sdf-js/src/present/atoms-2d/media/image-split.js)) — 137 LOC
- PL hero pattern: image one side + title/body/bullets other side
- Args: `src` (required), `title` (required), `body?`, `bullets?`, `imageSide`, `imageWidthPct`

### Wire-up

Registered in `media` category. Auto-picked up by `buildAtomCatalogString()`.

### Rule 15 (prompt — strict no-internet wording)

> Image atoms are strictly bound to images that were ALREADY embedded in the user's source document. We do NOT call image-generation models, we do NOT search the internet for stock photos:
> - Use ONLY when slide.body contains an explicit src for an image the user already had (data: URI or parser-emitted relative path).
> - If no such src exists in source, OMIT image atoms entirely. NEVER fabricate URLs. NEVER add picsum / unsplash / any internet host.
> - When valid src present: hero → `image-split`; full-bleed → `image` (fit:'cover').

### Test fixture

[yosemite-trip-2026.json](sdf-js/scripts/scaffold-pipeline-fixtures/yosemite-trip-2026.json) — slides 0, 2, 4 carry inline SVG `data:` URIs (gradient backgrounds with labels). Slides 1, 3, 5, 6 are text-only. Proves the no-internet path works end-to-end.

## Validation

Re-bake `yosemite-tier3c-noweb`:

```
00-cover            : image-split    ← SVG data: URI from source slide 0
01-executive-summary: cover, dashboard-multi-kpi-composite, bullet-list
03-wins             : cover, bullet-list
05-outlook          : cover, line, progression
06-next-steps       : cover, timeline, bullet-list
```

**LLM correctly OMITS image atoms for slots whose source body had no image: line.** grep verifies **zero http:// or https:// in any src** across the deck.

Visual: [screens/tier3-validation/yosemite-tier3c-noweb.png](screens/tier3-validation/yosemite-tier3c-noweb.png) — slot 0 renders the inline SVG (orange gradient + "Yosemite Trip Report").

## Tests

- `test-atoms-image.mjs`: **17 assertions** — registration, specs, args, catalog auto-pickup, Node-env safe render
- npm test: **94/94 PASS**

## Implementation note

Parser's `visuals[]` array is wired but doesn't yet extract embedded images from PDF/PPTX. Until that ships (Sprint 19+), these atoms only fire when source manually contains `data:` URIs. Code path is ready for parser extraction the day it lands — atom is URL-agnostic.

## Out of scope (Sprint 19+)

- Parser PDF/PPTX embedded-image extraction (the missing link to make these atoms fire from real uploads)
- Image-grid atom (4-6 thumbnail layout)
- Image + leader-line callouts (PL diagram pattern)

Per CLAUDE.md: DO NOT merge. Awaiting user review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)