### PR TITLE
fix(present): hide ‹ › nav arrows in single-scene mode

### DIFF
--- a/sdf-js/apps/present/index.html
+++ b/sdf-js/apps/present/index.html
@@ -84,6 +84,13 @@
         if (!document.fullscreenElement) w.requestFullscreen?.();
         else document.exitFullscreen?.();
       });
+      // The ‹ › arrows navigate a DECK (wired in deck-player.js). In single-scene
+      // mode (?scene=) there is no next/prev slide, so they'd be dead — hide them
+      // to avoid the "buttons do nothing" confusion. Visible only when ?deck= is set.
+      if (!new URLSearchParams(location.search).get('deck')) {
+        document.getElementById('nav-prev').style.display = 'none';
+        document.getElementById('nav-next').style.display = 'none';
+      }
     </script>
   </body>
 </html>


### PR DESCRIPTION
The ‹ / › arrows are deck navigation (wired in deck-player.js for `?deck=`). In single-scene mode (`?scene=`) deck-player doesn't run, so they had no click handler and looked broken. Hide them unless `?deck=` is set; fullscreen button stays.

Verified (Playwright): single-scene → arrows `display:none`; deck → `display:block` + clicking advances the slide (Slide 3→4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)