### PR TITLE
feat(present): 3D cube-family shape templates + wire cube-3d colors[]

### DIFF
--- a/sdf-js/scenes/deck-shapes-cubes.json
+++ b/sdf-js/scenes/deck-shapes-cubes.json
@@ -1,0 +1,11 @@
+{
+  "id": "deck-shapes-cubes",
+  "name": "3D Cubes — the PresentationLoad cube family",
+  "segments": [
+    { "file": "shape-cube-cluster.json", "title": "Cube Shapes", "kind": "slide", "durationSec": 7 },
+    { "file": "shape-cube-flow.json", "title": "Flow Process", "kind": "slide", "durationSec": 7 },
+    { "file": "shape-cube-steps.json", "title": "Flow Steps", "kind": "slide", "durationSec": 7 },
+    { "file": "shape-cube-semicircle.json", "title": "Semi-Circle", "kind": "slide", "durationSec": 7 },
+    { "file": "shape-cube-segmented.json", "title": "Segmented", "kind": "slide", "durationSec": 7 }
+  ]
+}

--- a/sdf-js/scenes/shape-cube-cluster.json
+++ b/sdf-js/scenes/shape-cube-cluster.json
@@ -1,0 +1,38 @@
+{
+  "v": 1,
+  "name": "shapes: 3D Cubes — Shapes / Cluster (twin)",
+  "subjects": [
+    {
+      "id": "cubes",
+      "type": "cube-3d",
+      "args": {
+        "count": 7,
+        "arrangement": "cluster",
+        "cubeSize": 0.62,
+        "spacing": 0.18,
+        "cornerRadius": 0.05,
+        "material": "solid",
+        "colors": [
+          { "hue": 0.57, "sat": 0.5, "value": 0.66 },
+          { "hue": 0.3, "sat": 0.55, "value": 0.62 },
+          { "hue": 0.04, "sat": 0.65, "value": 0.62 },
+          { "hue": 0.13, "sat": 0.6, "value": 0.72 },
+          { "hue": 0.62, "sat": 0.5, "value": 0.64 },
+          { "hue": 0.75, "sat": 0.45, "value": 0.62 },
+          { "hue": 0.45, "sat": 0.5, "value": 0.64 }
+        ]
+      },
+      "transform": { "translate": [0, 1.5, 0], "rotate": [0, 0.3, 0] },
+      "material": { "hue": 0.57, "sat": 0.5, "value": 0.66, "kind": "normal", "roughness": 0.3, "clearcoat": 0.4 }
+    }
+  ],
+  "overlay": [{ "text": "3D CUBES — SHAPES", "anchor": [0, 4.0, 0], "role": "title" }],
+  "cameraSequence": {
+    "loop": false,
+    "shots": [
+      { "duration": 0.01, "pos": [1.1, 2.0, 9.8], "target": [0, 1.5, 0], "fov": 52, "aperture": 0, "focalDistance": 9, "ease": "smooth" },
+      { "duration": 13, "pos": [0.1, 1.7, 8.3], "target": [0, 1.5, 0], "fov": 48, "transition": "blend", "aperture": 0, "focalDistance": 8.3, "ease": "smooth" }
+    ]
+  },
+  "defaults": { "stage": { "size": [16, 9, 11] } }
+}

--- a/sdf-js/scenes/shape-cube-flow.json
+++ b/sdf-js/scenes/shape-cube-flow.json
@@ -1,0 +1,44 @@
+{
+  "v": 1,
+  "name": "sequence: 3D Cubes — Flow Process (twin)",
+  "subjects": [
+    {
+      "id": "cubes",
+      "type": "cube-3d",
+      "args": {
+        "count": 4,
+        "arrangement": "flow",
+        "cubeSize": 0.8,
+        "spacing": 0.35,
+        "cornerRadius": 0.05,
+        "material": "solid",
+        "connector": "pipe-through",
+        "connectorThickness": 0.06,
+        "colors": [
+          { "hue": 0.57, "sat": 0.35, "value": 0.8 },
+          { "hue": 0.57, "sat": 0.5, "value": 0.68 },
+          { "hue": 0.57, "sat": 0.62, "value": 0.6 },
+          { "hue": 0.04, "sat": 0.7, "value": 0.62 }
+        ]
+      },
+      "transform": { "translate": [0, 1.4, 0] },
+      "material": { "hue": 0.57, "sat": 0.5, "value": 0.66, "kind": "normal", "roughness": 0.3, "clearcoat": 0.4 }
+    }
+  ],
+  "overlay": [
+    { "text": "3D CUBES — FLOW PROCESS", "anchor": [0, 3.9, 0], "role": "title" },
+
+    { "role": "value", "text": "01", "anchor": [-1.95, 1.4, 0.45], "radius": 0.4 },
+    { "role": "value", "text": "02", "anchor": [-0.65, 1.4, 0.45], "radius": 0.4 },
+    { "role": "value", "text": "03", "anchor": [0.65, 1.4, 0.45], "radius": 0.4 },
+    { "role": "value", "text": "04", "anchor": [1.95, 1.4, 0.45], "radius": 0.4 }
+  ],
+  "cameraSequence": {
+    "loop": false,
+    "shots": [
+      { "duration": 0.01, "pos": [1.0, 1.9, 9.6], "target": [0, 1.4, 0], "fov": 50, "aperture": 0, "focalDistance": 8.5, "ease": "smooth" },
+      { "duration": 13, "pos": [0, 1.6, 8.0], "target": [0, 1.4, 0], "fov": 46, "transition": "blend", "aperture": 0, "focalDistance": 8.0, "ease": "smooth" }
+    ]
+  },
+  "defaults": { "stage": { "size": [18, 8, 10] } }
+}

--- a/sdf-js/scenes/shape-cube-segmented.json
+++ b/sdf-js/scenes/shape-cube-segmented.json
@@ -1,0 +1,29 @@
+{
+  "v": 1,
+  "name": "layers: 3D Cubes — Segmented (twin)",
+  "subjects": [
+    {
+      "id": "seg",
+      "type": "cube-segmented-3d",
+      "args": { "segments": 4, "size": 1.5, "gap": 0.12, "axis": "x" },
+      "transform": { "translate": [-0.4, 1.5, 0], "rotate": [0.1, 0.45, 0] },
+      "material": { "hue": 0.57, "sat": 0.55, "value": 0.64, "kind": "normal", "roughness": 0.3, "clearcoat": 0.45 }
+    }
+  ],
+  "overlay": [
+    { "text": "3D CUBES — SEGMENTED", "anchor": [0, 4.0, 0], "role": "title" },
+
+    { "text": "DESCRIPTION 1", "anchor": [3.0, 2.6, 0], "role": "card", "align": "left" },
+    { "text": "This is a placeholder text.", "anchor": [3.0, 2.1, 0], "role": "body", "align": "left" },
+    { "text": "DESCRIPTION 2", "anchor": [3.0, 0.9, 0], "role": "card", "align": "left" },
+    { "text": "This is a placeholder text.", "anchor": [3.0, 0.4, 0], "role": "body", "align": "left" }
+  ],
+  "cameraSequence": {
+    "loop": false,
+    "shots": [
+      { "duration": 0.01, "pos": [1.2, 2.0, 9.8], "target": [-0.4, 1.5, 0], "fov": 50, "aperture": 0, "focalDistance": 9, "ease": "smooth" },
+      { "duration": 13, "pos": [0.2, 1.7, 8.3], "target": [-0.4, 1.5, 0], "fov": 46, "transition": "blend", "aperture": 0, "focalDistance": 8.3, "ease": "smooth" }
+    ]
+  },
+  "defaults": { "stage": { "size": [18, 9, 11] } }
+}

--- a/sdf-js/scenes/shape-cube-semicircle.json
+++ b/sdf-js/scenes/shape-cube-semicircle.json
@@ -1,0 +1,37 @@
+{
+  "v": 1,
+  "name": "relation: 3D Cubes — Semi-Circle (twin)",
+  "subjects": [
+    {
+      "id": "cubes",
+      "type": "cube-3d",
+      "args": {
+        "count": 6,
+        "arrangement": "semicircle",
+        "cubeSize": 0.7,
+        "spacing": 0.25,
+        "cornerRadius": 0.05,
+        "material": "solid",
+        "colors": [
+          { "hue": 0.3, "sat": 0.55, "value": 0.62 },
+          { "hue": 0.45, "sat": 0.55, "value": 0.64 },
+          { "hue": 0.57, "sat": 0.55, "value": 0.66 },
+          { "hue": 0.62, "sat": 0.55, "value": 0.64 },
+          { "hue": 0.75, "sat": 0.5, "value": 0.62 },
+          { "hue": 0.02, "sat": 0.6, "value": 0.62 }
+        ]
+      },
+      "transform": { "translate": [0, 1.4, 0] },
+      "material": { "hue": 0.57, "sat": 0.5, "value": 0.66, "kind": "normal", "roughness": 0.3, "clearcoat": 0.4 }
+    }
+  ],
+  "overlay": [{ "text": "3D CUBES — SEMI-CIRCLE", "anchor": [0, 4.0, 0], "role": "title" }],
+  "cameraSequence": {
+    "loop": false,
+    "shots": [
+      { "duration": 0.01, "pos": [1.1, 2.1, 10.2], "target": [0, 1.6, 0], "fov": 52, "aperture": 0, "focalDistance": 9, "ease": "smooth" },
+      { "duration": 13, "pos": [0.1, 1.8, 8.7], "target": [0, 1.6, 0], "fov": 48, "transition": "blend", "aperture": 0, "focalDistance": 8.7, "ease": "smooth" }
+    ]
+  },
+  "defaults": { "stage": { "size": [18, 9, 11] } }
+}

--- a/sdf-js/scenes/shape-cube-steps.json
+++ b/sdf-js/scenes/shape-cube-steps.json
@@ -1,0 +1,35 @@
+{
+  "v": 1,
+  "name": "sequence: 3D Cubes — Flow Steps (twin)",
+  "subjects": [
+    {
+      "id": "cubes",
+      "type": "cube-3d",
+      "args": {
+        "count": 4,
+        "arrangement": "steps",
+        "cubeSize": 0.85,
+        "spacing": 0.25,
+        "cornerRadius": 0.05,
+        "material": "solid",
+        "colors": [
+          { "hue": 0.57, "sat": 0.35, "value": 0.8 },
+          { "hue": 0.57, "sat": 0.48, "value": 0.7 },
+          { "hue": 0.57, "sat": 0.6, "value": 0.62 },
+          { "hue": 0.04, "sat": 0.7, "value": 0.62 }
+        ]
+      },
+      "transform": { "translate": [0, 1.0, 0] },
+      "material": { "hue": 0.57, "sat": 0.5, "value": 0.66, "kind": "normal", "roughness": 0.3, "clearcoat": 0.4 }
+    }
+  ],
+  "overlay": [{ "text": "3D CUBES — FLOW STEPS", "anchor": [0, 4.0, 0], "role": "title" }],
+  "cameraSequence": {
+    "loop": false,
+    "shots": [
+      { "duration": 0.01, "pos": [1.1, 2.2, 10.0], "target": [0, 1.7, 0], "fov": 52, "aperture": 0, "focalDistance": 9, "ease": "smooth" },
+      { "duration": 13, "pos": [0.1, 1.9, 8.5], "target": [0, 1.7, 0], "fov": 48, "transition": "blend", "aperture": 0, "focalDistance": 8.5, "ease": "smooth" }
+    ]
+  },
+  "defaults": { "stage": { "size": [18, 9, 10] } }
+}

--- a/sdf-js/src/scene/components/shapes/cube-3d.js
+++ b/sdf-js/src/scene/components/shapes/cube-3d.js
@@ -21,6 +21,7 @@
 import { rounded_box, wireframe_box, capsule } from '../../../sdf/d3.js';
 import { union } from '../../../sdf/dn.js';
 import { text3dPipeSDF, text3dExtrudedSDF } from '../typography/text-3d.js';
+import { resolveMaterial } from '../../spec.js';
 
 // ---- Arrangements -----------------------------------------------------------
 // Each arrangement returns an array of cube positions [x, y, z] for indices
@@ -271,6 +272,13 @@ export function cube3dSDF({
       if (rz) cube = cube.rotate(rz, [0, 0, 1]);
     }
     cube = cube.translate(effectivePositions[i]);
+    // Per-cube colour: colors[i] mirrors `material` (preset name or {hue,sat,value})
+    // and rides as a per-leaf _subjectMaterial so one subject carries N colours
+    // (flattenUnion's child-overrides-parent rule; survives the compile push-down).
+    if (colors && colors[i] != null) {
+      const m = resolveMaterial(colors[i]);
+      if (m) cube._subjectMaterial = m;
+    }
     cubes.push(cube);
   }
 


### PR DESCRIPTION
## PL Shapes 3D —— 第 2 个家族:Cubes(5 个)

基于 `cube-3d` 超级原子(9 个 arrangement)+ `cube-segmented-3d`。**顺手修了一个真 bug**:cube-3d 的 `colors[]` 参数**声明了但从没被使用**(方块不管传什么都渲染成统一暗蓝)。接通它。

- **cube-3d.js**:per-cube 颜色 —— `colors[i]`(preset 名 或 {hue,sat,value})→ per-leaf `_subjectMaterial`(镜像 sphere-fill 的 colors[],过 compile push-down)。之前是死参数,现在多色 cube 集生效。
- `shape-cube-flow` —— 'flow' + pipe 连接 + 01-04 编号 + 蓝渐变 + 红高亮。
- `shape-cube-steps` —— 'steps' 楼梯。
- `shape-cube-semicircle` —— 'semicircle' 彩色弧。
- `shape-cube-segmented` —— cube-segmented-3d 切片 + 蓝卡片。
- `shape-cube-cluster` —— 'cluster' 多色方块堆(Cube Shapes)。
- `deck-shapes-cubes` —— 5 个一个 deck。

## 验证(Playwright)

5 个全渲染正确;颜色现在生效(flow 渐变+红高亮,cluster 多色)。`npm test` **95/95**。

看 deck:`?deck=deck-shapes-cubes`

## 后续:circles(2)/ puzzle(2)/ arrow(1)/ gear(1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)