### PR TITLE
feat(present): 3 more Fill-Levels archetypes + assemble the full deck

### DIFF
--- a/sdf-js/scenes/deck-fill-levels.json
+++ b/sdf-js/scenes/deck-fill-levels.json
@@ -1,0 +1,14 @@
+{
+  "id": "deck-fill-levels",
+  "name": "3D Spheres — Fill Levels (PresentationLoad D0961 twin)",
+  "segments": [
+    { "file": "sphere-fill-cover.json", "title": "3D Spheres — Fill Levels", "kind": "slide", "durationSec": 6 },
+    { "file": "p3-sequence-gauges.json", "title": "A sequence of levels", "kind": "slide", "durationSec": 7 },
+    { "file": "p7-stage-gauges.json", "title": "On the stage", "kind": "slide", "durationSec": 7 },
+    { "file": "p9-grid-gauges.json", "title": "A full matrix", "kind": "slide", "durationSec": 7 },
+    { "file": "p11-hero-list-gauges.json", "title": "Hero + breakdown", "kind": "slide", "durationSec": 7 },
+    { "file": "p5-hero-textboxes.json", "title": "Framed hero + notes", "kind": "slide", "durationSec": 7 },
+    { "file": "p15-radial-gauge.json", "title": "Radial spokes", "kind": "slide", "durationSec": 7 },
+    { "file": "p17-list-rows.json", "title": "Row-by-row", "kind": "slide", "durationSec": 7 }
+  ]
+}

--- a/sdf-js/scenes/p17-list-rows.json
+++ b/sdf-js/scenes/p17-list-rows.json
@@ -1,0 +1,71 @@
+{
+  "v": 1,
+  "name": "list: 3D Spheres Fill Levels — gauge rows (p17)",
+  "subjects": [
+    {
+      "id": "g1",
+      "type": "sphere-fill-3d",
+      "args": { "levels": [0.2], "radius": 0.6 },
+      "transform": { "translate": [3.3, 2.55, 0] },
+      "material": { "hue": 0.57, "sat": 0.55, "value": 0.62, "kind": "fill", "roughness": 0.3, "clearcoat": 0.5 }
+    },
+    {
+      "id": "g2",
+      "type": "sphere-fill-3d",
+      "args": { "levels": [0.4], "radius": 0.6 },
+      "transform": { "translate": [3.3, 0.9, 0] },
+      "material": { "hue": 0.57, "sat": 0.55, "value": 0.62, "kind": "fill", "roughness": 0.3, "clearcoat": 0.5 }
+    },
+    {
+      "id": "g3",
+      "type": "sphere-fill-3d",
+      "args": { "levels": [0.9], "radius": 0.6 },
+      "transform": { "translate": [3.3, -0.75, 0] },
+      "material": { "hue": 0.57, "sat": 0.55, "value": 0.62, "kind": "fill", "roughness": 0.3, "clearcoat": 0.5 }
+    },
+    {
+      "id": "a1",
+      "type": "arrow-3d",
+      "args": { "length": 0.8, "shaftWidth": 0.14, "headLength": 0.3, "headWidth": 0.4, "depth": 0.16 },
+      "transform": { "translate": [1.85, 2.55, 0], "rotate": [0, 3.14159, 0] },
+      "material": { "hue": 0.57, "sat": 0.35, "value": 0.78, "kind": "normal" }
+    },
+    {
+      "id": "a2",
+      "type": "arrow-3d",
+      "args": { "length": 0.8, "shaftWidth": 0.14, "headLength": 0.3, "headWidth": 0.4, "depth": 0.16 },
+      "transform": { "translate": [1.85, 0.9, 0], "rotate": [0, 3.14159, 0] },
+      "material": { "hue": 0.57, "sat": 0.35, "value": 0.78, "kind": "normal" }
+    },
+    {
+      "id": "a3",
+      "type": "arrow-3d",
+      "args": { "length": 0.8, "shaftWidth": 0.14, "headLength": 0.3, "headWidth": 0.4, "depth": 0.16 },
+      "transform": { "translate": [1.85, -0.75, 0], "rotate": [0, 3.14159, 0] },
+      "material": { "hue": 0.57, "sat": 0.35, "value": 0.78, "kind": "normal" }
+    }
+  ],
+  "overlay": [
+    { "text": "3D SPHERES — FILL LEVELS", "anchor": [0, 4.0, 0], "role": "title" },
+
+    { "role": "value", "text": "20%", "anchor": [3.3, 2.55, 0], "radius": 0.6 },
+    { "role": "value", "text": "40%", "anchor": [3.3, 0.9, 0], "radius": 0.6 },
+    { "role": "value", "text": "90%", "anchor": [3.3, -0.75, 0], "radius": 0.6 },
+
+    { "text": "THIS IS A PLACEHOLDER TEXT", "anchor": [-1.6, 2.95, 0], "role": "head", "align": "left" },
+    { "text": "This is a placeholder text.\nReplace with your own.", "anchor": [-1.6, 2.4, 0], "role": "body", "align": "left" },
+
+    { "text": "THIS IS A PLACEHOLDER TEXT", "anchor": [-1.6, 1.3, 0], "role": "head", "align": "left" },
+    { "text": "This is a placeholder text.\nReplace with your own.", "anchor": [-1.6, 0.75, 0], "role": "body", "align": "left" },
+
+    { "text": "THIS IS A PLACEHOLDER TEXT", "anchor": [-1.6, -0.35, 0], "role": "head", "align": "left" },
+    { "text": "This is a placeholder text.\nReplace with your own.", "anchor": [-1.6, -0.9, 0], "role": "body", "align": "left" }
+  ],
+  "cameraSequence": {
+    "loop": false,
+    "shots": [
+      { "duration": 10, "pos": [0, 0.9, 9.8], "target": [0, 0.9, 0], "fov": 52, "aperture": 0, "focalDistance": 9.8, "ease": "smooth" }
+    ]
+  },
+  "defaults": { "stage": { "size": [20, 9, 10] } }
+}

--- a/sdf-js/scenes/p5-hero-textboxes.json
+++ b/sdf-js/scenes/p5-hero-textboxes.json
@@ -1,0 +1,43 @@
+{
+  "v": 1,
+  "name": "relation: 3D Spheres Fill Levels — framed hero + text (p5)",
+  "subjects": [
+    {
+      "id": "ring",
+      "type": "circle-frame-3d",
+      "args": { "radius": 1.62, "frameWidth": 0.16, "backDepth": 0.05, "back": false },
+      "transform": { "translate": [2.7, 1.4, -0.15] },
+      "material": { "hue": 0.6, "sat": 0.04, "value": 0.82, "metal": 0.9, "kind": "normal", "roughness": 0.25, "clearcoat": 0.5 }
+    },
+    {
+      "id": "hero",
+      "type": "sphere-fill-3d",
+      "args": { "levels": [1.0], "radius": 1.3 },
+      "transform": { "translate": [2.7, 1.4, 0] },
+      "material": { "hue": 0.57, "sat": 0.55, "value": 0.62, "kind": "fill", "roughness": 0.3, "clearcoat": 0.5 }
+    }
+  ],
+  "overlay": [
+    { "role": "value", "text": "100%", "anchor": [2.7, 1.4, 0], "radius": 1.3 },
+
+    { "role": "spoke", "from": [1.45, 1.95, 0], "to": [-0.7, 2.6, 0] },
+    { "role": "spoke", "from": [1.35, 1.4, 0], "to": [-0.7, 1.3, 0] },
+    { "role": "spoke", "from": [1.45, 0.85, 0], "to": [-0.7, 0.0, 0] },
+
+    { "text": "DESCRIPTION TEXT", "anchor": [-0.5, 2.65, 0], "role": "head", "align": "left" },
+    { "text": "This is a placeholder text.\nReplace with your own text.", "anchor": [-0.5, 2.1, 0], "role": "body", "align": "left" },
+
+    { "text": "DESCRIPTION TEXT", "anchor": [-0.5, 1.35, 0], "role": "head", "align": "left" },
+    { "text": "This is a placeholder text.\nReplace with your own text.", "anchor": [-0.5, 0.8, 0], "role": "body", "align": "left" },
+
+    { "text": "DESCRIPTION TEXT", "anchor": [-0.5, 0.05, 0], "role": "head", "align": "left" },
+    { "text": "This is a placeholder text.\nReplace with your own text.", "anchor": [-0.5, -0.5, 0], "role": "body", "align": "left" }
+  ],
+  "cameraSequence": {
+    "loop": false,
+    "shots": [
+      { "duration": 10, "pos": [0, 1.2, 9.5], "target": [0, 1.1, 0], "fov": 50, "aperture": 0, "focalDistance": 9.5, "ease": "smooth" }
+    ]
+  },
+  "defaults": { "stage": { "size": [20, 8, 11] } }
+}

--- a/sdf-js/scenes/p9-grid-gauges.json
+++ b/sdf-js/scenes/p9-grid-gauges.json
@@ -1,0 +1,40 @@
+{
+  "v": 1,
+  "name": "grid: 3D Spheres Fill Levels — matrix (p9)",
+  "subjects": [
+    {
+      "id": "row1",
+      "type": "sphere-fill-3d",
+      "args": { "levels": [0.1, 0.3, 0.5, 0.7], "radius": 0.5, "spacing": 0.7 },
+      "transform": { "translate": [0, 2.85, 0] },
+      "material": { "hue": 0.57, "sat": 0.55, "value": 0.62, "kind": "fill", "roughness": 0.3, "clearcoat": 0.5 }
+    },
+    {
+      "id": "row2",
+      "type": "sphere-fill-3d",
+      "args": { "levels": [0.2, 0.4, 0.6, 0.8], "radius": 0.5, "spacing": 0.7 },
+      "transform": { "translate": [0, 1.0, 0] },
+      "material": { "hue": 0.57, "sat": 0.55, "value": 0.62, "kind": "fill", "roughness": 0.3, "clearcoat": 0.5 }
+    }
+  ],
+  "overlay": [
+    { "text": "3D SPHERES — FILL LEVELS", "anchor": [0, 4.3, 0], "role": "title" },
+
+    { "role": "value", "text": "10%", "anchor": [-2.55, 2.05, 0], "radius": 0.5 },
+    { "role": "value", "text": "30%", "anchor": [-0.85, 2.05, 0], "radius": 0.5 },
+    { "role": "value", "text": "50%", "anchor": [0.85, 2.05, 0], "radius": 0.5 },
+    { "role": "value", "text": "70%", "anchor": [2.55, 2.05, 0], "radius": 0.5 },
+
+    { "role": "value", "text": "20%", "anchor": [-2.55, 0.2, 0], "radius": 0.5 },
+    { "role": "value", "text": "40%", "anchor": [-0.85, 0.2, 0], "radius": 0.5 },
+    { "role": "value", "text": "60%", "anchor": [0.85, 0.2, 0], "radius": 0.5 },
+    { "role": "value", "text": "80%", "anchor": [2.55, 0.2, 0], "radius": 0.5 }
+  ],
+  "cameraSequence": {
+    "loop": false,
+    "shots": [
+      { "duration": 10, "pos": [0, 1.9, 9.0], "target": [0, 1.9, 0], "fov": 50, "aperture": 0, "focalDistance": 9.0, "ease": "smooth" }
+    ]
+  },
+  "defaults": { "stage": { "size": [18, 9, 10] } }
+}


### PR DESCRIPTION
## A + B + 部分 C

承「把 20 页打磨完美」。盘清 PDF 20 页后,distinct 3D 版式 ≈ 8 个(2D 页是 3D 页的孪生,lift 后同一个 3D)。补齐剩下 3 个 + 组装成一个可演示 deck。

## A — 3 个新版式(gauge + overlay value % + DESCRIPTION chip)

- **p9 网格** `p9-grid-gauges.json` —— 4×2 gauge 阵列,% 在下方。
- **p17 纵列** `p17-list-rows.json` —— gauge + 箭头 + 标题/正文,3 行堆叠。
- **p5 框选 hero** `p5-hero-textboxes.json` —— 大 100% gauge 嵌**银色金属环**(circle-frame-3d,metal 材质)+ 3 文本框 + 虚线辐条。**金属框完美还原 PDF**。

## B — 组装 deck

`deck-fill-levels.json` 把 8 个版式(封面/序列/舞台/网格/hero+list/框选 hero/radial/纵列)串成**一个 deck**:`?deck=deck-fill-levels` 相机在段间飞 + 每段 caption + 投影 overlay。**产品形态:一个连续 deck,不是 N 个散场景。**

## C(部分)

p5 的金属环框已做。

## 验证(Playwright Chromium,WebGL2)

p5(铬环 + 100% + 辐条)、p9(网格 + %)、p17(gauge 行)、deck 自动翻页播放。`npm test` **94/94**。

## 后续 C

色条标题卡片、p19 标定图、p17 底行抬高、网格也加环框、每页手写 cameraSequence 运镜。

🤖 Generated with [Claude Code](https://claude.com/claude-code)