### PR TITLE
feat(present): 3D Charts & Diagrams — batch 1 (Data Driven / Layers / Org Chart)

### DIFF
--- a/sdf-js/scenes/deck-charts-3d.json
+++ b/sdf-js/scenes/deck-charts-3d.json
@@ -1,0 +1,11 @@
+{
+  "id": "deck-charts-3d",
+  "name": "3D Charts & Diagrams — PresentationLoad (batch 1)",
+  "segments": [
+    { "file": "shape-chart-bar.json", "title": "Data Driven — Bars", "kind": "slide", "durationSec": 7 },
+    { "file": "shape-chart-pie.json", "title": "Data Driven — Donut", "kind": "slide", "durationSec": 7 },
+    { "file": "shape-chart-line.json", "title": "Data Driven — Line", "kind": "slide", "durationSec": 7 },
+    { "file": "shape-layers-parallel.json", "title": "Layers — Parallel", "kind": "slide", "durationSec": 7 },
+    { "file": "shape-org-chart.json", "title": "Org Chart Toolbox", "kind": "slide", "durationSec": 7 }
+  ]
+}

--- a/sdf-js/scenes/shape-chart-bar.json
+++ b/sdf-js/scenes/shape-chart-bar.json
@@ -1,0 +1,30 @@
+{
+  "v": 1,
+  "name": "data: 3D Bar Chart (Data Driven twin)",
+  "subjects": [
+    {
+      "id": "bars",
+      "type": "bar-3d",
+      "args": { "values": [0.4, 0.65, 0.85, 0.55, 0.9], "barWidth": 0.55, "barDepth": 0.55, "gap": 0.25, "maxHeight": 2.2 },
+      "transform": { "translate": [0, 0.15, 0] },
+      "material": { "hue": 0.57, "sat": 0.55, "value": 0.64, "kind": "normal", "roughness": 0.3, "clearcoat": 0.45 }
+    }
+  ],
+  "overlay": [
+    { "text": "DATA DRIVEN 3D CHARTS", "anchor": [0, 3.7, 0], "role": "title" },
+
+    { "role": "value", "text": "40%", "anchor": [-1.6, 1.25, 0.3], "radius": 0.32 },
+    { "role": "value", "text": "65%", "anchor": [-0.8, 1.78, 0.3], "radius": 0.32 },
+    { "role": "value", "text": "85%", "anchor": [0, 2.22, 0.3], "radius": 0.32 },
+    { "role": "value", "text": "55%", "anchor": [0.8, 1.56, 0.3], "radius": 0.32 },
+    { "role": "value", "text": "90%", "anchor": [1.6, 2.33, 0.3], "radius": 0.32 }
+  ],
+  "cameraSequence": {
+    "loop": false,
+    "shots": [
+      { "duration": 0.01, "pos": [1.0, 2.0, 9.6], "target": [0, 1.1, 0], "fov": 50, "aperture": 0, "focalDistance": 9, "ease": "smooth" },
+      { "duration": 13, "pos": [0, 1.6, 8.0], "target": [0, 1.1, 0], "fov": 46, "transition": "blend", "aperture": 0, "focalDistance": 8.0, "ease": "smooth" }
+    ]
+  },
+  "defaults": { "stage": { "size": [18, 8, 10] } }
+}

--- a/sdf-js/scenes/shape-chart-line.json
+++ b/sdf-js/scenes/shape-chart-line.json
@@ -1,0 +1,22 @@
+{
+  "v": 1,
+  "name": "data: 3D Line Chart (Data Driven twin)",
+  "subjects": [
+    {
+      "id": "line",
+      "type": "line-3d",
+      "args": { "values": [0.3, 0.5, 0.42, 0.7, 0.62, 0.9], "pointSpacing": 0.7, "pointRadius": 0.11, "lineThickness": 0.06, "maxHeight": 2.0 },
+      "transform": { "translate": [0, 0.25, 0] },
+      "material": { "hue": 0.57, "sat": 0.55, "value": 0.66, "kind": "normal", "roughness": 0.3, "clearcoat": 0.45 }
+    }
+  ],
+  "overlay": [{ "text": "DATA DRIVEN 3D CHARTS", "anchor": [0, 3.6, 0], "role": "title" }],
+  "cameraSequence": {
+    "loop": false,
+    "shots": [
+      { "duration": 0.01, "pos": [1.0, 1.9, 9.6], "target": [0, 1.1, 0], "fov": 50, "aperture": 0, "focalDistance": 9, "ease": "smooth" },
+      { "duration": 13, "pos": [0, 1.5, 8.1], "target": [0, 1.1, 0], "fov": 46, "transition": "blend", "aperture": 0, "focalDistance": 8.1, "ease": "smooth" }
+    ]
+  },
+  "defaults": { "stage": { "size": [18, 8, 10] } }
+}

--- a/sdf-js/scenes/shape-chart-pie.json
+++ b/sdf-js/scenes/shape-chart-pie.json
@@ -1,0 +1,28 @@
+{
+  "v": 1,
+  "name": "data: 3D Pie / Donut Chart (Data Driven twin)",
+  "subjects": [
+    {
+      "id": "pie",
+      "type": "pie-3d",
+      "args": { "values": [0.35, 0.25, 0.22, 0.18], "outerRadius": 1.3, "innerRadius": 0.55, "thickness": 0.45 },
+      "transform": { "translate": [0, 1.5, 0], "rotate": [1.2, 0, 0] },
+      "material": { "hue": 0.57, "sat": 0.55, "value": 0.64, "kind": "normal", "roughness": 0.3, "clearcoat": 0.45 }
+    }
+  ],
+  "overlay": [
+    { "text": "DATA DRIVEN 3D CHARTS", "anchor": [0, 3.8, 0], "role": "title" },
+
+    { "text": "AWS 35%", "anchor": [3.0, 2.5, 0], "role": "card", "align": "left" },
+    { "text": "Azure 25%", "anchor": [3.0, 1.7, 0], "role": "card", "align": "left" },
+    { "text": "GCP 22%", "anchor": [3.0, 0.9, 0], "role": "card", "align": "left" }
+  ],
+  "cameraSequence": {
+    "loop": false,
+    "shots": [
+      { "duration": 0.01, "pos": [1.2, 2.1, 9.6], "target": [-0.3, 1.5, 0], "fov": 50, "aperture": 0, "focalDistance": 9, "ease": "smooth" },
+      { "duration": 13, "pos": [0.2, 1.8, 8.1], "target": [-0.3, 1.5, 0], "fov": 46, "transition": "blend", "aperture": 0, "focalDistance": 8.1, "ease": "smooth" }
+    ]
+  },
+  "defaults": { "stage": { "size": [18, 9, 11] } }
+}

--- a/sdf-js/scenes/shape-layers-parallel.json
+++ b/sdf-js/scenes/shape-layers-parallel.json
@@ -1,0 +1,29 @@
+{
+  "v": 1,
+  "name": "layers: 3D Layers — Parallel (twin)",
+  "subjects": [
+    {
+      "id": "layers",
+      "type": "layer-stack-3d",
+      "args": { "layers": 4, "layerW": 2.4, "layerD": 1.5, "layerH": 0.28, "gap": 0.45, "taper": 1.0 },
+      "transform": { "translate": [-0.3, 1.4, 0], "rotate": [0.35, 0.5, 0] },
+      "material": { "hue": 0.57, "sat": 0.55, "value": 0.64, "kind": "normal", "roughness": 0.3, "clearcoat": 0.45 }
+    }
+  ],
+  "overlay": [
+    { "text": "3D LAYERS — PARALLEL", "anchor": [0, 4.0, 0], "role": "title" },
+
+    { "text": "LAYER 1", "anchor": [3.0, 2.7, 0], "role": "card", "align": "left" },
+    { "text": "LAYER 2", "anchor": [3.0, 1.9, 0], "role": "card", "align": "left" },
+    { "text": "LAYER 3", "anchor": [3.0, 1.1, 0], "role": "card", "align": "left" },
+    { "text": "LAYER 4", "anchor": [3.0, 0.3, 0], "role": "card", "align": "left" }
+  ],
+  "cameraSequence": {
+    "loop": false,
+    "shots": [
+      { "duration": 0.01, "pos": [1.2, 2.2, 10.0], "target": [-0.3, 1.5, 0], "fov": 50, "aperture": 0, "focalDistance": 9, "ease": "smooth" },
+      { "duration": 13, "pos": [0.2, 1.9, 8.5], "target": [-0.3, 1.5, 0], "fov": 46, "transition": "blend", "aperture": 0, "focalDistance": 8.5, "ease": "smooth" }
+    ]
+  },
+  "defaults": { "stage": { "size": [18, 9, 11] } }
+}

--- a/sdf-js/scenes/shape-org-chart.json
+++ b/sdf-js/scenes/shape-org-chart.json
@@ -1,0 +1,22 @@
+{
+  "v": 1,
+  "name": "hierarchy: Org Chart — Toolbox 3D (twin)",
+  "subjects": [
+    {
+      "id": "org",
+      "type": "org-chart-3d",
+      "args": { "levels": 3, "branching": 2, "nodeW": 0.62, "nodeH": 0.36, "nodeD": 0.2, "levelHeight": 1.15, "spread": 4.0 },
+      "transform": { "translate": [0, 3.0, 0] },
+      "material": { "hue": 0.57, "sat": 0.5, "value": 0.64, "kind": "normal", "roughness": 0.3, "clearcoat": 0.45 }
+    }
+  ],
+  "overlay": [{ "text": "ORG CHART — TOOLBOX 3D", "anchor": [0, 4.5, 0], "role": "title" }],
+  "cameraSequence": {
+    "loop": false,
+    "shots": [
+      { "duration": 0.01, "pos": [1.0, 2.6, 11.0], "target": [0, 2.0, 0], "fov": 54, "aperture": 0, "focalDistance": 10, "ease": "smooth" },
+      { "duration": 13, "pos": [0, 2.3, 9.6], "target": [0, 2.0, 0], "fov": 50, "transition": "blend", "aperture": 0, "focalDistance": 9.6, "ease": "smooth" }
+    ]
+  },
+  "defaults": { "stage": { "size": [18, 10, 11] } }
+}


### PR DESCRIPTION
## PL「Charts & Diagrams」3D 复刻 —— Batch 1

Charts 类是个 hub(14 子类)。Landing 直接展示 4 个 3D 模板(Fill-Levels 已做),本批做其余 3 个 prominent 的,全复用现成 chart 原子:

- **Data Driven 3D Charts** → 3 个图:
  - `shape-chart-bar` —— bar-3d + 每柱 overlay 值标签(90/55/85/65/40%)
  - `shape-chart-pie` —— pie-3d 3D 甜甜圈(倾斜)+ 份额卡片
  - `shape-chart-line` —— line-3d 折线趋势 + 点标记
- **3D Layers Parallel** → `shape-layers-parallel` —— layer-stack-3d 4 层平行板 + LAYER 卡片
- **Org Chart Toolbox 3D** → `shape-org-chart` —— org-chart-3d 3 层方框层级
- `deck-charts-3d` —— 5 个一个 deck

## 验证(Playwright)

柱+值标签、3D 甜甜圈、趋势线、平行层、组织架构 —— 全渲染正确。`npm test` **97/97**。

看:`?deck=deck-charts-3d`

## 注意:子类里还有更多 3D

14 个子类(Data/Hierarchy/Layers/Pie/Column/Relationship...)藏着比 landing 更多的 3D 模板,后续 batch 爬取 + 复刻。

🤖 Generated with [Claude Code](https://claude.com/claude-code)