### PR TITLE
feat(present): circle / arrow / gear / puzzle templates — PL Shapes 3D complete (17/17)

### DIFF
--- a/sdf-js/scenes/deck-shapes-misc.json
+++ b/sdf-js/scenes/deck-shapes-misc.json
@@ -1,0 +1,12 @@
+{
+  "id": "deck-shapes-misc",
+  "name": "3D Shapes — circles, puzzle, arrows, gears",
+  "segments": [
+    { "file": "shape-circle-segmented.json", "title": "Circles — Segmented", "kind": "slide", "durationSec": 7 },
+    { "file": "shape-circle-shapes.json", "title": "Circle Shapes", "kind": "slide", "durationSec": 7 },
+    { "file": "shape-arrow.json", "title": "Arrows — Toolbox", "kind": "slide", "durationSec": 7 },
+    { "file": "shape-gear.json", "title": "Gearwheels", "kind": "slide", "durationSec": 7 },
+    { "file": "shape-puzzle.json", "title": "Puzzle", "kind": "slide", "durationSec": 7 },
+    { "file": "shape-puzzle-toolbox.json", "title": "Puzzle — Toolbox", "kind": "slide", "durationSec": 7 }
+  ]
+}

--- a/sdf-js/scenes/shape-arrow.json
+++ b/sdf-js/scenes/shape-arrow.json
@@ -1,0 +1,36 @@
+{
+  "v": 1,
+  "name": "sequence: 3D Arrows — Toolbox (twin)",
+  "subjects": [
+    {
+      "id": "ar1",
+      "type": "arrow-3d",
+      "args": { "length": 1.5, "shaftWidth": 0.3, "headLength": 0.55, "headWidth": 0.7, "depth": 0.28 },
+      "transform": { "translate": [-2.3, 1.5, 0] },
+      "material": { "hue": 0.3, "sat": 0.55, "value": 0.62, "kind": "normal", "roughness": 0.3, "clearcoat": 0.4 }
+    },
+    {
+      "id": "ar2",
+      "type": "arrow-3d",
+      "args": { "length": 1.5, "shaftWidth": 0.3, "headLength": 0.55, "headWidth": 0.7, "depth": 0.28 },
+      "transform": { "translate": [0, 1.5, 0] },
+      "material": { "hue": 0.57, "sat": 0.55, "value": 0.64, "kind": "normal", "roughness": 0.3, "clearcoat": 0.4 }
+    },
+    {
+      "id": "ar3",
+      "type": "arrow-3d",
+      "args": { "length": 1.5, "shaftWidth": 0.3, "headLength": 0.55, "headWidth": 0.7, "depth": 0.28 },
+      "transform": { "translate": [2.3, 1.5, 0] },
+      "material": { "hue": 0.04, "sat": 0.68, "value": 0.62, "kind": "normal", "roughness": 0.3, "clearcoat": 0.4 }
+    }
+  ],
+  "overlay": [{ "text": "3D ARROWS — TOOLBOX", "anchor": [0, 3.7, 0], "role": "title" }],
+  "cameraSequence": {
+    "loop": false,
+    "shots": [
+      { "duration": 0.01, "pos": [0.9, 1.9, 9.4], "target": [0, 1.5, 0], "fov": 50, "aperture": 0, "focalDistance": 8.5, "ease": "smooth" },
+      { "duration": 13, "pos": [0, 1.6, 7.9], "target": [0, 1.5, 0], "fov": 46, "transition": "blend", "aperture": 0, "focalDistance": 7.9, "ease": "smooth" }
+    ]
+  },
+  "defaults": { "stage": { "size": [18, 8, 10] } }
+}

--- a/sdf-js/scenes/shape-circle-segmented.json
+++ b/sdf-js/scenes/shape-circle-segmented.json
@@ -1,0 +1,25 @@
+{
+  "v": 1,
+  "name": "relation: 3D Circles — Segmented (twin)",
+  "subjects": [
+    {
+      "id": "ring",
+      "type": "circle-segmented-3d",
+      "args": { "segments": 6, "radius": 1.4, "innerRatio": 0.5, "thickness": 0.32, "gapWidth": 0.14 },
+      "transform": { "translate": [0, 1.6, 0], "rotate": [1.45, 0, 0] },
+      "material": { "hue": 0.57, "sat": 0.55, "value": 0.64, "kind": "normal", "roughness": 0.3, "clearcoat": 0.5 }
+    }
+  ],
+  "overlay": [
+    { "text": "3D CIRCLES — SEGMENTED", "anchor": [0, 4.0, 0], "role": "title" },
+    { "text": "Six stages", "anchor": [0, 1.6, 0], "role": "head" }
+  ],
+  "cameraSequence": {
+    "loop": false,
+    "shots": [
+      { "duration": 0.01, "pos": [1.0, 2.0, 9.8], "target": [0, 1.6, 0], "fov": 50, "aperture": 0, "focalDistance": 9, "ease": "smooth" },
+      { "duration": 13, "pos": [0, 1.7, 8.3], "target": [0, 1.6, 0], "fov": 46, "transition": "blend", "aperture": 0, "focalDistance": 8.3, "ease": "smooth" }
+    ]
+  },
+  "defaults": { "stage": { "size": [16, 9, 11] } }
+}

--- a/sdf-js/scenes/shape-circle-shapes.json
+++ b/sdf-js/scenes/shape-circle-shapes.json
@@ -1,0 +1,29 @@
+{
+  "v": 1,
+  "name": "layers: 3D Circle Shapes (stacked twin)",
+  "subjects": [
+    {
+      "id": "stack",
+      "type": "circle-stack-3d",
+      "args": { "count": 5, "radius": 1.3, "taper": 0.78, "diskHeight": 0.22, "gap": 0.1 },
+      "transform": { "translate": [0, 0.7, 0], "rotate": [0.1, 0.4, 0] },
+      "material": { "hue": 0.57, "sat": 0.55, "value": 0.64, "kind": "normal", "roughness": 0.3, "clearcoat": 0.5 }
+    }
+  ],
+  "overlay": [
+    { "text": "3D CIRCLE SHAPES", "anchor": [0, 4.0, 0], "role": "title" },
+
+    { "text": "DESCRIPTION 1", "anchor": [3.0, 2.5, 0], "role": "card", "align": "left" },
+    { "text": "This is a placeholder text.", "anchor": [3.0, 2.0, 0], "role": "body", "align": "left" },
+    { "text": "DESCRIPTION 2", "anchor": [3.0, 0.9, 0], "role": "card", "align": "left" },
+    { "text": "This is a placeholder text.", "anchor": [3.0, 0.4, 0], "role": "body", "align": "left" }
+  ],
+  "cameraSequence": {
+    "loop": false,
+    "shots": [
+      { "duration": 0.01, "pos": [1.2, 2.0, 9.8], "target": [-0.3, 1.4, 0], "fov": 50, "aperture": 0, "focalDistance": 9, "ease": "smooth" },
+      { "duration": 13, "pos": [0.2, 1.7, 8.3], "target": [-0.3, 1.4, 0], "fov": 46, "transition": "blend", "aperture": 0, "focalDistance": 8.3, "ease": "smooth" }
+    ]
+  },
+  "defaults": { "stage": { "size": [18, 9, 11] } }
+}

--- a/sdf-js/scenes/shape-gear.json
+++ b/sdf-js/scenes/shape-gear.json
@@ -1,0 +1,36 @@
+{
+  "v": 1,
+  "name": "relation: 3D Gearwheels (twin)",
+  "subjects": [
+    {
+      "id": "g1",
+      "type": "gear-3d",
+      "args": { "teeth": 14, "radius": 0.95, "thickness": 0.3, "toothDepth": 0.18, "toothWidth": 0.2, "holeRadius": 0.3 },
+      "transform": { "translate": [-1.0, 1.6, 0], "rotate": [1.5708, 0, 0] },
+      "material": { "hue": 0.6, "sat": 0.04, "value": 0.78, "metal": 0.85, "kind": "normal", "roughness": 0.22, "clearcoat": 0.5 }
+    },
+    {
+      "id": "g2",
+      "type": "gear-3d",
+      "args": { "teeth": 10, "radius": 0.66, "thickness": 0.3, "toothDepth": 0.16, "toothWidth": 0.18, "holeRadius": 0.22 },
+      "transform": { "translate": [0.62, 1.78, 0.05], "rotate": [1.5708, 0, 0.22] },
+      "material": { "hue": 0.57, "sat": 0.5, "value": 0.62, "kind": "normal", "roughness": 0.28, "clearcoat": 0.45 }
+    },
+    {
+      "id": "g3",
+      "type": "gear-3d",
+      "args": { "teeth": 9, "radius": 0.56, "thickness": 0.3, "toothDepth": 0.15, "toothWidth": 0.17, "holeRadius": 0.2 },
+      "transform": { "translate": [0.95, 0.72, -0.05], "rotate": [1.5708, 0, 0.1] },
+      "material": { "hue": 0.6, "sat": 0.04, "value": 0.78, "metal": 0.85, "kind": "normal", "roughness": 0.22, "clearcoat": 0.5 }
+    }
+  ],
+  "overlay": [{ "text": "3D GEARWHEELS", "anchor": [0, 3.7, 0], "role": "title" }],
+  "cameraSequence": {
+    "loop": false,
+    "shots": [
+      { "duration": 0.01, "pos": [1.0, 1.9, 9.3], "target": [0, 1.4, 0], "fov": 50, "aperture": 0, "focalDistance": 8.5, "ease": "smooth" },
+      { "duration": 13, "pos": [0.1, 1.6, 7.8], "target": [0, 1.4, 0], "fov": 46, "transition": "blend", "aperture": 0, "focalDistance": 7.8, "ease": "smooth" }
+    ]
+  },
+  "defaults": { "stage": { "size": [16, 8, 11] } }
+}

--- a/sdf-js/scenes/shape-puzzle-toolbox.json
+++ b/sdf-js/scenes/shape-puzzle-toolbox.json
@@ -1,0 +1,46 @@
+{
+  "v": 1,
+  "name": "compose: 3D Puzzle Toolbox — assembly (twin)",
+  "subjects": [
+    {
+      "id": "p1",
+      "type": "puzzle-piece-3d",
+      "args": { "size": 1.0, "depth": 0.28, "knob": 0.24 },
+      "transform": { "translate": [-1.05, 1.7, 0] },
+      "material": { "hue": 0.57, "sat": 0.55, "value": 0.64, "kind": "normal", "roughness": 0.3, "clearcoat": 0.45 }
+    },
+    {
+      "id": "p2",
+      "type": "puzzle-piece-3d",
+      "args": { "size": 1.0, "depth": 0.28, "knob": 0.24 },
+      "transform": { "translate": [-1.05, 0.66, 0], "rotate": [0, 0, 3.14159] },
+      "material": { "hue": 0.3, "sat": 0.55, "value": 0.62, "kind": "normal", "roughness": 0.3, "clearcoat": 0.45 }
+    },
+    {
+      "id": "p3",
+      "type": "puzzle-piece-3d",
+      "args": { "size": 1.0, "depth": 0.28, "knob": 0.24 },
+      "transform": { "translate": [-0.01, 0.66, 0] },
+      "material": { "hue": 0.13, "sat": 0.62, "value": 0.74, "kind": "normal", "roughness": 0.3, "clearcoat": 0.45 }
+    },
+    {
+      "id": "piece",
+      "type": "puzzle-piece-3d",
+      "args": { "size": 1.0, "depth": 0.28, "knob": 0.24 },
+      "transform": { "translate": [1.7, 2.0, 0.5], "rotate": [0.2, 0.3, 0.1] },
+      "material": { "hue": 0.04, "sat": 0.7, "value": 0.62, "kind": "normal", "roughness": 0.3, "clearcoat": 0.5 }
+    }
+  ],
+  "overlay": [
+    { "text": "3D PUZZLE — TOOLBOX", "anchor": [0, 3.9, 0], "role": "title" },
+    { "text": "ADD A PIECE", "anchor": [1.7, 2.9, 0.5], "role": "card" }
+  ],
+  "cameraSequence": {
+    "loop": false,
+    "shots": [
+      { "duration": 0.01, "pos": [1.0, 2.1, 9.6], "target": [0.1, 1.4, 0], "fov": 52, "aperture": 0, "focalDistance": 9, "ease": "smooth" },
+      { "duration": 13, "pos": [0.1, 1.7, 8.1], "target": [0.1, 1.4, 0], "fov": 48, "transition": "blend", "aperture": 0, "focalDistance": 8.1, "ease": "smooth" }
+    ]
+  },
+  "defaults": { "stage": { "size": [18, 9, 11] } }
+}

--- a/sdf-js/scenes/shape-puzzle.json
+++ b/sdf-js/scenes/shape-puzzle.json
@@ -1,0 +1,43 @@
+{
+  "v": 1,
+  "name": "compose: 3D Puzzle (twin)",
+  "subjects": [
+    {
+      "id": "p1",
+      "type": "puzzle-piece-3d",
+      "args": { "size": 1.0, "depth": 0.28, "knob": 0.24 },
+      "transform": { "translate": [-0.52, 2.0, 0] },
+      "material": { "hue": 0.57, "sat": 0.55, "value": 0.64, "kind": "normal", "roughness": 0.3, "clearcoat": 0.45 }
+    },
+    {
+      "id": "p2",
+      "type": "puzzle-piece-3d",
+      "args": { "size": 1.0, "depth": 0.28, "knob": 0.24 },
+      "transform": { "translate": [0.52, 2.0, 0], "rotate": [0, 0, 3.14159] },
+      "material": { "hue": 0.3, "sat": 0.55, "value": 0.62, "kind": "normal", "roughness": 0.3, "clearcoat": 0.45 }
+    },
+    {
+      "id": "p3",
+      "type": "puzzle-piece-3d",
+      "args": { "size": 1.0, "depth": 0.28, "knob": 0.24 },
+      "transform": { "translate": [-0.52, 0.96, 0], "rotate": [0, 0, 3.14159] },
+      "material": { "hue": 0.04, "sat": 0.68, "value": 0.62, "kind": "normal", "roughness": 0.3, "clearcoat": 0.45 }
+    },
+    {
+      "id": "p4",
+      "type": "puzzle-piece-3d",
+      "args": { "size": 1.0, "depth": 0.28, "knob": 0.24 },
+      "transform": { "translate": [0.52, 0.96, 0] },
+      "material": { "hue": 0.13, "sat": 0.62, "value": 0.74, "kind": "normal", "roughness": 0.3, "clearcoat": 0.45 }
+    }
+  ],
+  "overlay": [{ "text": "3D PUZZLE", "anchor": [0, 3.8, 0], "role": "title" }],
+  "cameraSequence": {
+    "loop": false,
+    "shots": [
+      { "duration": 0.01, "pos": [0.9, 2.0, 9.3], "target": [0, 1.5, 0], "fov": 50, "aperture": 0, "focalDistance": 8.5, "ease": "smooth" },
+      { "duration": 13, "pos": [0, 1.7, 7.8], "target": [0, 1.5, 0], "fov": 46, "transition": "blend", "aperture": 0, "focalDistance": 7.8, "ease": "smooth" }
+    ]
+  },
+  "defaults": { "stage": { "size": [16, 9, 11] } }
+}


### PR DESCRIPTION
## PL Shapes 3D —— 最后 4 个家族(Circles / Arrow / Gear / Puzzle)

至此 PresentationLoad「PowerPoint Shapes」分类页**全部 17 个 3D 模板都有了 Atlas 3D 孪生**。

- `shape-circle-segmented` —— circle-segmented-3d(6 段甜甜圈)
- `shape-circle-shapes` —— circle-stack-3d(锥形叠层圆盘)+ 卡片
- `shape-arrow` —— 3 个彩色 arrow-3d(箭头工具箱)
- `shape-gear` —— 3 个啮合 gear-3d(铬+蓝,齿面向相机)
- `shape-puzzle` —— 2×2 互锁拼图(4 色)
- `shape-puzzle-toolbox` —— 装配:3 块 + 1 块拎出来
- `deck-shapes-misc` —— 6 个一个 deck

**朝向坑(学到)**:gear-3d / circle-segmented-3d 默认在 XZ 平面(躺平),要加 `rotate [π/2,0,0]` 面向相机;circle-stack 竖直叠(无需)。

## 验证(Playwright)

齿轮齿清晰、分段甜甜圈、叠盘、彩色箭头、互锁拼图。`npm test` **95/95**。

## 🎉 全套完成

spheres(6,#159)+ cubes(5,#161)+ 本批(6)= **17 / 17**。看:`?deck=deck-shapes-spheres` / `deck-shapes-cubes` / `deck-shapes-misc`

🤖 Generated with [Claude Code](https://claude.com/claude-code)