### PR TITLE
polish(present): deck polish pass — cinematic push-in + colour-header cards

### DIFF
--- a/sdf-js/apps/present/overlay.js
+++ b/sdf-js/apps/present/overlay.js
@@ -31,6 +31,10 @@ const FONT = '-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif';
 const CHIP =
   'background:rgba(9,12,20,0.52);-webkit-backdrop-filter:blur(5px);backdrop-filter:blur(5px);' +
   'border:1px solid rgba(255,255,255,0.08);border-radius:9px;box-shadow:0 6px 20px rgba(0,0,0,0.28);';
+// Blue header chip — the PresentationLoad colour-bar header (`card` role).
+const CARD_CHIP =
+  'background:rgba(40,116,196,0.92);-webkit-backdrop-filter:blur(5px);backdrop-filter:blur(5px);' +
+  'border:1px solid rgba(255,255,255,0.14);border-radius:7px;box-shadow:0 6px 20px rgba(0,0,0,0.28);';
 
 const ROLE_CSS = {
   title: `font:700 28px/1.2 ${FONT};letter-spacing:-0.01em;color:#f4f7fc;padding:10px 22px;`,
@@ -42,6 +46,9 @@ const ROLE_CSS = {
   // both bright glass and coloured liquid. Font-size is set per-frame from the
   // object's projected radius (see tick) when the block carries `radius`.
   value: `font:800 30px/1 ${FONT};color:#ffffff;letter-spacing:-0.01em;text-shadow:0 1px 3px rgba(0,0,0,0.55),0 0 10px rgba(0,0,0,0.35);`,
+  // `card` is a coloured header bar (blue chip) — the PresentationLoad section
+  // header that sits above a `body` block.
+  card: `font:700 12.5px/1.2 ${FONT};letter-spacing:0.1em;text-transform:uppercase;color:#ffffff;padding:8px 16px;`,
 };
 
 const SVG_NS = 'http://www.w3.org/2000/svg';
@@ -104,9 +111,9 @@ export function makeOverlay(wrap, studio) {
       el.style.cssText =
         `position:absolute;transform:translate(${tx},-50%);text-align:${textAlign};white-space:pre-line;` +
         `opacity:0;transition:opacity 0.25s ease;will-change:left,top;` +
-        // a `value` readout has NO chip (it sits directly on its object); every
-        // other role gets the dark frosted chip.
-        (isValue ? '' : CHIP) +
+        // a `value` readout has NO chip (sits on its object); a `card` header gets
+        // the blue colour-bar chip; everything else gets the dark frosted chip.
+        (isValue ? '' : o.role === 'card' ? CARD_CHIP : CHIP) +
         (ROLE_CSS[o.role] || ROLE_CSS.body);
       layer.appendChild(el);
       blocks.push({

--- a/sdf-js/scenes/p11-hero-list-gauges.json
+++ b/sdf-js/scenes/p11-hero-list-gauges.json
@@ -5,54 +5,256 @@
     {
       "id": "hero",
       "type": "sphere-fill-3d",
-      "args": { "levels": [0.3], "radius": 1.35 },
-      "transform": { "translate": [-2.8, 1.5, 0] },
-      "material": { "hue": 0.57, "sat": 0.55, "value": 0.62, "kind": "fill", "roughness": 0.3, "clearcoat": 0.5 }
+      "args": {
+        "levels": [
+          0.3
+        ],
+        "radius": 1.35
+      },
+      "transform": {
+        "translate": [
+          -2.8,
+          1.5,
+          0
+        ]
+      },
+      "material": {
+        "hue": 0.57,
+        "sat": 0.55,
+        "value": 0.62,
+        "kind": "fill",
+        "roughness": 0.3,
+        "clearcoat": 0.5
+      }
     },
     {
       "id": "item1",
       "type": "sphere-fill-3d",
-      "args": { "levels": [0.5], "radius": 0.48 },
-      "transform": { "translate": [2.8, 2.7, 0] },
-      "material": { "hue": 0.57, "sat": 0.55, "value": 0.62, "kind": "fill", "roughness": 0.3, "clearcoat": 0.5 }
+      "args": {
+        "levels": [
+          0.5
+        ],
+        "radius": 0.48
+      },
+      "transform": {
+        "translate": [
+          2.8,
+          2.7,
+          0
+        ]
+      },
+      "material": {
+        "hue": 0.57,
+        "sat": 0.55,
+        "value": 0.62,
+        "kind": "fill",
+        "roughness": 0.3,
+        "clearcoat": 0.5
+      }
     },
     {
       "id": "item2",
       "type": "sphere-fill-3d",
-      "args": { "levels": [0.3], "radius": 0.48 },
-      "transform": { "translate": [2.8, 1.5, 0] },
-      "material": { "hue": 0.57, "sat": 0.55, "value": 0.62, "kind": "fill", "roughness": 0.3, "clearcoat": 0.5 }
+      "args": {
+        "levels": [
+          0.3
+        ],
+        "radius": 0.48
+      },
+      "transform": {
+        "translate": [
+          2.8,
+          1.5,
+          0
+        ]
+      },
+      "material": {
+        "hue": 0.57,
+        "sat": 0.55,
+        "value": 0.62,
+        "kind": "fill",
+        "roughness": 0.3,
+        "clearcoat": 0.5
+      }
     },
     {
       "id": "item3",
       "type": "sphere-fill-3d",
-      "args": { "levels": [0.2], "radius": 0.48 },
-      "transform": { "translate": [2.8, 0.3, 0] },
-      "material": { "hue": 0.57, "sat": 0.55, "value": 0.62, "kind": "fill", "roughness": 0.3, "clearcoat": 0.5 }
+      "args": {
+        "levels": [
+          0.2
+        ],
+        "radius": 0.48
+      },
+      "transform": {
+        "translate": [
+          2.8,
+          0.3,
+          0
+        ]
+      },
+      "material": {
+        "hue": 0.57,
+        "sat": 0.55,
+        "value": 0.62,
+        "kind": "fill",
+        "roughness": 0.3,
+        "clearcoat": 0.5
+      }
     }
   ],
   "overlay": [
-    { "role": "value", "text": "30%", "anchor": [-2.8, 1.5, 0], "radius": 1.35 },
-    { "role": "value", "text": "50%", "anchor": [2.8, 2.7, 0], "radius": 0.48 },
-    { "role": "value", "text": "30%", "anchor": [2.8, 1.5, 0], "radius": 0.48 },
-    { "role": "value", "text": "20%", "anchor": [2.8, 0.3, 0], "radius": 0.48 },
-
-    { "text": "DESCRIPTION 1", "anchor": [-2.8, -0.4, 0], "role": "head" },
-
-    { "text": "DESCRIPTION 2", "anchor": [0.7, 2.85, 0], "role": "head" },
-    { "text": "Placeholder for your own text.", "anchor": [0.7, 2.45, 0], "role": "body" },
-
-    { "text": "DESCRIPTION 3", "anchor": [0.7, 1.65, 0], "role": "head" },
-    { "text": "Placeholder for your own text.", "anchor": [0.7, 1.25, 0], "role": "body" },
-
-    { "text": "DESCRIPTION 4", "anchor": [0.7, 0.45, 0], "role": "head" },
-    { "text": "Placeholder for your own text.", "anchor": [0.7, 0.05, 0], "role": "body" }
+    {
+      "role": "value",
+      "text": "30%",
+      "anchor": [
+        -2.8,
+        1.5,
+        0
+      ],
+      "radius": 1.35
+    },
+    {
+      "role": "value",
+      "text": "50%",
+      "anchor": [
+        2.8,
+        2.7,
+        0
+      ],
+      "radius": 0.48
+    },
+    {
+      "role": "value",
+      "text": "30%",
+      "anchor": [
+        2.8,
+        1.5,
+        0
+      ],
+      "radius": 0.48
+    },
+    {
+      "role": "value",
+      "text": "20%",
+      "anchor": [
+        2.8,
+        0.3,
+        0
+      ],
+      "radius": 0.48
+    },
+    {
+      "text": "DESCRIPTION 1",
+      "anchor": [
+        -2.8,
+        -0.4,
+        0
+      ],
+      "role": "head"
+    },
+    {
+      "text": "DESCRIPTION 2",
+      "anchor": [
+        0.7,
+        2.85,
+        0
+      ],
+      "role": "head"
+    },
+    {
+      "text": "Placeholder for your own text.",
+      "anchor": [
+        0.7,
+        2.45,
+        0
+      ],
+      "role": "body"
+    },
+    {
+      "text": "DESCRIPTION 3",
+      "anchor": [
+        0.7,
+        1.65,
+        0
+      ],
+      "role": "head"
+    },
+    {
+      "text": "Placeholder for your own text.",
+      "anchor": [
+        0.7,
+        1.25,
+        0
+      ],
+      "role": "body"
+    },
+    {
+      "text": "DESCRIPTION 4",
+      "anchor": [
+        0.7,
+        0.45,
+        0
+      ],
+      "role": "head"
+    },
+    {
+      "text": "Placeholder for your own text.",
+      "anchor": [
+        0.7,
+        0.05,
+        0
+      ],
+      "role": "body"
+    }
   ],
   "cameraSequence": {
     "loop": false,
     "shots": [
-      { "duration": 10, "pos": [0, 1.6, 9.5], "target": [0, 1.4, 0], "fov": 46, "aperture": 0, "focalDistance": 9.5, "ease": "smooth" }
+      {
+        "duration": 0.01,
+        "pos": [
+          0.7,
+          1.788,
+          11.3
+        ],
+        "target": [
+          0,
+          1.4,
+          0
+        ],
+        "fov": 50,
+        "aperture": 0,
+        "focalDistance": 9.5,
+        "ease": "smooth"
+      },
+      {
+        "duration": 14,
+        "pos": [
+          0,
+          1.6,
+          9.5
+        ],
+        "target": [
+          0,
+          1.4,
+          0
+        ],
+        "fov": 46,
+        "aperture": 0,
+        "focalDistance": 9.5,
+        "ease": "smooth",
+        "transition": "blend"
+      }
     ]
   },
-  "defaults": { "stage": { "size": [22, 8, 11] } }
+  "defaults": {
+    "stage": {
+      "size": [
+        22,
+        8,
+        11
+      ]
+    }
+  }
 }

--- a/sdf-js/scenes/p15-radial-gauge.json
+++ b/sdf-js/scenes/p15-radial-gauge.json
@@ -5,8 +5,19 @@
     {
       "id": "hub",
       "type": "sphere-fill-3d",
-      "args": { "levels": [1.0], "radius": 1.25 },
-      "transform": { "translate": [0, 1.5, 0] },
+      "args": {
+        "levels": [
+          1
+        ],
+        "radius": 1.25
+      },
+      "transform": {
+        "translate": [
+          0,
+          1.5,
+          0
+        ]
+      },
       "material": {
         "hue": 0.57,
         "sat": 0.55,
@@ -18,40 +29,147 @@
     }
   ],
   "overlay": [
-    { "role": "value", "text": "100%", "anchor": [0, 1.5, 0], "radius": 1.25 },
-
-    { "text": "3D SPHERES — FILL LEVELS", "anchor": [0, 4.3, 0], "role": "title" },
-
-    { "role": "spoke", "from": [-1.21, 2.1, 0], "to": [-3.0, 3.0, 0] },
-    { "role": "spoke", "from": [1.21, 2.1, 0], "to": [3.0, 3.0, 0] },
-    { "role": "spoke", "from": [-1.28, 1.06, 0], "to": [-3.0, 0.55, 0] },
-    { "role": "spoke", "from": [1.28, 1.06, 0], "to": [3.0, 0.55, 0] },
-
-    { "text": "DESCRIPTION 1", "anchor": [-3.2, 3.1, 0], "role": "head" },
+    {
+      "role": "value",
+      "text": "100%",
+      "anchor": [
+        0,
+        1.5,
+        0
+      ],
+      "radius": 1.25
+    },
+    {
+      "text": "3D SPHERES — FILL LEVELS",
+      "anchor": [
+        0,
+        4.3,
+        0
+      ],
+      "role": "title"
+    },
+    {
+      "role": "spoke",
+      "from": [
+        -1.21,
+        2.1,
+        0
+      ],
+      "to": [
+        -3,
+        3,
+        0
+      ]
+    },
+    {
+      "role": "spoke",
+      "from": [
+        1.21,
+        2.1,
+        0
+      ],
+      "to": [
+        3,
+        3,
+        0
+      ]
+    },
+    {
+      "role": "spoke",
+      "from": [
+        -1.28,
+        1.06,
+        0
+      ],
+      "to": [
+        -3,
+        0.55,
+        0
+      ]
+    },
+    {
+      "role": "spoke",
+      "from": [
+        1.28,
+        1.06,
+        0
+      ],
+      "to": [
+        3,
+        0.55,
+        0
+      ]
+    },
+    {
+      "text": "DESCRIPTION 1",
+      "anchor": [
+        -3.2,
+        3.1,
+        0
+      ],
+      "role": "head"
+    },
     {
       "text": "This is a placeholder text.\nReplace with your own.",
-      "anchor": [-3.2, 2.55, 0],
+      "anchor": [
+        -3.2,
+        2.55,
+        0
+      ],
       "role": "body"
     },
-
-    { "text": "DESCRIPTION 2", "anchor": [3.2, 3.1, 0], "role": "head" },
+    {
+      "text": "DESCRIPTION 2",
+      "anchor": [
+        3.2,
+        3.1,
+        0
+      ],
+      "role": "head"
+    },
     {
       "text": "This is a placeholder text.\nReplace with your own.",
-      "anchor": [3.2, 2.55, 0],
+      "anchor": [
+        3.2,
+        2.55,
+        0
+      ],
       "role": "body"
     },
-
-    { "text": "DESCRIPTION 3", "anchor": [-3.2, 0.4, 0], "role": "head" },
+    {
+      "text": "DESCRIPTION 3",
+      "anchor": [
+        -3.2,
+        0.4,
+        0
+      ],
+      "role": "head"
+    },
     {
       "text": "This is a placeholder text.\nReplace with your own.",
-      "anchor": [-3.2, -0.15, 0],
+      "anchor": [
+        -3.2,
+        -0.15,
+        0
+      ],
       "role": "body"
     },
-
-    { "text": "DESCRIPTION 4", "anchor": [3.2, 0.4, 0], "role": "head" },
+    {
+      "text": "DESCRIPTION 4",
+      "anchor": [
+        3.2,
+        0.4,
+        0
+      ],
+      "role": "head"
+    },
     {
       "text": "This is a placeholder text.\nReplace with your own.",
-      "anchor": [3.2, -0.15, 0],
+      "anchor": [
+        3.2,
+        -0.15,
+        0
+      ],
       "role": "body"
     }
   ],
@@ -59,15 +177,49 @@
     "loop": false,
     "shots": [
       {
-        "duration": 10,
-        "pos": [0, 1.7, 9.0],
-        "target": [0, 1.4, 0],
+        "duration": 0.01,
+        "pos": [
+          0.7,
+          1.91,
+          10.799
+        ],
+        "target": [
+          0,
+          1.4,
+          0
+        ],
+        "fov": 50,
+        "aperture": 0,
+        "focalDistance": 9,
+        "ease": "smooth"
+      },
+      {
+        "duration": 14,
+        "pos": [
+          0,
+          1.7,
+          9
+        ],
+        "target": [
+          0,
+          1.4,
+          0
+        ],
         "fov": 46,
         "aperture": 0,
-        "focalDistance": 9.0,
-        "ease": "smooth"
+        "focalDistance": 9,
+        "ease": "smooth",
+        "transition": "blend"
       }
     ]
   },
-  "defaults": { "stage": { "size": [20, 8, 11] } }
+  "defaults": {
+    "stage": {
+      "size": [
+        20,
+        8,
+        11
+      ]
+    }
+  }
 }

--- a/sdf-js/scenes/p17-list-rows.json
+++ b/sdf-js/scenes/p17-list-rows.json
@@ -5,67 +5,314 @@
     {
       "id": "g1",
       "type": "sphere-fill-3d",
-      "args": { "levels": [0.2], "radius": 0.6 },
-      "transform": { "translate": [3.3, 2.55, 0] },
-      "material": { "hue": 0.57, "sat": 0.55, "value": 0.62, "kind": "fill", "roughness": 0.3, "clearcoat": 0.5 }
+      "args": {
+        "levels": [
+          0.2
+        ],
+        "radius": 0.6
+      },
+      "transform": {
+        "translate": [
+          3.3,
+          2.55,
+          0
+        ]
+      },
+      "material": {
+        "hue": 0.57,
+        "sat": 0.55,
+        "value": 0.62,
+        "kind": "fill",
+        "roughness": 0.3,
+        "clearcoat": 0.5
+      }
     },
     {
       "id": "g2",
       "type": "sphere-fill-3d",
-      "args": { "levels": [0.4], "radius": 0.6 },
-      "transform": { "translate": [3.3, 0.9, 0] },
-      "material": { "hue": 0.57, "sat": 0.55, "value": 0.62, "kind": "fill", "roughness": 0.3, "clearcoat": 0.5 }
+      "args": {
+        "levels": [
+          0.4
+        ],
+        "radius": 0.6
+      },
+      "transform": {
+        "translate": [
+          3.3,
+          0.9,
+          0
+        ]
+      },
+      "material": {
+        "hue": 0.57,
+        "sat": 0.55,
+        "value": 0.62,
+        "kind": "fill",
+        "roughness": 0.3,
+        "clearcoat": 0.5
+      }
     },
     {
       "id": "g3",
       "type": "sphere-fill-3d",
-      "args": { "levels": [0.9], "radius": 0.6 },
-      "transform": { "translate": [3.3, -0.75, 0] },
-      "material": { "hue": 0.57, "sat": 0.55, "value": 0.62, "kind": "fill", "roughness": 0.3, "clearcoat": 0.5 }
+      "args": {
+        "levels": [
+          0.9
+        ],
+        "radius": 0.6
+      },
+      "transform": {
+        "translate": [
+          3.3,
+          -0.75,
+          0
+        ]
+      },
+      "material": {
+        "hue": 0.57,
+        "sat": 0.55,
+        "value": 0.62,
+        "kind": "fill",
+        "roughness": 0.3,
+        "clearcoat": 0.5
+      }
     },
     {
       "id": "a1",
       "type": "arrow-3d",
-      "args": { "length": 0.8, "shaftWidth": 0.14, "headLength": 0.3, "headWidth": 0.4, "depth": 0.16 },
-      "transform": { "translate": [1.85, 2.55, 0], "rotate": [0, 3.14159, 0] },
-      "material": { "hue": 0.57, "sat": 0.35, "value": 0.78, "kind": "normal" }
+      "args": {
+        "length": 0.8,
+        "shaftWidth": 0.14,
+        "headLength": 0.3,
+        "headWidth": 0.4,
+        "depth": 0.16
+      },
+      "transform": {
+        "translate": [
+          1.85,
+          2.55,
+          0
+        ],
+        "rotate": [
+          0,
+          3.14159,
+          0
+        ]
+      },
+      "material": {
+        "hue": 0.57,
+        "sat": 0.35,
+        "value": 0.78,
+        "kind": "normal"
+      }
     },
     {
       "id": "a2",
       "type": "arrow-3d",
-      "args": { "length": 0.8, "shaftWidth": 0.14, "headLength": 0.3, "headWidth": 0.4, "depth": 0.16 },
-      "transform": { "translate": [1.85, 0.9, 0], "rotate": [0, 3.14159, 0] },
-      "material": { "hue": 0.57, "sat": 0.35, "value": 0.78, "kind": "normal" }
+      "args": {
+        "length": 0.8,
+        "shaftWidth": 0.14,
+        "headLength": 0.3,
+        "headWidth": 0.4,
+        "depth": 0.16
+      },
+      "transform": {
+        "translate": [
+          1.85,
+          0.9,
+          0
+        ],
+        "rotate": [
+          0,
+          3.14159,
+          0
+        ]
+      },
+      "material": {
+        "hue": 0.57,
+        "sat": 0.35,
+        "value": 0.78,
+        "kind": "normal"
+      }
     },
     {
       "id": "a3",
       "type": "arrow-3d",
-      "args": { "length": 0.8, "shaftWidth": 0.14, "headLength": 0.3, "headWidth": 0.4, "depth": 0.16 },
-      "transform": { "translate": [1.85, -0.75, 0], "rotate": [0, 3.14159, 0] },
-      "material": { "hue": 0.57, "sat": 0.35, "value": 0.78, "kind": "normal" }
+      "args": {
+        "length": 0.8,
+        "shaftWidth": 0.14,
+        "headLength": 0.3,
+        "headWidth": 0.4,
+        "depth": 0.16
+      },
+      "transform": {
+        "translate": [
+          1.85,
+          -0.75,
+          0
+        ],
+        "rotate": [
+          0,
+          3.14159,
+          0
+        ]
+      },
+      "material": {
+        "hue": 0.57,
+        "sat": 0.35,
+        "value": 0.78,
+        "kind": "normal"
+      }
     }
   ],
   "overlay": [
-    { "text": "3D SPHERES — FILL LEVELS", "anchor": [0, 4.0, 0], "role": "title" },
-
-    { "role": "value", "text": "20%", "anchor": [3.3, 2.55, 0], "radius": 0.6 },
-    { "role": "value", "text": "40%", "anchor": [3.3, 0.9, 0], "radius": 0.6 },
-    { "role": "value", "text": "90%", "anchor": [3.3, -0.75, 0], "radius": 0.6 },
-
-    { "text": "THIS IS A PLACEHOLDER TEXT", "anchor": [-1.6, 2.95, 0], "role": "head", "align": "left" },
-    { "text": "This is a placeholder text.\nReplace with your own.", "anchor": [-1.6, 2.4, 0], "role": "body", "align": "left" },
-
-    { "text": "THIS IS A PLACEHOLDER TEXT", "anchor": [-1.6, 1.3, 0], "role": "head", "align": "left" },
-    { "text": "This is a placeholder text.\nReplace with your own.", "anchor": [-1.6, 0.75, 0], "role": "body", "align": "left" },
-
-    { "text": "THIS IS A PLACEHOLDER TEXT", "anchor": [-1.6, -0.35, 0], "role": "head", "align": "left" },
-    { "text": "This is a placeholder text.\nReplace with your own.", "anchor": [-1.6, -0.9, 0], "role": "body", "align": "left" }
+    {
+      "text": "3D SPHERES — FILL LEVELS",
+      "anchor": [
+        0,
+        4,
+        0
+      ],
+      "role": "title"
+    },
+    {
+      "role": "value",
+      "text": "20%",
+      "anchor": [
+        3.3,
+        2.55,
+        0
+      ],
+      "radius": 0.6
+    },
+    {
+      "role": "value",
+      "text": "40%",
+      "anchor": [
+        3.3,
+        0.9,
+        0
+      ],
+      "radius": 0.6
+    },
+    {
+      "role": "value",
+      "text": "90%",
+      "anchor": [
+        3.3,
+        -0.75,
+        0
+      ],
+      "radius": 0.6
+    },
+    {
+      "text": "THIS IS A PLACEHOLDER TEXT",
+      "anchor": [
+        -1.6,
+        2.95,
+        0
+      ],
+      "role": "head",
+      "align": "left"
+    },
+    {
+      "text": "This is a placeholder text.\nReplace with your own.",
+      "anchor": [
+        -1.6,
+        2.4,
+        0
+      ],
+      "role": "body",
+      "align": "left"
+    },
+    {
+      "text": "THIS IS A PLACEHOLDER TEXT",
+      "anchor": [
+        -1.6,
+        1.3,
+        0
+      ],
+      "role": "head",
+      "align": "left"
+    },
+    {
+      "text": "This is a placeholder text.\nReplace with your own.",
+      "anchor": [
+        -1.6,
+        0.75,
+        0
+      ],
+      "role": "body",
+      "align": "left"
+    },
+    {
+      "text": "THIS IS A PLACEHOLDER TEXT",
+      "anchor": [
+        -1.6,
+        -0.35,
+        0
+      ],
+      "role": "head",
+      "align": "left"
+    },
+    {
+      "text": "This is a placeholder text.\nReplace with your own.",
+      "anchor": [
+        -1.6,
+        -0.9,
+        0
+      ],
+      "role": "body",
+      "align": "left"
+    }
   ],
   "cameraSequence": {
     "loop": false,
     "shots": [
-      { "duration": 10, "pos": [0, 0.9, 9.8], "target": [0, 0.9, 0], "fov": 52, "aperture": 0, "focalDistance": 9.8, "ease": "smooth" }
+      {
+        "duration": 0.01,
+        "pos": [
+          0.7,
+          1.05,
+          11.6
+        ],
+        "target": [
+          0,
+          0.9,
+          0
+        ],
+        "fov": 56,
+        "aperture": 0,
+        "focalDistance": 9.8,
+        "ease": "smooth"
+      },
+      {
+        "duration": 14,
+        "pos": [
+          0,
+          0.9,
+          9.8
+        ],
+        "target": [
+          0,
+          0.9,
+          0
+        ],
+        "fov": 52,
+        "aperture": 0,
+        "focalDistance": 9.8,
+        "ease": "smooth",
+        "transition": "blend"
+      }
     ]
   },
-  "defaults": { "stage": { "size": [20, 9, 10] } }
+  "defaults": {
+    "stage": {
+      "size": [
+        20,
+        9,
+        10
+      ]
+    }
+  }
 }

--- a/sdf-js/scenes/p17-list-rows.json
+++ b/sdf-js/scenes/p17-list-rows.json
@@ -212,7 +212,7 @@
         2.95,
         0
       ],
-      "role": "head",
+      "role": "card",
       "align": "left"
     },
     {
@@ -232,7 +232,7 @@
         1.3,
         0
       ],
-      "role": "head",
+      "role": "card",
       "align": "left"
     },
     {
@@ -252,7 +252,7 @@
         -0.35,
         0
       ],
-      "role": "head",
+      "role": "card",
       "align": "left"
     },
     {

--- a/sdf-js/scenes/p3-sequence-gauges.json
+++ b/sdf-js/scenes/p3-sequence-gauges.json
@@ -5,46 +5,232 @@
     {
       "id": "gauges",
       "type": "sphere-fill-3d",
-      "args": { "levels": [0.1, 0.6, 0.5], "radius": 0.72, "spacing": 1.5 },
-      "transform": { "translate": [0, 1.1, 0] },
-      "material": { "hue": 0.57, "sat": 0.55, "value": 0.62, "kind": "fill", "roughness": 0.3, "clearcoat": 0.5 }
+      "args": {
+        "levels": [
+          0.1,
+          0.6,
+          0.5
+        ],
+        "radius": 0.72,
+        "spacing": 1.5
+      },
+      "transform": {
+        "translate": [
+          0,
+          1.1,
+          0
+        ]
+      },
+      "material": {
+        "hue": 0.57,
+        "sat": 0.55,
+        "value": 0.62,
+        "kind": "fill",
+        "roughness": 0.3,
+        "clearcoat": 0.5
+      }
     },
     {
       "id": "arrowA",
       "type": "arrow-3d",
-      "args": { "length": 0.9, "shaftWidth": 0.12, "headLength": 0.32, "headWidth": 0.34, "depth": 0.16 },
-      "transform": { "translate": [-1.47, 1.1, 0], "rotate": [0, 3.14159, 0] },
-      "material": { "hue": 0.0, "sat": 0.0, "value": 0.7, "kind": "normal" }
+      "args": {
+        "length": 0.9,
+        "shaftWidth": 0.12,
+        "headLength": 0.32,
+        "headWidth": 0.34,
+        "depth": 0.16
+      },
+      "transform": {
+        "translate": [
+          -1.47,
+          1.1,
+          0
+        ],
+        "rotate": [
+          0,
+          3.14159,
+          0
+        ]
+      },
+      "material": {
+        "hue": 0,
+        "sat": 0,
+        "value": 0.7,
+        "kind": "normal"
+      }
     },
     {
       "id": "arrowB",
       "type": "arrow-3d",
-      "args": { "length": 0.9, "shaftWidth": 0.12, "headLength": 0.32, "headWidth": 0.34, "depth": 0.16 },
-      "transform": { "translate": [1.47, 1.1, 0], "rotate": [0, 3.14159, 0] },
-      "material": { "hue": 0.0, "sat": 0.0, "value": 0.7, "kind": "normal" }
+      "args": {
+        "length": 0.9,
+        "shaftWidth": 0.12,
+        "headLength": 0.32,
+        "headWidth": 0.34,
+        "depth": 0.16
+      },
+      "transform": {
+        "translate": [
+          1.47,
+          1.1,
+          0
+        ],
+        "rotate": [
+          0,
+          3.14159,
+          0
+        ]
+      },
+      "material": {
+        "hue": 0,
+        "sat": 0,
+        "value": 0.7,
+        "kind": "normal"
+      }
     }
   ],
   "overlay": [
-    { "role": "value", "text": "10%", "anchor": [-2.94, 1.1, 0], "radius": 0.72 },
-    { "role": "value", "text": "60%", "anchor": [0, 1.1, 0], "radius": 0.72 },
-    { "role": "value", "text": "50%", "anchor": [2.94, 1.1, 0], "radius": 0.72 },
-
-    { "text": "3D SPHERES — FILL LEVELS", "anchor": [0, 4.0, 0], "role": "title" },
-
-    { "text": "DESCRIPTION 1", "anchor": [2.94, 2.5, 0], "role": "head" },
-    { "text": "Placeholder for your text.", "anchor": [2.94, -0.15, 0], "role": "body" },
-
-    { "text": "DESCRIPTION 2", "anchor": [0, 2.5, 0], "role": "head" },
-    { "text": "Placeholder for your text.", "anchor": [0, -0.15, 0], "role": "body" },
-
-    { "text": "DESCRIPTION 3", "anchor": [-2.94, 2.5, 0], "role": "head" },
-    { "text": "Placeholder for your text.", "anchor": [-2.94, -0.15, 0], "role": "body" }
+    {
+      "role": "value",
+      "text": "10%",
+      "anchor": [
+        -2.94,
+        1.1,
+        0
+      ],
+      "radius": 0.72
+    },
+    {
+      "role": "value",
+      "text": "60%",
+      "anchor": [
+        0,
+        1.1,
+        0
+      ],
+      "radius": 0.72
+    },
+    {
+      "role": "value",
+      "text": "50%",
+      "anchor": [
+        2.94,
+        1.1,
+        0
+      ],
+      "radius": 0.72
+    },
+    {
+      "text": "3D SPHERES — FILL LEVELS",
+      "anchor": [
+        0,
+        4,
+        0
+      ],
+      "role": "title"
+    },
+    {
+      "text": "DESCRIPTION 1",
+      "anchor": [
+        2.94,
+        2.5,
+        0
+      ],
+      "role": "head"
+    },
+    {
+      "text": "Placeholder for your text.",
+      "anchor": [
+        2.94,
+        -0.15,
+        0
+      ],
+      "role": "body"
+    },
+    {
+      "text": "DESCRIPTION 2",
+      "anchor": [
+        0,
+        2.5,
+        0
+      ],
+      "role": "head"
+    },
+    {
+      "text": "Placeholder for your text.",
+      "anchor": [
+        0,
+        -0.15,
+        0
+      ],
+      "role": "body"
+    },
+    {
+      "text": "DESCRIPTION 3",
+      "anchor": [
+        -2.94,
+        2.5,
+        0
+      ],
+      "role": "head"
+    },
+    {
+      "text": "Placeholder for your text.",
+      "anchor": [
+        -2.94,
+        -0.15,
+        0
+      ],
+      "role": "body"
+    }
   ],
   "cameraSequence": {
     "loop": false,
     "shots": [
-      { "duration": 10, "pos": [0, 1.5, 9.5], "target": [0, 1.0, 0], "fov": 44, "aperture": 0, "focalDistance": 9.5, "ease": "smooth" }
+      {
+        "duration": 0.01,
+        "pos": [
+          0.7,
+          1.745,
+          11.298
+        ],
+        "target": [
+          0,
+          1,
+          0
+        ],
+        "fov": 48,
+        "aperture": 0,
+        "focalDistance": 9.5,
+        "ease": "smooth"
+      },
+      {
+        "duration": 14,
+        "pos": [
+          0,
+          1.5,
+          9.5
+        ],
+        "target": [
+          0,
+          1,
+          0
+        ],
+        "fov": 44,
+        "aperture": 0,
+        "focalDistance": 9.5,
+        "ease": "smooth",
+        "transition": "blend"
+      }
     ]
   },
-  "defaults": { "stage": { "size": [20, 7, 11] } }
+  "defaults": {
+    "stage": {
+      "size": [
+        20,
+        7,
+        11
+      ]
+    }
+  }
 }

--- a/sdf-js/scenes/p5-hero-textboxes.json
+++ b/sdf-js/scenes/p5-hero-textboxes.json
@@ -111,7 +111,7 @@
         2.65,
         0
       ],
-      "role": "head",
+      "role": "card",
       "align": "left"
     },
     {
@@ -131,7 +131,7 @@
         1.35,
         0
       ],
-      "role": "head",
+      "role": "card",
       "align": "left"
     },
     {
@@ -151,7 +151,7 @@
         0.05,
         0
       ],
-      "role": "head",
+      "role": "card",
       "align": "left"
     },
     {

--- a/sdf-js/scenes/p5-hero-textboxes.json
+++ b/sdf-js/scenes/p5-hero-textboxes.json
@@ -5,39 +5,213 @@
     {
       "id": "ring",
       "type": "circle-frame-3d",
-      "args": { "radius": 1.62, "frameWidth": 0.16, "backDepth": 0.05, "back": false },
-      "transform": { "translate": [2.7, 1.4, -0.15] },
-      "material": { "hue": 0.6, "sat": 0.04, "value": 0.82, "metal": 0.9, "kind": "normal", "roughness": 0.25, "clearcoat": 0.5 }
+      "args": {
+        "radius": 1.62,
+        "frameWidth": 0.16,
+        "backDepth": 0.05,
+        "back": false
+      },
+      "transform": {
+        "translate": [
+          2.7,
+          1.4,
+          -0.15
+        ]
+      },
+      "material": {
+        "hue": 0.6,
+        "sat": 0.04,
+        "value": 0.82,
+        "metal": 0.9,
+        "kind": "normal",
+        "roughness": 0.25,
+        "clearcoat": 0.5
+      }
     },
     {
       "id": "hero",
       "type": "sphere-fill-3d",
-      "args": { "levels": [1.0], "radius": 1.3 },
-      "transform": { "translate": [2.7, 1.4, 0] },
-      "material": { "hue": 0.57, "sat": 0.55, "value": 0.62, "kind": "fill", "roughness": 0.3, "clearcoat": 0.5 }
+      "args": {
+        "levels": [
+          1
+        ],
+        "radius": 1.3
+      },
+      "transform": {
+        "translate": [
+          2.7,
+          1.4,
+          0
+        ]
+      },
+      "material": {
+        "hue": 0.57,
+        "sat": 0.55,
+        "value": 0.62,
+        "kind": "fill",
+        "roughness": 0.3,
+        "clearcoat": 0.5
+      }
     }
   ],
   "overlay": [
-    { "role": "value", "text": "100%", "anchor": [2.7, 1.4, 0], "radius": 1.3 },
-
-    { "role": "spoke", "from": [1.45, 1.95, 0], "to": [-0.7, 2.6, 0] },
-    { "role": "spoke", "from": [1.35, 1.4, 0], "to": [-0.7, 1.3, 0] },
-    { "role": "spoke", "from": [1.45, 0.85, 0], "to": [-0.7, 0.0, 0] },
-
-    { "text": "DESCRIPTION TEXT", "anchor": [-0.5, 2.65, 0], "role": "head", "align": "left" },
-    { "text": "This is a placeholder text.\nReplace with your own text.", "anchor": [-0.5, 2.1, 0], "role": "body", "align": "left" },
-
-    { "text": "DESCRIPTION TEXT", "anchor": [-0.5, 1.35, 0], "role": "head", "align": "left" },
-    { "text": "This is a placeholder text.\nReplace with your own text.", "anchor": [-0.5, 0.8, 0], "role": "body", "align": "left" },
-
-    { "text": "DESCRIPTION TEXT", "anchor": [-0.5, 0.05, 0], "role": "head", "align": "left" },
-    { "text": "This is a placeholder text.\nReplace with your own text.", "anchor": [-0.5, -0.5, 0], "role": "body", "align": "left" }
+    {
+      "role": "value",
+      "text": "100%",
+      "anchor": [
+        2.7,
+        1.4,
+        0
+      ],
+      "radius": 1.3
+    },
+    {
+      "role": "spoke",
+      "from": [
+        1.45,
+        1.95,
+        0
+      ],
+      "to": [
+        -0.7,
+        2.6,
+        0
+      ]
+    },
+    {
+      "role": "spoke",
+      "from": [
+        1.35,
+        1.4,
+        0
+      ],
+      "to": [
+        -0.7,
+        1.3,
+        0
+      ]
+    },
+    {
+      "role": "spoke",
+      "from": [
+        1.45,
+        0.85,
+        0
+      ],
+      "to": [
+        -0.7,
+        0,
+        0
+      ]
+    },
+    {
+      "text": "DESCRIPTION TEXT",
+      "anchor": [
+        -0.5,
+        2.65,
+        0
+      ],
+      "role": "head",
+      "align": "left"
+    },
+    {
+      "text": "This is a placeholder text.\nReplace with your own text.",
+      "anchor": [
+        -0.5,
+        2.1,
+        0
+      ],
+      "role": "body",
+      "align": "left"
+    },
+    {
+      "text": "DESCRIPTION TEXT",
+      "anchor": [
+        -0.5,
+        1.35,
+        0
+      ],
+      "role": "head",
+      "align": "left"
+    },
+    {
+      "text": "This is a placeholder text.\nReplace with your own text.",
+      "anchor": [
+        -0.5,
+        0.8,
+        0
+      ],
+      "role": "body",
+      "align": "left"
+    },
+    {
+      "text": "DESCRIPTION TEXT",
+      "anchor": [
+        -0.5,
+        0.05,
+        0
+      ],
+      "role": "head",
+      "align": "left"
+    },
+    {
+      "text": "This is a placeholder text.\nReplace with your own text.",
+      "anchor": [
+        -0.5,
+        -0.5,
+        0
+      ],
+      "role": "body",
+      "align": "left"
+    }
   ],
   "cameraSequence": {
     "loop": false,
     "shots": [
-      { "duration": 10, "pos": [0, 1.2, 9.5], "target": [0, 1.1, 0], "fov": 50, "aperture": 0, "focalDistance": 9.5, "ease": "smooth" }
+      {
+        "duration": 0.01,
+        "pos": [
+          0.7,
+          1.369,
+          11.3
+        ],
+        "target": [
+          0,
+          1.1,
+          0
+        ],
+        "fov": 54,
+        "aperture": 0,
+        "focalDistance": 9.5,
+        "ease": "smooth"
+      },
+      {
+        "duration": 14,
+        "pos": [
+          0,
+          1.2,
+          9.5
+        ],
+        "target": [
+          0,
+          1.1,
+          0
+        ],
+        "fov": 50,
+        "aperture": 0,
+        "focalDistance": 9.5,
+        "ease": "smooth",
+        "transition": "blend"
+      }
     ]
   },
-  "defaults": { "stage": { "size": [20, 8, 11] } }
+  "defaults": {
+    "stage": {
+      "size": [
+        20,
+        8,
+        11
+      ]
+    }
+  }
 }

--- a/sdf-js/scenes/p7-stage-gauges.json
+++ b/sdf-js/scenes/p7-stage-gauges.json
@@ -5,8 +5,26 @@
     {
       "id": "gauges",
       "type": "sphere-fill-3d",
-      "args": { "levels": [0.8, 1.0, 0.5], "radii": [0.85, 1.05, 0.7], "spacing": 0.6 },
-      "transform": { "translate": [0, 1.1, 0] },
+      "args": {
+        "levels": [
+          0.8,
+          1,
+          0.5
+        ],
+        "radii": [
+          0.85,
+          1.05,
+          0.7
+        ],
+        "spacing": 0.6
+      },
+      "transform": {
+        "translate": [
+          0,
+          1.1,
+          0
+        ]
+      },
       "material": {
         "hue": 0.57,
         "sat": 0.55,
@@ -18,30 +36,97 @@
     }
   ],
   "overlay": [
-    { "role": "value", "text": "80%", "anchor": [-2.425, 1.1, 0], "radius": 0.85 },
-    { "role": "value", "text": "100%", "anchor": [0.075, 1.1, 0], "radius": 1.05 },
-    { "role": "value", "text": "50%", "anchor": [2.425, 1.1, 0], "radius": 0.7 },
-
-    { "text": "3D SPHERES — FILL LEVELS", "anchor": [0, 4.15, 0], "role": "title" },
-
-    { "text": "DESCRIPTION 1", "anchor": [2.425, 3.2, 0], "role": "head" },
+    {
+      "role": "value",
+      "text": "80%",
+      "anchor": [
+        -2.425,
+        1.1,
+        0
+      ],
+      "radius": 0.85
+    },
+    {
+      "role": "value",
+      "text": "100%",
+      "anchor": [
+        0.075,
+        1.1,
+        0
+      ],
+      "radius": 1.05
+    },
+    {
+      "role": "value",
+      "text": "50%",
+      "anchor": [
+        2.425,
+        1.1,
+        0
+      ],
+      "radius": 0.7
+    },
+    {
+      "text": "3D SPHERES — FILL LEVELS",
+      "anchor": [
+        0,
+        4.15,
+        0
+      ],
+      "role": "title"
+    },
+    {
+      "text": "DESCRIPTION 1",
+      "anchor": [
+        2.425,
+        3.2,
+        0
+      ],
+      "role": "head"
+    },
     {
       "text": "The text demonstrates how\nyour own text will look here.",
-      "anchor": [2.425, 2.5, 0],
+      "anchor": [
+        2.425,
+        2.5,
+        0
+      ],
       "role": "body"
     },
-
-    { "text": "DESCRIPTION 2", "anchor": [0.075, 3.55, 0], "role": "head" },
+    {
+      "text": "DESCRIPTION 2",
+      "anchor": [
+        0.075,
+        3.55,
+        0
+      ],
+      "role": "head"
+    },
     {
       "text": "The text demonstrates how\nyour own text will look here.",
-      "anchor": [0.075, 2.85, 0],
+      "anchor": [
+        0.075,
+        2.85,
+        0
+      ],
       "role": "body"
     },
-
-    { "text": "DESCRIPTION 3", "anchor": [-2.425, 3.35, 0], "role": "head" },
+    {
+      "text": "DESCRIPTION 3",
+      "anchor": [
+        -2.425,
+        3.35,
+        0
+      ],
+      "role": "head"
+    },
     {
       "text": "The text demonstrates how\nyour own text will look here.",
-      "anchor": [-2.425, 2.65, 0],
+      "anchor": [
+        -2.425,
+        2.65,
+        0
+      ],
       "role": "body"
     }
   ],
@@ -49,15 +134,49 @@
     "loop": false,
     "shots": [
       {
-        "duration": 10,
-        "pos": [0, 1.6, 8.5],
-        "target": [0, 1.0, 0],
-        "fov": 44,
+        "duration": 0.01,
+        "pos": [
+          0.7,
+          1.877,
+          10.296
+        ],
+        "target": [
+          0,
+          1,
+          0
+        ],
+        "fov": 48,
         "aperture": 0,
         "focalDistance": 8.5,
         "ease": "smooth"
+      },
+      {
+        "duration": 14,
+        "pos": [
+          0,
+          1.6,
+          8.5
+        ],
+        "target": [
+          0,
+          1,
+          0
+        ],
+        "fov": 44,
+        "aperture": 0,
+        "focalDistance": 8.5,
+        "ease": "smooth",
+        "transition": "blend"
       }
     ]
   },
-  "defaults": { "stage": { "size": [18, 7, 11] } }
+  "defaults": {
+    "stage": {
+      "size": [
+        18,
+        7,
+        11
+      ]
+    }
+  }
 }

--- a/sdf-js/scenes/p9-grid-gauges.json
+++ b/sdf-js/scenes/p9-grid-gauges.json
@@ -5,36 +5,200 @@
     {
       "id": "row1",
       "type": "sphere-fill-3d",
-      "args": { "levels": [0.1, 0.3, 0.5, 0.7], "radius": 0.5, "spacing": 0.7 },
-      "transform": { "translate": [0, 2.85, 0] },
-      "material": { "hue": 0.57, "sat": 0.55, "value": 0.62, "kind": "fill", "roughness": 0.3, "clearcoat": 0.5 }
+      "args": {
+        "levels": [
+          0.1,
+          0.3,
+          0.5,
+          0.7
+        ],
+        "radius": 0.5,
+        "spacing": 0.7
+      },
+      "transform": {
+        "translate": [
+          0,
+          2.85,
+          0
+        ]
+      },
+      "material": {
+        "hue": 0.57,
+        "sat": 0.55,
+        "value": 0.62,
+        "kind": "fill",
+        "roughness": 0.3,
+        "clearcoat": 0.5
+      }
     },
     {
       "id": "row2",
       "type": "sphere-fill-3d",
-      "args": { "levels": [0.2, 0.4, 0.6, 0.8], "radius": 0.5, "spacing": 0.7 },
-      "transform": { "translate": [0, 1.0, 0] },
-      "material": { "hue": 0.57, "sat": 0.55, "value": 0.62, "kind": "fill", "roughness": 0.3, "clearcoat": 0.5 }
+      "args": {
+        "levels": [
+          0.2,
+          0.4,
+          0.6,
+          0.8
+        ],
+        "radius": 0.5,
+        "spacing": 0.7
+      },
+      "transform": {
+        "translate": [
+          0,
+          1,
+          0
+        ]
+      },
+      "material": {
+        "hue": 0.57,
+        "sat": 0.55,
+        "value": 0.62,
+        "kind": "fill",
+        "roughness": 0.3,
+        "clearcoat": 0.5
+      }
     }
   ],
   "overlay": [
-    { "text": "3D SPHERES — FILL LEVELS", "anchor": [0, 4.3, 0], "role": "title" },
-
-    { "role": "value", "text": "10%", "anchor": [-2.55, 2.05, 0], "radius": 0.5 },
-    { "role": "value", "text": "30%", "anchor": [-0.85, 2.05, 0], "radius": 0.5 },
-    { "role": "value", "text": "50%", "anchor": [0.85, 2.05, 0], "radius": 0.5 },
-    { "role": "value", "text": "70%", "anchor": [2.55, 2.05, 0], "radius": 0.5 },
-
-    { "role": "value", "text": "20%", "anchor": [-2.55, 0.2, 0], "radius": 0.5 },
-    { "role": "value", "text": "40%", "anchor": [-0.85, 0.2, 0], "radius": 0.5 },
-    { "role": "value", "text": "60%", "anchor": [0.85, 0.2, 0], "radius": 0.5 },
-    { "role": "value", "text": "80%", "anchor": [2.55, 0.2, 0], "radius": 0.5 }
+    {
+      "text": "3D SPHERES — FILL LEVELS",
+      "anchor": [
+        0,
+        4.3,
+        0
+      ],
+      "role": "title"
+    },
+    {
+      "role": "value",
+      "text": "10%",
+      "anchor": [
+        -2.55,
+        2.05,
+        0
+      ],
+      "radius": 0.5
+    },
+    {
+      "role": "value",
+      "text": "30%",
+      "anchor": [
+        -0.85,
+        2.05,
+        0
+      ],
+      "radius": 0.5
+    },
+    {
+      "role": "value",
+      "text": "50%",
+      "anchor": [
+        0.85,
+        2.05,
+        0
+      ],
+      "radius": 0.5
+    },
+    {
+      "role": "value",
+      "text": "70%",
+      "anchor": [
+        2.55,
+        2.05,
+        0
+      ],
+      "radius": 0.5
+    },
+    {
+      "role": "value",
+      "text": "20%",
+      "anchor": [
+        -2.55,
+        0.2,
+        0
+      ],
+      "radius": 0.5
+    },
+    {
+      "role": "value",
+      "text": "40%",
+      "anchor": [
+        -0.85,
+        0.2,
+        0
+      ],
+      "radius": 0.5
+    },
+    {
+      "role": "value",
+      "text": "60%",
+      "anchor": [
+        0.85,
+        0.2,
+        0
+      ],
+      "radius": 0.5
+    },
+    {
+      "role": "value",
+      "text": "80%",
+      "anchor": [
+        2.55,
+        0.2,
+        0
+      ],
+      "radius": 0.5
+    }
   ],
   "cameraSequence": {
     "loop": false,
     "shots": [
-      { "duration": 10, "pos": [0, 1.9, 9.0], "target": [0, 1.9, 0], "fov": 50, "aperture": 0, "focalDistance": 9.0, "ease": "smooth" }
+      {
+        "duration": 0.01,
+        "pos": [
+          0.7,
+          2.05,
+          10.8
+        ],
+        "target": [
+          0,
+          1.9,
+          0
+        ],
+        "fov": 54,
+        "aperture": 0,
+        "focalDistance": 9,
+        "ease": "smooth"
+      },
+      {
+        "duration": 14,
+        "pos": [
+          0,
+          1.9,
+          9
+        ],
+        "target": [
+          0,
+          1.9,
+          0
+        ],
+        "fov": 50,
+        "aperture": 0,
+        "focalDistance": 9,
+        "ease": "smooth",
+        "transition": "blend"
+      }
     ]
   },
-  "defaults": { "stage": { "size": [18, 9, 10] } }
+  "defaults": {
+    "stage": {
+      "size": [
+        18,
+        9,
+        10
+      ]
+    }
+  }
 }

--- a/sdf-js/scenes/sphere-fill-cover.json
+++ b/sdf-js/scenes/sphere-fill-cover.json
@@ -6,17 +6,43 @@
       "id": "gauges",
       "type": "sphere-fill-3d",
       "args": {
-        "levels": [0.8, 0.4, 0.2],
-        "radii": [1.0, 0.72, 0.55],
+        "levels": [
+          0.8,
+          0.4,
+          0.2
+        ],
+        "radii": [
+          1,
+          0.72,
+          0.55
+        ],
         "spacing": 0.5,
         "labels": [],
         "colors": [
-          { "hue": 0.58, "sat": 0.82, "value": 0.66 },
-          { "hue": 0.99, "sat": 0.85, "value": 0.5 },
-          { "hue": 0.3, "sat": 0.72, "value": 0.6 }
+          {
+            "hue": 0.58,
+            "sat": 0.82,
+            "value": 0.66
+          },
+          {
+            "hue": 0.99,
+            "sat": 0.85,
+            "value": 0.5
+          },
+          {
+            "hue": 0.3,
+            "sat": 0.72,
+            "value": 0.6
+          }
         ]
       },
-      "transform": { "translate": [0, 1.1, 0] },
+      "transform": {
+        "translate": [
+          0,
+          1.1,
+          0
+        ]
+      },
       "material": {
         "hue": 0.58,
         "sat": 0.82,
@@ -28,23 +54,84 @@
     }
   ],
   "overlay": [
-    { "role": "value", "text": "80%", "anchor": [-1.995, 1.0, 0], "radius": 1.0 },
-    { "role": "value", "text": "40%", "anchor": [0.225, 1.0, 0], "radius": 0.72 },
-    { "role": "value", "text": "20%", "anchor": [1.995, 1.0, 0], "radius": 0.55 }
+    {
+      "role": "value",
+      "text": "80%",
+      "anchor": [
+        -1.995,
+        1,
+        0
+      ],
+      "radius": 1
+    },
+    {
+      "role": "value",
+      "text": "40%",
+      "anchor": [
+        0.225,
+        1,
+        0
+      ],
+      "radius": 0.72
+    },
+    {
+      "role": "value",
+      "text": "20%",
+      "anchor": [
+        1.995,
+        1,
+        0
+      ],
+      "radius": 0.55
+    }
   ],
   "cameraSequence": {
     "loop": false,
     "shots": [
       {
-        "duration": 8,
-        "pos": [0, 1.6, 8.5],
-        "target": [0, 1.0, 0],
-        "fov": 44,
+        "duration": 0.01,
+        "pos": [
+          0.7,
+          1.877,
+          10.296
+        ],
+        "target": [
+          0,
+          1,
+          0
+        ],
+        "fov": 48,
         "aperture": 0,
         "focalDistance": 8.5,
         "ease": "smooth"
+      },
+      {
+        "duration": 12,
+        "pos": [
+          0,
+          1.6,
+          8.5
+        ],
+        "target": [
+          0,
+          1,
+          0
+        ],
+        "fov": 44,
+        "aperture": 0,
+        "focalDistance": 8.5,
+        "ease": "smooth",
+        "transition": "blend"
       }
     ]
   },
-  "defaults": { "stage": { "size": [16, 6, 11] } }
+  "defaults": {
+    "stage": {
+      "size": [
+        16,
+        6,
+        11
+      ]
+    }
+  }
 }

--- a/sdf-js/scenes/sphere-fill-multicolor.json
+++ b/sdf-js/scenes/sphere-fill-multicolor.json
@@ -6,16 +6,38 @@
       "id": "gauges",
       "type": "sphere-fill-3d",
       "args": {
-        "levels": [0.8, 0.4, 0.2],
+        "levels": [
+          0.8,
+          0.4,
+          0.2
+        ],
         "radius": 0.8,
         "spacing": 0.5,
         "colors": [
-          { "hue": 0.58, "sat": 0.82, "value": 0.66 },
-          { "hue": 0.99, "sat": 0.85, "value": 0.5 },
-          { "hue": 0.3, "sat": 0.72, "value": 0.6 }
+          {
+            "hue": 0.58,
+            "sat": 0.82,
+            "value": 0.66
+          },
+          {
+            "hue": 0.99,
+            "sat": 0.85,
+            "value": 0.5
+          },
+          {
+            "hue": 0.3,
+            "sat": 0.72,
+            "value": 0.6
+          }
         ]
       },
-      "transform": { "translate": [0, 1.0, 0] },
+      "transform": {
+        "translate": [
+          0,
+          1,
+          0
+        ]
+      },
       "material": {
         "hue": 0.58,
         "sat": 0.82,
@@ -27,23 +49,84 @@
     }
   ],
   "overlay": [
-    { "role": "value", "text": "80%", "anchor": [-2.1, 1.0, 0], "radius": 0.8 },
-    { "role": "value", "text": "40%", "anchor": [0, 1.0, 0], "radius": 0.8 },
-    { "role": "value", "text": "20%", "anchor": [2.1, 1.0, 0], "radius": 0.8 }
+    {
+      "role": "value",
+      "text": "80%",
+      "anchor": [
+        -2.1,
+        1,
+        0
+      ],
+      "radius": 0.8
+    },
+    {
+      "role": "value",
+      "text": "40%",
+      "anchor": [
+        0,
+        1,
+        0
+      ],
+      "radius": 0.8
+    },
+    {
+      "role": "value",
+      "text": "20%",
+      "anchor": [
+        2.1,
+        1,
+        0
+      ],
+      "radius": 0.8
+    }
   ],
   "cameraSequence": {
     "loop": false,
     "shots": [
       {
-        "duration": 8,
-        "pos": [0, 1.5, 7.5],
-        "target": [0, 1.0, 0],
-        "fov": 46,
+        "duration": 0.01,
+        "pos": [
+          0.7,
+          1.77,
+          9.296
+        ],
+        "target": [
+          0,
+          1,
+          0
+        ],
+        "fov": 50,
         "aperture": 0,
         "focalDistance": 7.5,
         "ease": "smooth"
+      },
+      {
+        "duration": 12,
+        "pos": [
+          0,
+          1.5,
+          7.5
+        ],
+        "target": [
+          0,
+          1,
+          0
+        ],
+        "fov": 46,
+        "aperture": 0,
+        "focalDistance": 7.5,
+        "ease": "smooth",
+        "transition": "blend"
       }
     ]
   },
-  "defaults": { "stage": { "size": [14, 5.5, 10] } }
+  "defaults": {
+    "stage": {
+      "size": [
+        14,
+        5.5,
+        10
+      ]
+    }
+  }
 }


### PR DESCRIPTION
## C ③ — 运镜(感知提升最大的一项)

每页之前是**单静止镜头**,太平。给 9 个 deck 场景都加**缓慢推入**:2-shot cameraSequence —— shot0 在稍后/偏移/广角处,shot1(`transition:"blend"`)缓 ease 到最终取景(~12s)。deck 里相机一直在微动,单看则推入后停住。

- 9 场景:start = end + viewDir×1.8 + drift(0.7,0.15) + fov+4 → blend 回原框。
- **刻意克制**(慢推胜过晕眩的甩镜)。

## 验证

Playwright + `studio.project` 采样:`setSequenceTime(0)` 后让时钟跑,投影锚点平滑推进 start→end(`0.3475→0.3101` / ~9s)—— blend 在动。(headless rAF 节流会把 sequence parked 在 end,所以单帧截图看不出,用采样确认;真实产品里 deck-player 驱动每段时钟。)

`npm test` **94/94**,9 场景全 E0/W0(camera validator 接受 2-shot blend)。

## 剩余 C

色条标题卡片、p19 标定图、p17 底行抬高 —— 下个 PR。

🤖 Generated with [Claude Code](https://claude.com/claude-code)