### PR TITLE
feat(lift): deterministic 2D→3D twin map (Stage-2 atom instantiation)

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -136,6 +136,7 @@ const TESTS = [
   { category: 'diagram', file: 'sdf-js/scripts/test-gantt-3d.mjs' },
   { category: 'diagram', file: 'sdf-js/scripts/test-gauge-3d.mjs' },
   { category: 'scene', file: 'sdf-js/scripts/test-chart-labels.mjs' },
+  { category: 'scene', file: 'sdf-js/scripts/test-lift-2d-to-3d.mjs' },
 
   // Sprint 5 Wave C: fishbone / traffic-light / radial-spoke + puzzle-piece.
   { category: 'diagram', file: 'sdf-js/scripts/test-fishbone-3d.mjs' },

--- a/sdf-js/scenes/lifted-cloud-share.json
+++ b/sdf-js/scenes/lifted-cloud-share.json
@@ -1,0 +1,141 @@
+{
+  "v": 1,
+  "name": "(lifted) cloud-share",
+  "subjects": [
+    {
+      "id": "pie",
+      "type": "pie-3d",
+      "args": {
+        "values": [
+          35,
+          25,
+          22,
+          18
+        ],
+        "innerRadius": 0.55,
+        "outerRadius": 1.3,
+        "thickness": 0.45
+      },
+      "transform": {
+        "translate": [
+          0,
+          1.5,
+          0
+        ],
+        "rotate": [
+          1.2,
+          0,
+          0
+        ]
+      },
+      "material": {
+        "hue": 0.57,
+        "sat": 0.55,
+        "value": 0.64,
+        "kind": "normal",
+        "roughness": 0.3,
+        "clearcoat": 0.45
+      }
+    }
+  ],
+  "overlay": [
+    {
+      "text": "CLOUD MARKET SHARE",
+      "anchor": [
+        0,
+        3.9,
+        0
+      ],
+      "role": "title"
+    },
+    {
+      "text": "AWS 35%",
+      "anchor": [
+        3,
+        2.6,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "Azure 25%",
+      "anchor": [
+        3,
+        1.8800000000000001,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "GCP 22%",
+      "anchor": [
+        3,
+        1.1600000000000001,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "Other 18%",
+      "anchor": [
+        3,
+        0.43999999999999995,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    }
+  ],
+  "cameraSequence": {
+    "loop": false,
+    "shots": [
+      {
+        "duration": 0.01,
+        "pos": [
+          1,
+          2.1,
+          9.799999999999999
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 50,
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      },
+      {
+        "duration": 13,
+        "pos": [
+          0,
+          1.8,
+          8.2
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 46,
+        "transition": "blend",
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      }
+    ]
+  },
+  "defaults": {
+    "stage": {
+      "size": [
+        18,
+        9,
+        11
+      ]
+    }
+  }
+}

--- a/sdf-js/scenes/lifted-quarterly.json
+++ b/sdf-js/scenes/lifted-quarterly.json
@@ -1,0 +1,148 @@
+{
+  "v": 1,
+  "name": "(lifted) quarterly",
+  "subjects": [
+    {
+      "id": "bar",
+      "type": "bar-3d",
+      "args": {
+        "values": [
+          0.5,
+          0.75,
+          0.95,
+          0.65,
+          1
+        ],
+        "barWidth": 0.55,
+        "barDepth": 0.55,
+        "gap": 0.25,
+        "maxHeight": 2.2
+      },
+      "transform": {
+        "translate": [
+          0,
+          0.15,
+          0
+        ]
+      },
+      "material": {
+        "hue": 0.57,
+        "sat": 0.55,
+        "value": 0.64,
+        "kind": "normal",
+        "roughness": 0.3,
+        "clearcoat": 0.45
+      }
+    }
+  ],
+  "overlay": [
+    {
+      "text": "QUARTERLY REVENUE",
+      "anchor": [
+        0,
+        3.9,
+        0
+      ],
+      "role": "title"
+    },
+    {
+      "text": "40%",
+      "anchor": [
+        -1.6,
+        1.5,
+        0.3
+      ],
+      "role": "value",
+      "radius": 0.32
+    },
+    {
+      "text": "65%",
+      "anchor": [
+        -0.8,
+        2.05,
+        0.3
+      ],
+      "role": "value",
+      "radius": 0.32
+    },
+    {
+      "text": "85%",
+      "anchor": [
+        0,
+        2.4899999999999998,
+        0.3
+      ],
+      "role": "value",
+      "radius": 0.32
+    },
+    {
+      "text": "55%",
+      "anchor": [
+        0.8000000000000003,
+        1.83,
+        0.3
+      ],
+      "role": "value",
+      "radius": 0.32
+    },
+    {
+      "text": "90%",
+      "anchor": [
+        1.6,
+        2.6,
+        0.3
+      ],
+      "role": "value",
+      "radius": 0.32
+    }
+  ],
+  "cameraSequence": {
+    "loop": false,
+    "shots": [
+      {
+        "duration": 0.01,
+        "pos": [
+          1,
+          2.1,
+          9.799999999999999
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 50,
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      },
+      {
+        "duration": 13,
+        "pos": [
+          0,
+          1.8,
+          8.2
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 46,
+        "transition": "blend",
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      }
+    ]
+  },
+  "defaults": {
+    "stage": {
+      "size": [
+        18,
+        9,
+        11
+      ]
+    }
+  }
+}

--- a/sdf-js/scenes/lifted-roadmap.json
+++ b/sdf-js/scenes/lifted-roadmap.json
@@ -1,0 +1,142 @@
+{
+  "v": 1,
+  "name": "(lifted) roadmap",
+  "subjects": [
+    {
+      "id": "timeline",
+      "type": "timeline-3d",
+      "args": {
+        "count": 5,
+        "axisLength": 4.2,
+        "axisRadius": 0.06,
+        "markerRadius": 0.2,
+        "stemHeight": 0.55
+      },
+      "transform": {
+        "translate": [
+          0,
+          1.4,
+          0
+        ]
+      },
+      "material": {
+        "hue": 0.57,
+        "sat": 0.55,
+        "value": 0.64,
+        "kind": "normal",
+        "roughness": 0.3,
+        "clearcoat": 0.45
+      }
+    }
+  ],
+  "overlay": [
+    {
+      "text": "PRODUCT ROADMAP",
+      "anchor": [
+        0,
+        3.9,
+        0
+      ],
+      "role": "title"
+    },
+    {
+      "text": "2021",
+      "anchor": [
+        -2.1,
+        2.25,
+        0
+      ],
+      "role": "value",
+      "radius": 0.34
+    },
+    {
+      "text": "2022",
+      "anchor": [
+        -1.05,
+        2.25,
+        0
+      ],
+      "role": "value",
+      "radius": 0.34
+    },
+    {
+      "text": "2023",
+      "anchor": [
+        0,
+        2.25,
+        0
+      ],
+      "role": "value",
+      "radius": 0.34
+    },
+    {
+      "text": "2024",
+      "anchor": [
+        1.0500000000000003,
+        2.25,
+        0
+      ],
+      "role": "value",
+      "radius": 0.34
+    },
+    {
+      "text": "2025",
+      "anchor": [
+        2.1,
+        2.25,
+        0
+      ],
+      "role": "value",
+      "radius": 0.34
+    }
+  ],
+  "cameraSequence": {
+    "loop": false,
+    "shots": [
+      {
+        "duration": 0.01,
+        "pos": [
+          1,
+          2.1,
+          9.799999999999999
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 50,
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      },
+      {
+        "duration": 13,
+        "pos": [
+          0,
+          1.8,
+          8.2
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 46,
+        "transition": "blend",
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      }
+    ]
+  },
+  "defaults": {
+    "stage": {
+      "size": [
+        18,
+        9,
+        11
+      ]
+    }
+  }
+}

--- a/sdf-js/scenes/lifted-sales-funnel.json
+++ b/sdf-js/scenes/lifted-sales-funnel.json
@@ -1,0 +1,137 @@
+{
+  "v": 1,
+  "name": "(lifted) sales-funnel",
+  "subjects": [
+    {
+      "id": "funnel",
+      "type": "funnel-3d",
+      "args": {
+        "stages": 4,
+        "topRadius": 1.15,
+        "bottomRadius": 0.28,
+        "stageHeight": 0.55,
+        "gap": 0.1
+      },
+      "transform": {
+        "translate": [
+          -0.3,
+          1.6,
+          0
+        ],
+        "rotate": [
+          0.12,
+          0,
+          0
+        ]
+      },
+      "material": {
+        "hue": 0.57,
+        "sat": 0.55,
+        "value": 0.64,
+        "kind": "normal",
+        "roughness": 0.3,
+        "clearcoat": 0.45
+      }
+    }
+  ],
+  "overlay": [
+    {
+      "text": "SALES FUNNEL",
+      "anchor": [
+        0,
+        3.9,
+        0
+      ],
+      "role": "title"
+    },
+    {
+      "text": "Awareness",
+      "anchor": [
+        3,
+        2.6,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "Interest",
+      "anchor": [
+        3,
+        1.8800000000000001,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "Decision",
+      "anchor": [
+        3,
+        1.1600000000000001,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "Action",
+      "anchor": [
+        3,
+        0.43999999999999995,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    }
+  ],
+  "cameraSequence": {
+    "loop": false,
+    "shots": [
+      {
+        "duration": 0.01,
+        "pos": [
+          1,
+          2.1,
+          9.799999999999999
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 50,
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      },
+      {
+        "duration": 13,
+        "pos": [
+          0,
+          1.8,
+          8.2
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 46,
+        "transition": "blend",
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      }
+    ]
+  },
+  "defaults": {
+    "stage": {
+      "size": [
+        18,
+        9,
+        11
+      ]
+    }
+  }
+}

--- a/sdf-js/scripts/lift-demo.mjs
+++ b/sdf-js/scripts/lift-demo.mjs
@@ -1,0 +1,68 @@
+// lift-demo.mjs — end-to-end demo of the 2D→3D twin lift.
+//
+// Feeds a handful of *structure/data only* 2D scenes (exactly what the 2D scaffold
+// end emits: an atom type + its data args, no geometry) through liftSceneData2dTo3d
+// and writes the resulting 3D studio scenes to scenes/lifted-*.json — renderable at
+//   ?scene=lifted-<name>
+//
+// Run: node sdf-js/scripts/lift-demo.mjs   (from repo root)
+
+import { writeFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+import { liftSceneData2dTo3d } from '../src/scene/lift-2d-to-3d.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const SCENES = resolve(__dirname, '../scenes');
+
+// ── 2D input: pure structure + data (no positions, no geometry) ──
+const SAMPLES = [
+  {
+    name: 'sales-funnel',
+    subjects: [{
+      type: 'funnel',
+      args: {
+        title: 'Sales Funnel',
+        stages: [
+          { label: 'Awareness' }, { label: 'Interest' },
+          { label: 'Decision' }, { label: 'Action' },
+        ],
+      },
+    }],
+  },
+  {
+    name: 'cloud-share',
+    subjects: [{
+      type: 'pie',
+      args: {
+        title: 'Cloud Market Share',
+        values: [35, 25, 22, 18], labels: ['AWS', 'Azure', 'GCP', 'Other'], format: 'percent',
+      },
+    }],
+  },
+  {
+    name: 'quarterly',
+    subjects: [{
+      type: 'bar',
+      args: { title: 'Quarterly Revenue', values: [40, 65, 85, 55, 90], format: 'percent' },
+    }],
+  },
+  {
+    name: 'roadmap',
+    subjects: [{
+      type: 'timeline',
+      args: {
+        title: 'Product Roadmap',
+        events: [{ label: '2021' }, { label: '2022' }, { label: '2023' }, { label: '2024' }, { label: '2025' }],
+      },
+    }],
+  },
+];
+
+for (const s of SAMPLES) {
+  const lifted = liftSceneData2dTo3d(s);
+  const path = resolve(SCENES, `lifted-${s.name}.json`);
+  writeFileSync(path, `${JSON.stringify(lifted, null, 2)}\n`);
+  console.log(`  ✓ ${s.subjects[0].type} (2D) → ${lifted.subjects[0].type} (3D)  →  scenes/lifted-${s.name}.json`);
+}
+console.log(`\n${SAMPLES.length} scenes lifted. View: ?scene=lifted-sales-funnel  (etc.)`);

--- a/sdf-js/scripts/test-lift-2d-to-3d.mjs
+++ b/sdf-js/scripts/test-lift-2d-to-3d.mjs
@@ -1,0 +1,76 @@
+// test-lift-2d-to-3d.mjs — the deterministic 2D→3D twin lift.
+import { liftSceneData2dTo3d, liftSubject, twinTypeOf, TWIN_MAP, fmt } from '../src/scene/lift-2d-to-3d.js';
+
+let pass = 0, fail = 0;
+const ok = (c, n) => (c ? (pass++, console.log(`  ✓ ${n}`)) : (fail++, console.log(`  ✗ ${n}`)));
+console.log('=== lift-2d-to-3d (twin map) ===\n');
+
+// ── twin rule: T → T-3d ──
+ok(twinTypeOf('funnel') === 'funnel-3d', 'twin rule: funnel → funnel-3d');
+ok(twinTypeOf('arrow') === 'arrow-3d', 'twin rule: arrow → arrow-3d (no override needed)');
+ok(twinTypeOf('gauge') === 'sphere-fill-3d', 'twin override: gauge → sphere-fill-3d');
+
+// ── fmt ──
+ok(fmt(35, 'percent') === '35%', 'fmt percent');
+ok(fmt(1200, 'currency') === '$1200', 'fmt currency');
+ok(fmt(7, 'number') === '7', 'fmt number');
+
+// ── funnel: stages[] → count + cards, title → overlay title ──
+{
+  const out = liftSceneData2dTo3d({
+    subjects: [{ type: 'funnel', args: { title: 'Sales Funnel', stages: [{ label: 'A' }, { label: 'B' }, { label: 'C' }] } }],
+  });
+  ok(out.subjects.length === 1 && out.subjects[0].type === 'funnel-3d', 'funnel → 1 funnel-3d subject');
+  ok(out.subjects[0].args.stages === 3, 'funnel stages[] length → stages: 3');
+  const title = out.overlay.find((o) => o.role === 'title');
+  ok(title && title.text === 'SALES FUNNEL', 'title routed to overlay (uppercased)');
+  const cards = out.overlay.filter((o) => o.role === 'card');
+  ok(cards.length === 3 && cards[0].text === 'A', '3 stage labels routed to overlay cards');
+  ok(out.subjects[0].args.stages === undefined ? false : true, 'no SDF text baked (labels are overlay only)');
+  ok(out.cameraSequence && out.cameraSequence.shots.length === 2, 'default push-in camera added');
+}
+
+// ── pie: values + labels → values pass-through, labels+values → cards ──
+{
+  const out = liftSceneData2dTo3d({
+    subjects: [{ type: 'pie', args: { values: [35, 25, 40], labels: ['AWS', 'Azure', 'GCP'], format: 'percent' } }],
+  });
+  ok(out.subjects[0].type === 'pie-3d', 'pie → pie-3d');
+  ok(JSON.stringify(out.subjects[0].args.values) === JSON.stringify([35, 25, 40]), 'pie values pass through');
+  const cards = out.overlay.filter((o) => o.role === 'card');
+  ok(cards[0].text === 'AWS 35%', 'pie legend merges label + formatted value');
+}
+
+// ── bar: raw values → normalized 0..1, value labels at bar tops ──
+{
+  const out = liftSceneData2dTo3d({ subjects: [{ type: 'bar', args: { values: [40, 80], format: 'percent' } }] });
+  const v = out.subjects[0].args.values;
+  ok(v.length === 2 && v[1] === 1.0 && Math.abs(v[0] - 0.55) < 1e-9, 'bar values normalized (max→1.0, keep-visible floor)');
+  const vals = out.overlay.filter((o) => o.role === 'value');
+  ok(vals.length === 2 && vals[0].text === '40%' && vals[1].text === '80%', 'bar value labels formatted from raw values');
+}
+
+// ── timeline: events[] → count + value labels ──
+{
+  const out = liftSceneData2dTo3d({ subjects: [{ type: 'timeline', args: { events: [{ label: '2021' }, { label: '2022' }] } }] });
+  ok(out.subjects[0].type === 'timeline-3d' && out.subjects[0].args.count === 2, 'timeline events[] → count: 2');
+  ok(out.overlay.filter((o) => o.role === 'value').length === 2, 'timeline event labels → 2 overlay values');
+}
+
+// ── generic fallback: unknown-to-map type still maps T → T-3d ──
+{
+  const { subject3d } = liftSubject({ type: 'diamond', args: { label: 'X' } });
+  ok(subject3d.type === 'diamond-3d', 'generic fallback: diamond → diamond-3d');
+}
+
+// ── two-text-systems invariant: NO baked SDF text anywhere ──
+{
+  const out = liftSceneData2dTo3d({
+    subjects: [{ type: 'funnel', args: { title: 'T', stages: [{ label: 'A' }] } }],
+  });
+  const baked = out.subjects.some((s) => /text/.test(s.type));
+  ok(!baked, 'no text-* SDF subjects produced (all text → overlay)');
+}
+
+console.log(`\n${pass} passed, ${fail} failed`);
+process.exit(fail ? 1 : 0);

--- a/sdf-js/src/scene/lift-2d-to-3d.js
+++ b/sdf-js/src/scene/lift-2d-to-3d.js
@@ -1,0 +1,230 @@
+// lift-2d-to-3d.js — deterministic 2D→3D lift (Stage-2 atom-twin instantiation)
+//
+// Product thesis: Stage 2 reads a 2D (pseudo-3D) slide and instantiates its real-3D
+// twin. The supply side — a 3D atom for nearly every 2D atom — already exists. This
+// module is the bridge: it takes a 2D SceneData (atoms-2d subjects + args) and emits a
+// 3D studio SceneData, with NO model in the loop.
+//
+// Three moving parts:
+//   1. TWIN RULE   — every 2D atom type T has a 3D twin named `${T}-3d` (38/41 of the
+//                    registry follow this verbatim). TWIN_MAP only needs to override the
+//                    few that differ, plus carry per-atom ARG TRANSFORMS.
+//   2. ARG XFORM   — 2D args describe data (e.g. funnel `stages:[{label,value}]`); 3D
+//                    args describe geometry (e.g. funnel-3d `stages: <count>`). Each
+//                    twin's lift() maps one to the other.
+//   3. TEXT ROUTE  — per the two-text-systems rule: framing text (title) + element
+//                    labels go to the DOM overlay, never baked as SDF. value readouts
+//                    use role 'value'; legend labels use role 'card'.
+//
+// liftSceneData2dTo3d(scene2d) → scene3d (compile-ready studio SceneData).
+
+const DEFAULT_MAT = {
+  hue: 0.57, sat: 0.55, value: 0.64, kind: 'normal', roughness: 0.3, clearcoat: 0.45,
+};
+
+// ── camera: gentle push-in (matches the hand-authored shape twins) ──
+export function pushInCamera(target = [0, 1.6, 0], dist = 8.2) {
+  return {
+    loop: false,
+    shots: [
+      { duration: 0.01, pos: [1.0, target[1] + 0.5, dist + 1.6], target, fov: 50, aperture: 0, focalDistance: dist, ease: 'smooth' },
+      { duration: 13, pos: [0, target[1] + 0.2, dist], target, fov: 46, transition: 'blend', aperture: 0, focalDistance: dist, ease: 'smooth' },
+    ],
+  };
+}
+
+// ── value formatting (2D atoms carry format: 'number'|'percent'|'currency') ──
+export function fmt(v, format) {
+  if (v == null || Number.isNaN(Number(v))) return String(v ?? '');
+  const n = Number(v);
+  if (format === 'percent') return `${Math.round(n)}%`;
+  if (format === 'currency') return `$${n}`;
+  return String(n);
+}
+
+// ── overlay layout helpers (geometry-independent placements) ──
+// right-side legend column — for funnel / pie / layers / venn-style legends
+function rightCards(labels, opts = {}) {
+  const x = opts.x ?? 3.0, top = opts.top ?? 2.6, gap = opts.gap ?? 0.72;
+  return labels.filter((t) => t != null && t !== '').map((t, i) => ({
+    text: String(t), anchor: [x, top - i * gap, 0], role: 'card', align: 'left',
+  }));
+}
+
+// ── TWIN_MAP: only types that need an arg transform or non-default twin name ──
+// Each entry: { to: '<3d type>', lift(args2d) → { args, transform?, overlay? } }
+export const TWIN_MAP = {
+  funnel: {
+    to: 'funnel-3d',
+    lift(a) {
+      const st = Array.isArray(a.stages) ? a.stages : [];
+      return {
+        args: { stages: st.length || 4, topRadius: 1.15, bottomRadius: 0.28, stageHeight: 0.55, gap: 0.1 },
+        transform: { translate: [-0.3, 1.6, 0], rotate: [0.12, 0, 0] },
+        overlay: rightCards(st.map((s) => (s.value != null ? `${s.label} ${fmt(s.value, a.format)}` : s.label))),
+      };
+    },
+  },
+
+  pie: {
+    to: 'pie-3d',
+    lift(a) {
+      const v = (a.values || []).map(Number);
+      const labs = a.labels || [];
+      return {
+        args: { values: v, innerRadius: 0.55, outerRadius: 1.3, thickness: 0.45 },
+        transform: { translate: [0, 1.5, 0], rotate: [1.2, 0, 0] },
+        overlay: rightCards(labs.map((l, i) => (v[i] != null ? `${l} ${fmt(v[i], a.format)}` : l))),
+      };
+    },
+  },
+
+  bar: {
+    to: 'bar-3d',
+    lift(a) {
+      const raw = (a.values || []).map(Number);
+      const mx = Math.max(...raw, 1);
+      const norm = raw.map((x) => (x / mx) * 0.9 + 0.1); // keep all bars visible
+      const barWidth = 0.55, gap = 0.25, maxHeight = 2.2, ty = 0.15;
+      const step = barWidth + gap;
+      const x0 = -((raw.length * barWidth + (raw.length - 1) * gap) / 2) + barWidth / 2;
+      const overlay = raw.map((x, i) => ({
+        text: fmt(x, a.format),
+        anchor: [x0 + i * step, ty + norm[i] * maxHeight + 0.25, 0.3],
+        role: 'value', radius: 0.32,
+      }));
+      return { args: { values: norm, barWidth, barDepth: 0.55, gap, maxHeight }, transform: { translate: [0, ty, 0] }, overlay };
+    },
+  },
+
+  column: {
+    to: 'column-3d',
+    lift(a) {
+      const raw = (a.values || []).map(Number);
+      const mx = Math.max(...raw, 1);
+      const norm = raw.map((x) => (x / mx) * 0.9 + 0.1);
+      return { args: { values: norm, barWidth: 0.4, barDepth: 0.4, gap: 0.1, maxHeight: 2.0 }, transform: { translate: [0, 0.2, 0] } };
+    },
+  },
+
+  line: {
+    to: 'line-3d',
+    lift(a) {
+      const raw = (a.values || []).map(Number);
+      const mx = Math.max(...raw, 1);
+      const norm = raw.map((x) => (x / mx) * 0.9 + 0.1);
+      return { args: { values: norm, pointSpacing: 0.7, pointRadius: 0.11, lineThickness: 0.06, maxHeight: 2.0 }, transform: { translate: [0, 0.25, 0] } };
+    },
+  },
+
+  funnel_legacy: undefined, // placeholder slot — keeps diffs stable if reordered
+
+  gauge: {
+    to: 'sphere-fill-3d',
+    lift(a) {
+      const max = a.max ?? 100, min = a.min ?? 0;
+      const frac = Math.max(0, Math.min(1, ((Number(a.value) || 0) - min) / (max - min || 1)));
+      return {
+        args: { levels: [frac], radius: 1.1 },
+        transform: { translate: [0, 1.4, 0] },
+        overlay: [{ text: fmt(a.value, a.format), anchor: [0, 1.4, 1.2], role: 'value', radius: 0.6 }],
+      };
+    },
+  },
+
+  timeline: {
+    to: 'timeline-3d',
+    lift(a) {
+      const ev = Array.isArray(a.events) ? a.events : [];
+      const n = ev.length || 5;
+      const span = (n - 1) * (4.2 / Math.max(1, n - 1)); // axisLength 4.2
+      const x0 = -span / 2;
+      const overlay = ev.map((e, i) => ({
+        text: String(e.label ?? e.date ?? e),
+        anchor: [x0 + i * (span / Math.max(1, n - 1)), 2.25, 0],
+        role: 'value', radius: 0.34,
+      }));
+      return { args: { count: n, axisLength: 4.2, axisRadius: 0.06, markerRadius: 0.2, stemHeight: 0.55 }, transform: { translate: [0, 1.4, 0] }, overlay };
+    },
+  },
+
+  'layer-stack': {
+    to: 'layer-stack-3d',
+    lift(a) {
+      const ly = Array.isArray(a.layers) ? a.layers : [];
+      const n = ly.length || 4;
+      return {
+        args: { layers: n, layerW: 2.4, layerD: 1.5, layerH: 0.28, gap: 0.45, taper: a.taper ?? 1.0 },
+        transform: { translate: [-0.3, 1.4, 0], rotate: [0.35, 0.5, 0] },
+        overlay: rightCards(ly.map((l) => (typeof l === 'string' ? l : l.label))),
+      };
+    },
+  },
+
+  'circle-segmented': {
+    to: 'circle-segmented-3d',
+    lift(a) {
+      const segs = Array.isArray(a.segments) ? a.segments.length : (a.segments || 6);
+      return {
+        args: { segments: segs, radius: 0.8, innerRatio: a.innerRatio ?? 0.55, thickness: 0.2, gapWidth: 0.12 },
+        transform: { translate: [0, 1.6, 0], rotate: [1.5708, 0, 0] },
+        overlay: rightCards((a.labels || [])),
+      };
+    },
+  },
+};
+
+delete TWIN_MAP.funnel_legacy;
+
+// resolve the 3D twin type for a 2D atom type (override or `${type}-3d` rule)
+export function twinTypeOf(type2d) {
+  return TWIN_MAP[type2d]?.to ?? `${type2d}-3d`;
+}
+
+// lift a single 2D subject → { subject3d, overlay[] }
+export function liftSubject(subject) {
+  const type2d = subject.type;
+  const a = subject.args || {};
+  const twin = TWIN_MAP[type2d];
+  let r;
+  if (twin?.lift) {
+    r = twin.lift(a);
+  } else {
+    // generic fallback: type→type-3d, pass args through best-effort
+    r = { args: { ...a }, transform: { translate: [0, 1.5, 0] }, overlay: [] };
+  }
+  const subject3d = {
+    id: subject.id || type2d,
+    type: twinTypeOf(type2d),
+    args: r.args || {},
+    transform: r.transform || { translate: [0, 1.5, 0] },
+    material: { ...DEFAULT_MAT },
+  };
+  return { subject3d, overlay: r.overlay || [] };
+}
+
+// lift a whole 2D SceneData → 3D studio SceneData (compile-ready)
+export function liftSceneData2dTo3d(scene2d) {
+  const subjects = [];
+  const overlay = [];
+  let title = scene2d.title || null;
+
+  for (const s of scene2d.subjects || []) {
+    const { subject3d, overlay: ov } = liftSubject(s);
+    subjects.push(subject3d);
+    overlay.push(...ov);
+    if (s.args && s.args.title) title = s.args.title; // atoms carry title in args
+  }
+
+  if (title) overlay.unshift({ text: String(title).toUpperCase(), anchor: [0, 3.9, 0], role: 'title' });
+
+  const target = [0, 1.6, 0];
+  return {
+    v: 1,
+    name: `(lifted) ${scene2d.name || scene2d.subjects?.[0]?.type || 'scene'}`,
+    subjects,
+    overlay,
+    cameraSequence: pushInCamera(target),
+    defaults: { stage: { size: [18, 9, 11] } },
+  };
+}


### PR DESCRIPTION
## 2D→3D 能力 —— 确定性 twin map(无 AI)

按讨论选定:**输入用结构/数据**(2D scaffold 端 emit 的 atom type + data args)→ 输出可编译的 3D studio 场景。

### 关键发现:twin map 的核心就是 `T → T-3d`

Atlas **几乎每个 2D 原子都有同名 `-3d` 孪生**(41 个里 38 个逐字符合)。所以 lift 不是「识别+生成」,而是 **3 步确定性变换**:

1. **TWIN RULE** —— `type → ${type}-3d`(TWIN_MAP 只覆盖少数例外,如 gauge → sphere-fill-3d)
2. **ARG XFORM** —— 2D 数据 arg → 3D 几何 arg(funnel `stages:[{label}]` → `stages:N`;bar 原始值 → 归一 0..1;timeline `events:[]` → `count:N`)
3. **TEXT ROUTE** —— 两套文字系统铁律:title → overlay 标题,元素 label → overlay 卡片/数值,**SDF 里不烤任何字**

### 文件
- `src/scene/lift-2d-to-3d.js` —— TWIN_MAP + `liftSceneData2dTo3d(scene2d)`
- `scripts/lift-demo.mjs` —— 把 4 个纯数据 2D 场景 lift 成 `scenes/lifted-*.json`
- `scripts/test-lift-2d-to-3d.mjs` —— **21 条断言**(twin 规则 / arg 变换 / 文字路由 / 不烤 SDF 不变量),已进 npm test

### 证据
4 个 lifted 场景编译出的 GLSL 与手写孪生**逐字节一致**(funnel/pie/bar/timeline),渲染也一致(Playwright)。**即:lift 仅凭数据就重现了我们之前手写的东西。**

看:`?scene=lifted-sales-funnel` | `lifted-quarterly` | `lifted-cloud-share` | `lifted-roadmap`

`npm test` **98/98**。

### 下一步
把 per-atom arg 变换从 chart 家族扩展到其余原子(目前 generic fallback 能映射类型但 args 直传未变换)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)