### PR TITLE
feat(present): PL recommendations decks — round 1 (AI / Status / OKR / Digital)

### DIFF
--- a/sdf-js/scenes/deck-rec-ai.json
+++ b/sdf-js/scenes/deck-rec-ai.json
@@ -1,0 +1,36 @@
+{
+  "id": "deck-rec-ai",
+  "name": "Artificial Intelligence",
+  "segments": [
+    {
+      "file": "rec-ai-1.json",
+      "title": "AI Landscape",
+      "kind": "slide",
+      "durationSec": 7
+    },
+    {
+      "file": "rec-ai-2.json",
+      "title": "ML Pipeline",
+      "kind": "slide",
+      "durationSec": 7
+    },
+    {
+      "file": "rec-ai-3.json",
+      "title": "Model Types",
+      "kind": "slide",
+      "durationSec": 7
+    },
+    {
+      "file": "rec-ai-4.json",
+      "title": "AI Roadmap",
+      "kind": "slide",
+      "durationSec": 7
+    },
+    {
+      "file": "rec-ai-5.json",
+      "title": "Value Funnel",
+      "kind": "slide",
+      "durationSec": 7
+    }
+  ]
+}

--- a/sdf-js/scenes/deck-rec-digital.json
+++ b/sdf-js/scenes/deck-rec-digital.json
@@ -1,0 +1,36 @@
+{
+  "id": "deck-rec-digital",
+  "name": "Digital Transformation",
+  "segments": [
+    {
+      "file": "rec-digital-1.json",
+      "title": "Transformation Stack",
+      "kind": "slide",
+      "durationSec": 7
+    },
+    {
+      "file": "rec-digital-2.json",
+      "title": "Roadmap",
+      "kind": "slide",
+      "durationSec": 7
+    },
+    {
+      "file": "rec-digital-3.json",
+      "title": "Maturity Model",
+      "kind": "slide",
+      "durationSec": 7
+    },
+    {
+      "file": "rec-digital-4.json",
+      "title": "Pillars",
+      "kind": "slide",
+      "durationSec": 7
+    },
+    {
+      "file": "rec-digital-5.json",
+      "title": "Value Funnel",
+      "kind": "slide",
+      "durationSec": 7
+    }
+  ]
+}

--- a/sdf-js/scenes/deck-rec-okr.json
+++ b/sdf-js/scenes/deck-rec-okr.json
@@ -1,0 +1,36 @@
+{
+  "id": "deck-rec-okr",
+  "name": "Objectives & Key Results",
+  "segments": [
+    {
+      "file": "rec-okr-1.json",
+      "title": "OKR Overview",
+      "kind": "slide",
+      "durationSec": 7
+    },
+    {
+      "file": "rec-okr-2.json",
+      "title": "Key Results",
+      "kind": "slide",
+      "durationSec": 7
+    },
+    {
+      "file": "rec-okr-3.json",
+      "title": "Alignment",
+      "kind": "slide",
+      "durationSec": 7
+    },
+    {
+      "file": "rec-okr-4.json",
+      "title": "Cadence",
+      "kind": "slide",
+      "durationSec": 7
+    },
+    {
+      "file": "rec-okr-5.json",
+      "title": "Maturity",
+      "kind": "slide",
+      "durationSec": 7
+    }
+  ]
+}

--- a/sdf-js/scenes/deck-rec-status.json
+++ b/sdf-js/scenes/deck-rec-status.json
@@ -1,0 +1,36 @@
+{
+  "id": "deck-rec-status",
+  "name": "Project Status Report",
+  "segments": [
+    {
+      "file": "rec-status-1.json",
+      "title": "Status Overview",
+      "kind": "slide",
+      "durationSec": 7
+    },
+    {
+      "file": "rec-status-2.json",
+      "title": "Milestones",
+      "kind": "slide",
+      "durationSec": 7
+    },
+    {
+      "file": "rec-status-3.json",
+      "title": "Workstreams",
+      "kind": "slide",
+      "durationSec": 7
+    },
+    {
+      "file": "rec-status-4.json",
+      "title": "KPIs",
+      "kind": "slide",
+      "durationSec": 7
+    },
+    {
+      "file": "rec-status-5.json",
+      "title": "Phase Plan",
+      "kind": "slide",
+      "durationSec": 7
+    }
+  ]
+}

--- a/sdf-js/scenes/rec-ai-1.json
+++ b/sdf-js/scenes/rec-ai-1.json
@@ -1,0 +1,139 @@
+{
+  "v": 1,
+  "name": "(lifted) ai-AI Landscape",
+  "subjects": [
+    {
+      "id": "sphere-network",
+      "type": "sphere-network-3d",
+      "args": {
+        "count": 5,
+        "arrangement": "sphere"
+      },
+      "transform": {
+        "translate": [
+          0,
+          1.8,
+          0
+        ]
+      },
+      "material": {
+        "hue": 0.57,
+        "sat": 0.55,
+        "value": 0.64,
+        "kind": "normal",
+        "roughness": 0.3,
+        "clearcoat": 0.45
+      }
+    }
+  ],
+  "overlay": [
+    {
+      "text": "ARTIFICIAL INTELLIGENCE",
+      "anchor": [
+        0,
+        3.9,
+        0
+      ],
+      "role": "title"
+    },
+    {
+      "text": "Machine Learning",
+      "anchor": [
+        3,
+        2.6,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "Deep Learning",
+      "anchor": [
+        3,
+        1.8800000000000001,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "NLP",
+      "anchor": [
+        3,
+        1.1600000000000001,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "Computer Vision",
+      "anchor": [
+        3,
+        0.43999999999999995,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "Robotics",
+      "anchor": [
+        3,
+        -0.2799999999999998,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    }
+  ],
+  "cameraSequence": {
+    "loop": false,
+    "shots": [
+      {
+        "duration": 0.01,
+        "pos": [
+          1,
+          2.1,
+          9.799999999999999
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 50,
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      },
+      {
+        "duration": 13,
+        "pos": [
+          0,
+          1.8,
+          8.2
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 46,
+        "transition": "blend",
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      }
+    ]
+  },
+  "defaults": {
+    "stage": {
+      "size": [
+        18,
+        9,
+        11
+      ]
+    }
+  }
+}

--- a/sdf-js/scenes/rec-ai-2.json
+++ b/sdf-js/scenes/rec-ai-2.json
@@ -1,0 +1,138 @@
+{
+  "v": 1,
+  "name": "(lifted) ai-ML Pipeline",
+  "subjects": [
+    {
+      "id": "progression",
+      "type": "progression-3d",
+      "args": {
+        "steps": 5
+      },
+      "transform": {
+        "translate": [
+          -1,
+          0.6,
+          0
+        ]
+      },
+      "material": {
+        "hue": 0.57,
+        "sat": 0.55,
+        "value": 0.64,
+        "kind": "normal",
+        "roughness": 0.3,
+        "clearcoat": 0.45
+      }
+    }
+  ],
+  "overlay": [
+    {
+      "text": "MACHINE LEARNING PIPELINE",
+      "anchor": [
+        0,
+        3.9,
+        0
+      ],
+      "role": "title"
+    },
+    {
+      "text": "Collect",
+      "anchor": [
+        3,
+        2.6,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "Train",
+      "anchor": [
+        3,
+        1.8800000000000001,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "Validate",
+      "anchor": [
+        3,
+        1.1600000000000001,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "Deploy",
+      "anchor": [
+        3,
+        0.43999999999999995,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "Monitor",
+      "anchor": [
+        3,
+        -0.2799999999999998,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    }
+  ],
+  "cameraSequence": {
+    "loop": false,
+    "shots": [
+      {
+        "duration": 0.01,
+        "pos": [
+          1,
+          2.1,
+          9.799999999999999
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 50,
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      },
+      {
+        "duration": 13,
+        "pos": [
+          0,
+          1.8,
+          8.2
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 46,
+        "transition": "blend",
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      }
+    ]
+  },
+  "defaults": {
+    "stage": {
+      "size": [
+        18,
+        9,
+        11
+      ]
+    }
+  }
+}

--- a/sdf-js/scenes/rec-ai-3.json
+++ b/sdf-js/scenes/rec-ai-3.json
@@ -1,0 +1,130 @@
+{
+  "v": 1,
+  "name": "(lifted) ai-Model Types",
+  "subjects": [
+    {
+      "id": "pie",
+      "type": "pie-3d",
+      "args": {
+        "values": [
+          40,
+          35,
+          25
+        ],
+        "innerRadius": 0.55,
+        "outerRadius": 1.3,
+        "thickness": 0.45
+      },
+      "transform": {
+        "translate": [
+          0,
+          1.5,
+          0
+        ],
+        "rotate": [
+          1.2,
+          0,
+          0
+        ]
+      },
+      "material": {
+        "hue": 0.57,
+        "sat": 0.55,
+        "value": 0.64,
+        "kind": "normal",
+        "roughness": 0.3,
+        "clearcoat": 0.45
+      }
+    }
+  ],
+  "overlay": [
+    {
+      "text": "MODEL TYPES",
+      "anchor": [
+        0,
+        3.9,
+        0
+      ],
+      "role": "title"
+    },
+    {
+      "text": "Supervised 40%",
+      "anchor": [
+        3,
+        2.6,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "Unsupervised 35%",
+      "anchor": [
+        3,
+        1.8800000000000001,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "Reinforcement 25%",
+      "anchor": [
+        3,
+        1.1600000000000001,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    }
+  ],
+  "cameraSequence": {
+    "loop": false,
+    "shots": [
+      {
+        "duration": 0.01,
+        "pos": [
+          1,
+          2.1,
+          9.799999999999999
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 50,
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      },
+      {
+        "duration": 13,
+        "pos": [
+          0,
+          1.8,
+          8.2
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 46,
+        "transition": "blend",
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      }
+    ]
+  },
+  "defaults": {
+    "stage": {
+      "size": [
+        18,
+        9,
+        11
+      ]
+    }
+  }
+}

--- a/sdf-js/scenes/rec-ai-4.json
+++ b/sdf-js/scenes/rec-ai-4.json
@@ -1,0 +1,132 @@
+{
+  "v": 1,
+  "name": "(lifted) ai-AI Roadmap",
+  "subjects": [
+    {
+      "id": "timeline",
+      "type": "timeline-3d",
+      "args": {
+        "count": 4,
+        "axisLength": 4.2,
+        "axisRadius": 0.06,
+        "markerRadius": 0.2,
+        "stemHeight": 0.55
+      },
+      "transform": {
+        "translate": [
+          0,
+          1.4,
+          0
+        ]
+      },
+      "material": {
+        "hue": 0.57,
+        "sat": 0.55,
+        "value": 0.64,
+        "kind": "normal",
+        "roughness": 0.3,
+        "clearcoat": 0.45
+      }
+    }
+  ],
+  "overlay": [
+    {
+      "text": "AI ROADMAP",
+      "anchor": [
+        0,
+        3.9,
+        0
+      ],
+      "role": "title"
+    },
+    {
+      "text": "Research",
+      "anchor": [
+        -2.1,
+        2.25,
+        0
+      ],
+      "role": "value",
+      "radius": 0.34
+    },
+    {
+      "text": "Pilot",
+      "anchor": [
+        -0.7,
+        2.25,
+        0
+      ],
+      "role": "value",
+      "radius": 0.34
+    },
+    {
+      "text": "Scale",
+      "anchor": [
+        0.7000000000000002,
+        2.25,
+        0
+      ],
+      "role": "value",
+      "radius": 0.34
+    },
+    {
+      "text": "Production",
+      "anchor": [
+        2.1,
+        2.25,
+        0
+      ],
+      "role": "value",
+      "radius": 0.34
+    }
+  ],
+  "cameraSequence": {
+    "loop": false,
+    "shots": [
+      {
+        "duration": 0.01,
+        "pos": [
+          1,
+          2.1,
+          9.799999999999999
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 50,
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      },
+      {
+        "duration": 13,
+        "pos": [
+          0,
+          1.8,
+          8.2
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 46,
+        "transition": "blend",
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      }
+    ]
+  },
+  "defaults": {
+    "stage": {
+      "size": [
+        18,
+        9,
+        11
+      ]
+    }
+  }
+}

--- a/sdf-js/scenes/rec-ai-5.json
+++ b/sdf-js/scenes/rec-ai-5.json
@@ -1,0 +1,147 @@
+{
+  "v": 1,
+  "name": "(lifted) ai-Value Funnel",
+  "subjects": [
+    {
+      "id": "funnel",
+      "type": "funnel-3d",
+      "args": {
+        "stages": 5,
+        "topRadius": 1.15,
+        "bottomRadius": 0.28,
+        "stageHeight": 0.55,
+        "gap": 0.1
+      },
+      "transform": {
+        "translate": [
+          -0.3,
+          1.6,
+          0
+        ],
+        "rotate": [
+          0.12,
+          0,
+          0
+        ]
+      },
+      "material": {
+        "hue": 0.57,
+        "sat": 0.55,
+        "value": 0.64,
+        "kind": "normal",
+        "roughness": 0.3,
+        "clearcoat": 0.45
+      }
+    }
+  ],
+  "overlay": [
+    {
+      "text": "DATA → DECISION",
+      "anchor": [
+        0,
+        3.9,
+        0
+      ],
+      "role": "title"
+    },
+    {
+      "text": "Raw Data",
+      "anchor": [
+        3,
+        2.6,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "Features",
+      "anchor": [
+        3,
+        1.8800000000000001,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "Model",
+      "anchor": [
+        3,
+        1.1600000000000001,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "Prediction",
+      "anchor": [
+        3,
+        0.43999999999999995,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "Decision",
+      "anchor": [
+        3,
+        -0.2799999999999998,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    }
+  ],
+  "cameraSequence": {
+    "loop": false,
+    "shots": [
+      {
+        "duration": 0.01,
+        "pos": [
+          1,
+          2.1,
+          9.799999999999999
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 50,
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      },
+      {
+        "duration": 13,
+        "pos": [
+          0,
+          1.8,
+          8.2
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 46,
+        "transition": "blend",
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      }
+    ]
+  },
+  "defaults": {
+    "stage": {
+      "size": [
+        18,
+        9,
+        11
+      ]
+    }
+  }
+}

--- a/sdf-js/scenes/rec-digital-1.json
+++ b/sdf-js/scenes/rec-digital-1.json
@@ -1,0 +1,138 @@
+{
+  "v": 1,
+  "name": "(lifted) digital-Transformation Stack",
+  "subjects": [
+    {
+      "id": "layer-stack",
+      "type": "layer-stack-3d",
+      "args": {
+        "layers": 4,
+        "layerW": 2.4,
+        "layerD": 1.5,
+        "layerH": 0.28,
+        "gap": 0.45,
+        "taper": 1
+      },
+      "transform": {
+        "translate": [
+          -0.3,
+          1.4,
+          0
+        ],
+        "rotate": [
+          0.35,
+          0.5,
+          0
+        ]
+      },
+      "material": {
+        "hue": 0.57,
+        "sat": 0.55,
+        "value": 0.64,
+        "kind": "normal",
+        "roughness": 0.3,
+        "clearcoat": 0.45
+      }
+    }
+  ],
+  "overlay": [
+    {
+      "text": "DIGITAL TRANSFORMATION",
+      "anchor": [
+        0,
+        3.9,
+        0
+      ],
+      "role": "title"
+    },
+    {
+      "text": "Strategy",
+      "anchor": [
+        3,
+        2.6,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "Process",
+      "anchor": [
+        3,
+        1.8800000000000001,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "Technology",
+      "anchor": [
+        3,
+        1.1600000000000001,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "Culture",
+      "anchor": [
+        3,
+        0.43999999999999995,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    }
+  ],
+  "cameraSequence": {
+    "loop": false,
+    "shots": [
+      {
+        "duration": 0.01,
+        "pos": [
+          1,
+          2.1,
+          9.799999999999999
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 50,
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      },
+      {
+        "duration": 13,
+        "pos": [
+          0,
+          1.8,
+          8.2
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 46,
+        "transition": "blend",
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      }
+    ]
+  },
+  "defaults": {
+    "stage": {
+      "size": [
+        18,
+        9,
+        11
+      ]
+    }
+  }
+}

--- a/sdf-js/scenes/rec-digital-2.json
+++ b/sdf-js/scenes/rec-digital-2.json
@@ -1,0 +1,142 @@
+{
+  "v": 1,
+  "name": "(lifted) digital-Roadmap",
+  "subjects": [
+    {
+      "id": "timeline",
+      "type": "timeline-3d",
+      "args": {
+        "count": 5,
+        "axisLength": 4.2,
+        "axisRadius": 0.06,
+        "markerRadius": 0.2,
+        "stemHeight": 0.55
+      },
+      "transform": {
+        "translate": [
+          0,
+          1.4,
+          0
+        ]
+      },
+      "material": {
+        "hue": 0.57,
+        "sat": 0.55,
+        "value": 0.64,
+        "kind": "normal",
+        "roughness": 0.3,
+        "clearcoat": 0.45
+      }
+    }
+  ],
+  "overlay": [
+    {
+      "text": "TRANSFORMATION ROADMAP",
+      "anchor": [
+        0,
+        3.9,
+        0
+      ],
+      "role": "title"
+    },
+    {
+      "text": "Assess",
+      "anchor": [
+        -2.1,
+        2.25,
+        0
+      ],
+      "role": "value",
+      "radius": 0.34
+    },
+    {
+      "text": "Design",
+      "anchor": [
+        -1.05,
+        2.25,
+        0
+      ],
+      "role": "value",
+      "radius": 0.34
+    },
+    {
+      "text": "Pilot",
+      "anchor": [
+        0,
+        2.25,
+        0
+      ],
+      "role": "value",
+      "radius": 0.34
+    },
+    {
+      "text": "Scale",
+      "anchor": [
+        1.0500000000000003,
+        2.25,
+        0
+      ],
+      "role": "value",
+      "radius": 0.34
+    },
+    {
+      "text": "Optimize",
+      "anchor": [
+        2.1,
+        2.25,
+        0
+      ],
+      "role": "value",
+      "radius": 0.34
+    }
+  ],
+  "cameraSequence": {
+    "loop": false,
+    "shots": [
+      {
+        "duration": 0.01,
+        "pos": [
+          1,
+          2.1,
+          9.799999999999999
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 50,
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      },
+      {
+        "duration": 13,
+        "pos": [
+          0,
+          1.8,
+          8.2
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 46,
+        "transition": "blend",
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      }
+    ]
+  },
+  "defaults": {
+    "stage": {
+      "size": [
+        18,
+        9,
+        11
+      ]
+    }
+  }
+}

--- a/sdf-js/scenes/rec-digital-3.json
+++ b/sdf-js/scenes/rec-digital-3.json
@@ -1,0 +1,128 @@
+{
+  "v": 1,
+  "name": "(lifted) digital-Maturity Model",
+  "subjects": [
+    {
+      "id": "pyramid",
+      "type": "pyramid-3d",
+      "args": {
+        "levels": 4
+      },
+      "transform": {
+        "translate": [
+          0,
+          0.6,
+          0
+        ]
+      },
+      "material": {
+        "hue": 0.57,
+        "sat": 0.55,
+        "value": 0.64,
+        "kind": "normal",
+        "roughness": 0.3,
+        "clearcoat": 0.45
+      }
+    }
+  ],
+  "overlay": [
+    {
+      "text": "DIGITAL MATURITY",
+      "anchor": [
+        0,
+        3.9,
+        0
+      ],
+      "role": "title"
+    },
+    {
+      "text": "Optimized",
+      "anchor": [
+        3,
+        2.6,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "Integrated",
+      "anchor": [
+        3,
+        1.8800000000000001,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "Defined",
+      "anchor": [
+        3,
+        1.1600000000000001,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "Initial",
+      "anchor": [
+        3,
+        0.43999999999999995,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    }
+  ],
+  "cameraSequence": {
+    "loop": false,
+    "shots": [
+      {
+        "duration": 0.01,
+        "pos": [
+          1,
+          2.1,
+          9.799999999999999
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 50,
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      },
+      {
+        "duration": 13,
+        "pos": [
+          0,
+          1.8,
+          8.2
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 46,
+        "transition": "blend",
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      }
+    ]
+  },
+  "defaults": {
+    "stage": {
+      "size": [
+        18,
+        9,
+        11
+      ]
+    }
+  }
+}

--- a/sdf-js/scenes/rec-digital-4.json
+++ b/sdf-js/scenes/rec-digital-4.json
@@ -1,0 +1,138 @@
+{
+  "v": 1,
+  "name": "(lifted) digital-Pillars",
+  "subjects": [
+    {
+      "id": "radial-spoke",
+      "type": "radial-spoke-3d",
+      "args": {
+        "spokes": 5
+      },
+      "transform": {
+        "translate": [
+          0,
+          1.7,
+          0
+        ]
+      },
+      "material": {
+        "hue": 0.57,
+        "sat": 0.55,
+        "value": 0.64,
+        "kind": "normal",
+        "roughness": 0.3,
+        "clearcoat": 0.45
+      }
+    }
+  ],
+  "overlay": [
+    {
+      "text": "TRANSFORMATION PILLARS",
+      "anchor": [
+        0,
+        3.9,
+        0
+      ],
+      "role": "title"
+    },
+    {
+      "text": "Customer 1",
+      "anchor": [
+        3,
+        2.6,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "Data 1",
+      "anchor": [
+        3,
+        1.8800000000000001,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "Cloud 1",
+      "anchor": [
+        3,
+        1.1600000000000001,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "Agility 1",
+      "anchor": [
+        3,
+        0.43999999999999995,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "Talent 1",
+      "anchor": [
+        3,
+        -0.2799999999999998,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    }
+  ],
+  "cameraSequence": {
+    "loop": false,
+    "shots": [
+      {
+        "duration": 0.01,
+        "pos": [
+          1,
+          2.1,
+          9.799999999999999
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 50,
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      },
+      {
+        "duration": 13,
+        "pos": [
+          0,
+          1.8,
+          8.2
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 46,
+        "transition": "blend",
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      }
+    ]
+  },
+  "defaults": {
+    "stage": {
+      "size": [
+        18,
+        9,
+        11
+      ]
+    }
+  }
+}

--- a/sdf-js/scenes/rec-digital-5.json
+++ b/sdf-js/scenes/rec-digital-5.json
@@ -1,0 +1,137 @@
+{
+  "v": 1,
+  "name": "(lifted) digital-Value Funnel",
+  "subjects": [
+    {
+      "id": "funnel",
+      "type": "funnel-3d",
+      "args": {
+        "stages": 4,
+        "topRadius": 1.15,
+        "bottomRadius": 0.28,
+        "stageHeight": 0.55,
+        "gap": 0.1
+      },
+      "transform": {
+        "translate": [
+          -0.3,
+          1.6,
+          0
+        ],
+        "rotate": [
+          0.12,
+          0,
+          0
+        ]
+      },
+      "material": {
+        "hue": 0.57,
+        "sat": 0.55,
+        "value": 0.64,
+        "kind": "normal",
+        "roughness": 0.3,
+        "clearcoat": 0.45
+      }
+    }
+  ],
+  "overlay": [
+    {
+      "text": "VALUE REALIZATION",
+      "anchor": [
+        0,
+        3.9,
+        0
+      ],
+      "role": "title"
+    },
+    {
+      "text": "Vision",
+      "anchor": [
+        3,
+        2.6,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "Capability",
+      "anchor": [
+        3,
+        1.8800000000000001,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "Adoption",
+      "anchor": [
+        3,
+        1.1600000000000001,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "Value",
+      "anchor": [
+        3,
+        0.43999999999999995,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    }
+  ],
+  "cameraSequence": {
+    "loop": false,
+    "shots": [
+      {
+        "duration": 0.01,
+        "pos": [
+          1,
+          2.1,
+          9.799999999999999
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 50,
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      },
+      {
+        "duration": 13,
+        "pos": [
+          0,
+          1.8,
+          8.2
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 46,
+        "transition": "blend",
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      }
+    ]
+  },
+  "defaults": {
+    "stage": {
+      "size": [
+        18,
+        9,
+        11
+      ]
+    }
+  }
+}

--- a/sdf-js/scenes/rec-okr-1.json
+++ b/sdf-js/scenes/rec-okr-1.json
@@ -1,0 +1,128 @@
+{
+  "v": 1,
+  "name": "(lifted) okr-OKR Overview",
+  "subjects": [
+    {
+      "id": "radial-spoke",
+      "type": "radial-spoke-3d",
+      "args": {
+        "spokes": 4
+      },
+      "transform": {
+        "translate": [
+          0,
+          1.7,
+          0
+        ]
+      },
+      "material": {
+        "hue": 0.57,
+        "sat": 0.55,
+        "value": 0.64,
+        "kind": "normal",
+        "roughness": 0.3,
+        "clearcoat": 0.45
+      }
+    }
+  ],
+  "overlay": [
+    {
+      "text": "OBJECTIVES & KEY RESULTS",
+      "anchor": [
+        0,
+        3.9,
+        0
+      ],
+      "role": "title"
+    },
+    {
+      "text": "Grow Revenue 1",
+      "anchor": [
+        3,
+        2.6,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "Delight Users 1",
+      "anchor": [
+        3,
+        1.8800000000000001,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "Scale Ops 1",
+      "anchor": [
+        3,
+        1.1600000000000001,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "Build Team 1",
+      "anchor": [
+        3,
+        0.43999999999999995,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    }
+  ],
+  "cameraSequence": {
+    "loop": false,
+    "shots": [
+      {
+        "duration": 0.01,
+        "pos": [
+          1,
+          2.1,
+          9.799999999999999
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 50,
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      },
+      {
+        "duration": 13,
+        "pos": [
+          0,
+          1.8,
+          8.2
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 46,
+        "transition": "blend",
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      }
+    ]
+  },
+  "defaults": {
+    "stage": {
+      "size": [
+        18,
+        9,
+        11
+      ]
+    }
+  }
+}

--- a/sdf-js/scenes/rec-okr-2.json
+++ b/sdf-js/scenes/rec-okr-2.json
@@ -1,0 +1,137 @@
+{
+  "v": 1,
+  "name": "(lifted) okr-Key Results",
+  "subjects": [
+    {
+      "id": "bar",
+      "type": "bar-3d",
+      "args": {
+        "values": [
+          0.85,
+          0.7,
+          1,
+          0.55
+        ],
+        "barWidth": 0.55,
+        "barDepth": 0.55,
+        "gap": 0.25,
+        "maxHeight": 2.2
+      },
+      "transform": {
+        "translate": [
+          0,
+          0.15,
+          0
+        ]
+      },
+      "material": {
+        "hue": 0.57,
+        "sat": 0.55,
+        "value": 0.64,
+        "kind": "normal",
+        "roughness": 0.3,
+        "clearcoat": 0.45
+      }
+    }
+  ],
+  "overlay": [
+    {
+      "text": "KEY RESULT PROGRESS",
+      "anchor": [
+        0,
+        3.9,
+        0
+      ],
+      "role": "title"
+    },
+    {
+      "text": "75%",
+      "anchor": [
+        -1.2000000000000002,
+        2.27,
+        0.3
+      ],
+      "role": "value",
+      "radius": 0.32
+    },
+    {
+      "text": "60%",
+      "anchor": [
+        -0.40000000000000013,
+        1.94,
+        0.3
+      ],
+      "role": "value",
+      "radius": 0.32
+    },
+    {
+      "text": "90%",
+      "anchor": [
+        0.3999999999999999,
+        2.6,
+        0.3
+      ],
+      "role": "value",
+      "radius": 0.32
+    },
+    {
+      "text": "45%",
+      "anchor": [
+        1.2000000000000002,
+        1.61,
+        0.3
+      ],
+      "role": "value",
+      "radius": 0.32
+    }
+  ],
+  "cameraSequence": {
+    "loop": false,
+    "shots": [
+      {
+        "duration": 0.01,
+        "pos": [
+          1,
+          2.1,
+          9.799999999999999
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 50,
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      },
+      {
+        "duration": 13,
+        "pos": [
+          0,
+          1.8,
+          8.2
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 46,
+        "transition": "blend",
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      }
+    ]
+  },
+  "defaults": {
+    "stage": {
+      "size": [
+        18,
+        9,
+        11
+      ]
+    }
+  }
+}

--- a/sdf-js/scenes/rec-okr-3.json
+++ b/sdf-js/scenes/rec-okr-3.json
@@ -1,0 +1,93 @@
+{
+  "v": 1,
+  "name": "(lifted) okr-Alignment",
+  "subjects": [
+    {
+      "id": "org-chart",
+      "type": "org-chart-3d",
+      "args": {
+        "levels": 3,
+        "branching": 2,
+        "nodeW": 0.62,
+        "nodeH": 0.36,
+        "levelHeight": 1.15,
+        "spread": 4
+      },
+      "transform": {
+        "translate": [
+          0,
+          3,
+          0
+        ]
+      },
+      "material": {
+        "hue": 0.57,
+        "sat": 0.55,
+        "value": 0.64,
+        "kind": "normal",
+        "roughness": 0.3,
+        "clearcoat": 0.45
+      }
+    }
+  ],
+  "overlay": [
+    {
+      "text": "OKR ALIGNMENT",
+      "anchor": [
+        0,
+        3.9,
+        0
+      ],
+      "role": "title"
+    }
+  ],
+  "cameraSequence": {
+    "loop": false,
+    "shots": [
+      {
+        "duration": 0.01,
+        "pos": [
+          1,
+          2.1,
+          9.799999999999999
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 50,
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      },
+      {
+        "duration": 13,
+        "pos": [
+          0,
+          1.8,
+          8.2
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 46,
+        "transition": "blend",
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      }
+    ]
+  },
+  "defaults": {
+    "stage": {
+      "size": [
+        18,
+        9,
+        11
+      ]
+    }
+  }
+}

--- a/sdf-js/scenes/rec-okr-4.json
+++ b/sdf-js/scenes/rec-okr-4.json
@@ -1,0 +1,132 @@
+{
+  "v": 1,
+  "name": "(lifted) okr-Cadence",
+  "subjects": [
+    {
+      "id": "timeline",
+      "type": "timeline-3d",
+      "args": {
+        "count": 4,
+        "axisLength": 4.2,
+        "axisRadius": 0.06,
+        "markerRadius": 0.2,
+        "stemHeight": 0.55
+      },
+      "transform": {
+        "translate": [
+          0,
+          1.4,
+          0
+        ]
+      },
+      "material": {
+        "hue": 0.57,
+        "sat": 0.55,
+        "value": 0.64,
+        "kind": "normal",
+        "roughness": 0.3,
+        "clearcoat": 0.45
+      }
+    }
+  ],
+  "overlay": [
+    {
+      "text": "QUARTERLY CADENCE",
+      "anchor": [
+        0,
+        3.9,
+        0
+      ],
+      "role": "title"
+    },
+    {
+      "text": "Q1 Set",
+      "anchor": [
+        -2.1,
+        2.25,
+        0
+      ],
+      "role": "value",
+      "radius": 0.34
+    },
+    {
+      "text": "Q2 Check",
+      "anchor": [
+        -0.7,
+        2.25,
+        0
+      ],
+      "role": "value",
+      "radius": 0.34
+    },
+    {
+      "text": "Q3 Adjust",
+      "anchor": [
+        0.7000000000000002,
+        2.25,
+        0
+      ],
+      "role": "value",
+      "radius": 0.34
+    },
+    {
+      "text": "Q4 Score",
+      "anchor": [
+        2.1,
+        2.25,
+        0
+      ],
+      "role": "value",
+      "radius": 0.34
+    }
+  ],
+  "cameraSequence": {
+    "loop": false,
+    "shots": [
+      {
+        "duration": 0.01,
+        "pos": [
+          1,
+          2.1,
+          9.799999999999999
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 50,
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      },
+      {
+        "duration": 13,
+        "pos": [
+          0,
+          1.8,
+          8.2
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 46,
+        "transition": "blend",
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      }
+    ]
+  },
+  "defaults": {
+    "stage": {
+      "size": [
+        18,
+        9,
+        11
+      ]
+    }
+  }
+}

--- a/sdf-js/scenes/rec-okr-5.json
+++ b/sdf-js/scenes/rec-okr-5.json
@@ -1,0 +1,128 @@
+{
+  "v": 1,
+  "name": "(lifted) okr-Maturity",
+  "subjects": [
+    {
+      "id": "pyramid",
+      "type": "pyramid-3d",
+      "args": {
+        "levels": 4
+      },
+      "transform": {
+        "translate": [
+          0,
+          0.6,
+          0
+        ]
+      },
+      "material": {
+        "hue": 0.57,
+        "sat": 0.55,
+        "value": 0.64,
+        "kind": "normal",
+        "roughness": 0.3,
+        "clearcoat": 0.45
+      }
+    }
+  ],
+  "overlay": [
+    {
+      "text": "OKR MATURITY",
+      "anchor": [
+        0,
+        3.9,
+        0
+      ],
+      "role": "title"
+    },
+    {
+      "text": "Aspirational",
+      "anchor": [
+        3,
+        2.6,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "Committed",
+      "anchor": [
+        3,
+        1.8800000000000001,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "Tracked",
+      "anchor": [
+        3,
+        1.1600000000000001,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "Foundational",
+      "anchor": [
+        3,
+        0.43999999999999995,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    }
+  ],
+  "cameraSequence": {
+    "loop": false,
+    "shots": [
+      {
+        "duration": 0.01,
+        "pos": [
+          1,
+          2.1,
+          9.799999999999999
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 50,
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      },
+      {
+        "duration": 13,
+        "pos": [
+          0,
+          1.8,
+          8.2
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 46,
+        "transition": "blend",
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      }
+    ]
+  },
+  "defaults": {
+    "stage": {
+      "size": [
+        18,
+        9,
+        11
+      ]
+    }
+  }
+}

--- a/sdf-js/scenes/rec-status-1.json
+++ b/sdf-js/scenes/rec-status-1.json
@@ -1,0 +1,118 @@
+{
+  "v": 1,
+  "name": "(lifted) status-Status Overview",
+  "subjects": [
+    {
+      "id": "traffic-light",
+      "type": "traffic-light-3d",
+      "args": {
+        "lights": 3
+      },
+      "transform": {
+        "translate": [
+          0,
+          1.8,
+          0
+        ]
+      },
+      "material": {
+        "hue": 0.57,
+        "sat": 0.55,
+        "value": 0.64,
+        "kind": "normal",
+        "roughness": 0.3,
+        "clearcoat": 0.45
+      }
+    }
+  ],
+  "overlay": [
+    {
+      "text": "PROJECT STATUS REPORT",
+      "anchor": [
+        0,
+        3.9,
+        0
+      ],
+      "role": "title"
+    },
+    {
+      "text": "Scope",
+      "anchor": [
+        3,
+        2.6,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "Budget",
+      "anchor": [
+        3,
+        1.8800000000000001,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "Schedule",
+      "anchor": [
+        3,
+        1.1600000000000001,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    }
+  ],
+  "cameraSequence": {
+    "loop": false,
+    "shots": [
+      {
+        "duration": 0.01,
+        "pos": [
+          1,
+          2.1,
+          9.799999999999999
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 50,
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      },
+      {
+        "duration": 13,
+        "pos": [
+          0,
+          1.8,
+          8.2
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 46,
+        "transition": "blend",
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      }
+    ]
+  },
+  "defaults": {
+    "stage": {
+      "size": [
+        18,
+        9,
+        11
+      ]
+    }
+  }
+}

--- a/sdf-js/scenes/rec-status-2.json
+++ b/sdf-js/scenes/rec-status-2.json
@@ -1,0 +1,142 @@
+{
+  "v": 1,
+  "name": "(lifted) status-Milestones",
+  "subjects": [
+    {
+      "id": "timeline",
+      "type": "timeline-3d",
+      "args": {
+        "count": 5,
+        "axisLength": 4.2,
+        "axisRadius": 0.06,
+        "markerRadius": 0.2,
+        "stemHeight": 0.55
+      },
+      "transform": {
+        "translate": [
+          0,
+          1.4,
+          0
+        ]
+      },
+      "material": {
+        "hue": 0.57,
+        "sat": 0.55,
+        "value": 0.64,
+        "kind": "normal",
+        "roughness": 0.3,
+        "clearcoat": 0.45
+      }
+    }
+  ],
+  "overlay": [
+    {
+      "text": "MILESTONES",
+      "anchor": [
+        0,
+        3.9,
+        0
+      ],
+      "role": "title"
+    },
+    {
+      "text": "Kickoff",
+      "anchor": [
+        -2.1,
+        2.25,
+        0
+      ],
+      "role": "value",
+      "radius": 0.34
+    },
+    {
+      "text": "Design",
+      "anchor": [
+        -1.05,
+        2.25,
+        0
+      ],
+      "role": "value",
+      "radius": 0.34
+    },
+    {
+      "text": "Build",
+      "anchor": [
+        0,
+        2.25,
+        0
+      ],
+      "role": "value",
+      "radius": 0.34
+    },
+    {
+      "text": "Test",
+      "anchor": [
+        1.0500000000000003,
+        2.25,
+        0
+      ],
+      "role": "value",
+      "radius": 0.34
+    },
+    {
+      "text": "Launch",
+      "anchor": [
+        2.1,
+        2.25,
+        0
+      ],
+      "role": "value",
+      "radius": 0.34
+    }
+  ],
+  "cameraSequence": {
+    "loop": false,
+    "shots": [
+      {
+        "duration": 0.01,
+        "pos": [
+          1,
+          2.1,
+          9.799999999999999
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 50,
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      },
+      {
+        "duration": 13,
+        "pos": [
+          0,
+          1.8,
+          8.2
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 46,
+        "transition": "blend",
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      }
+    ]
+  },
+  "defaults": {
+    "stage": {
+      "size": [
+        18,
+        9,
+        11
+      ]
+    }
+  }
+}

--- a/sdf-js/scenes/rec-status-3.json
+++ b/sdf-js/scenes/rec-status-3.json
@@ -1,0 +1,128 @@
+{
+  "v": 1,
+  "name": "(lifted) status-Workstreams",
+  "subjects": [
+    {
+      "id": "gantt",
+      "type": "gantt-3d",
+      "args": {
+        "tasks": 4
+      },
+      "transform": {
+        "translate": [
+          0,
+          1.6,
+          0
+        ]
+      },
+      "material": {
+        "hue": 0.57,
+        "sat": 0.55,
+        "value": 0.64,
+        "kind": "normal",
+        "roughness": 0.3,
+        "clearcoat": 0.45
+      }
+    }
+  ],
+  "overlay": [
+    {
+      "text": "WORKSTREAMS",
+      "anchor": [
+        0,
+        3.9,
+        0
+      ],
+      "role": "title"
+    },
+    {
+      "text": "Discovery",
+      "anchor": [
+        3,
+        2.6,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "Development",
+      "anchor": [
+        3,
+        1.8800000000000001,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "QA",
+      "anchor": [
+        3,
+        1.1600000000000001,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "Rollout",
+      "anchor": [
+        3,
+        0.43999999999999995,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    }
+  ],
+  "cameraSequence": {
+    "loop": false,
+    "shots": [
+      {
+        "duration": 0.01,
+        "pos": [
+          1,
+          2.1,
+          9.799999999999999
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 50,
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      },
+      {
+        "duration": 13,
+        "pos": [
+          0,
+          1.8,
+          8.2
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 46,
+        "transition": "blend",
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      }
+    ]
+  },
+  "defaults": {
+    "stage": {
+      "size": [
+        18,
+        9,
+        11
+      ]
+    }
+  }
+}

--- a/sdf-js/scenes/rec-status-4.json
+++ b/sdf-js/scenes/rec-status-4.json
@@ -1,0 +1,137 @@
+{
+  "v": 1,
+  "name": "(lifted) status-KPIs",
+  "subjects": [
+    {
+      "id": "bar",
+      "type": "bar-3d",
+      "args": {
+        "values": [
+          1,
+          0.8630434782608696,
+          0.9315217391304348,
+          0.9608695652173913
+        ],
+        "barWidth": 0.55,
+        "barDepth": 0.55,
+        "gap": 0.25,
+        "maxHeight": 2.2
+      },
+      "transform": {
+        "translate": [
+          0,
+          0.15,
+          0
+        ]
+      },
+      "material": {
+        "hue": 0.57,
+        "sat": 0.55,
+        "value": 0.64,
+        "kind": "normal",
+        "roughness": 0.3,
+        "clearcoat": 0.45
+      }
+    }
+  ],
+  "overlay": [
+    {
+      "text": "KEY METRICS",
+      "anchor": [
+        0,
+        3.9,
+        0
+      ],
+      "role": "title"
+    },
+    {
+      "text": "92%",
+      "anchor": [
+        -1.2000000000000002,
+        2.6,
+        0.3
+      ],
+      "role": "value",
+      "radius": 0.32
+    },
+    {
+      "text": "78%",
+      "anchor": [
+        -0.40000000000000013,
+        2.298695652173913,
+        0.3
+      ],
+      "role": "value",
+      "radius": 0.32
+    },
+    {
+      "text": "85%",
+      "anchor": [
+        0.3999999999999999,
+        2.4493478260869566,
+        0.3
+      ],
+      "role": "value",
+      "radius": 0.32
+    },
+    {
+      "text": "88%",
+      "anchor": [
+        1.2000000000000002,
+        2.513913043478261,
+        0.3
+      ],
+      "role": "value",
+      "radius": 0.32
+    }
+  ],
+  "cameraSequence": {
+    "loop": false,
+    "shots": [
+      {
+        "duration": 0.01,
+        "pos": [
+          1,
+          2.1,
+          9.799999999999999
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 50,
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      },
+      {
+        "duration": 13,
+        "pos": [
+          0,
+          1.8,
+          8.2
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 46,
+        "transition": "blend",
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      }
+    ]
+  },
+  "defaults": {
+    "stage": {
+      "size": [
+        18,
+        9,
+        11
+      ]
+    }
+  }
+}

--- a/sdf-js/scenes/rec-status-5.json
+++ b/sdf-js/scenes/rec-status-5.json
@@ -1,0 +1,128 @@
+{
+  "v": 1,
+  "name": "(lifted) status-Phase Plan",
+  "subjects": [
+    {
+      "id": "progression",
+      "type": "progression-3d",
+      "args": {
+        "steps": 4
+      },
+      "transform": {
+        "translate": [
+          -1,
+          0.6,
+          0
+        ]
+      },
+      "material": {
+        "hue": 0.57,
+        "sat": 0.55,
+        "value": 0.64,
+        "kind": "normal",
+        "roughness": 0.3,
+        "clearcoat": 0.45
+      }
+    }
+  ],
+  "overlay": [
+    {
+      "text": "PHASE PLAN",
+      "anchor": [
+        0,
+        3.9,
+        0
+      ],
+      "role": "title"
+    },
+    {
+      "text": "Plan",
+      "anchor": [
+        3,
+        2.6,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "Execute",
+      "anchor": [
+        3,
+        1.8800000000000001,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "Review",
+      "anchor": [
+        3,
+        1.1600000000000001,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "Close",
+      "anchor": [
+        3,
+        0.43999999999999995,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    }
+  ],
+  "cameraSequence": {
+    "loop": false,
+    "shots": [
+      {
+        "duration": 0.01,
+        "pos": [
+          1,
+          2.1,
+          9.799999999999999
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 50,
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      },
+      {
+        "duration": 13,
+        "pos": [
+          0,
+          1.8,
+          8.2
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 46,
+        "transition": "blend",
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      }
+    ]
+  },
+  "defaults": {
+    "stage": {
+      "size": [
+        18,
+        9,
+        11
+      ]
+    }
+  }
+}

--- a/sdf-js/scripts/lift-rec-round1.mjs
+++ b/sdf-js/scripts/lift-rec-round1.mjs
@@ -1,0 +1,78 @@
+// lift-rec-round1.mjs — reproduce PresentationLoad "recommendations" templates as
+// Atlas 3D narrative decks. Each template → a themed multi-slide deck, every slide
+// authored as 2D structure+data and lifted by the deterministic twin map.
+//
+// Round 1: 4 templates. Run: node sdf-js/scripts/lift-rec-round1.mjs (from repo root)
+
+import { writeFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+import { liftSceneData2dTo3d } from '../src/scene/lift-2d-to-3d.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const SCENES = resolve(__dirname, '../scenes');
+
+// each deck = { id, name, slides:[{title, type, args}] }. title is the slide caption
+// in the deck; the per-scene heading comes from args.title.
+const DECKS = [
+  {
+    id: 'ai',
+    name: 'Artificial Intelligence',
+    slides: [
+      { title: 'AI Landscape', type: 'sphere-network', args: { title: 'Artificial Intelligence', hub: 'AI', satellites: [{ label: 'Machine Learning' }, { label: 'Deep Learning' }, { label: 'NLP' }, { label: 'Computer Vision' }, { label: 'Robotics' }] } },
+      { title: 'ML Pipeline', type: 'progression', args: { title: 'Machine Learning Pipeline', steps: [{ label: 'Collect' }, { label: 'Train' }, { label: 'Validate' }, { label: 'Deploy' }, { label: 'Monitor' }] } },
+      { title: 'Model Types', type: 'pie', args: { title: 'Model Types', values: [40, 35, 25], labels: ['Supervised', 'Unsupervised', 'Reinforcement'], format: 'percent' } },
+      { title: 'AI Roadmap', type: 'timeline', args: { title: 'AI Roadmap', events: [{ label: 'Research' }, { label: 'Pilot' }, { label: 'Scale' }, { label: 'Production' }] } },
+      { title: 'Value Funnel', type: 'funnel', args: { title: 'Data → Decision', stages: [{ label: 'Raw Data' }, { label: 'Features' }, { label: 'Model' }, { label: 'Prediction' }, { label: 'Decision' }] } },
+    ],
+  },
+  {
+    id: 'status',
+    name: 'Project Status Report',
+    slides: [
+      { title: 'Status Overview', type: 'traffic-light', args: { title: 'Project Status Report', lights: [{ label: 'Scope' }, { label: 'Budget' }, { label: 'Schedule' }] } },
+      { title: 'Milestones', type: 'timeline', args: { title: 'Milestones', events: [{ label: 'Kickoff' }, { label: 'Design' }, { label: 'Build' }, { label: 'Test' }, { label: 'Launch' }] } },
+      { title: 'Workstreams', type: 'gantt', args: { title: 'Workstreams', tasks: [{ label: 'Discovery' }, { label: 'Development' }, { label: 'QA' }, { label: 'Rollout' }] } },
+      { title: 'KPIs', type: 'bar', args: { title: 'Key Metrics', values: [92, 78, 85, 88], labels: ['On-time', 'Budget', 'Quality', 'Scope'], format: 'percent' } },
+      { title: 'Phase Plan', type: 'progression', args: { title: 'Phase Plan', steps: [{ label: 'Plan' }, { label: 'Execute' }, { label: 'Review' }, { label: 'Close' }] } },
+    ],
+  },
+  {
+    id: 'okr',
+    name: 'Objectives & Key Results',
+    slides: [
+      { title: 'OKR Overview', type: 'radial-spoke', args: { title: 'Objectives & Key Results', values: [1, 1, 1, 1], labels: ['Grow Revenue', 'Delight Users', 'Scale Ops', 'Build Team'] } },
+      { title: 'Key Results', type: 'bar', args: { title: 'Key Result Progress', values: [75, 60, 90, 45], labels: ['KR1', 'KR2', 'KR3', 'KR4'], format: 'percent' } },
+      { title: 'Alignment', type: 'org-chart', args: { title: 'OKR Alignment', root: { label: 'Company', children: [{ label: 'Product', children: [{ label: 'Team A' }, { label: 'Team B' }] }, { label: 'GTM', children: [{ label: 'Sales' }, { label: 'Marketing' }] }] } } },
+      { title: 'Cadence', type: 'timeline', args: { title: 'Quarterly Cadence', events: [{ label: 'Q1 Set' }, { label: 'Q2 Check' }, { label: 'Q3 Adjust' }, { label: 'Q4 Score' }] } },
+      { title: 'Maturity', type: 'pyramid', args: { title: 'OKR Maturity', layers: [{ label: 'Aspirational' }, { label: 'Committed' }, { label: 'Tracked' }, { label: 'Foundational' }] } },
+    ],
+  },
+  {
+    id: 'digital',
+    name: 'Digital Transformation',
+    slides: [
+      { title: 'Transformation Stack', type: 'layer-stack', args: { title: 'Digital Transformation', layers: [{ label: 'Strategy' }, { label: 'Process' }, { label: 'Technology' }, { label: 'Culture' }] } },
+      { title: 'Roadmap', type: 'timeline', args: { title: 'Transformation Roadmap', events: [{ label: 'Assess' }, { label: 'Design' }, { label: 'Pilot' }, { label: 'Scale' }, { label: 'Optimize' }] } },
+      { title: 'Maturity Model', type: 'pyramid', args: { title: 'Digital Maturity', layers: [{ label: 'Optimized' }, { label: 'Integrated' }, { label: 'Defined' }, { label: 'Initial' }] } },
+      { title: 'Pillars', type: 'radial-spoke', args: { title: 'Transformation Pillars', values: [1, 1, 1, 1, 1], labels: ['Customer', 'Data', 'Cloud', 'Agility', 'Talent'] } },
+      { title: 'Value Funnel', type: 'funnel', args: { title: 'Value Realization', stages: [{ label: 'Vision' }, { label: 'Capability' }, { label: 'Adoption' }, { label: 'Value' }] } },
+    ],
+  },
+];
+
+const links = [];
+for (const deck of DECKS) {
+  const segments = [];
+  deck.slides.forEach((slide, i) => {
+    const scene = liftSceneData2dTo3d({ name: `${deck.id}-${slide.title}`, subjects: [{ type: slide.type, args: slide.args }] });
+    const file = `rec-${deck.id}-${i + 1}.json`;
+    writeFileSync(resolve(SCENES, file), `${JSON.stringify(scene, null, 2)}\n`);
+    segments.push({ file, title: slide.title, kind: 'slide', durationSec: 7 });
+  });
+  const deckFile = `deck-rec-${deck.id}.json`;
+  writeFileSync(resolve(SCENES, deckFile), `${JSON.stringify({ id: `deck-rec-${deck.id}`, name: deck.name, segments }, null, 2)}\n`);
+  links.push({ id: deck.id, name: deck.name, n: deck.slides.length });
+  console.log(`  ✓ ${deck.name.padEnd(32)} ${deck.slides.length} slides → ?deck=deck-rec-${deck.id}`);
+}
+console.log(`\n${links.length} decks generated.`);


### PR DESCRIPTION
Round 1/5 实战检验:把 PL「recommendations」商业模板复刻成 Atlas 3D 叙事 deck,每页纯数据 → twin map lift。

- `?deck=deck-rec-ai` —— Artificial Intelligence
- `?deck=deck-rec-status` —— Project Status Report
- `?deck=deck-rec-okr` —— Objectives & Key Results
- `?deck=deck-rec-digital` —— Digital Transformation

20 slide 全编译;Playwright 验证 sphere-network/traffic-light/gantt/radial-spoke。`npm test` 99/99。剩余 19 个模板 rounds 2-5 续。

🤖 Generated with [Claude Code](https://claude.com/claude-code)