### PR TITLE
feat(present): 3D sphere-family shape templates (5 of the PL Shapes 3D set)

### DIFF
--- a/sdf-js/scenes/deck-shapes-spheres.json
+++ b/sdf-js/scenes/deck-shapes-spheres.json
@@ -1,0 +1,12 @@
+{
+  "id": "deck-shapes-spheres",
+  "name": "3D Spheres — the PresentationLoad sphere family",
+  "segments": [
+    { "file": "shape-sphere-plain.json", "title": "3D Spheres", "kind": "slide", "durationSec": 7 },
+    { "file": "shape-sphere-chrome.json", "title": "Chrome Spheres", "kind": "slide", "durationSec": 7 },
+    { "file": "sphere-fill-cover.json", "title": "Fill Levels", "kind": "slide", "durationSec": 7 },
+    { "file": "shape-sphere-divisions.json", "title": "Divisions", "kind": "slide", "durationSec": 7 },
+    { "file": "shape-sphere-network.json", "title": "Network", "kind": "slide", "durationSec": 7 },
+    { "file": "shape-sphere-tree.json", "title": "Tree Structures", "kind": "slide", "durationSec": 7 }
+  ]
+}

--- a/sdf-js/scenes/shape-sphere-chrome.json
+++ b/sdf-js/scenes/shape-sphere-chrome.json
@@ -1,0 +1,36 @@
+{
+  "v": 1,
+  "name": "kpi: 3D Chrome Spheres (twin)",
+  "subjects": [
+    {
+      "id": "c1",
+      "type": "sphere",
+      "args": { "radius": 1.0 },
+      "transform": { "translate": [-1.7, 1.3, 0.2] },
+      "material": { "hue": 0.6, "sat": 0.02, "value": 0.85, "metal": 0.95, "kind": "normal", "roughness": 0.12, "clearcoat": 0.6 }
+    },
+    {
+      "id": "c2",
+      "type": "sphere",
+      "args": { "radius": 0.66 },
+      "transform": { "translate": [0.5, 1.0, 0.9] },
+      "material": { "hue": 0.6, "sat": 0.02, "value": 0.85, "metal": 0.95, "kind": "normal", "roughness": 0.12, "clearcoat": 0.6 }
+    },
+    {
+      "id": "c3",
+      "type": "sphere",
+      "args": { "radius": 0.82 },
+      "transform": { "translate": [1.9, 1.5, -0.4] },
+      "material": { "hue": 0.6, "sat": 0.02, "value": 0.85, "metal": 0.95, "kind": "normal", "roughness": 0.12, "clearcoat": 0.6 }
+    }
+  ],
+  "overlay": [{ "text": "3D CHROME SPHERES", "anchor": [0, 3.7, 0], "role": "title" }],
+  "cameraSequence": {
+    "loop": false,
+    "shots": [
+      { "duration": 0.01, "pos": [1.1, 1.8, 9.4], "target": [0.2, 1.3, 0], "fov": 50, "aperture": 0, "focalDistance": 8.5, "ease": "smooth" },
+      { "duration": 13, "pos": [0.1, 1.5, 7.9], "target": [0.2, 1.3, 0], "fov": 46, "transition": "blend", "aperture": 0, "focalDistance": 7.9, "ease": "smooth" }
+    ]
+  },
+  "defaults": { "stage": { "size": [16, 8, 11] } }
+}

--- a/sdf-js/scenes/shape-sphere-divisions.json
+++ b/sdf-js/scenes/shape-sphere-divisions.json
@@ -1,0 +1,29 @@
+{
+  "v": 1,
+  "name": "layers: 3D Spheres — Divisions (segmented twin)",
+  "subjects": [
+    {
+      "id": "seg",
+      "type": "sphere-segmented-3d",
+      "args": { "segments": 5, "radius": 1.4, "explode": 0.2, "gapAngle": 0.07 },
+      "transform": { "translate": [0, 1.6, 0], "rotate": [0.15, 0.5, 0] },
+      "material": { "hue": 0.57, "sat": 0.55, "value": 0.62, "kind": "normal", "roughness": 0.3, "clearcoat": 0.5 }
+    }
+  ],
+  "overlay": [
+    { "text": "3D SPHERES — DIVISIONS", "anchor": [0, 4.0, 0], "role": "title" },
+
+    { "text": "DESCRIPTION 1", "anchor": [3.0, 2.7, 0], "role": "card", "align": "left" },
+    { "text": "This is a placeholder text.", "anchor": [3.0, 2.2, 0], "role": "body", "align": "left" },
+    { "text": "DESCRIPTION 2", "anchor": [3.0, 1.0, 0], "role": "card", "align": "left" },
+    { "text": "This is a placeholder text.", "anchor": [3.0, 0.5, 0], "role": "body", "align": "left" }
+  ],
+  "cameraSequence": {
+    "loop": false,
+    "shots": [
+      { "duration": 0.01, "pos": [1.2, 2.0, 9.8], "target": [-0.4, 1.6, 0], "fov": 50, "aperture": 0, "focalDistance": 9, "ease": "smooth" },
+      { "duration": 13, "pos": [0.2, 1.7, 8.3], "target": [-0.4, 1.6, 0], "fov": 46, "transition": "blend", "aperture": 0, "focalDistance": 8.3, "ease": "smooth" }
+    ]
+  },
+  "defaults": { "stage": { "size": [18, 9, 11] } }
+}

--- a/sdf-js/scenes/shape-sphere-network.json
+++ b/sdf-js/scenes/shape-sphere-network.json
@@ -1,0 +1,25 @@
+{
+  "v": 1,
+  "name": "relation: 3D Spheres — Network (D1241 twin)",
+  "subjects": [
+    {
+      "id": "net",
+      "type": "sphere-network-3d",
+      "args": { "count": 9, "arrangement": "sphere", "radius": 1.7, "hubRadius": 0.55, "satelliteRadius": 0.32, "linkThickness": 0.05 },
+      "transform": { "translate": [0, 1.6, 0], "rotate": [0, 0.5, 0] },
+      "material": { "hue": 0.57, "sat": 0.5, "value": 0.64, "metal": 0.2, "kind": "normal", "roughness": 0.25, "clearcoat": 0.5 }
+    }
+  ],
+  "overlay": [
+    { "text": "3D SPHERES — NETWORK", "anchor": [0, 4.0, 0], "role": "title" },
+    { "text": "Central concept", "anchor": [0, 1.6, 1.9], "role": "head" }
+  ],
+  "cameraSequence": {
+    "loop": false,
+    "shots": [
+      { "duration": 0.01, "pos": [1.0, 2.0, 9.6], "target": [0, 1.6, 0], "fov": 50, "aperture": 0, "focalDistance": 8.5, "ease": "smooth" },
+      { "duration": 13, "pos": [0, 1.7, 8.0], "target": [0, 1.6, 0], "fov": 46, "transition": "blend", "aperture": 0, "focalDistance": 8.0, "ease": "smooth" }
+    ]
+  },
+  "defaults": { "stage": { "size": [16, 9, 11] } }
+}

--- a/sdf-js/scenes/shape-sphere-plain.json
+++ b/sdf-js/scenes/shape-sphere-plain.json
@@ -1,0 +1,38 @@
+{
+  "v": 1,
+  "name": "kpi: 3D Spheres (twin)",
+  "subjects": [
+    {
+      "id": "spheres",
+      "type": "sphere-fill-3d",
+      "args": {
+        "levels": [1.0, 1.0, 1.0],
+        "radii": [0.7, 0.95, 0.7],
+        "spacing": 0.6,
+        "labels": [],
+        "colors": [
+          { "hue": 0.3, "sat": 0.6, "value": 0.62 },
+          { "hue": 0.57, "sat": 0.6, "value": 0.64 },
+          { "hue": 0.02, "sat": 0.7, "value": 0.6 }
+        ]
+      },
+      "transform": { "translate": [0, 1.3, 0] },
+      "material": { "hue": 0.57, "sat": 0.6, "value": 0.62, "kind": "fill", "roughness": 0.25, "clearcoat": 0.5 }
+    }
+  ],
+  "overlay": [
+    { "text": "3D SPHERES", "anchor": [0, 3.7, 0], "role": "title" },
+
+    { "text": "FEATURE A", "anchor": [-2.1, 0.05, 0], "role": "card" },
+    { "text": "FEATURE B", "anchor": [0, -0.15, 0], "role": "card" },
+    { "text": "FEATURE C", "anchor": [2.1, 0.05, 0], "role": "card" }
+  ],
+  "cameraSequence": {
+    "loop": false,
+    "shots": [
+      { "duration": 0.01, "pos": [0.9, 1.7, 9.3], "target": [0, 1.2, 0], "fov": 50, "aperture": 0, "focalDistance": 8.5, "ease": "smooth" },
+      { "duration": 13, "pos": [0, 1.5, 7.8], "target": [0, 1.2, 0], "fov": 46, "transition": "blend", "aperture": 0, "focalDistance": 7.8, "ease": "smooth" }
+    ]
+  },
+  "defaults": { "stage": { "size": [16, 8, 10] } }
+}

--- a/sdf-js/scenes/shape-sphere-tree.json
+++ b/sdf-js/scenes/shape-sphere-tree.json
@@ -1,0 +1,24 @@
+{
+  "v": 1,
+  "name": "hierarchy: 3D Spheres — Tree Structures (twin)",
+  "subjects": [
+    {
+      "id": "tree",
+      "type": "sphere-tree-3d",
+      "args": { "levels": 3, "branching": 2, "rootRadius": 0.5, "radiusFalloff": 0.74, "levelHeight": 1.25, "spread": 4.2, "linkThickness": 0.05 },
+      "transform": { "translate": [0, 3.2, 0] },
+      "material": { "hue": 0.57, "sat": 0.5, "value": 0.64, "kind": "normal", "roughness": 0.25, "clearcoat": 0.5 }
+    }
+  ],
+  "overlay": [
+    { "text": "3D SPHERES — TREE STRUCTURES", "anchor": [0, 4.4, 0], "role": "title" }
+  ],
+  "cameraSequence": {
+    "loop": false,
+    "shots": [
+      { "duration": 0.01, "pos": [1.0, 2.5, 11.0], "target": [0, 2.0, 0], "fov": 54, "aperture": 0, "focalDistance": 10, "ease": "smooth" },
+      { "duration": 13, "pos": [0, 2.2, 9.6], "target": [0, 2.0, 0], "fov": 50, "transition": "blend", "aperture": 0, "focalDistance": 9.6, "ease": "smooth" }
+    ]
+  },
+  "defaults": { "stage": { "size": [18, 9, 11] } }
+}


### PR DESCRIPTION
## PL「PowerPoint Shapes」3D 模板复刻 —— 第 1 个家族:Spheres

那个分类页有 **17 个带「3D」的模板**,Fill-Levels 已做。从 **Sphere 家族**开始(全部复用现成原子,每个一个验证过的 showcase 场景 + overlay 标题/标签 + 缓慢推入):

- `shape-sphere-network` —— `sphere-network-3d`(hub + 卫星 + 连接线,分子状网络)
- `shape-sphere-tree` —— `sphere-tree-3d`(3 层二叉球树)
- `shape-sphere-divisions` —— `sphere-segmented-3d`(炸开的球分层)+ 蓝卡片
- `shape-sphere-plain` —— 3 个实色玻璃球(sphere-fill 100%)+ feature 卡片
- `shape-sphere-chrome` —— 反射铬金属球(sphere 原语 + metal 材质)
- `deck-shapes-spheres` —— 6 个 sphere 模板组成一个 deck(含 Fill-Levels)

## 验证(Playwright Chromium,WebGL2)

5 个全部正确渲染(分子网络 / 二叉树 / 炸开分层 / 彩球 / 铬反射)。`npm test` **94/94**,全 E0/W0。

看 deck:`?deck=deck-shapes-spheres`

## 后续家族

cubes(5)/ circles(2)/ puzzle(2)/ arrow(1)/ gear(1)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)