### PR TITLE
Sprint 20 B2: 4 new atoms + 2 polish fixes (vertical-timeline, segmented-bar, pull-quote-banner, circle-process-cycle)

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -169,6 +169,8 @@ const TESTS = [
   { category: 'present', file: 'sdf-js/scripts/test-sprint19-batch2-atoms.mjs' },
   // Sprint 20 Batch 1 — new atoms (process-arrows / stat-grid-large / number-list / call-to-action)
   { category: 'present', file: 'sdf-js/scripts/test-sprint20-batch1-atoms.mjs' },
+  // Sprint 20 Batch 2 — new atoms (vertical-timeline / segmented-bar / pull-quote-banner / circle-process-cycle)
+  { category: 'present', file: 'sdf-js/scripts/test-sprint20-batch2-atoms.mjs' },
 ];
 
 // -----------------------------------------------------------------------------

--- a/sdf-js/examples/scaffold-pipeline/sprint20-b2-atomdemo/deck.json
+++ b/sdf-js/examples/scaffold-pipeline/sprint20-b2-atomdemo/deck.json
@@ -1,0 +1,67 @@
+{
+  "deckName": "sprint20-b2-atomdemo",
+  "scaffold": {
+    "id": "demo",
+    "label": "Atom Demo",
+    "description": "Direct render of 4 Sprint 20 Batch 2 atoms",
+    "pickScore": 0,
+    "pickSignals": ["manual demo"],
+    "fallback": false,
+    "pickerMethod": "manual"
+  },
+  "theme": {
+    "id": "financial-navy-cerulean",
+    "label": "Financial Navy Cerulean",
+    "macroCluster": "financial",
+    "bg": [240, 244, 252],
+    "accent": [30, 80, 180],
+    "colors": [
+      [30, 80, 180],
+      [60, 140, 220],
+      [20, 160, 130],
+      [200, 100, 40],
+      [160, 60, 160]
+    ],
+    "silhouetteColor": [20, 28, 50]
+  },
+  "meta": { "model": "manual-demo", "timestamp": "2026-06-25" },
+  "totals": { "slotsBaked": 4, "slotsEmpty": 0, "totalCostUSD": 0 },
+  "slots": [
+    {
+      "slotIdx": 0,
+      "slotName": "roadmap",
+      "slotTitle": "vertical-timeline",
+      "slotPurpose": "vertical date/event stacked timeline demo",
+      "sourceSlideIdx": 0,
+      "subjectTypes": ["vertical-timeline"],
+      "liftFile": "slots/slot-00-vtimeline.json"
+    },
+    {
+      "slotIdx": 1,
+      "slotName": "allocation",
+      "slotTitle": "segmented-bar",
+      "slotPurpose": "single horizontal bar split into segments demo",
+      "sourceSlideIdx": 1,
+      "subjectTypes": ["segmented-bar"],
+      "liftFile": "slots/slot-01-segbar.json"
+    },
+    {
+      "slotIdx": 2,
+      "slotName": "banner",
+      "slotTitle": "pull-quote-banner",
+      "slotPurpose": "full-bleed accent bg hero quote banner demo",
+      "sourceSlideIdx": 2,
+      "subjectTypes": ["pull-quote-banner"],
+      "liftFile": "slots/slot-02-banner.json"
+    },
+    {
+      "slotIdx": 3,
+      "slotName": "cycle",
+      "slotTitle": "circle-process-cycle",
+      "slotPurpose": "PDCA-style circular process demo",
+      "sourceSlideIdx": 3,
+      "subjectTypes": ["circle-process-cycle"],
+      "liftFile": "slots/slot-03-cycle.json"
+    }
+  ]
+}

--- a/sdf-js/examples/scaffold-pipeline/sprint20-b2-atomdemo/slots/slot-00-vtimeline.json
+++ b/sdf-js/examples/scaffold-pipeline/sprint20-b2-atomdemo/slots/slot-00-vtimeline.json
@@ -1,0 +1,31 @@
+{
+  "slotIdx": 0,
+  "slotName": "roadmap",
+  "slotTitle": "vertical-timeline",
+  "sceneData": {
+    "subjects": [
+      {
+        "type": "vertical-timeline",
+        "x": 0,
+        "y": 0,
+        "w": 1280,
+        "h": 720,
+        "args": {
+          "title": "Investment Milestones",
+          "axisLabel": "2025–2027 Roadmap",
+          "events": [
+            { "date": "Q3 2025", "label": "Seed Round", "sublabel": "$2M raised" },
+            {
+              "date": "Q1 2026",
+              "label": "Product Launch",
+              "sublabel": "MVP shipped to 50 customers"
+            },
+            { "date": "Q2 2026", "label": "Series A", "sublabel": "$12M at $60M valuation" },
+            { "date": "Q4 2026", "label": "10,000 Customers", "sublabel": "$4M ARR" },
+            { "date": "Q2 2027", "label": "Series B", "sublabel": "$40M target" }
+          ]
+        }
+      }
+    ]
+  }
+}

--- a/sdf-js/examples/scaffold-pipeline/sprint20-b2-atomdemo/slots/slot-01-segbar.json
+++ b/sdf-js/examples/scaffold-pipeline/sprint20-b2-atomdemo/slots/slot-01-segbar.json
@@ -1,0 +1,27 @@
+{
+  "slotIdx": 1,
+  "slotName": "allocation",
+  "slotTitle": "segmented-bar",
+  "sceneData": {
+    "subjects": [
+      {
+        "type": "segmented-bar",
+        "x": 0,
+        "y": 0,
+        "w": 1280,
+        "h": 720,
+        "args": {
+          "title": "FY2026 Budget Allocation",
+          "segments": [
+            { "label": "Engineering", "value": 42 },
+            { "label": "Sales", "value": 28 },
+            { "label": "Marketing", "value": 18 },
+            { "label": "G&A", "value": 12 }
+          ],
+          "format": "pct",
+          "showPct": true
+        }
+      }
+    ]
+  }
+}

--- a/sdf-js/examples/scaffold-pipeline/sprint20-b2-atomdemo/slots/slot-02-banner.json
+++ b/sdf-js/examples/scaffold-pipeline/sprint20-b2-atomdemo/slots/slot-02-banner.json
@@ -1,0 +1,22 @@
+{
+  "slotIdx": 2,
+  "slotName": "banner",
+  "slotTitle": "pull-quote-banner",
+  "sceneData": {
+    "subjects": [
+      {
+        "type": "pull-quote-banner",
+        "x": 0,
+        "y": 0,
+        "w": 1280,
+        "h": 720,
+        "args": {
+          "quote": "We don't just build software — we build the infrastructure for how the next generation of companies will think.",
+          "author": "Sarah Chen",
+          "attribution": "CEO, Meridian Analytics",
+          "bg": "accent"
+        }
+      }
+    ]
+  }
+}

--- a/sdf-js/examples/scaffold-pipeline/sprint20-b2-atomdemo/slots/slot-03-cycle.json
+++ b/sdf-js/examples/scaffold-pipeline/sprint20-b2-atomdemo/slots/slot-03-cycle.json
@@ -1,0 +1,27 @@
+{
+  "slotIdx": 3,
+  "slotName": "cycle",
+  "slotTitle": "circle-process-cycle",
+  "sceneData": {
+    "subjects": [
+      {
+        "type": "circle-process-cycle",
+        "x": 0,
+        "y": 0,
+        "w": 1280,
+        "h": 720,
+        "args": {
+          "title": "Our Agile Delivery Cycle",
+          "steps": [
+            { "label": "Plan", "sublabel": "Sprint planning" },
+            { "label": "Build", "sublabel": "2-week sprints" },
+            { "label": "Test", "sublabel": "QA & review" },
+            { "label": "Ship", "sublabel": "Deploy to prod" },
+            { "label": "Learn", "sublabel": "Retro & metrics" }
+          ],
+          "centerLabel": "CONTINUOUS DELIVERY"
+        }
+      }
+    ]
+  }
+}

--- a/sdf-js/scripts/test-sprint20-batch2-atoms.mjs
+++ b/sdf-js/scripts/test-sprint20-batch2-atoms.mjs
@@ -1,0 +1,286 @@
+#!/usr/bin/env node
+// Smoke test for Sprint 20 Batch 2 atoms:
+// vertical-timeline, segmented-bar, pull-quote-banner, circle-process-cycle
+
+import { isAtom2DType, getAtomSpec, renderAtom } from '../src/present/atoms-2d/registry.js';
+import { buildAtomCatalogString, _resetCatalogCache } from '../src/present/atoms-2d/catalog.js';
+
+let pass = 0;
+let fail = 0;
+
+function ok(label, cond) {
+  if (cond) {
+    pass++;
+    console.log('  ✓ ' + label);
+  } else {
+    fail++;
+    console.log('  ✗ ' + label);
+  }
+}
+
+// Minimal Canvas2D context mock
+const stubCtx = {
+  save() {},
+  restore() {},
+  beginPath() {},
+  moveTo() {},
+  lineTo() {},
+  quadraticCurveTo() {},
+  bezierCurveTo() {},
+  closePath() {},
+  clip() {},
+  fillRect() {},
+  strokeRect() {},
+  fillText() {},
+  measureText() {
+    return { width: 50 };
+  },
+  drawImage() {},
+  createLinearGradient() {
+    return { addColorStop() {} };
+  },
+  createRadialGradient() {
+    return { addColorStop() {} };
+  },
+  arc() {},
+  fill() {},
+  stroke() {},
+  rotate() {},
+  translate() {},
+  scale() {},
+  setLineDash() {},
+  rect() {},
+  set fillStyle(_v) {},
+  set strokeStyle(_v) {},
+  set lineWidth(_v) {},
+  set lineCap(_v) {},
+  set lineJoin(_v) {},
+  set font(_v) {},
+  set textAlign(_v) {},
+  set textBaseline(_v) {},
+  set shadowColor(_v) {},
+  set shadowBlur(_v) {},
+  set shadowOffsetY(_v) {},
+};
+
+console.log('=== Sprint 20 Batch 2 atom smoke ===');
+
+// ──────────────────────────────────────────────────────────────────────────────
+// 1. Registration checks
+// ──────────────────────────────────────────────────────────────────────────────
+console.log('\n-- Registration --');
+ok('vertical-timeline registered', isAtom2DType('vertical-timeline'));
+ok('segmented-bar registered', isAtom2DType('segmented-bar'));
+ok('pull-quote-banner registered', isAtom2DType('pull-quote-banner'));
+ok('circle-process-cycle registered', isAtom2DType('circle-process-cycle'));
+
+// ──────────────────────────────────────────────────────────────────────────────
+// 2. Spec checks
+// ──────────────────────────────────────────────────────────────────────────────
+console.log('\n-- Specs --');
+
+const vtSpec = await getAtomSpec('vertical-timeline');
+ok('vertical-timeline spec exists', Boolean(vtSpec));
+ok('vertical-timeline spec.type correct', vtSpec?.type === 'vertical-timeline');
+ok('vertical-timeline spec has events (required)', vtSpec?.args?.events?.required === true);
+ok('vertical-timeline spec has optional title', 'title' in (vtSpec?.args ?? {}));
+ok('vertical-timeline spec has optional axisLabel', 'axisLabel' in (vtSpec?.args ?? {}));
+
+const sbSpec = await getAtomSpec('segmented-bar');
+ok('segmented-bar spec exists', Boolean(sbSpec));
+ok('segmented-bar spec.type correct', sbSpec?.type === 'segmented-bar');
+ok('segmented-bar spec has segments (required)', sbSpec?.args?.segments?.required === true);
+ok('segmented-bar spec has optional title', 'title' in (sbSpec?.args ?? {}));
+ok('segmented-bar spec has optional showPct', 'showPct' in (sbSpec?.args ?? {}));
+ok('segmented-bar spec has optional format', 'format' in (sbSpec?.args ?? {}));
+
+const pqbSpec = await getAtomSpec('pull-quote-banner');
+ok('pull-quote-banner spec exists', Boolean(pqbSpec));
+ok('pull-quote-banner spec.type correct', pqbSpec?.type === 'pull-quote-banner');
+ok('pull-quote-banner spec has quote (required)', pqbSpec?.args?.quote?.required === true);
+ok('pull-quote-banner spec has optional author', 'author' in (pqbSpec?.args ?? {}));
+ok('pull-quote-banner spec has optional attribution', 'attribution' in (pqbSpec?.args ?? {}));
+ok('pull-quote-banner spec has optional bg', 'bg' in (pqbSpec?.args ?? {}));
+
+const cpcSpec = await getAtomSpec('circle-process-cycle');
+ok('circle-process-cycle spec exists', Boolean(cpcSpec));
+ok('circle-process-cycle spec.type correct', cpcSpec?.type === 'circle-process-cycle');
+ok('circle-process-cycle spec has steps (required)', cpcSpec?.args?.steps?.required === true);
+ok('circle-process-cycle spec has optional title', 'title' in (cpcSpec?.args ?? {}));
+ok('circle-process-cycle spec has optional centerLabel', 'centerLabel' in (cpcSpec?.args ?? {}));
+
+// ──────────────────────────────────────────────────────────────────────────────
+// 3. Render checks — no throw
+// ──────────────────────────────────────────────────────────────────────────────
+console.log('\n-- Render (no-throw) --');
+
+const palette = {
+  bg: [248, 246, 240],
+  silhouetteColor: [30, 27, 30],
+  accent: [42, 130, 200],
+  colors: [
+    [42, 130, 200],
+    [60, 180, 140],
+    [200, 120, 60],
+    [180, 80, 160],
+  ],
+};
+const renderOpts = { x: 0, y: 0, w: 720, h: 480, palette };
+
+// vertical-timeline
+const r1 = renderAtom(
+  stubCtx,
+  'vertical-timeline',
+  {
+    title: 'Company Milestones',
+    events: [
+      { date: 'Q1 2026', label: 'Product Launch', sublabel: 'MVP shipped' },
+      { date: 'Q2 2026', label: 'Series A', sublabel: '$8M raised' },
+      { date: 'Q3 2026', label: '10K Users' },
+      { date: 'Q4 2026', label: 'Profitability' },
+    ],
+    axisLabel: '2026 Roadmap',
+  },
+  'pseudo3d',
+  renderOpts,
+);
+ok('vertical-timeline render returns Promise', r1 instanceof Promise);
+await r1;
+ok('vertical-timeline render resolves without throw', true);
+
+// vertical-timeline minimal (no title, no axisLabel, no sublabel)
+const r1b = renderAtom(
+  stubCtx,
+  'vertical-timeline',
+  {
+    events: [
+      { date: 'Jan', label: 'Start' },
+      { date: 'Feb', label: 'End' },
+      { date: 'Mar', label: 'Done' },
+    ],
+  },
+  'pseudo3d',
+  renderOpts,
+);
+ok('vertical-timeline minimal render resolves without throw', r1b instanceof Promise);
+await r1b;
+
+// segmented-bar
+const r2 = renderAtom(
+  stubCtx,
+  'segmented-bar',
+  {
+    title: 'Budget Allocation',
+    segments: [
+      { label: 'Engineering', value: 45 },
+      { label: 'Sales', value: 30 },
+      { label: 'Marketing', value: 15 },
+      { label: 'Other', value: 10 },
+    ],
+    showPct: true,
+    format: 'pct',
+  },
+  'pseudo3d',
+  renderOpts,
+);
+ok('segmented-bar render returns Promise', r2 instanceof Promise);
+await r2;
+ok('segmented-bar render resolves without throw', true);
+
+// segmented-bar value format
+const r2b = renderAtom(
+  stubCtx,
+  'segmented-bar',
+  {
+    segments: [
+      { label: 'A', value: 60 },
+      { label: 'B', value: 40 },
+    ],
+    format: 'value',
+    total: 100,
+  },
+  'pseudo3d',
+  renderOpts,
+);
+ok('segmented-bar value format resolves without throw', r2b instanceof Promise);
+await r2b;
+
+// pull-quote-banner accent bg
+const r3 = renderAtom(
+  stubCtx,
+  'pull-quote-banner',
+  {
+    quote: "We don't just sell software — we transform how teams work.",
+    author: 'Sarah Chen',
+    attribution: 'CEO, Meridian Analytics',
+    bg: 'accent',
+  },
+  'pseudo3d',
+  renderOpts,
+);
+ok('pull-quote-banner render returns Promise', r3 instanceof Promise);
+await r3;
+ok('pull-quote-banner render resolves without throw', true);
+
+// pull-quote-banner dark bg
+const r3b = renderAtom(
+  stubCtx,
+  'pull-quote-banner',
+  { quote: 'Simple is hard.', bg: 'dark' },
+  'pseudo3d',
+  renderOpts,
+);
+ok('pull-quote-banner dark bg resolves without throw', r3b instanceof Promise);
+await r3b;
+
+// pull-quote-banner gradient bg
+const r3c = renderAtom(
+  stubCtx,
+  'pull-quote-banner',
+  { quote: 'Gradient quote.', bg: 'gradient', author: 'Someone' },
+  'pseudo3d',
+  renderOpts,
+);
+ok('pull-quote-banner gradient bg resolves without throw', r3c instanceof Promise);
+await r3c;
+
+// circle-process-cycle (4-step PDCA)
+const r4 = renderAtom(
+  stubCtx,
+  'circle-process-cycle',
+  {
+    title: 'Continuous Improvement',
+    steps: [{ label: 'Plan' }, { label: 'Do' }, { label: 'Check' }, { label: 'Act' }],
+    centerLabel: 'PDCA',
+  },
+  'pseudo3d',
+  renderOpts,
+);
+ok('circle-process-cycle render returns Promise', r4 instanceof Promise);
+await r4;
+ok('circle-process-cycle render resolves without throw', true);
+
+// circle-process-cycle (3-step, no center)
+const r4b = renderAtom(
+  stubCtx,
+  'circle-process-cycle',
+  { steps: [{ label: 'Discover' }, { label: 'Build' }, { label: 'Ship' }] },
+  'pseudo3d',
+  renderOpts,
+);
+ok('circle-process-cycle 3-step no-center resolves without throw', r4b instanceof Promise);
+await r4b;
+
+// ──────────────────────────────────────────────────────────────────────────────
+// 4. Catalog auto-pickup
+// ──────────────────────────────────────────────────────────────────────────────
+console.log('\n-- Catalog --');
+_resetCatalogCache();
+const catalog = await buildAtomCatalogString();
+ok('catalog includes vertical-timeline', catalog.includes('`vertical-timeline`'));
+ok('catalog includes segmented-bar', catalog.includes('`segmented-bar`'));
+ok('catalog includes pull-quote-banner', catalog.includes('`pull-quote-banner`'));
+ok('catalog includes circle-process-cycle', catalog.includes('`circle-process-cycle`'));
+
+console.log(`\n=== Result: ${pass} passed, ${fail} failed ===`);
+if (fail > 0) process.exit(1);

--- a/sdf-js/src/present/atoms-2d/charts/data/segmented-bar.js
+++ b/sdf-js/src/present/atoms-2d/charts/data/segmented-bar.js
@@ -148,7 +148,11 @@ export function drawPseudo3D(ctx, args, opts = {}) {
     if (segW >= MIN_LABEL_W) {
       const inFontSize = Math.round(barH * 0.3);
       const pctStr =
-        format === 'value' ? String(s.value) : `${Math.round((s.value / total) * 100)}%`;
+        format === 'value'
+          ? String(s.value)
+          : total > 0
+            ? `${Math.round((s.value / total) * 100)}%`
+            : '0%';
       const displayStr = `${s.label} ${pctStr}`;
       ctx.save();
       ctx.fillStyle = 'rgba(255,255,255,0.95)';
@@ -182,7 +186,6 @@ export function drawPseudo3D(ctx, args, opts = {}) {
   const legendY = barY + barH + 18;
   const legendFontSize = Math.round(h * 0.042);
   const dotR = legendFontSize * 0.45;
-  const itemPad = 20;
   const itemW = (w - PAD * 2) / segs.length;
 
   for (let i = 0; i < segs.length; i++) {

--- a/sdf-js/src/present/atoms-2d/charts/data/segmented-bar.js
+++ b/sdf-js/src/present/atoms-2d/charts/data/segmented-bar.js
@@ -1,0 +1,211 @@
+// =============================================================================
+// atoms-2d/charts/data/segmented-bar.js — Single horizontal segmented bar
+// -----------------------------------------------------------------------------
+// One horizontal bar split into N colored segments proportional to values.
+// Use cases: market share, budget allocation, time allocation.
+//
+// Args:
+//   title?    — optional heading
+//   segments  — array of { label, value, color? } (2-8) REQUIRED
+//   total?    — custom total (default: sum of values)
+//   showPct?  — show percentage (default: true)
+//   format?   — 'pct' | 'value' (default: 'pct')
+// =============================================================================
+
+import { rgbCss, rgbaCss } from '../../renderer.js';
+
+export const spec = {
+  type: 'segmented-bar',
+  category: 'charts/data',
+  description:
+    'Single horizontal bar split into N colored segments. Market share / budget allocation / time breakdown.',
+  args: {
+    title: { type: 'string?', example: 'Budget Allocation' },
+    segments: {
+      type: 'array of { label, value, color? } (2-8)',
+      required: true,
+      example: [
+        { label: 'Eng', value: 45 },
+        { label: 'Sales', value: 30 },
+        { label: 'Marketing', value: 15 },
+        { label: 'Other', value: 10 },
+      ],
+    },
+    total: { type: 'number?', example: 100 },
+    showPct: { type: 'boolean?', default: true },
+    format: { type: "'pct'|'value'?", default: "'pct'" },
+  },
+};
+
+const BAR_CORNER = 8;
+const MIN_LABEL_W = 60;
+
+export function drawPseudo3D(ctx, args, opts = {}) {
+  const x = opts.x ?? 0;
+  const y = opts.y ?? 0;
+  const w = opts.w ?? 720;
+  const h = opts.h ?? 380;
+  const palette = opts.palette || {};
+  const fg = palette.silhouetteColor || [30, 27, 30];
+  const bg = palette.bg || [248, 246, 240];
+  const accent = palette.accent || palette.colors?.[0] || [60, 100, 200];
+  const colors = palette.colors || [accent, [80, 160, 200], [200, 120, 60], [140, 200, 80]];
+
+  // Background
+  ctx.fillStyle = rgbCss(bg);
+  ctx.fillRect(x, y, w, h);
+
+  const rawSegs = Array.isArray(args.segments) ? args.segments.slice(0, 8) : [];
+  if (rawSegs.length === 0) return;
+
+  const segs = rawSegs.map((s, i) => ({
+    label: String(s.label || ''),
+    value: Number(s.value) || 0,
+    color: s.color || colors[i % colors.length],
+  }));
+
+  const total = args.total != null ? Number(args.total) : segs.reduce((a, s) => a + s.value, 0);
+  const showPct = args.showPct !== false;
+  const format = args.format || 'pct';
+
+  // Title bar
+  let plotTop = y + 16;
+  if (args.title) {
+    const titleFontSize = Math.round(h * 0.07);
+    ctx.fillStyle = rgbCss(fg);
+    ctx.font = `700 ${titleFontSize}px Inter, system-ui, sans-serif`;
+    ctx.textAlign = 'left';
+    ctx.textBaseline = 'top';
+    ctx.fillText(String(args.title), x + 24, plotTop);
+    plotTop += titleFontSize + 16;
+  }
+
+  const PAD = 24;
+  const barX = x + PAD;
+  const barW = w - PAD * 2;
+  const barH = Math.round(h * 0.18);
+  const barY = plotTop + (h - (plotTop - y) - barH) / 3; // upper third of remaining
+
+  // Total label above-right
+  const totalFontSize = Math.round(h * 0.05);
+  if (total > 0) {
+    ctx.fillStyle = rgbaCss(fg, 0.45);
+    ctx.font = `500 ${totalFontSize}px Inter, system-ui, sans-serif`;
+    ctx.textAlign = 'right';
+    ctx.textBaseline = 'bottom';
+    ctx.fillText(`Total: ${total}`, x + w - PAD, barY - 6);
+  }
+
+  // Draw bar segments
+  let curX = barX;
+  for (let i = 0; i < segs.length; i++) {
+    const s = segs[i];
+    const frac = total > 0 ? s.value / total : 1 / segs.length;
+    const segW = Math.round(barW * frac);
+    const isFirst = i === 0;
+    const isLast = i === segs.length - 1;
+
+    ctx.save();
+    ctx.fillStyle = Array.isArray(s.color) ? rgbCss(s.color) : s.color;
+
+    // Rounded corners only on first and last segment
+    ctx.beginPath();
+    const r = BAR_CORNER;
+    if (isFirst && isLast) {
+      // Full rounded
+      ctx.moveTo(curX + r, barY);
+      ctx.lineTo(curX + segW - r, barY);
+      ctx.quadraticCurveTo(curX + segW, barY, curX + segW, barY + r);
+      ctx.lineTo(curX + segW, barY + barH - r);
+      ctx.quadraticCurveTo(curX + segW, barY + barH, curX + segW - r, barY + barH);
+      ctx.lineTo(curX + r, barY + barH);
+      ctx.quadraticCurveTo(curX, barY + barH, curX, barY + barH - r);
+      ctx.lineTo(curX, barY + r);
+      ctx.quadraticCurveTo(curX, barY, curX + r, barY);
+    } else if (isFirst) {
+      ctx.moveTo(curX + r, barY);
+      ctx.lineTo(curX + segW, barY);
+      ctx.lineTo(curX + segW, barY + barH);
+      ctx.lineTo(curX + r, barY + barH);
+      ctx.quadraticCurveTo(curX, barY + barH, curX, barY + barH - r);
+      ctx.lineTo(curX, barY + r);
+      ctx.quadraticCurveTo(curX, barY, curX + r, barY);
+    } else if (isLast) {
+      ctx.moveTo(curX, barY);
+      ctx.lineTo(curX + segW - r, barY);
+      ctx.quadraticCurveTo(curX + segW, barY, curX + segW, barY + r);
+      ctx.lineTo(curX + segW, barY + barH - r);
+      ctx.quadraticCurveTo(curX + segW, barY + barH, curX + segW - r, barY + barH);
+      ctx.lineTo(curX, barY + barH);
+    } else {
+      ctx.rect(curX, barY, segW, barH);
+    }
+    ctx.closePath();
+    ctx.fill();
+    ctx.restore();
+
+    // Segment label inside bar (if wide enough)
+    if (segW >= MIN_LABEL_W) {
+      const inFontSize = Math.round(barH * 0.3);
+      const pctStr =
+        format === 'value' ? String(s.value) : `${Math.round((s.value / total) * 100)}%`;
+      const displayStr = `${s.label} ${pctStr}`;
+      ctx.save();
+      ctx.fillStyle = 'rgba(255,255,255,0.95)';
+      ctx.font = `700 ${inFontSize}px Inter, system-ui, sans-serif`;
+      ctx.textAlign = 'center';
+      ctx.textBaseline = 'middle';
+      // Clip to segment so text doesn't bleed
+      ctx.beginPath();
+      ctx.rect(curX, barY, segW, barH);
+      ctx.clip();
+      ctx.fillText(displayStr, curX + segW / 2, barY + barH / 2);
+      ctx.restore();
+    }
+
+    // Subtle 1px white divider between segments (not before first)
+    if (!isFirst) {
+      ctx.save();
+      ctx.strokeStyle = 'rgba(255,255,255,0.4)';
+      ctx.lineWidth = 1;
+      ctx.beginPath();
+      ctx.moveTo(curX, barY + 2);
+      ctx.lineTo(curX, barY + barH - 2);
+      ctx.stroke();
+      ctx.restore();
+    }
+
+    curX += segW;
+  }
+
+  // Legend row below bar
+  const legendY = barY + barH + 18;
+  const legendFontSize = Math.round(h * 0.042);
+  const dotR = legendFontSize * 0.45;
+  const itemPad = 20;
+  const itemW = (w - PAD * 2) / segs.length;
+
+  for (let i = 0; i < segs.length; i++) {
+    const s = segs[i];
+    const lx = barX + i * itemW;
+    const pct = total > 0 ? Math.round((s.value / total) * 100) : 0;
+    const valueStr = format === 'value' ? String(s.value) : `${pct}%`;
+
+    // Color dot
+    ctx.save();
+    ctx.fillStyle = Array.isArray(s.color) ? rgbCss(s.color) : s.color;
+    ctx.beginPath();
+    ctx.arc(lx + dotR, legendY + legendFontSize / 2, dotR, 0, Math.PI * 2);
+    ctx.fill();
+    ctx.restore();
+
+    // Label
+    ctx.save();
+    ctx.fillStyle = rgbaCss(fg, 0.75);
+    ctx.font = `500 ${legendFontSize}px Inter, system-ui, sans-serif`;
+    ctx.textAlign = 'left';
+    ctx.textBaseline = 'middle';
+    ctx.fillText(`${s.label}  ${valueStr}`, lx + dotR * 2 + 6, legendY + legendFontSize / 2);
+    ctx.restore();
+  }
+}

--- a/sdf-js/src/present/atoms-2d/charts/data/stat-grid-large.js
+++ b/sdf-js/src/present/atoms-2d/charts/data/stat-grid-large.js
@@ -97,17 +97,24 @@ export function drawPseudo3D(ctx, args, opts = {}) {
       ctx.restore();
     }
 
-    // Giant value
+    // Giant value — auto-shrink to fit col width
+    const targetValueFontSize = Math.min(Math.round(availH * 0.52), Math.round(colW * 0.38));
+    let vFontSize = targetValueFontSize;
+    ctx.font = `900 ${vFontSize}px "Inter Display", Inter, system-ui, sans-serif`;
+    while (vFontSize > 16 && ctx.measureText(s.value).width > colW * 0.85) {
+      vFontSize--;
+      ctx.font = `900 ${vFontSize}px "Inter Display", Inter, system-ui, sans-serif`;
+    }
+
     ctx.save();
     ctx.fillStyle = rgbCss(accent);
-    ctx.font = `900 ${valueFontSize}px "Inter Display", Inter, system-ui, sans-serif`;
+    ctx.font = `900 ${vFontSize}px "Inter Display", Inter, system-ui, sans-serif`;
     ctx.textAlign = 'center';
     ctx.textBaseline = 'top';
-    const maxValW = colW - 16;
-    ctx.fillText(fitText(ctx, s.value, maxValW), cx, blockTop);
+    ctx.fillText(s.value, cx, blockTop);
     ctx.restore();
 
-    const labelTop = blockTop + valueFontSize + 6;
+    const labelTop = blockTop + vFontSize + 6;
 
     // Label
     ctx.save();

--- a/sdf-js/src/present/atoms-2d/charts/diagrams/circle-process-cycle.js
+++ b/sdf-js/src/present/atoms-2d/charts/diagrams/circle-process-cycle.js
@@ -1,0 +1,227 @@
+// =============================================================================
+// atoms-2d/charts/diagrams/circle-process-cycle.js — Circular PDCA-style process
+// -----------------------------------------------------------------------------
+// N steps arranged in a circle with clockwise arrows between them.
+// Complement to linear process-arrows. PDCA / OODA / continuous improvement.
+//
+// Args:
+//   title?       — optional title bar
+//   steps        — array of { label, sublabel? } (3-7) REQUIRED
+//   centerLabel? — text in center circle (e.g. 'CONTINUOUS IMPROVEMENT')
+// =============================================================================
+
+import { rgbCss, rgbaCss } from '../../renderer.js';
+
+export const spec = {
+  type: 'circle-process-cycle',
+  category: 'charts/diagrams',
+  description:
+    'Circular PDCA-style process — N steps in a circle with clockwise arrows. Complement to process-arrows.',
+  args: {
+    title: { type: 'string?', example: 'Continuous Improvement' },
+    steps: {
+      type: 'array of { label, sublabel? } (3-7)',
+      required: true,
+      example: [{ label: 'Plan' }, { label: 'Do' }, { label: 'Check' }, { label: 'Act' }],
+    },
+    centerLabel: { type: 'string?', example: 'PDCA' },
+  },
+};
+
+export function drawPseudo3D(ctx, args, opts = {}) {
+  const x = opts.x ?? 0;
+  const y = opts.y ?? 0;
+  const w = opts.w ?? 720;
+  const h = opts.h ?? 480;
+  const palette = opts.palette || {};
+  const fg = palette.silhouetteColor || [30, 27, 30];
+  const bg = palette.bg || [248, 246, 240];
+  const accent = palette.accent || palette.colors?.[0] || [60, 100, 200];
+  const colors = palette.colors || [accent];
+
+  // Background
+  ctx.fillStyle = rgbCss(bg);
+  ctx.fillRect(x, y, w, h);
+
+  const rawSteps = Array.isArray(args.steps) ? args.steps.slice(0, 7) : [];
+  const steps = rawSteps.map((s) => ({
+    label: String(s.label || ''),
+    sublabel: s.sublabel ? String(s.sublabel) : '',
+  }));
+  const N = steps.length;
+  if (N === 0) return;
+
+  // Title bar
+  let plotTop = y;
+  if (args.title) {
+    const titleFontSize = Math.round(h * 0.07);
+    ctx.fillStyle = rgbCss(fg);
+    ctx.font = `700 ${titleFontSize}px Inter, system-ui, sans-serif`;
+    ctx.textAlign = 'left';
+    ctx.textBaseline = 'top';
+    ctx.fillText(String(args.title), x + 20, y + 16);
+    plotTop = y + titleFontSize + 28;
+  }
+
+  const availH = h - (plotTop - y);
+  const cx = x + w / 2;
+  const cy = plotTop + availH / 2;
+
+  // Step circles radius
+  const stepR = Math.min(w, availH) * 0.09;
+  // Orbit radius where centers live
+  const orbitR = Math.min(w * 0.32, availH * 0.38);
+  // Center circle radius
+  const centerR = args.centerLabel ? orbitR * 0.28 : 0;
+
+  // Compute step center positions (start at top, clockwise)
+  const centers = [];
+  for (let i = 0; i < N; i++) {
+    const angle = (2 * Math.PI * i) / N - Math.PI / 2;
+    centers.push({ px: cx + orbitR * Math.cos(angle), py: cy + orbitR * Math.sin(angle), angle });
+  }
+
+  // Draw curved arrows between consecutive steps (clockwise)
+  for (let i = 0; i < N; i++) {
+    const from = centers[i];
+    const to = centers[(i + 1) % N];
+
+    // Bezier control point pushed outward (1.3× orbit radius)
+    const midAngle = from.angle + Math.PI / N;
+    const cpDist = orbitR * 1.35;
+    const cpx = cx + cpDist * Math.cos(midAngle);
+    const cpy = cy + cpDist * Math.sin(midAngle);
+
+    // Direction vector from control point to destination (for arrow head)
+    const dx = to.px - cpx;
+    const dy = to.py - cpy;
+    const dLen = Math.sqrt(dx * dx + dy * dy);
+    const nx = dx / dLen;
+    const ny = dy / dLen;
+
+    // End point at step circle edge
+    const endX = to.px - nx * stepR;
+    const endY = to.py - ny * stepR;
+
+    ctx.save();
+    ctx.strokeStyle = rgbaCss(accent, 0.55);
+    ctx.lineWidth = 2;
+    ctx.setLineDash([]);
+    ctx.beginPath();
+    ctx.moveTo(from.px + nx * stepR * 0.1, from.py + ny * stepR * 0.1);
+    ctx.quadraticCurveTo(cpx, cpy, endX, endY);
+    ctx.stroke();
+
+    // Arrow head
+    const aLen = stepR * 0.45;
+    const aW = stepR * 0.28;
+    const arrowAngle = Math.atan2(endY - cpy, endX - cpx);
+    ctx.fillStyle = rgbaCss(accent, 0.75);
+    ctx.beginPath();
+    ctx.moveTo(endX, endY);
+    ctx.lineTo(
+      endX - aLen * Math.cos(arrowAngle) + aW * Math.sin(arrowAngle),
+      endY - aLen * Math.sin(arrowAngle) - aW * Math.cos(arrowAngle),
+    );
+    ctx.lineTo(
+      endX - aLen * Math.cos(arrowAngle) - aW * Math.sin(arrowAngle),
+      endY - aLen * Math.sin(arrowAngle) + aW * Math.cos(arrowAngle),
+    );
+    ctx.closePath();
+    ctx.fill();
+    ctx.restore();
+  }
+
+  // Draw step circles + labels
+  for (let i = 0; i < N; i++) {
+    const { px, py } = centers[i];
+    const color = colors[i % colors.length];
+
+    // Circle fill
+    ctx.save();
+    ctx.fillStyle = Array.isArray(color) ? rgbCss(color) : rgbCss(accent);
+    ctx.beginPath();
+    ctx.arc(px, py, stepR, 0, Math.PI * 2);
+    ctx.fill();
+    ctx.restore();
+
+    // Step label inside circle — auto-shrink
+    const labelFontSize = Math.round(stepR * 0.5);
+    const maxLabelW = stepR * 1.6;
+    let lfs = labelFontSize;
+    ctx.font = `700 ${lfs}px Inter, system-ui, sans-serif`;
+    while (lfs > 8 && ctx.measureText(steps[i].label).width > maxLabelW) {
+      lfs--;
+      ctx.font = `700 ${lfs}px Inter, system-ui, sans-serif`;
+    }
+
+    ctx.save();
+    ctx.fillStyle = 'rgba(255,255,255,0.97)';
+    ctx.font = `700 ${lfs}px Inter, system-ui, sans-serif`;
+    ctx.textAlign = 'center';
+    ctx.textBaseline = 'middle';
+    ctx.fillText(steps[i].label, px, steps[i].sublabel ? py - lfs * 0.35 : py);
+    ctx.restore();
+
+    // Sublabel below circle
+    if (steps[i].sublabel) {
+      const subFontSize = Math.round(stepR * 0.3);
+      ctx.save();
+      ctx.fillStyle = rgbaCss(fg, 0.55);
+      ctx.font = `500 ${subFontSize}px Inter, system-ui, sans-serif`;
+      ctx.textAlign = 'center';
+      ctx.textBaseline = 'top';
+      ctx.fillText(steps[i].sublabel, px, py + stepR + 4);
+      ctx.restore();
+    }
+  }
+
+  // Center label circle
+  if (args.centerLabel && centerR > 0) {
+    ctx.save();
+    ctx.fillStyle = rgbaCss(accent, 0.12);
+    ctx.beginPath();
+    ctx.arc(cx, cy, centerR, 0, Math.PI * 2);
+    ctx.fill();
+    ctx.strokeStyle = rgbaCss(accent, 0.35);
+    ctx.lineWidth = 2;
+    ctx.stroke();
+    ctx.restore();
+
+    const centerFontSize = Math.round(centerR * 0.35);
+    const centerText = String(args.centerLabel);
+    // Word-wrap center label (max 2 lines)
+    const maxCenterW = centerR * 1.6;
+    ctx.font = `700 ${centerFontSize}px Inter, system-ui, sans-serif`;
+    const cLines = wrapText(ctx, centerText, maxCenterW, 2);
+    const cLineH = centerFontSize * 1.3;
+    cLines.forEach((line, i) => {
+      const lineY = cy - ((cLines.length - 1) * cLineH) / 2 + i * cLineH;
+      ctx.save();
+      ctx.fillStyle = rgbCss(accent);
+      ctx.font = `700 ${centerFontSize}px Inter, system-ui, sans-serif`;
+      ctx.textAlign = 'center';
+      ctx.textBaseline = 'middle';
+      ctx.fillText(line, cx, lineY);
+      ctx.restore();
+    });
+  }
+}
+
+function wrapText(ctx, text, maxW, maxLines) {
+  const words = String(text).split(/\s+/);
+  const lines = [];
+  let cur = '';
+  for (const word of words) {
+    const test = cur ? cur + ' ' + word : word;
+    if (ctx.measureText(test).width > maxW && cur) {
+      lines.push(cur);
+      if (lines.length >= maxLines) return lines;
+      cur = word;
+    } else {
+      cur = test;
+    }
+  }
+  if (cur && lines.length < maxLines) lines.push(cur);
+  return lines;
+}

--- a/sdf-js/src/present/atoms-2d/charts/diagrams/process-arrows.js
+++ b/sdf-js/src/present/atoms-2d/charts/diagrams/process-arrows.js
@@ -146,7 +146,6 @@ export function drawPseudo3D(ctx, args, opts = {}) {
 
     // Label text — auto-shrink to fit chevron width
     const targetFontSize = Math.min(Math.round(arrowH * 0.2), Math.round(stepW * 0.16));
-    const subFontSize = Math.round(targetFontSize * 0.72);
     const hasSub = Boolean(steps[i].sublabel);
     const centerX = shapeX + shapeW / 2;
     const centerY = arrowY + arrowH / 2;

--- a/sdf-js/src/present/atoms-2d/charts/diagrams/process-arrows.js
+++ b/sdf-js/src/present/atoms-2d/charts/diagrams/process-arrows.js
@@ -144,12 +144,21 @@ export function drawPseudo3D(ctx, args, opts = {}) {
     ctx.fill();
     ctx.restore();
 
-    // Label text
-    const labelFontSize = Math.min(Math.round(arrowH * 0.2), Math.round(stepW * 0.16));
-    const subFontSize = Math.round(labelFontSize * 0.72);
+    // Label text — auto-shrink to fit chevron width
+    const targetFontSize = Math.min(Math.round(arrowH * 0.2), Math.round(stepW * 0.16));
+    const subFontSize = Math.round(targetFontSize * 0.72);
     const hasSub = Boolean(steps[i].sublabel);
     const centerX = shapeX + shapeW / 2;
     const centerY = arrowY + arrowH / 2;
+    const maxLabelW = shapeW - notch * 2 - 8;
+
+    // Auto-shrink: find largest font where label fits without ellipsis
+    let labelFontSize = targetFontSize;
+    ctx.font = `700 ${labelFontSize}px Inter, system-ui, sans-serif`;
+    while (labelFontSize > 10 && ctx.measureText(String(steps[i].label)).width > maxLabelW * 0.85) {
+      labelFontSize--;
+      ctx.font = `700 ${labelFontSize}px Inter, system-ui, sans-serif`;
+    }
     const labelY = hasSub ? centerY - labelFontSize * 0.6 : centerY;
 
     ctx.save();
@@ -157,21 +166,17 @@ export function drawPseudo3D(ctx, args, opts = {}) {
     ctx.font = `700 ${labelFontSize}px Inter, system-ui, sans-serif`;
     ctx.textAlign = 'center';
     ctx.textBaseline = 'middle';
-    const maxLabelW = shapeW - notch * 2 - 8;
-    ctx.fillText(fitText(ctx, String(steps[i].label), maxLabelW), centerX, labelY);
+    ctx.fillText(String(steps[i].label), centerX, labelY);
     ctx.restore();
 
     if (hasSub) {
+      const subFont = Math.round(labelFontSize * 0.72);
       ctx.save();
       ctx.fillStyle = 'rgba(255,255,255,0.75)';
-      ctx.font = `500 ${subFontSize}px Inter, system-ui, sans-serif`;
+      ctx.font = `500 ${subFont}px Inter, system-ui, sans-serif`;
       ctx.textAlign = 'center';
       ctx.textBaseline = 'middle';
-      ctx.fillText(
-        fitText(ctx, String(steps[i].sublabel), maxLabelW),
-        centerX,
-        centerY + labelFontSize * 0.75,
-      );
+      ctx.fillText(String(steps[i].sublabel), centerX, centerY + labelFontSize * 0.75);
       ctx.restore();
     }
   }

--- a/sdf-js/src/present/atoms-2d/charts/diagrams/process-arrows.js
+++ b/sdf-js/src/present/atoms-2d/charts/diagrams/process-arrows.js
@@ -169,7 +169,12 @@ export function drawPseudo3D(ctx, args, opts = {}) {
     ctx.restore();
 
     if (hasSub) {
-      const subFont = Math.round(labelFontSize * 0.72);
+      let subFont = Math.round(labelFontSize * 0.72);
+      ctx.font = `500 ${subFont}px Inter, system-ui, sans-serif`;
+      while (subFont > 8 && ctx.measureText(String(steps[i].sublabel)).width > maxLabelW * 0.85) {
+        subFont--;
+        ctx.font = `500 ${subFont}px Inter, system-ui, sans-serif`;
+      }
       ctx.save();
       ctx.fillStyle = 'rgba(255,255,255,0.75)';
       ctx.font = `500 ${subFont}px Inter, system-ui, sans-serif`;
@@ -179,11 +184,4 @@ export function drawPseudo3D(ctx, args, opts = {}) {
       ctx.restore();
     }
   }
-}
-
-function fitText(ctx, text, maxW) {
-  if (ctx.measureText(text).width <= maxW) return text;
-  let s = text;
-  while (s.length > 1 && ctx.measureText(s + '…').width > maxW) s = s.slice(0, -1);
-  return s + '…';
 }

--- a/sdf-js/src/present/atoms-2d/charts/diagrams/vertical-timeline.js
+++ b/sdf-js/src/present/atoms-2d/charts/diagrams/vertical-timeline.js
@@ -1,0 +1,178 @@
+// =============================================================================
+// atoms-2d/charts/diagrams/vertical-timeline.js — Vertical stacked timeline
+// -----------------------------------------------------------------------------
+// Date/event pairs stacked vertically with a left axis line + dots.
+// Complement to horizontal `timeline` atom.
+//
+// Args:
+//   title?     — optional title bar
+//   events     — array of { date, label, sublabel? } (3-8) REQUIRED
+//   axisLabel? — optional label above the axis
+// =============================================================================
+
+import { rgbCss, rgbaCss } from '../../renderer.js';
+
+export const spec = {
+  type: 'vertical-timeline',
+  category: 'charts/diagrams',
+  description:
+    'Vertical stacked timeline — date/event pairs with left axis line + filled dots. Complement to horizontal timeline.',
+  args: {
+    title: { type: 'string?', example: 'Company Milestones' },
+    events: {
+      type: 'array of { date, label, sublabel? } (3-8)',
+      required: true,
+      example: [
+        { date: 'Q1 2026', label: 'Launch' },
+        { date: 'Q2 2026', label: 'Series A', sublabel: '$8M raised' },
+        { date: 'Q3 2026', label: '10K users' },
+      ],
+    },
+    axisLabel: { type: 'string?', example: '2026 Roadmap' },
+  },
+};
+
+const PAD = 20;
+const AXIS_X_FRAC = 0.22; // axis line at 22% of width
+const DOT_RADIUS = 7;
+
+export function drawPseudo3D(ctx, args, opts = {}) {
+  const x = opts.x ?? 0;
+  const y = opts.y ?? 0;
+  const w = opts.w ?? 720;
+  const h = opts.h ?? 480;
+  const palette = opts.palette || {};
+  const fg = palette.silhouetteColor || [30, 27, 30];
+  const bg = palette.bg || [248, 246, 240];
+  const accent = palette.accent || palette.colors?.[0] || [60, 100, 200];
+
+  // Background
+  ctx.fillStyle = rgbCss(bg);
+  ctx.fillRect(x, y, w, h);
+
+  const rawEvents = Array.isArray(args.events) ? args.events.slice(0, 8) : [];
+  const events = rawEvents.map((e) => ({
+    date: String(e.date || ''),
+    label: String(e.label || ''),
+    sublabel: e.sublabel ? String(e.sublabel) : '',
+  }));
+  const N = events.length;
+  if (N === 0) return;
+
+  // Title bar
+  let plotTop = y + PAD;
+  if (args.title) {
+    const titleFontSize = Math.round(h * 0.07);
+    ctx.fillStyle = rgbCss(fg);
+    ctx.font = `700 ${titleFontSize}px Inter, system-ui, sans-serif`;
+    ctx.textAlign = 'left';
+    ctx.textBaseline = 'top';
+    ctx.fillText(String(args.title), x + PAD, plotTop);
+    plotTop += titleFontSize + 16;
+  }
+
+  // Axis label
+  if (args.axisLabel) {
+    const axLabelSize = Math.round(h * 0.038);
+    ctx.fillStyle = rgbaCss(accent, 0.75);
+    ctx.font = `600 ${axLabelSize}px Inter, system-ui, sans-serif`;
+    ctx.textAlign = 'left';
+    ctx.textBaseline = 'top';
+    ctx.fillText(String(args.axisLabel), x + PAD, plotTop);
+    plotTop += axLabelSize + 10;
+  }
+
+  const availH = h - (plotTop - y) - PAD;
+  const rowH = availH / N;
+  const axisX = x + w * AXIS_X_FRAC;
+
+  // Draw vertical axis line
+  ctx.save();
+  ctx.strokeStyle = rgbaCss(accent, 0.5);
+  ctx.lineWidth = 2;
+  ctx.setLineDash([]);
+  ctx.beginPath();
+  ctx.moveTo(axisX, plotTop);
+  ctx.lineTo(axisX, plotTop + availH);
+  ctx.stroke();
+  ctx.restore();
+
+  // Per-event layout
+  for (let i = 0; i < N; i++) {
+    const ev = events[i];
+    const rowMidY = plotTop + i * rowH + rowH / 2;
+
+    // Dot on axis
+    ctx.save();
+    ctx.fillStyle = rgbCss(accent);
+    ctx.beginPath();
+    ctx.arc(axisX, rowMidY, DOT_RADIUS, 0, Math.PI * 2);
+    ctx.fill();
+    // White center
+    ctx.fillStyle = 'rgba(255,255,255,0.85)';
+    ctx.beginPath();
+    ctx.arc(axisX, rowMidY, DOT_RADIUS * 0.35, 0, Math.PI * 2);
+    ctx.fill();
+    ctx.restore();
+
+    // Date — right-aligned to LEFT of axis
+    const dateFontSize = Math.round(rowH * 0.28);
+    if (ev.date) {
+      ctx.save();
+      ctx.fillStyle = rgbaCss(fg, 0.45);
+      ctx.font = `700 ${dateFontSize}px Inter, system-ui, sans-serif`;
+      ctx.textAlign = 'right';
+      ctx.textBaseline = 'middle';
+      ctx.fillText(ev.date, axisX - DOT_RADIUS - 10, rowMidY);
+      ctx.restore();
+    }
+
+    // Label — left-aligned to RIGHT of axis
+    const labelFontSize = Math.round(rowH * 0.32);
+    if (ev.label) {
+      const labelX = axisX + DOT_RADIUS + 12;
+      const maxLabelW = x + w - PAD - labelX;
+
+      // Auto-shrink
+      let lfs = labelFontSize;
+      ctx.font = `700 ${lfs}px Inter, system-ui, sans-serif`;
+      while (lfs > 10 && ctx.measureText(ev.label).width > maxLabelW) {
+        lfs--;
+        ctx.font = `700 ${lfs}px Inter, system-ui, sans-serif`;
+      }
+      const labelY = ev.sublabel ? rowMidY - lfs * 0.35 : rowMidY;
+
+      ctx.save();
+      ctx.fillStyle = rgbCss(fg);
+      ctx.font = `700 ${lfs}px Inter, system-ui, sans-serif`;
+      ctx.textAlign = 'left';
+      ctx.textBaseline = 'middle';
+      ctx.fillText(ev.label, labelX, labelY);
+      ctx.restore();
+
+      // Sublabel
+      if (ev.sublabel) {
+        const subFontSize = Math.round(rowH * 0.22);
+        ctx.save();
+        ctx.fillStyle = rgbaCss(fg, 0.5);
+        ctx.font = `500 ${subFontSize}px Inter, system-ui, sans-serif`;
+        ctx.textAlign = 'left';
+        ctx.textBaseline = 'middle';
+        ctx.fillText(ev.sublabel, labelX, rowMidY + lfs * 0.5);
+        ctx.restore();
+      }
+    }
+
+    // Subtle horizontal separator between rows (not after last)
+    if (i < N - 1) {
+      ctx.save();
+      ctx.strokeStyle = rgbaCss(fg, 0.07);
+      ctx.lineWidth = 1;
+      ctx.beginPath();
+      ctx.moveTo(x + PAD, plotTop + (i + 1) * rowH);
+      ctx.lineTo(x + w - PAD, plotTop + (i + 1) * rowH);
+      ctx.stroke();
+      ctx.restore();
+    }
+  }
+}

--- a/sdf-js/src/present/atoms-2d/charts/typography/pull-quote-banner.js
+++ b/sdf-js/src/present/atoms-2d/charts/typography/pull-quote-banner.js
@@ -77,12 +77,16 @@ export function drawPseudo3D(ctx, args, opts = {}) {
 
   // Iteratively shrink until 4 lines fit
   ctx.font = `500 ${quoteFontSize}px Inter, system-ui, sans-serif`;
-  let lines = wrapText(ctx, quoteText, maxQuoteW, maxLines);
+  // Measure with no line cap to detect how many lines are actually needed
+  let lines = wrapText(ctx, quoteText, maxQuoteW, 999);
+  // Shrink font if text needs more than maxLines lines
   while (quoteFontSize > 18 && lines.length > maxLines) {
     quoteFontSize--;
     ctx.font = `500 ${quoteFontSize}px Inter, system-ui, sans-serif`;
-    lines = wrapText(ctx, quoteText, maxQuoteW, maxLines);
+    lines = wrapText(ctx, quoteText, maxQuoteW, 999);
   }
+  // Now cap to maxLines for actual rendering
+  lines = wrapText(ctx, quoteText, maxQuoteW, maxLines);
 
   const lineH = quoteFontSize * 1.35;
   const totalTextH =

--- a/sdf-js/src/present/atoms-2d/charts/typography/pull-quote-banner.js
+++ b/sdf-js/src/present/atoms-2d/charts/typography/pull-quote-banner.js
@@ -1,0 +1,156 @@
+// =============================================================================
+// atoms-2d/charts/typography/pull-quote-banner.js — Full-bleed hero quote banner
+// -----------------------------------------------------------------------------
+// Full-width banner with accent/dark/gradient background + large white quote +
+// attribution. "Hero quote slide" pattern — contrast with quote-pull (white bg).
+//
+// Args:
+//   quote        — the quote text (REQUIRED)
+//   author?      — author name
+//   attribution? — author title/org
+//   bg?          — 'accent' | 'dark' | 'gradient' (default: 'accent')
+// =============================================================================
+
+import { rgbCss, rgbaCss } from '../../renderer.js';
+
+export const spec = {
+  type: 'pull-quote-banner',
+  category: 'charts/typography',
+  description:
+    'Full-bleed hero quote banner — accent/dark/gradient bg, large white centered quote + attribution. Hero quote slide.',
+  args: {
+    quote: {
+      type: 'string',
+      required: true,
+      example: "We don't just sell software — we transform how teams work.",
+    },
+    author: { type: 'string?', example: 'Sarah Chen' },
+    attribution: { type: 'string?', example: 'CEO, Meridian Analytics' },
+    bg: { type: "'accent'|'dark'|'gradient'?", default: "'accent'", example: 'accent' },
+  },
+};
+
+const PAD = 48;
+
+export function drawPseudo3D(ctx, args, opts = {}) {
+  const x = opts.x ?? 0;
+  const y = opts.y ?? 0;
+  const w = opts.w ?? 720;
+  const h = opts.h ?? 480;
+  const palette = opts.palette || {};
+  const accent = palette.accent || palette.colors?.[0] || [60, 100, 200];
+  const colors = palette.colors || [accent];
+  const bgMode = args.bg || 'accent';
+
+  // Full-bleed background
+  if (bgMode === 'gradient' && colors.length >= 2) {
+    const grad = ctx.createLinearGradient(x, y, x + w, y + h);
+    grad.addColorStop(0, rgbCss(colors[0]));
+    grad.addColorStop(1, rgbCss(colors[Math.min(colors.length - 1, 2)]));
+    ctx.fillStyle = grad;
+  } else if (bgMode === 'dark') {
+    ctx.fillStyle = 'rgb(18,20,28)';
+  } else {
+    // accent
+    ctx.fillStyle = rgbCss(accent);
+  }
+  ctx.fillRect(x, y, w, h);
+
+  // Decorative large opening quote mark (subtle, back-layer)
+  const markSize = Math.round(h * 0.6);
+  ctx.save();
+  ctx.fillStyle = 'rgba(255,255,255,0.07)';
+  ctx.font = `900 ${markSize}px Georgia, serif`;
+  ctx.textAlign = 'left';
+  ctx.textBaseline = 'top';
+  ctx.fillText('"', x + PAD * 0.5, y - markSize * 0.15);
+  ctx.restore();
+
+  const quoteText = String(args.quote || '');
+  const author = args.author ? String(args.author) : '';
+  const attribution = args.attribution ? String(args.attribution) : '';
+
+  // Quote text — centered, auto-shrink for long quotes, word-wrap max 4 lines
+  let quoteFontSize = Math.round(h * 0.13);
+  const maxQuoteW = w - PAD * 2;
+  const maxLines = 4;
+
+  // Iteratively shrink until 4 lines fit
+  ctx.font = `500 ${quoteFontSize}px Inter, system-ui, sans-serif`;
+  let lines = wrapText(ctx, quoteText, maxQuoteW, maxLines);
+  while (quoteFontSize > 18 && lines.length > maxLines) {
+    quoteFontSize--;
+    ctx.font = `500 ${quoteFontSize}px Inter, system-ui, sans-serif`;
+    lines = wrapText(ctx, quoteText, maxQuoteW, maxLines);
+  }
+
+  const lineH = quoteFontSize * 1.35;
+  const totalTextH =
+    lines.length * lineH +
+    (author ? quoteFontSize * 0.15 + h * 0.06 : 0) +
+    (attribution ? h * 0.04 : 0) +
+    (author ? h * 0.04 : 0);
+  const textBlockTop = y + (h - totalTextH) / 2;
+
+  ctx.save();
+  ctx.fillStyle = 'rgba(255,255,255,0.95)';
+  ctx.font = `500 ${quoteFontSize}px Inter, system-ui, sans-serif`;
+  ctx.textAlign = 'center';
+  ctx.textBaseline = 'top';
+  lines.forEach((line, i) => {
+    ctx.fillText(line, x + w / 2, textBlockTop + i * lineH);
+  });
+  ctx.restore();
+
+  // Accent rule
+  const ruleY = textBlockTop + lines.length * lineH + h * 0.025;
+  const ruleW = 60;
+  ctx.save();
+  ctx.fillStyle = 'rgba(255,255,255,0.55)';
+  ctx.fillRect(x + w / 2 - ruleW / 2, ruleY, ruleW, 3);
+  ctx.restore();
+
+  // Author
+  const authorY = ruleY + 3 + h * 0.025;
+  if (author) {
+    const authorFontSize = Math.round(h * 0.06);
+    ctx.save();
+    ctx.fillStyle = 'rgba(255,255,255,0.97)';
+    ctx.font = `700 ${authorFontSize}px Inter, system-ui, sans-serif`;
+    ctx.textAlign = 'center';
+    ctx.textBaseline = 'top';
+    ctx.fillText(author, x + w / 2, authorY);
+    ctx.restore();
+
+    // Attribution
+    if (attribution) {
+      const attrFontSize = Math.round(h * 0.04);
+      ctx.save();
+      ctx.fillStyle = 'rgba(255,255,255,0.65)';
+      ctx.font = `500 ${attrFontSize}px Inter, system-ui, sans-serif`;
+      ctx.textAlign = 'center';
+      ctx.textBaseline = 'top';
+      ctx.fillText(attribution, x + w / 2, authorY + Math.round(h * 0.06) * 1.4);
+      ctx.restore();
+    }
+  }
+}
+
+// Wrap text to maxLines. Returns array of line strings.
+function wrapText(ctx, text, maxW, maxLines) {
+  const words = String(text).split(/\s+/);
+  const lines = [];
+  let cur = '';
+  for (const word of words) {
+    const test = cur ? cur + ' ' + word : word;
+    if (ctx.measureText(test).width > maxW && cur) {
+      lines.push(cur);
+      if (lines.length >= maxLines) return lines;
+      cur = word;
+    } else {
+      cur = test;
+    }
+  }
+  if (cur && lines.length < maxLines) lines.push(cur);
+  return lines;
+}

--- a/sdf-js/src/present/atoms-2d/registry.js
+++ b/sdf-js/src/present/atoms-2d/registry.js
@@ -152,6 +152,7 @@ const ATOM_LOADERS = {
 
   // Sprint 20 Batch 2 — diagrams / data / typography
   'vertical-timeline': () => import('./charts/diagrams/vertical-timeline.js'),
+  'circle-process-cycle': () => import('./charts/diagrams/circle-process-cycle.js'),
   'segmented-bar': () => import('./charts/data/segmented-bar.js'),
   'pull-quote-banner': () => import('./charts/typography/pull-quote-banner.js'),
 

--- a/sdf-js/src/present/atoms-2d/registry.js
+++ b/sdf-js/src/present/atoms-2d/registry.js
@@ -153,6 +153,7 @@ const ATOM_LOADERS = {
   // Sprint 20 Batch 2 — diagrams / data / typography
   'vertical-timeline': () => import('./charts/diagrams/vertical-timeline.js'),
   'segmented-bar': () => import('./charts/data/segmented-bar.js'),
+  'pull-quote-banner': () => import('./charts/typography/pull-quote-banner.js'),
 
   // Charts / diagrams (Phase 2)
   // Charts / hierarchy (Phase 2)

--- a/sdf-js/src/present/atoms-2d/registry.js
+++ b/sdf-js/src/present/atoms-2d/registry.js
@@ -150,6 +150,9 @@ const ATOM_LOADERS = {
   'number-list': () => import('./charts/lists/number-list.js'),
   'call-to-action': () => import('./charts/typography/call-to-action.js'),
 
+  // Sprint 20 Batch 2 — diagrams / data / typography
+  'vertical-timeline': () => import('./charts/diagrams/vertical-timeline.js'),
+
   // Charts / diagrams (Phase 2)
   // Charts / hierarchy (Phase 2)
   // Shapes (Phase 3)

--- a/sdf-js/src/present/atoms-2d/registry.js
+++ b/sdf-js/src/present/atoms-2d/registry.js
@@ -152,6 +152,7 @@ const ATOM_LOADERS = {
 
   // Sprint 20 Batch 2 — diagrams / data / typography
   'vertical-timeline': () => import('./charts/diagrams/vertical-timeline.js'),
+  'segmented-bar': () => import('./charts/data/segmented-bar.js'),
 
   // Charts / diagrams (Phase 2)
   // Charts / hierarchy (Phase 2)


### PR DESCRIPTION
## Summary
- **2 polish fixes**: `process-arrows` auto-shrink (no more \`Disc...\`) + `stat-grid-large` value auto-shrink (no more \`$2...\`). Also added sublabel auto-shrink and removed dead `fitText()` helper.
- **4 new atoms**: `vertical-timeline` / `segmented-bar` / `pull-quote-banner` / `circle-process-cycle`
- **Tests**: 98/98 pass (97 → 98, +1 test file, 43 new assertions)
- **Visual demo**: `sprint20-b2-atomdemo` deck with all 4 atoms + 4 slot JSON files

## Atoms shipped
| Atom | Category | LOC |
|------|----------|-----|
| `vertical-timeline` | charts/diagrams | 178 |
| `segmented-bar` | charts/data | 214 |
| `pull-quote-banner` | charts/typography | 160 |
| `circle-process-cycle` | charts/diagrams | 227 |

## Bugs fixed during review
- `segmented-bar`: division by zero when `total=0` in segment label pctStr path
- `pull-quote-banner`: auto-shrink while-loop was unreachable (wrapText cap vs uncapped fix)
- `segmented-bar`: unused `itemPad` dead variable removed

## Test plan
- [ ] `npm test` → 98/98
- [ ] Open scaffold-deck-viewer → load `sprint20-b2-atomdemo` → all 4 slots render
- [ ] Reload `sprint20-b1-atomdemo` → process-arrows chevrons show full labels (no ellipsis on "Discover")
- [ ] Reload `sprint20-b1-atomdemo` → stat-grid-large shows full values (no truncation on "\$24M")

🤖 Generated with [Claude Code](https://claude.com/claude-code)