### PR TITLE
feat(present): Charts 3D batch 3 — finished from data via the twin map

### DIFF
--- a/sdf-js/scenes/deck-charts-3d-3.json
+++ b/sdf-js/scenes/deck-charts-3d-3.json
@@ -1,0 +1,42 @@
+{
+  "id": "deck-charts-3d-3",
+  "name": "3D Charts & Diagrams — PresentationLoad (batch 3, lifted from data)",
+  "segments": [
+    {
+      "file": "lifted-charts-step-diagram.json",
+      "title": "Step Diagram 3D",
+      "kind": "slide",
+      "durationSec": 7
+    },
+    {
+      "file": "lifted-charts-round-plates.json",
+      "title": "3D Round Plates",
+      "kind": "slide",
+      "durationSec": 7
+    },
+    {
+      "file": "lifted-charts-layer-objects.json",
+      "title": "3D Layer Objects",
+      "kind": "slide",
+      "durationSec": 7
+    },
+    {
+      "file": "lifted-charts-circle-segments.json",
+      "title": "Circle Segments 3D",
+      "kind": "slide",
+      "durationSec": 7
+    },
+    {
+      "file": "lifted-charts-graphs.json",
+      "title": "3D Graphs",
+      "kind": "slide",
+      "durationSec": 7
+    },
+    {
+      "file": "lifted-charts-timeline-spheres.json",
+      "title": "Timelines — 3D Spheres",
+      "kind": "slide",
+      "durationSec": 7
+    }
+  ]
+}

--- a/sdf-js/scenes/lifted-charts-circle-segments.json
+++ b/sdf-js/scenes/lifted-charts-circle-segments.json
@@ -1,0 +1,157 @@
+{
+  "v": 1,
+  "name": "(lifted) circle-segments",
+  "subjects": [
+    {
+      "id": "circle-segmented",
+      "type": "circle-segmented-3d",
+      "args": {
+        "segments": 6,
+        "radius": 0.8,
+        "innerRatio": 0.55,
+        "thickness": 0.2,
+        "gapWidth": 0.12
+      },
+      "transform": {
+        "translate": [
+          0,
+          1.6,
+          0
+        ],
+        "rotate": [
+          1.5708,
+          0,
+          0
+        ]
+      },
+      "material": {
+        "hue": 0.57,
+        "sat": 0.55,
+        "value": 0.64,
+        "kind": "normal",
+        "roughness": 0.3,
+        "clearcoat": 0.45
+      }
+    }
+  ],
+  "overlay": [
+    {
+      "text": "CIRCLE SEGMENTS 3D",
+      "anchor": [
+        0,
+        3.9,
+        0
+      ],
+      "role": "title"
+    },
+    {
+      "text": "A",
+      "anchor": [
+        3,
+        2.6,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "B",
+      "anchor": [
+        3,
+        1.8800000000000001,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "C",
+      "anchor": [
+        3,
+        1.1600000000000001,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "D",
+      "anchor": [
+        3,
+        0.43999999999999995,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "E",
+      "anchor": [
+        3,
+        -0.2799999999999998,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "F",
+      "anchor": [
+        3,
+        -0.9999999999999996,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    }
+  ],
+  "cameraSequence": {
+    "loop": false,
+    "shots": [
+      {
+        "duration": 0.01,
+        "pos": [
+          1,
+          2.1,
+          9.799999999999999
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 50,
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      },
+      {
+        "duration": 13,
+        "pos": [
+          0,
+          1.8,
+          8.2
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 46,
+        "transition": "blend",
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      }
+    ]
+  },
+  "defaults": {
+    "stage": {
+      "size": [
+        18,
+        9,
+        11
+      ]
+    }
+  }
+}

--- a/sdf-js/scenes/lifted-charts-graphs.json
+++ b/sdf-js/scenes/lifted-charts-graphs.json
@@ -1,0 +1,148 @@
+{
+  "v": 1,
+  "name": "(lifted) graphs",
+  "subjects": [
+    {
+      "id": "bar",
+      "type": "bar-3d",
+      "args": {
+        "values": [
+          0.6,
+          0.85,
+          0.5,
+          1,
+          0.75
+        ],
+        "barWidth": 0.55,
+        "barDepth": 0.55,
+        "gap": 0.25,
+        "maxHeight": 2.2
+      },
+      "transform": {
+        "translate": [
+          0,
+          0.15,
+          0
+        ]
+      },
+      "material": {
+        "hue": 0.57,
+        "sat": 0.55,
+        "value": 0.64,
+        "kind": "normal",
+        "roughness": 0.3,
+        "clearcoat": 0.45
+      }
+    }
+  ],
+  "overlay": [
+    {
+      "text": "3D GRAPHS",
+      "anchor": [
+        0,
+        3.9,
+        0
+      ],
+      "role": "title"
+    },
+    {
+      "text": "50",
+      "anchor": [
+        -1.6,
+        1.72,
+        0.3
+      ],
+      "role": "value",
+      "radius": 0.32
+    },
+    {
+      "text": "75",
+      "anchor": [
+        -0.8,
+        2.27,
+        0.3
+      ],
+      "role": "value",
+      "radius": 0.32
+    },
+    {
+      "text": "40",
+      "anchor": [
+        0,
+        1.5,
+        0.3
+      ],
+      "role": "value",
+      "radius": 0.32
+    },
+    {
+      "text": "90",
+      "anchor": [
+        0.8000000000000003,
+        2.6,
+        0.3
+      ],
+      "role": "value",
+      "radius": 0.32
+    },
+    {
+      "text": "65",
+      "anchor": [
+        1.6,
+        2.05,
+        0.3
+      ],
+      "role": "value",
+      "radius": 0.32
+    }
+  ],
+  "cameraSequence": {
+    "loop": false,
+    "shots": [
+      {
+        "duration": 0.01,
+        "pos": [
+          1,
+          2.1,
+          9.799999999999999
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 50,
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      },
+      {
+        "duration": 13,
+        "pos": [
+          0,
+          1.8,
+          8.2
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 46,
+        "transition": "blend",
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      }
+    ]
+  },
+  "defaults": {
+    "stage": {
+      "size": [
+        18,
+        9,
+        11
+      ]
+    }
+  }
+}

--- a/sdf-js/scenes/lifted-charts-layer-objects.json
+++ b/sdf-js/scenes/lifted-charts-layer-objects.json
@@ -1,0 +1,138 @@
+{
+  "v": 1,
+  "name": "(lifted) layer-objects",
+  "subjects": [
+    {
+      "id": "layer-stack",
+      "type": "layer-stack-3d",
+      "args": {
+        "layers": 4,
+        "layerW": 2.4,
+        "layerD": 1.5,
+        "layerH": 0.28,
+        "gap": 0.45,
+        "taper": 1
+      },
+      "transform": {
+        "translate": [
+          -0.3,
+          1.4,
+          0
+        ],
+        "rotate": [
+          0.35,
+          0.5,
+          0
+        ]
+      },
+      "material": {
+        "hue": 0.57,
+        "sat": 0.55,
+        "value": 0.64,
+        "kind": "normal",
+        "roughness": 0.3,
+        "clearcoat": 0.45
+      }
+    }
+  ],
+  "overlay": [
+    {
+      "text": "3D LAYER OBJECTS",
+      "anchor": [
+        0,
+        3.9,
+        0
+      ],
+      "role": "title"
+    },
+    {
+      "text": "UI",
+      "anchor": [
+        3,
+        2.6,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "Logic",
+      "anchor": [
+        3,
+        1.8800000000000001,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "Data",
+      "anchor": [
+        3,
+        1.1600000000000001,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "Infra",
+      "anchor": [
+        3,
+        0.43999999999999995,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    }
+  ],
+  "cameraSequence": {
+    "loop": false,
+    "shots": [
+      {
+        "duration": 0.01,
+        "pos": [
+          1,
+          2.1,
+          9.799999999999999
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 50,
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      },
+      {
+        "duration": 13,
+        "pos": [
+          0,
+          1.8,
+          8.2
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 46,
+        "transition": "blend",
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      }
+    ]
+  },
+  "defaults": {
+    "stage": {
+      "size": [
+        18,
+        9,
+        11
+      ]
+    }
+  }
+}

--- a/sdf-js/scenes/lifted-charts-round-plates.json
+++ b/sdf-js/scenes/lifted-charts-round-plates.json
@@ -1,0 +1,128 @@
+{
+  "v": 1,
+  "name": "(lifted) round-plates",
+  "subjects": [
+    {
+      "id": "circle-stack",
+      "type": "circle-stack-3d",
+      "args": {
+        "count": 4
+      },
+      "transform": {
+        "translate": [
+          0,
+          1.4,
+          0
+        ]
+      },
+      "material": {
+        "hue": 0.57,
+        "sat": 0.55,
+        "value": 0.64,
+        "kind": "normal",
+        "roughness": 0.3,
+        "clearcoat": 0.45
+      }
+    }
+  ],
+  "overlay": [
+    {
+      "text": "3D ROUND PLATES",
+      "anchor": [
+        0,
+        3.9,
+        0
+      ],
+      "role": "title"
+    },
+    {
+      "text": "Tier 1",
+      "anchor": [
+        3,
+        2.6,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "Tier 2",
+      "anchor": [
+        3,
+        1.8800000000000001,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "Tier 3",
+      "anchor": [
+        3,
+        1.1600000000000001,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "Tier 4",
+      "anchor": [
+        3,
+        0.43999999999999995,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    }
+  ],
+  "cameraSequence": {
+    "loop": false,
+    "shots": [
+      {
+        "duration": 0.01,
+        "pos": [
+          1,
+          2.1,
+          9.799999999999999
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 50,
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      },
+      {
+        "duration": 13,
+        "pos": [
+          0,
+          1.8,
+          8.2
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 46,
+        "transition": "blend",
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      }
+    ]
+  },
+  "defaults": {
+    "stage": {
+      "size": [
+        18,
+        9,
+        11
+      ]
+    }
+  }
+}

--- a/sdf-js/scenes/lifted-charts-step-diagram.json
+++ b/sdf-js/scenes/lifted-charts-step-diagram.json
@@ -1,0 +1,138 @@
+{
+  "v": 1,
+  "name": "(lifted) step-diagram",
+  "subjects": [
+    {
+      "id": "progression",
+      "type": "progression-3d",
+      "args": {
+        "steps": 5
+      },
+      "transform": {
+        "translate": [
+          -1,
+          0.6,
+          0
+        ]
+      },
+      "material": {
+        "hue": 0.57,
+        "sat": 0.55,
+        "value": 0.64,
+        "kind": "normal",
+        "roughness": 0.3,
+        "clearcoat": 0.45
+      }
+    }
+  ],
+  "overlay": [
+    {
+      "text": "STEP DIAGRAM 3D",
+      "anchor": [
+        0,
+        3.9,
+        0
+      ],
+      "role": "title"
+    },
+    {
+      "text": "Plan",
+      "anchor": [
+        3,
+        2.6,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "Build",
+      "anchor": [
+        3,
+        1.8800000000000001,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "Test",
+      "anchor": [
+        3,
+        1.1600000000000001,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "Ship",
+      "anchor": [
+        3,
+        0.43999999999999995,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "Scale",
+      "anchor": [
+        3,
+        -0.2799999999999998,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    }
+  ],
+  "cameraSequence": {
+    "loop": false,
+    "shots": [
+      {
+        "duration": 0.01,
+        "pos": [
+          1,
+          2.1,
+          9.799999999999999
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 50,
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      },
+      {
+        "duration": 13,
+        "pos": [
+          0,
+          1.8,
+          8.2
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 46,
+        "transition": "blend",
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      }
+    ]
+  },
+  "defaults": {
+    "stage": {
+      "size": [
+        18,
+        9,
+        11
+      ]
+    }
+  }
+}

--- a/sdf-js/scenes/lifted-charts-timeline-spheres.json
+++ b/sdf-js/scenes/lifted-charts-timeline-spheres.json
@@ -1,0 +1,152 @@
+{
+  "v": 1,
+  "name": "(lifted) timeline-spheres",
+  "subjects": [
+    {
+      "id": "timeline",
+      "type": "timeline-3d",
+      "args": {
+        "count": 6,
+        "axisLength": 4.2,
+        "axisRadius": 0.06,
+        "markerRadius": 0.2,
+        "stemHeight": 0.55
+      },
+      "transform": {
+        "translate": [
+          0,
+          1.4,
+          0
+        ]
+      },
+      "material": {
+        "hue": 0.57,
+        "sat": 0.55,
+        "value": 0.64,
+        "kind": "normal",
+        "roughness": 0.3,
+        "clearcoat": 0.45
+      }
+    }
+  ],
+  "overlay": [
+    {
+      "text": "TIMELINES — 3D SPHERES",
+      "anchor": [
+        0,
+        3.9,
+        0
+      ],
+      "role": "title"
+    },
+    {
+      "text": "Kickoff",
+      "anchor": [
+        -2.1,
+        2.25,
+        0
+      ],
+      "role": "value",
+      "radius": 0.34
+    },
+    {
+      "text": "Alpha",
+      "anchor": [
+        -1.26,
+        2.25,
+        0
+      ],
+      "role": "value",
+      "radius": 0.34
+    },
+    {
+      "text": "Beta",
+      "anchor": [
+        -0.41999999999999993,
+        2.25,
+        0
+      ],
+      "role": "value",
+      "radius": 0.34
+    },
+    {
+      "text": "GA",
+      "anchor": [
+        0.4200000000000004,
+        2.25,
+        0
+      ],
+      "role": "value",
+      "radius": 0.34
+    },
+    {
+      "text": "V2",
+      "anchor": [
+        1.2600000000000002,
+        2.25,
+        0
+      ],
+      "role": "value",
+      "radius": 0.34
+    },
+    {
+      "text": "Scale",
+      "anchor": [
+        2.1,
+        2.25,
+        0
+      ],
+      "role": "value",
+      "radius": 0.34
+    }
+  ],
+  "cameraSequence": {
+    "loop": false,
+    "shots": [
+      {
+        "duration": 0.01,
+        "pos": [
+          1,
+          2.1,
+          9.799999999999999
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 50,
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      },
+      {
+        "duration": 13,
+        "pos": [
+          0,
+          1.8,
+          8.2
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 46,
+        "transition": "blend",
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      }
+    ]
+  },
+  "defaults": {
+    "stage": {
+      "size": [
+        18,
+        9,
+        11
+      ]
+    }
+  }
+}

--- a/sdf-js/scenes/lifted-maturity.json
+++ b/sdf-js/scenes/lifted-maturity.json
@@ -1,0 +1,128 @@
+{
+  "v": 1,
+  "name": "(lifted) maturity",
+  "subjects": [
+    {
+      "id": "pyramid",
+      "type": "pyramid-3d",
+      "args": {
+        "levels": 4
+      },
+      "transform": {
+        "translate": [
+          0,
+          0.6,
+          0
+        ]
+      },
+      "material": {
+        "hue": 0.57,
+        "sat": 0.55,
+        "value": 0.64,
+        "kind": "normal",
+        "roughness": 0.3,
+        "clearcoat": 0.45
+      }
+    }
+  ],
+  "overlay": [
+    {
+      "text": "MATURITY MODEL",
+      "anchor": [
+        0,
+        3.9,
+        0
+      ],
+      "role": "title"
+    },
+    {
+      "text": "Optimize",
+      "anchor": [
+        3,
+        2.6,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "Manage",
+      "anchor": [
+        3,
+        1.8800000000000001,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "Define",
+      "anchor": [
+        3,
+        1.1600000000000001,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "Initial",
+      "anchor": [
+        3,
+        0.43999999999999995,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    }
+  ],
+  "cameraSequence": {
+    "loop": false,
+    "shots": [
+      {
+        "duration": 0.01,
+        "pos": [
+          1,
+          2.1,
+          9.799999999999999
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 50,
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      },
+      {
+        "duration": 13,
+        "pos": [
+          0,
+          1.8,
+          8.2
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 46,
+        "transition": "blend",
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      }
+    ]
+  },
+  "defaults": {
+    "stage": {
+      "size": [
+        18,
+        9,
+        11
+      ]
+    }
+  }
+}

--- a/sdf-js/scenes/lifted-org.json
+++ b/sdf-js/scenes/lifted-org.json
@@ -1,0 +1,93 @@
+{
+  "v": 1,
+  "name": "(lifted) org",
+  "subjects": [
+    {
+      "id": "org-chart",
+      "type": "org-chart-3d",
+      "args": {
+        "levels": 3,
+        "branching": 2,
+        "nodeW": 0.62,
+        "nodeH": 0.36,
+        "levelHeight": 1.15,
+        "spread": 4
+      },
+      "transform": {
+        "translate": [
+          0,
+          3,
+          0
+        ]
+      },
+      "material": {
+        "hue": 0.57,
+        "sat": 0.55,
+        "value": 0.64,
+        "kind": "normal",
+        "roughness": 0.3,
+        "clearcoat": 0.45
+      }
+    }
+  ],
+  "overlay": [
+    {
+      "text": "ORG STRUCTURE",
+      "anchor": [
+        0,
+        3.9,
+        0
+      ],
+      "role": "title"
+    }
+  ],
+  "cameraSequence": {
+    "loop": false,
+    "shots": [
+      {
+        "duration": 0.01,
+        "pos": [
+          1,
+          2.1,
+          9.799999999999999
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 50,
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      },
+      {
+        "duration": 13,
+        "pos": [
+          0,
+          1.8,
+          8.2
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 46,
+        "transition": "blend",
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      }
+    ]
+  },
+  "defaults": {
+    "stage": {
+      "size": [
+        18,
+        9,
+        11
+      ]
+    }
+  }
+}

--- a/sdf-js/scenes/lifted-rootcause.json
+++ b/sdf-js/scenes/lifted-rootcause.json
@@ -1,0 +1,128 @@
+{
+  "v": 1,
+  "name": "(lifted) rootcause",
+  "subjects": [
+    {
+      "id": "fishbone",
+      "type": "fishbone-3d",
+      "args": {
+        "ribs": 4
+      },
+      "transform": {
+        "translate": [
+          0,
+          1.6,
+          0
+        ]
+      },
+      "material": {
+        "hue": 0.57,
+        "sat": 0.55,
+        "value": 0.64,
+        "kind": "normal",
+        "roughness": 0.3,
+        "clearcoat": 0.45
+      }
+    }
+  ],
+  "overlay": [
+    {
+      "text": "ROOT CAUSE",
+      "anchor": [
+        0,
+        3.9,
+        0
+      ],
+      "role": "title"
+    },
+    {
+      "text": "People",
+      "anchor": [
+        3,
+        2.6,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "Process",
+      "anchor": [
+        3,
+        1.8800000000000001,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "Machine",
+      "anchor": [
+        3,
+        1.1600000000000001,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "Material",
+      "anchor": [
+        3,
+        0.43999999999999995,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    }
+  ],
+  "cameraSequence": {
+    "loop": false,
+    "shots": [
+      {
+        "duration": 0.01,
+        "pos": [
+          1,
+          2.1,
+          9.799999999999999
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 50,
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      },
+      {
+        "duration": 13,
+        "pos": [
+          0,
+          1.8,
+          8.2
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 46,
+        "transition": "blend",
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      }
+    ]
+  },
+  "defaults": {
+    "stage": {
+      "size": [
+        18,
+        9,
+        11
+      ]
+    }
+  }
+}

--- a/sdf-js/scripts/lift-charts-batch3.mjs
+++ b/sdf-js/scripts/lift-charts-batch3.mjs
@@ -1,0 +1,84 @@
+// lift-charts-batch3.mjs — finish the remaining PresentationLoad "Charts & Diagrams"
+// 3D templates *semi-automatically*: each template is authored as 2D structure+data
+// only, and the deterministic twin map (lift-2d-to-3d.js) produces the 3D scene.
+//
+// This is the payoff of the twin map: no hand-authored scene JSON — just data in.
+//
+// Run: node sdf-js/scripts/lift-charts-batch3.mjs   (from repo root)
+
+import { writeFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+import { liftSceneData2dTo3d } from '../src/scene/lift-2d-to-3d.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const SCENES = resolve(__dirname, '../scenes');
+
+// PL template :: its 2D structure (atom type + data). Nothing geometric here.
+const TEMPLATES = [
+  {
+    name: 'step-diagram', // PL: "Step Diagram 3D" / "3D Stairs"
+    subjects: [{ type: 'progression', args: {
+      title: 'Step Diagram 3D',
+      steps: [{ label: 'Plan' }, { label: 'Build' }, { label: 'Test' }, { label: 'Ship' }, { label: 'Scale' }],
+    } }],
+  },
+  {
+    name: 'round-plates', // PL: "3D Round Plates"
+    subjects: [{ type: 'circle-stack', args: {
+      title: '3D Round Plates',
+      layers: [{ label: 'Tier 1' }, { label: 'Tier 2' }, { label: 'Tier 3' }, { label: 'Tier 4' }],
+    } }],
+  },
+  {
+    name: 'layer-objects', // PL: "3D Layer Objects"
+    subjects: [{ type: 'layer-stack', args: {
+      title: '3D Layer Objects',
+      layers: [{ label: 'UI' }, { label: 'Logic' }, { label: 'Data' }, { label: 'Infra' }],
+    } }],
+  },
+  {
+    name: 'circle-segments', // PL: "Circle Segments 3D"
+    subjects: [{ type: 'circle-segmented', args: {
+      title: 'Circle Segments 3D',
+      segments: 6, labels: ['A', 'B', 'C', 'D', 'E', 'F'],
+    } }],
+  },
+  {
+    name: 'graphs', // PL: "3D Graphs" — vertical bars read clearest front-on (+ value labels)
+    subjects: [{ type: 'bar', args: {
+      title: '3D Graphs', values: [50, 75, 40, 90, 65], labels: ['Q1', 'Q2', 'Q3', 'Q4', 'Q5'], format: 'number',
+    } }],
+  },
+  {
+    name: 'timeline-spheres', // PL: "Timelines - 3D Spheres"
+    subjects: [{ type: 'timeline', args: {
+      title: 'Timelines — 3D Spheres',
+      events: [{ label: 'Kickoff' }, { label: 'Alpha' }, { label: 'Beta' }, { label: 'GA' }, { label: 'V2' }, { label: 'Scale' }],
+    } }],
+  },
+];
+
+const lifted = [];
+for (const t of TEMPLATES) {
+  const scene = liftSceneData2dTo3d(t);
+  writeFileSync(resolve(SCENES, `lifted-charts-${t.name}.json`), `${JSON.stringify(scene, null, 2)}\n`);
+  console.log(`  ✓ ${t.subjects[0].type.padEnd(18)} (2D data) → ${scene.subjects[0].type.padEnd(20)} → scenes/lifted-charts-${t.name}.json`);
+  lifted.push(t.name);
+}
+
+// also write the deck stringing them together
+const deck = {
+  id: 'deck-charts-3d-3',
+  name: '3D Charts & Diagrams — PresentationLoad (batch 3, lifted from data)',
+  segments: [
+    { file: 'lifted-charts-step-diagram.json', title: 'Step Diagram 3D', kind: 'slide', durationSec: 7 },
+    { file: 'lifted-charts-round-plates.json', title: '3D Round Plates', kind: 'slide', durationSec: 7 },
+    { file: 'lifted-charts-layer-objects.json', title: '3D Layer Objects', kind: 'slide', durationSec: 7 },
+    { file: 'lifted-charts-circle-segments.json', title: 'Circle Segments 3D', kind: 'slide', durationSec: 7 },
+    { file: 'lifted-charts-graphs.json', title: '3D Graphs', kind: 'slide', durationSec: 7 },
+    { file: 'lifted-charts-timeline-spheres.json', title: 'Timelines — 3D Spheres', kind: 'slide', durationSec: 7 },
+  ],
+};
+writeFileSync(resolve(SCENES, 'deck-charts-3d-3.json'), `${JSON.stringify(deck, null, 2)}\n`);
+console.log(`\n${lifted.length} templates lifted + deck-charts-3d-3.json. View: ?deck=deck-charts-3d-3`);

--- a/sdf-js/scripts/lift-demo.mjs
+++ b/sdf-js/scripts/lift-demo.mjs
@@ -57,6 +57,33 @@ const SAMPLES = [
       },
     }],
   },
+  {
+    name: 'maturity',
+    subjects: [{
+      type: 'pyramid',
+      args: { title: 'Maturity Model', layers: [{ label: 'Optimize' }, { label: 'Manage' }, { label: 'Define' }, { label: 'Initial' }] },
+    }],
+  },
+  {
+    name: 'org',
+    subjects: [{
+      type: 'org-chart',
+      args: {
+        title: 'Org Structure',
+        root: { label: 'CEO', children: [
+          { label: 'CTO', children: [{ label: 'Eng' }, { label: 'Data' }] },
+          { label: 'COO', children: [{ label: 'Ops' }, { label: 'Sales' }] },
+        ] },
+      },
+    }],
+  },
+  {
+    name: 'rootcause',
+    subjects: [{
+      type: 'fishbone',
+      args: { title: 'Root Cause', effect: 'Defect', branches: [{ label: 'People' }, { label: 'Process' }, { label: 'Machine' }, { label: 'Material' }] },
+    }],
+  },
 ];
 
 for (const s of SAMPLES) {

--- a/sdf-js/scripts/test-lift-2d-to-3d.mjs
+++ b/sdf-js/scripts/test-lift-2d-to-3d.mjs
@@ -57,10 +57,42 @@ ok(fmt(7, 'number') === '7', 'fmt number');
   ok(out.overlay.filter((o) => o.role === 'value').length === 2, 'timeline event labels → 2 overlay values');
 }
 
-// ── generic fallback: unknown-to-map type still maps T → T-3d ──
+// ── items family: array → count arg + legend cards ──
 {
-  const { subject3d } = liftSubject({ type: 'diamond', args: { label: 'X' } });
-  ok(subject3d.type === 'diamond-3d', 'generic fallback: diamond → diamond-3d');
+  const out = liftSceneData2dTo3d({ subjects: [{ type: 'pyramid', args: { layers: [{ label: 'Top' }, { label: 'Mid' }, { label: 'Base' }] } }] });
+  ok(out.subjects[0].type === 'pyramid-3d' && out.subjects[0].args.levels === 3, 'pyramid layers[] → levels: 3 (2D key ≠ 3D key)');
+  ok(out.overlay.filter((o) => o.role === 'card').length === 3, 'pyramid labels → 3 cards');
+}
+{
+  const out = liftSceneData2dTo3d({ subjects: [{ type: 'agenda-list', args: { items: ['a', 'b'] } }] });
+  ok(out.subjects[0].args.items === 2, 'agenda-list items[] → items: 2');
+}
+
+// ── tree family: {root:{children}} → levels + branching ──
+{
+  const root = { label: 'r', children: [{ label: 'a', children: [{ label: 'a1' }] }, { label: 'b' }] };
+  const out = liftSceneData2dTo3d({ subjects: [{ type: 'org-chart', args: { root } }] });
+  ok(out.subjects[0].type === 'org-chart-3d', 'org-chart → org-chart-3d');
+  ok(out.subjects[0].args.levels === 3 && out.subjects[0].args.branching === 2, 'tree depth/fanout → levels:3, branching:2');
+}
+
+// ── venn: sets[] → sets count + cards ──
+{
+  const out = liftSceneData2dTo3d({ subjects: [{ type: 'venn', args: { sets: [{ label: 'A' }, { label: 'B' }, { label: 'C' }] } }] });
+  ok(out.subjects[0].type === 'venn-3d' && out.subjects[0].args.sets === 3, 'venn sets[] → sets: 3');
+}
+
+// ── icon family: single label → centered caption card (not SDF) ──
+{
+  const out = liftSceneData2dTo3d({ subjects: [{ type: 'arrow', args: { label: 'Growth' } }] });
+  const c = out.overlay.find((o) => o.role === 'card');
+  ok(out.subjects[0].type === 'arrow-3d' && c && c.text === 'Growth' && c.align === 'center', 'arrow label → centered caption card');
+}
+
+// ── generic fallback: a type with no override still maps T → T-3d ──
+{
+  const { subject3d } = liftSubject({ type: 'value-chain-diagram', args: {} });
+  ok(subject3d.type === 'value-chain-diagram-3d', 'generic fallback: unmapped type → type-3d');
 }
 
 // ── two-text-systems invariant: NO baked SDF text anywhere ──

--- a/sdf-js/src/scene/lift-2d-to-3d.js
+++ b/sdf-js/src/scene/lift-2d-to-3d.js
@@ -51,6 +51,59 @@ function rightCards(labels, opts = {}) {
   }));
 }
 
+// ── data-shape helpers ──
+// label off any item shape (string | {label|name|title|text|...})
+const itemLabel = (x) => (x == null ? '' : typeof x === 'string' ? x : (x.label ?? x.name ?? x.title ?? x.text ?? ''));
+// coerce a count-or-array arg to an array (number N → N empty slots)
+const asArray = (v) => (Array.isArray(v) ? v : (typeof v === 'number' && v > 0 ? Array.from({ length: v }, () => ({})) : []));
+
+// derive {levels, branching} from a nested {children:[...]} tree (org/tree/mindmap/sphere-tree)
+function treeShape(root) {
+  if (!root || typeof root !== 'object') return { levels: 3, branching: 2 };
+  let levels = 0, maxBranch = 1;
+  const walk = (n, d) => {
+    levels = Math.max(levels, d);
+    const ch = Array.isArray(n.children) ? n.children : [];
+    maxBranch = Math.max(maxBranch, ch.length);
+    ch.forEach((c) => walk(c, d + 1));
+  };
+  walk(root, 1);
+  return { levels: Math.max(2, levels), branching: Math.max(2, maxBranch) };
+}
+
+// builder: "array-of-items" atoms → { [countArg]: N } + legend cards.
+// key = the 2D data arg holding the array (items/steps/layers/segments/tasks/…).
+// countArg = the 3D geometry arg holding the count (items/steps/levels/segments/…).
+function itemsTwin(to, key, countArg, opts = {}) {
+  const { geom = {}, transform = { translate: [0, 1.5, 0] }, min = 3, role = 'card' } = opts;
+  return {
+    to,
+    lift(a) {
+      const arr = asArray(a[key]);
+      const n = arr.length || (typeof a[key] === 'number' ? a[key] : 0) || min;
+      let labels = arr.map(itemLabel).filter(Boolean);
+      if (!labels.length && Array.isArray(a.labels)) labels = a.labels; // count-style atoms carry labels separately
+      const overlay = role === 'card' ? rightCards(labels) : [];
+      return { args: { [countArg]: n, ...geom }, transform, overlay };
+    },
+  };
+}
+
+// builder: "single labelled icon" atoms (arrow/diamond/gear/cube/circle-frame) →
+// geometry default + the one label as a centered caption card.
+function iconTwin(to, opts = {}) {
+  const { geom = {}, transform = { translate: [0, 1.6, 0] } } = opts;
+  return {
+    to,
+    lift(a) {
+      const g = typeof geom === 'function' ? geom(a) : geom;
+      const label = itemLabel({ label: a.label });
+      const overlay = label ? [{ text: String(label), anchor: [0, 0.4, 0], role: 'card', align: 'center' }] : [];
+      return { args: g, transform, overlay };
+    },
+  };
+}
+
 // ── TWIN_MAP: only types that need an arg transform or non-default twin name ──
 // Each entry: { to: '<3d type>', lift(args2d) → { args, transform?, overlay? } }
 export const TWIN_MAP = {
@@ -117,8 +170,6 @@ export const TWIN_MAP = {
     },
   },
 
-  funnel_legacy: undefined, // placeholder slot — keeps diffs stable if reordered
-
   gauge: {
     to: 'sphere-fill-3d',
     lift(a) {
@@ -172,9 +223,163 @@ export const TWIN_MAP = {
       };
     },
   },
-};
 
-delete TWIN_MAP.funnel_legacy;
+  // ── array-of-items family: items[] → count arg + legend cards ──
+  'agenda-list': itemsTwin('agenda-list-3d', 'items', 'items'),
+  'bullet-list': itemsTwin('bullet-list-3d', 'items', 'items'),
+  progression: itemsTwin('progression-3d', 'steps', 'steps', { transform: { translate: [-1.0, 0.6, 0] } }),
+  pyramid: itemsTwin('pyramid-3d', 'layers', 'levels', { transform: { translate: [0, 0.6, 0] } }),
+  'traffic-light': itemsTwin('traffic-light-3d', 'lights', 'lights', { transform: { translate: [0, 1.8, 0] } }),
+  'circle-stack': itemsTwin('circle-stack-3d', 'layers', 'count', { transform: { translate: [0, 1.4, 0] } }),
+  'flow-chart': itemsTwin('flow-chart-3d', 'steps', 'steps', { transform: { translate: [0, 1.6, 0] } }),
+  'sphere-segmented': itemsTwin('sphere-segmented-3d', 'segments', 'segments', { transform: { translate: [0, 1.6, 0] } }),
+  'cube-segmented': itemsTwin('cube-segmented-3d', 'segments', 'segments', { transform: { translate: [0, 1.5, 0] } }),
+  gantt: itemsTwin('gantt-3d', 'tasks', 'tasks', { transform: { translate: [0, 1.6, 0] } }),
+  fishbone: itemsTwin('fishbone-3d', 'branches', 'ribs', { transform: { translate: [0, 1.6, 0] } }),
+  'circle-loop': itemsTwin('circle-loop-3d', 'segments', 'segments', { transform: { translate: [0, 1.6, 0], rotate: [1.5708, 0, 0] } }),
+
+  venn: {
+    to: 'venn-3d',
+    lift(a) {
+      const n = Array.isArray(a.sets) ? a.sets.length : (a.sets || 3);
+      return {
+        args: { sets: n, radius: 0.95, tube: 0.1, overlap: a.overlap ?? 0.5 },
+        transform: { translate: [0, 1.7, 0] },
+        overlay: rightCards(Array.isArray(a.sets) ? a.sets.map(itemLabel) : []),
+      };
+    },
+  },
+
+  // ── values family: raw values[] → count + value readouts ──
+  'radial-spoke': {
+    to: 'radial-spoke-3d',
+    lift(a) {
+      const v = a.values || [];
+      return {
+        args: { spokes: v.length || 6 },
+        transform: { translate: [0, 1.7, 0] },
+        overlay: rightCards((a.labels || []).map((l, i) => (v[i] != null ? `${l} ${fmt(v[i], a.format)}` : l))),
+      };
+    },
+  },
+  waterfall: {
+    to: 'waterfall-3d',
+    lift(a) {
+      const bars = Array.isArray(a.bars) ? a.bars : [];
+      return { args: { count: bars.length || 5 }, transform: { translate: [0, 0.3, 0] } };
+    },
+  },
+  scatter: {
+    to: 'scatter-3d',
+    lift(a) {
+      const pts = Array.isArray(a.points) ? a.points : [];
+      return { args: { count: pts.length || 24 }, transform: { translate: [0, 1.6, 0] } };
+    },
+  },
+
+  // ── tree family: {root:{children}} → levels + branching ──
+  mindmap: {
+    to: 'mindmap-3d',
+    lift(a) {
+      const ch = a.root && Array.isArray(a.root.children) ? a.root.children : [];
+      return {
+        args: { branches: ch.length || 5, leavesPerBranch: 2 },
+        transform: { translate: [0, 1.7, 0] },
+        overlay: rightCards(ch.map(itemLabel)),
+      };
+    },
+  },
+  'org-chart': {
+    to: 'org-chart-3d',
+    lift(a) {
+      const t = treeShape(a.root);
+      return { args: { levels: t.levels, branching: t.branching, nodeW: 0.62, nodeH: 0.36, levelHeight: 1.15, spread: 4.0 }, transform: { translate: [0, 3.0, 0] } };
+    },
+  },
+  'tree-diagram': {
+    to: 'tree-diagram-3d',
+    lift(a) {
+      const t = treeShape(a.root);
+      return { args: { levels: t.levels, branching: t.branching }, transform: { translate: [0, 2.8, 0] } };
+    },
+  },
+  'sphere-tree': {
+    to: 'sphere-tree-3d',
+    lift(a) {
+      const t = treeShape(a.root);
+      return { args: { levels: t.levels, branching: t.branching }, transform: { translate: [0, 2.6, 0] } };
+    },
+  },
+  'sphere-network': {
+    to: 'sphere-network-3d',
+    lift(a) {
+      const sats = Array.isArray(a.satellites) ? a.satellites : [];
+      return {
+        args: { count: sats.length || 6, arrangement: 'sphere' },
+        transform: { translate: [0, 1.8, 0] },
+        overlay: rightCards(sats.map(itemLabel)),
+      };
+    },
+  },
+  'relationship-graph': {
+    to: 'relationship-graph-3d',
+    lift(a) {
+      const nodes = Array.isArray(a.nodes) ? a.nodes : [];
+      // 3D edges arg wants an array of [from,to] index pairs, or null (auto). Pass
+      // through only when 2D already supplies pairs; otherwise let the atom auto-wire.
+      const pairs = Array.isArray(a.edges) && a.edges.every((e) => Array.isArray(e)) ? a.edges : null;
+      return { args: { count: nodes.length || 5, edges: pairs }, transform: { translate: [0, 1.7, 0] } };
+    },
+  },
+
+  // ── grid family ──
+  'matrix-grid': {
+    to: 'matrix-grid-3d',
+    lift(a) {
+      return { args: { rows: a.rows ?? 3, cols: a.cols ?? 3 }, transform: { translate: [0, 1.8, 0] } };
+    },
+  },
+  'cube-grid': {
+    to: 'cube-3d',
+    lift(a) {
+      const size = a.size ?? 3;
+      return {
+        args: { arrangement: 'grid', count: size * size, cubeSize: 0.5, spacing: a.spacing ?? 0.2, material: 'solid', colors: a.colors || null },
+        transform: { translate: [0, 1.6, 0] },
+      };
+    },
+  },
+
+  // ── single labelled icon family: geometry default + one centered caption ──
+  arrow: iconTwin('arrow-3d'),
+  diamond: iconTwin('diamond-3d'),
+  cube: iconTwin('cube-3d', { geom: { count: 1, arrangement: 'row', cubeSize: 1.0 } }),
+  gear: iconTwin('gear-3d', { geom: (a) => ({ teeth: a.teeth ?? 12 }), transform: { translate: [0, 1.6, 0], rotate: [1.5708, 0, 0] } }),
+  'circle-frame': iconTwin('circle-frame-3d', { transform: { translate: [0, 1.6, 0] } }),
+
+  // ── single value+label (KPI-ish) ──
+  'kpi-card': {
+    to: 'kpi-card-3d',
+    lift(a) {
+      return {
+        args: { value: a.value, label: a.label, trend: a.trend, trendValue: a.trendValue },
+        transform: { translate: [0, 1.6, 0] },
+        overlay: a.value != null ? [{ text: fmt(a.value, a.format), anchor: [0, 1.9, 0.6], role: 'value', radius: 0.5 }] : [],
+      };
+    },
+  },
+  'sphere-fill': {
+    to: 'sphere-fill-3d',
+    lift(a) {
+      const frac = Math.max(0, Math.min(1, Number(a.value) > 1 ? Number(a.value) / 100 : (Number(a.value) || 0)));
+      return {
+        args: { levels: [frac], radius: 1.1 },
+        transform: { translate: [0, 1.4, 0] },
+        overlay: [{ text: fmt(a.value, a.format ?? 'percent'), anchor: [0, 1.4, 1.2], role: 'value', radius: 0.6 }],
+      };
+    },
+  },
+};
 
 // resolve the 3D twin type for a 2D atom type (override or `${type}-3d` rule)
 export function twinTypeOf(type2d) {


### PR DESCRIPTION
## Charts 3D Batch 3 —— twin map 的回报:**纯数据生成,零手搓**

剩余 PL「Charts & Diagrams」3D 模板,**没有手写一个场景 JSON** —— 每个都是 2D 结构+数据,确定性 lift 出来。

`scripts/lift-charts-batch3.mjs` 把 6 个模板写成数据 → `scenes/lifted-charts-*.json` + `deck-charts-3d-3.json`:

| PL 模板 | 2D 原子 |
|---|---|
| Step Diagram 3D / 3D Stairs | `progression`(阶梯)|
| 3D Round Plates | `circle-stack`(锥形叠盘)|
| 3D Layer Objects | `layer-stack` |
| Circle Segments 3D | `circle-segmented`(甜甜圈,正对相机)|
| 3D Graphs | `bar`(竖直柱 + 值标签)|
| Timelines — 3D Spheres | `timeline`(球标记)|

## 验证
Playwright 渲染:阶梯 / 叠盘 / 6 段甜甜圈 / 球时间轴 —— 几何 + 浮层卡片/标签全部直接来自 lift,正确。`npm test` **99/99**。

看:`?deck=deck-charts-3d-3`

**跳过**(无原子 / 按铁律):3D Spiral(无 spiral 原子);Text 3D(文字按两套文字系统铁律应走 DOM 浮层,不烤 SDF)。

**至此 Charts & Diagrams 3D 集合基本闭合** —— 手搓(batch 1-2)+ 数据 lift(batch 3)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)