### PR TITLE
feat(present): 3D Charts & Diagrams — batch 2 (funnel / venn / timeline / cubes / layers)

### DIFF
--- a/sdf-js/scenes/deck-charts-3d-2.json
+++ b/sdf-js/scenes/deck-charts-3d-2.json
@@ -1,0 +1,11 @@
+{
+  "id": "deck-charts-3d-2",
+  "name": "3D Charts & Diagrams — PresentationLoad (batch 2)",
+  "segments": [
+    { "file": "shape-funnel.json", "title": "Funnels — 3D", "kind": "slide", "durationSec": 7 },
+    { "file": "shape-venn.json", "title": "Venn — 3D", "kind": "slide", "durationSec": 7 },
+    { "file": "shape-timeline.json", "title": "Road Timeline — 3D", "kind": "slide", "durationSec": 7 },
+    { "file": "shape-cubes-count.json", "title": "Cubes — Count", "kind": "slide", "durationSec": 7 },
+    { "file": "shape-layers-perspective.json", "title": "Layers — Perspective", "kind": "slide", "durationSec": 7 }
+  ]
+}

--- a/sdf-js/scenes/shape-cubes-count.json
+++ b/sdf-js/scenes/shape-cubes-count.json
@@ -1,0 +1,42 @@
+{
+  "v": 1,
+  "name": "data: 3D Cubes Count (twin)",
+  "subjects": [
+    {
+      "id": "cubes",
+      "type": "cube-3d",
+      "args": {
+        "count": 4,
+        "arrangement": "row",
+        "cubeSize": 0.9,
+        "spacing": 0.4,
+        "cornerRadius": 0.05,
+        "material": "solid",
+        "colors": [
+          { "hue": 0.57, "sat": 0.4, "value": 0.78 },
+          { "hue": 0.3, "sat": 0.5, "value": 0.62 },
+          { "hue": 0.13, "sat": 0.6, "value": 0.74 },
+          { "hue": 0.04, "sat": 0.68, "value": 0.62 }
+        ]
+      },
+      "transform": { "translate": [0, 1.5, 0] },
+      "material": { "hue": 0.57, "sat": 0.5, "value": 0.66, "kind": "normal", "roughness": 0.3, "clearcoat": 0.4 }
+    }
+  ],
+  "overlay": [
+    { "text": "3D CUBES — COUNT", "anchor": [0, 3.8, 0], "role": "title" },
+
+    { "role": "value", "text": "128", "anchor": [-1.95, 1.5, 0.5], "radius": 0.45 },
+    { "role": "value", "text": "64", "anchor": [-0.65, 1.5, 0.5], "radius": 0.45 },
+    { "role": "value", "text": "32", "anchor": [0.65, 1.5, 0.5], "radius": 0.45 },
+    { "role": "value", "text": "8", "anchor": [1.95, 1.5, 0.5], "radius": 0.45 }
+  ],
+  "cameraSequence": {
+    "loop": false,
+    "shots": [
+      { "duration": 0.01, "pos": [1.0, 2.0, 9.7], "target": [0, 1.5, 0], "fov": 50, "aperture": 0, "focalDistance": 9, "ease": "smooth" },
+      { "duration": 13, "pos": [0, 1.7, 8.2], "target": [0, 1.5, 0], "fov": 46, "transition": "blend", "aperture": 0, "focalDistance": 8.2, "ease": "smooth" }
+    ]
+  },
+  "defaults": { "stage": { "size": [18, 8, 10] } }
+}

--- a/sdf-js/scenes/shape-funnel.json
+++ b/sdf-js/scenes/shape-funnel.json
@@ -1,0 +1,29 @@
+{
+  "v": 1,
+  "name": "data: 3D Funnel (twin)",
+  "subjects": [
+    {
+      "id": "funnel",
+      "type": "funnel-3d",
+      "args": { "stages": 4, "topRadius": 1.15, "bottomRadius": 0.28, "stageHeight": 0.55, "gap": 0.1 },
+      "transform": { "translate": [-0.3, 1.6, 0], "rotate": [0.12, 0, 0] },
+      "material": { "hue": 0.57, "sat": 0.55, "value": 0.64, "kind": "normal", "roughness": 0.3, "clearcoat": 0.45 }
+    }
+  ],
+  "overlay": [
+    { "text": "3D FUNNELS", "anchor": [0, 4.0, 0], "role": "title" },
+
+    { "text": "AWARENESS", "anchor": [3.0, 2.6, 0], "role": "card", "align": "left" },
+    { "text": "INTEREST", "anchor": [3.0, 1.9, 0], "role": "card", "align": "left" },
+    { "text": "DECISION", "anchor": [3.0, 1.2, 0], "role": "card", "align": "left" },
+    { "text": "ACTION", "anchor": [3.0, 0.5, 0], "role": "card", "align": "left" }
+  ],
+  "cameraSequence": {
+    "loop": false,
+    "shots": [
+      { "duration": 0.01, "pos": [1.2, 2.1, 9.8], "target": [-0.3, 1.5, 0], "fov": 50, "aperture": 0, "focalDistance": 9, "ease": "smooth" },
+      { "duration": 13, "pos": [0.2, 1.8, 8.3], "target": [-0.3, 1.5, 0], "fov": 46, "transition": "blend", "aperture": 0, "focalDistance": 8.3, "ease": "smooth" }
+    ]
+  },
+  "defaults": { "stage": { "size": [18, 9, 11] } }
+}

--- a/sdf-js/scenes/shape-layers-perspective.json
+++ b/sdf-js/scenes/shape-layers-perspective.json
@@ -1,0 +1,29 @@
+{
+  "v": 1,
+  "name": "layers: 3D Layers — Perspective (twin)",
+  "subjects": [
+    {
+      "id": "layers",
+      "type": "layer-stack-3d",
+      "args": { "layers": 5, "layerW": 2.6, "layerD": 1.7, "layerH": 0.26, "gap": 0.3, "taper": 0.82 },
+      "transform": { "translate": [-0.2, 1.5, 0], "rotate": [0.6, 0.75, 0] },
+      "material": { "hue": 0.57, "sat": 0.55, "value": 0.64, "kind": "normal", "roughness": 0.3, "clearcoat": 0.45 }
+    }
+  ],
+  "overlay": [
+    { "text": "3D LAYERS — PERSPECTIVE", "anchor": [0, 4.1, 0], "role": "title" },
+
+    { "text": "DESCRIPTION 1", "anchor": [3.2, 2.6, 0], "role": "card", "align": "left" },
+    { "text": "This is a placeholder text.", "anchor": [3.2, 2.1, 0], "role": "body", "align": "left" },
+    { "text": "DESCRIPTION 2", "anchor": [3.2, 0.9, 0], "role": "card", "align": "left" },
+    { "text": "This is a placeholder text.", "anchor": [3.2, 0.4, 0], "role": "body", "align": "left" }
+  ],
+  "cameraSequence": {
+    "loop": false,
+    "shots": [
+      { "duration": 0.01, "pos": [1.2, 2.2, 10.2], "target": [-0.2, 1.6, 0], "fov": 50, "aperture": 0, "focalDistance": 9, "ease": "smooth" },
+      { "duration": 13, "pos": [0.2, 1.9, 8.7], "target": [-0.2, 1.6, 0], "fov": 46, "transition": "blend", "aperture": 0, "focalDistance": 8.7, "ease": "smooth" }
+    ]
+  },
+  "defaults": { "stage": { "size": [18, 9, 11] } }
+}

--- a/sdf-js/scenes/shape-timeline.json
+++ b/sdf-js/scenes/shape-timeline.json
@@ -1,0 +1,30 @@
+{
+  "v": 1,
+  "name": "sequence: 3D Timeline (twin)",
+  "subjects": [
+    {
+      "id": "tl",
+      "type": "timeline-3d",
+      "args": { "count": 5, "axisLength": 4.2, "axisRadius": 0.06, "markerRadius": 0.2, "stemHeight": 0.55 },
+      "transform": { "translate": [0, 1.4, 0] },
+      "material": { "hue": 0.57, "sat": 0.55, "value": 0.64, "kind": "normal", "roughness": 0.3, "clearcoat": 0.45 }
+    }
+  ],
+  "overlay": [
+    { "text": "ROAD TIMELINE — 3D", "anchor": [0, 3.8, 0], "role": "title" },
+
+    { "role": "value", "text": "2021", "anchor": [-2.1, 2.25, 0], "radius": 0.36 },
+    { "role": "value", "text": "2022", "anchor": [-1.05, 2.25, 0], "radius": 0.36 },
+    { "role": "value", "text": "2023", "anchor": [0, 2.25, 0], "radius": 0.36 },
+    { "role": "value", "text": "2024", "anchor": [1.05, 2.25, 0], "radius": 0.36 },
+    { "role": "value", "text": "2025", "anchor": [2.1, 2.25, 0], "radius": 0.36 }
+  ],
+  "cameraSequence": {
+    "loop": false,
+    "shots": [
+      { "duration": 0.01, "pos": [1.0, 1.9, 9.8], "target": [0, 1.4, 0], "fov": 52, "aperture": 0, "focalDistance": 9, "ease": "smooth" },
+      { "duration": 13, "pos": [0, 1.6, 8.3], "target": [0, 1.4, 0], "fov": 48, "transition": "blend", "aperture": 0, "focalDistance": 8.3, "ease": "smooth" }
+    ]
+  },
+  "defaults": { "stage": { "size": [20, 8, 10] } }
+}

--- a/sdf-js/scenes/shape-venn.json
+++ b/sdf-js/scenes/shape-venn.json
@@ -1,0 +1,27 @@
+{
+  "v": 1,
+  "name": "relation: 3D Venn Diagram (twin)",
+  "subjects": [
+    {
+      "id": "venn",
+      "type": "venn-3d",
+      "args": { "sets": 3, "radius": 0.95, "tube": 0.1, "overlap": 0.5 },
+      "transform": { "translate": [0, 1.7, 0] },
+      "material": { "hue": 0.57, "sat": 0.55, "value": 0.64, "kind": "normal", "roughness": 0.3, "clearcoat": 0.5 }
+    }
+  ],
+  "overlay": [
+    { "text": "3D VENN DIAGRAMS", "anchor": [0, 4.0, 0], "role": "title" },
+    { "text": "A", "anchor": [-0.85, 2.05, 0.1], "role": "value", "radius": 0.45 },
+    { "text": "B", "anchor": [0.85, 2.05, 0.1], "role": "value", "radius": 0.45 },
+    { "text": "C", "anchor": [0, 1.0, 0.1], "role": "value", "radius": 0.45 }
+  ],
+  "cameraSequence": {
+    "loop": false,
+    "shots": [
+      { "duration": 0.01, "pos": [1.0, 2.1, 9.6], "target": [0, 1.7, 0], "fov": 50, "aperture": 0, "focalDistance": 9, "ease": "smooth" },
+      { "duration": 13, "pos": [0, 1.8, 8.1], "target": [0, 1.7, 0], "fov": 46, "transition": "blend", "aperture": 0, "focalDistance": 8.1, "ease": "smooth" }
+    ]
+  },
+  "defaults": { "stage": { "size": [16, 9, 11] } }
+}


### PR DESCRIPTION
## Charts 3D — Batch 2

爬完 14 个子类:Charts 共 ~19 个 3D 模板(4 已做)。本批再做 5 个,全复用现成原子:

- `shape-funnel` —— funnel-3d 4 段销售漏斗 + 阶段卡片
- `shape-venn` —— venn-3d 3 环交叠 + A/B/C
- `shape-timeline` —— timeline-3d 轴 + 5 标记 + 年份
- `shape-cubes-count` —— cube-3d 行 + 计数值标签(8/32/64/128)
- `shape-layers-perspective` —— layer-stack-3d 透视倾斜

`?deck=deck-charts-3d-2`。Playwright 验证全部正确。`npm test` 97/97。

**朝向坑**:venn-3d 默认面向相机(XY,无需 rotate),与 gear/circle-segmented(XZ 躺平)相反。

**剩余 Charts 3D**(后续 batch):3D Graphs / 3D Stairs / Step diagram / Timelines-3D Spheres / 3D Layer Objects·Blocks·Round Plates·Spiral / Circle Segments 3D / Text 3D。

🤖 Generated with [Claude Code](https://claude.com/claude-code)