### PR TITLE
feat(present): PL recommendations decks — round 2 (Consulting / Cyber / BizPlan / Journey / Pitch)

### DIFF
--- a/sdf-js/scenes/deck-rec-bizplan.json
+++ b/sdf-js/scenes/deck-rec-bizplan.json
@@ -1,0 +1,36 @@
+{
+  "id": "deck-rec-bizplan",
+  "name": "Business Plan",
+  "segments": [
+    {
+      "file": "rec-bizplan-1.json",
+      "title": "Strategy Pyramid",
+      "kind": "slide",
+      "durationSec": 7
+    },
+    {
+      "file": "rec-bizplan-2.json",
+      "title": "Milestones",
+      "kind": "slide",
+      "durationSec": 7
+    },
+    {
+      "file": "rec-bizplan-3.json",
+      "title": "Revenue Plan",
+      "kind": "slide",
+      "durationSec": 7
+    },
+    {
+      "file": "rec-bizplan-4.json",
+      "title": "Market Mix",
+      "kind": "slide",
+      "durationSec": 7
+    },
+    {
+      "file": "rec-bizplan-5.json",
+      "title": "Sales Funnel",
+      "kind": "slide",
+      "durationSec": 7
+    }
+  ]
+}

--- a/sdf-js/scenes/deck-rec-consulting.json
+++ b/sdf-js/scenes/deck-rec-consulting.json
@@ -1,0 +1,36 @@
+{
+  "id": "deck-rec-consulting",
+  "name": "Consulting Toolbox",
+  "segments": [
+    {
+      "file": "rec-consulting-1.json",
+      "title": "Toolbox",
+      "kind": "slide",
+      "durationSec": 7
+    },
+    {
+      "file": "rec-consulting-2.json",
+      "title": "2x2 Matrix",
+      "kind": "slide",
+      "durationSec": 7
+    },
+    {
+      "file": "rec-consulting-3.json",
+      "title": "Value Chain",
+      "kind": "slide",
+      "durationSec": 7
+    },
+    {
+      "file": "rec-consulting-4.json",
+      "title": "Pyramid Principle",
+      "kind": "slide",
+      "durationSec": 7
+    },
+    {
+      "file": "rec-consulting-5.json",
+      "title": "Engagement Plan",
+      "kind": "slide",
+      "durationSec": 7
+    }
+  ]
+}

--- a/sdf-js/scenes/deck-rec-cyber.json
+++ b/sdf-js/scenes/deck-rec-cyber.json
@@ -1,0 +1,36 @@
+{
+  "id": "deck-rec-cyber",
+  "name": "Cybersecurity",
+  "segments": [
+    {
+      "file": "rec-cyber-1.json",
+      "title": "Threat Landscape",
+      "kind": "slide",
+      "durationSec": 7
+    },
+    {
+      "file": "rec-cyber-2.json",
+      "title": "Defense in Depth",
+      "kind": "slide",
+      "durationSec": 7
+    },
+    {
+      "file": "rec-cyber-3.json",
+      "title": "Threat Funnel",
+      "kind": "slide",
+      "durationSec": 7
+    },
+    {
+      "file": "rec-cyber-4.json",
+      "title": "Maturity",
+      "kind": "slide",
+      "durationSec": 7
+    },
+    {
+      "file": "rec-cyber-5.json",
+      "title": "Incident Response",
+      "kind": "slide",
+      "durationSec": 7
+    }
+  ]
+}

--- a/sdf-js/scenes/deck-rec-journey.json
+++ b/sdf-js/scenes/deck-rec-journey.json
@@ -1,0 +1,36 @@
+{
+  "id": "deck-rec-journey",
+  "name": "Customer Journey / Experience Map",
+  "segments": [
+    {
+      "file": "rec-journey-1.json",
+      "title": "Journey",
+      "kind": "slide",
+      "durationSec": 7
+    },
+    {
+      "file": "rec-journey-2.json",
+      "title": "Stages",
+      "kind": "slide",
+      "durationSec": 7
+    },
+    {
+      "file": "rec-journey-3.json",
+      "title": "Touchpoints",
+      "kind": "slide",
+      "durationSec": 7
+    },
+    {
+      "file": "rec-journey-4.json",
+      "title": "Satisfaction",
+      "kind": "slide",
+      "durationSec": 7
+    },
+    {
+      "file": "rec-journey-5.json",
+      "title": "Conversion Funnel",
+      "kind": "slide",
+      "durationSec": 7
+    }
+  ]
+}

--- a/sdf-js/scenes/deck-rec-pitch.json
+++ b/sdf-js/scenes/deck-rec-pitch.json
@@ -1,0 +1,36 @@
+{
+  "id": "deck-rec-pitch",
+  "name": "Startup Pitch Deck",
+  "segments": [
+    {
+      "file": "rec-pitch-1.json",
+      "title": "Ecosystem",
+      "kind": "slide",
+      "durationSec": 7
+    },
+    {
+      "file": "rec-pitch-2.json",
+      "title": "Problem → Solution",
+      "kind": "slide",
+      "durationSec": 7
+    },
+    {
+      "file": "rec-pitch-3.json",
+      "title": "Market Size",
+      "kind": "slide",
+      "durationSec": 7
+    },
+    {
+      "file": "rec-pitch-4.json",
+      "title": "Traction",
+      "kind": "slide",
+      "durationSec": 7
+    },
+    {
+      "file": "rec-pitch-5.json",
+      "title": "Roadmap",
+      "kind": "slide",
+      "durationSec": 7
+    }
+  ]
+}

--- a/sdf-js/scenes/rec-bizplan-1.json
+++ b/sdf-js/scenes/rec-bizplan-1.json
@@ -1,0 +1,128 @@
+{
+  "v": 1,
+  "name": "(lifted) bizplan-Strategy Pyramid",
+  "subjects": [
+    {
+      "id": "pyramid",
+      "type": "pyramid-3d",
+      "args": {
+        "levels": 4
+      },
+      "transform": {
+        "translate": [
+          0,
+          0.6,
+          0
+        ]
+      },
+      "material": {
+        "hue": 0.57,
+        "sat": 0.55,
+        "value": 0.64,
+        "kind": "normal",
+        "roughness": 0.3,
+        "clearcoat": 0.45
+      }
+    }
+  ],
+  "overlay": [
+    {
+      "text": "BUSINESS PLAN",
+      "anchor": [
+        0,
+        3.9,
+        0
+      ],
+      "role": "title"
+    },
+    {
+      "text": "Vision",
+      "anchor": [
+        3,
+        2.6,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "Strategy",
+      "anchor": [
+        3,
+        1.8800000000000001,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "Tactics",
+      "anchor": [
+        3,
+        1.1600000000000001,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "Operations",
+      "anchor": [
+        3,
+        0.43999999999999995,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    }
+  ],
+  "cameraSequence": {
+    "loop": false,
+    "shots": [
+      {
+        "duration": 0.01,
+        "pos": [
+          1,
+          2.1,
+          9.799999999999999
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 50,
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      },
+      {
+        "duration": 13,
+        "pos": [
+          0,
+          1.8,
+          8.2
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 46,
+        "transition": "blend",
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      }
+    ]
+  },
+  "defaults": {
+    "stage": {
+      "size": [
+        18,
+        9,
+        11
+      ]
+    }
+  }
+}

--- a/sdf-js/scenes/rec-bizplan-2.json
+++ b/sdf-js/scenes/rec-bizplan-2.json
@@ -1,0 +1,142 @@
+{
+  "v": 1,
+  "name": "(lifted) bizplan-Milestones",
+  "subjects": [
+    {
+      "id": "timeline",
+      "type": "timeline-3d",
+      "args": {
+        "count": 5,
+        "axisLength": 4.2,
+        "axisRadius": 0.06,
+        "markerRadius": 0.2,
+        "stemHeight": 0.55
+      },
+      "transform": {
+        "translate": [
+          0,
+          1.4,
+          0
+        ]
+      },
+      "material": {
+        "hue": 0.57,
+        "sat": 0.55,
+        "value": 0.64,
+        "kind": "normal",
+        "roughness": 0.3,
+        "clearcoat": 0.45
+      }
+    }
+  ],
+  "overlay": [
+    {
+      "text": "MILESTONES",
+      "anchor": [
+        0,
+        3.9,
+        0
+      ],
+      "role": "title"
+    },
+    {
+      "text": "Found",
+      "anchor": [
+        -2.1,
+        2.25,
+        0
+      ],
+      "role": "value",
+      "radius": 0.34
+    },
+    {
+      "text": "MVP",
+      "anchor": [
+        -1.05,
+        2.25,
+        0
+      ],
+      "role": "value",
+      "radius": 0.34
+    },
+    {
+      "text": "Launch",
+      "anchor": [
+        0,
+        2.25,
+        0
+      ],
+      "role": "value",
+      "radius": 0.34
+    },
+    {
+      "text": "Scale",
+      "anchor": [
+        1.0500000000000003,
+        2.25,
+        0
+      ],
+      "role": "value",
+      "radius": 0.34
+    },
+    {
+      "text": "Exit",
+      "anchor": [
+        2.1,
+        2.25,
+        0
+      ],
+      "role": "value",
+      "radius": 0.34
+    }
+  ],
+  "cameraSequence": {
+    "loop": false,
+    "shots": [
+      {
+        "duration": 0.01,
+        "pos": [
+          1,
+          2.1,
+          9.799999999999999
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 50,
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      },
+      {
+        "duration": 13,
+        "pos": [
+          0,
+          1.8,
+          8.2
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 46,
+        "transition": "blend",
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      }
+    ]
+  },
+  "defaults": {
+    "stage": {
+      "size": [
+        18,
+        9,
+        11
+      ]
+    }
+  }
+}

--- a/sdf-js/scenes/rec-bizplan-3.json
+++ b/sdf-js/scenes/rec-bizplan-3.json
@@ -1,0 +1,148 @@
+{
+  "v": 1,
+  "name": "(lifted) bizplan-Revenue Plan",
+  "subjects": [
+    {
+      "id": "bar",
+      "type": "bar-3d",
+      "args": {
+        "values": [
+          0.19,
+          0.3025,
+          0.4600000000000001,
+          0.685,
+          1
+        ],
+        "barWidth": 0.55,
+        "barDepth": 0.55,
+        "gap": 0.25,
+        "maxHeight": 2.2
+      },
+      "transform": {
+        "translate": [
+          0,
+          0.15,
+          0
+        ]
+      },
+      "material": {
+        "hue": 0.57,
+        "sat": 0.55,
+        "value": 0.64,
+        "kind": "normal",
+        "roughness": 0.3,
+        "clearcoat": 0.45
+      }
+    }
+  ],
+  "overlay": [
+    {
+      "text": "REVENUE PLAN",
+      "anchor": [
+        0,
+        3.9,
+        0
+      ],
+      "role": "title"
+    },
+    {
+      "text": "$20",
+      "anchor": [
+        -1.6,
+        0.8180000000000001,
+        0.3
+      ],
+      "role": "value",
+      "radius": 0.32
+    },
+    {
+      "text": "$45",
+      "anchor": [
+        -0.8,
+        1.0655000000000001,
+        0.3
+      ],
+      "role": "value",
+      "radius": 0.32
+    },
+    {
+      "text": "$80",
+      "anchor": [
+        0,
+        1.4120000000000001,
+        0.3
+      ],
+      "role": "value",
+      "radius": 0.32
+    },
+    {
+      "text": "$130",
+      "anchor": [
+        0.8000000000000003,
+        1.9070000000000003,
+        0.3
+      ],
+      "role": "value",
+      "radius": 0.32
+    },
+    {
+      "text": "$200",
+      "anchor": [
+        1.6,
+        2.6,
+        0.3
+      ],
+      "role": "value",
+      "radius": 0.32
+    }
+  ],
+  "cameraSequence": {
+    "loop": false,
+    "shots": [
+      {
+        "duration": 0.01,
+        "pos": [
+          1,
+          2.1,
+          9.799999999999999
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 50,
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      },
+      {
+        "duration": 13,
+        "pos": [
+          0,
+          1.8,
+          8.2
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 46,
+        "transition": "blend",
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      }
+    ]
+  },
+  "defaults": {
+    "stage": {
+      "size": [
+        18,
+        9,
+        11
+      ]
+    }
+  }
+}

--- a/sdf-js/scenes/rec-bizplan-4.json
+++ b/sdf-js/scenes/rec-bizplan-4.json
@@ -1,0 +1,130 @@
+{
+  "v": 1,
+  "name": "(lifted) bizplan-Market Mix",
+  "subjects": [
+    {
+      "id": "pie",
+      "type": "pie-3d",
+      "args": {
+        "values": [
+          45,
+          30,
+          25
+        ],
+        "innerRadius": 0.55,
+        "outerRadius": 1.3,
+        "thickness": 0.45
+      },
+      "transform": {
+        "translate": [
+          0,
+          1.5,
+          0
+        ],
+        "rotate": [
+          1.2,
+          0,
+          0
+        ]
+      },
+      "material": {
+        "hue": 0.57,
+        "sat": 0.55,
+        "value": 0.64,
+        "kind": "normal",
+        "roughness": 0.3,
+        "clearcoat": 0.45
+      }
+    }
+  ],
+  "overlay": [
+    {
+      "text": "MARKET SEGMENTS",
+      "anchor": [
+        0,
+        3.9,
+        0
+      ],
+      "role": "title"
+    },
+    {
+      "text": "Enterprise 45%",
+      "anchor": [
+        3,
+        2.6,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "SMB 30%",
+      "anchor": [
+        3,
+        1.8800000000000001,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "Consumer 25%",
+      "anchor": [
+        3,
+        1.1600000000000001,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    }
+  ],
+  "cameraSequence": {
+    "loop": false,
+    "shots": [
+      {
+        "duration": 0.01,
+        "pos": [
+          1,
+          2.1,
+          9.799999999999999
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 50,
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      },
+      {
+        "duration": 13,
+        "pos": [
+          0,
+          1.8,
+          8.2
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 46,
+        "transition": "blend",
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      }
+    ]
+  },
+  "defaults": {
+    "stage": {
+      "size": [
+        18,
+        9,
+        11
+      ]
+    }
+  }
+}

--- a/sdf-js/scenes/rec-bizplan-5.json
+++ b/sdf-js/scenes/rec-bizplan-5.json
@@ -1,0 +1,137 @@
+{
+  "v": 1,
+  "name": "(lifted) bizplan-Sales Funnel",
+  "subjects": [
+    {
+      "id": "funnel",
+      "type": "funnel-3d",
+      "args": {
+        "stages": 4,
+        "topRadius": 1.15,
+        "bottomRadius": 0.28,
+        "stageHeight": 0.55,
+        "gap": 0.1
+      },
+      "transform": {
+        "translate": [
+          -0.3,
+          1.6,
+          0
+        ],
+        "rotate": [
+          0.12,
+          0,
+          0
+        ]
+      },
+      "material": {
+        "hue": 0.57,
+        "sat": 0.55,
+        "value": 0.64,
+        "kind": "normal",
+        "roughness": 0.3,
+        "clearcoat": 0.45
+      }
+    }
+  ],
+  "overlay": [
+    {
+      "text": "SALES FUNNEL",
+      "anchor": [
+        0,
+        3.9,
+        0
+      ],
+      "role": "title"
+    },
+    {
+      "text": "Leads",
+      "anchor": [
+        3,
+        2.6,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "Qualified",
+      "anchor": [
+        3,
+        1.8800000000000001,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "Proposal",
+      "anchor": [
+        3,
+        1.1600000000000001,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "Closed",
+      "anchor": [
+        3,
+        0.43999999999999995,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    }
+  ],
+  "cameraSequence": {
+    "loop": false,
+    "shots": [
+      {
+        "duration": 0.01,
+        "pos": [
+          1,
+          2.1,
+          9.799999999999999
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 50,
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      },
+      {
+        "duration": 13,
+        "pos": [
+          0,
+          1.8,
+          8.2
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 46,
+        "transition": "blend",
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      }
+    ]
+  },
+  "defaults": {
+    "stage": {
+      "size": [
+        18,
+        9,
+        11
+      ]
+    }
+  }
+}

--- a/sdf-js/scenes/rec-consulting-1.json
+++ b/sdf-js/scenes/rec-consulting-1.json
@@ -1,0 +1,148 @@
+{
+  "v": 1,
+  "name": "(lifted) consulting-Toolbox",
+  "subjects": [
+    {
+      "id": "radial-spoke",
+      "type": "radial-spoke-3d",
+      "args": {
+        "spokes": 6
+      },
+      "transform": {
+        "translate": [
+          0,
+          1.7,
+          0
+        ]
+      },
+      "material": {
+        "hue": 0.57,
+        "sat": 0.55,
+        "value": 0.64,
+        "kind": "normal",
+        "roughness": 0.3,
+        "clearcoat": 0.45
+      }
+    }
+  ],
+  "overlay": [
+    {
+      "text": "CONSULTING TOOLBOX",
+      "anchor": [
+        0,
+        3.9,
+        0
+      ],
+      "role": "title"
+    },
+    {
+      "text": "SWOT 1",
+      "anchor": [
+        3,
+        2.6,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "Porter 5F 1",
+      "anchor": [
+        3,
+        1.8800000000000001,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "BCG 1",
+      "anchor": [
+        3,
+        1.1600000000000001,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "Value Chain 1",
+      "anchor": [
+        3,
+        0.43999999999999995,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "McKinsey 7S 1",
+      "anchor": [
+        3,
+        -0.2799999999999998,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "Ansoff 1",
+      "anchor": [
+        3,
+        -0.9999999999999996,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    }
+  ],
+  "cameraSequence": {
+    "loop": false,
+    "shots": [
+      {
+        "duration": 0.01,
+        "pos": [
+          1,
+          2.1,
+          9.799999999999999
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 50,
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      },
+      {
+        "duration": 13,
+        "pos": [
+          0,
+          1.8,
+          8.2
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 46,
+        "transition": "blend",
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      }
+    ]
+  },
+  "defaults": {
+    "stage": {
+      "size": [
+        18,
+        9,
+        11
+      ]
+    }
+  }
+}

--- a/sdf-js/scenes/rec-consulting-2.json
+++ b/sdf-js/scenes/rec-consulting-2.json
@@ -1,0 +1,89 @@
+{
+  "v": 1,
+  "name": "(lifted) consulting-2x2 Matrix",
+  "subjects": [
+    {
+      "id": "matrix-grid",
+      "type": "matrix-grid-3d",
+      "args": {
+        "rows": 2,
+        "cols": 2
+      },
+      "transform": {
+        "translate": [
+          0,
+          1.8,
+          0
+        ]
+      },
+      "material": {
+        "hue": 0.57,
+        "sat": 0.55,
+        "value": 0.64,
+        "kind": "normal",
+        "roughness": 0.3,
+        "clearcoat": 0.45
+      }
+    }
+  ],
+  "overlay": [
+    {
+      "text": "PRIORITY MATRIX",
+      "anchor": [
+        0,
+        3.9,
+        0
+      ],
+      "role": "title"
+    }
+  ],
+  "cameraSequence": {
+    "loop": false,
+    "shots": [
+      {
+        "duration": 0.01,
+        "pos": [
+          1,
+          2.1,
+          9.799999999999999
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 50,
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      },
+      {
+        "duration": 13,
+        "pos": [
+          0,
+          1.8,
+          8.2
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 46,
+        "transition": "blend",
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      }
+    ]
+  },
+  "defaults": {
+    "stage": {
+      "size": [
+        18,
+        9,
+        11
+      ]
+    }
+  }
+}

--- a/sdf-js/scenes/rec-consulting-3.json
+++ b/sdf-js/scenes/rec-consulting-3.json
@@ -1,0 +1,138 @@
+{
+  "v": 1,
+  "name": "(lifted) consulting-Value Chain",
+  "subjects": [
+    {
+      "id": "progression",
+      "type": "progression-3d",
+      "args": {
+        "steps": 5
+      },
+      "transform": {
+        "translate": [
+          -1,
+          0.6,
+          0
+        ]
+      },
+      "material": {
+        "hue": 0.57,
+        "sat": 0.55,
+        "value": 0.64,
+        "kind": "normal",
+        "roughness": 0.3,
+        "clearcoat": 0.45
+      }
+    }
+  ],
+  "overlay": [
+    {
+      "text": "VALUE CHAIN",
+      "anchor": [
+        0,
+        3.9,
+        0
+      ],
+      "role": "title"
+    },
+    {
+      "text": "Inbound",
+      "anchor": [
+        3,
+        2.6,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "Operations",
+      "anchor": [
+        3,
+        1.8800000000000001,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "Outbound",
+      "anchor": [
+        3,
+        1.1600000000000001,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "Marketing",
+      "anchor": [
+        3,
+        0.43999999999999995,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "Service",
+      "anchor": [
+        3,
+        -0.2799999999999998,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    }
+  ],
+  "cameraSequence": {
+    "loop": false,
+    "shots": [
+      {
+        "duration": 0.01,
+        "pos": [
+          1,
+          2.1,
+          9.799999999999999
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 50,
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      },
+      {
+        "duration": 13,
+        "pos": [
+          0,
+          1.8,
+          8.2
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 46,
+        "transition": "blend",
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      }
+    ]
+  },
+  "defaults": {
+    "stage": {
+      "size": [
+        18,
+        9,
+        11
+      ]
+    }
+  }
+}

--- a/sdf-js/scenes/rec-consulting-4.json
+++ b/sdf-js/scenes/rec-consulting-4.json
@@ -1,0 +1,118 @@
+{
+  "v": 1,
+  "name": "(lifted) consulting-Pyramid Principle",
+  "subjects": [
+    {
+      "id": "pyramid",
+      "type": "pyramid-3d",
+      "args": {
+        "levels": 3
+      },
+      "transform": {
+        "translate": [
+          0,
+          0.6,
+          0
+        ]
+      },
+      "material": {
+        "hue": 0.57,
+        "sat": 0.55,
+        "value": 0.64,
+        "kind": "normal",
+        "roughness": 0.3,
+        "clearcoat": 0.45
+      }
+    }
+  ],
+  "overlay": [
+    {
+      "text": "PYRAMID PRINCIPLE",
+      "anchor": [
+        0,
+        3.9,
+        0
+      ],
+      "role": "title"
+    },
+    {
+      "text": "Recommendation",
+      "anchor": [
+        3,
+        2.6,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "Arguments",
+      "anchor": [
+        3,
+        1.8800000000000001,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "Evidence",
+      "anchor": [
+        3,
+        1.1600000000000001,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    }
+  ],
+  "cameraSequence": {
+    "loop": false,
+    "shots": [
+      {
+        "duration": 0.01,
+        "pos": [
+          1,
+          2.1,
+          9.799999999999999
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 50,
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      },
+      {
+        "duration": 13,
+        "pos": [
+          0,
+          1.8,
+          8.2
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 46,
+        "transition": "blend",
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      }
+    ]
+  },
+  "defaults": {
+    "stage": {
+      "size": [
+        18,
+        9,
+        11
+      ]
+    }
+  }
+}

--- a/sdf-js/scenes/rec-consulting-5.json
+++ b/sdf-js/scenes/rec-consulting-5.json
@@ -1,0 +1,132 @@
+{
+  "v": 1,
+  "name": "(lifted) consulting-Engagement Plan",
+  "subjects": [
+    {
+      "id": "timeline",
+      "type": "timeline-3d",
+      "args": {
+        "count": 4,
+        "axisLength": 4.2,
+        "axisRadius": 0.06,
+        "markerRadius": 0.2,
+        "stemHeight": 0.55
+      },
+      "transform": {
+        "translate": [
+          0,
+          1.4,
+          0
+        ]
+      },
+      "material": {
+        "hue": 0.57,
+        "sat": 0.55,
+        "value": 0.64,
+        "kind": "normal",
+        "roughness": 0.3,
+        "clearcoat": 0.45
+      }
+    }
+  ],
+  "overlay": [
+    {
+      "text": "ENGAGEMENT PLAN",
+      "anchor": [
+        0,
+        3.9,
+        0
+      ],
+      "role": "title"
+    },
+    {
+      "text": "Scope",
+      "anchor": [
+        -2.1,
+        2.25,
+        0
+      ],
+      "role": "value",
+      "radius": 0.34
+    },
+    {
+      "text": "Analyze",
+      "anchor": [
+        -0.7,
+        2.25,
+        0
+      ],
+      "role": "value",
+      "radius": 0.34
+    },
+    {
+      "text": "Recommend",
+      "anchor": [
+        0.7000000000000002,
+        2.25,
+        0
+      ],
+      "role": "value",
+      "radius": 0.34
+    },
+    {
+      "text": "Implement",
+      "anchor": [
+        2.1,
+        2.25,
+        0
+      ],
+      "role": "value",
+      "radius": 0.34
+    }
+  ],
+  "cameraSequence": {
+    "loop": false,
+    "shots": [
+      {
+        "duration": 0.01,
+        "pos": [
+          1,
+          2.1,
+          9.799999999999999
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 50,
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      },
+      {
+        "duration": 13,
+        "pos": [
+          0,
+          1.8,
+          8.2
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 46,
+        "transition": "blend",
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      }
+    ]
+  },
+  "defaults": {
+    "stage": {
+      "size": [
+        18,
+        9,
+        11
+      ]
+    }
+  }
+}

--- a/sdf-js/scenes/rec-cyber-1.json
+++ b/sdf-js/scenes/rec-cyber-1.json
@@ -1,0 +1,139 @@
+{
+  "v": 1,
+  "name": "(lifted) cyber-Threat Landscape",
+  "subjects": [
+    {
+      "id": "sphere-network",
+      "type": "sphere-network-3d",
+      "args": {
+        "count": 5,
+        "arrangement": "sphere"
+      },
+      "transform": {
+        "translate": [
+          0,
+          1.8,
+          0
+        ]
+      },
+      "material": {
+        "hue": 0.57,
+        "sat": 0.55,
+        "value": 0.64,
+        "kind": "normal",
+        "roughness": 0.3,
+        "clearcoat": 0.45
+      }
+    }
+  ],
+  "overlay": [
+    {
+      "text": "CYBERSECURITY",
+      "anchor": [
+        0,
+        3.9,
+        0
+      ],
+      "role": "title"
+    },
+    {
+      "text": "Malware",
+      "anchor": [
+        3,
+        2.6,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "Phishing",
+      "anchor": [
+        3,
+        1.8800000000000001,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "Ransomware",
+      "anchor": [
+        3,
+        1.1600000000000001,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "Insider",
+      "anchor": [
+        3,
+        0.43999999999999995,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "DDoS",
+      "anchor": [
+        3,
+        -0.2799999999999998,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    }
+  ],
+  "cameraSequence": {
+    "loop": false,
+    "shots": [
+      {
+        "duration": 0.01,
+        "pos": [
+          1,
+          2.1,
+          9.799999999999999
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 50,
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      },
+      {
+        "duration": 13,
+        "pos": [
+          0,
+          1.8,
+          8.2
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 46,
+        "transition": "blend",
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      }
+    ]
+  },
+  "defaults": {
+    "stage": {
+      "size": [
+        18,
+        9,
+        11
+      ]
+    }
+  }
+}

--- a/sdf-js/scenes/rec-cyber-2.json
+++ b/sdf-js/scenes/rec-cyber-2.json
@@ -1,0 +1,148 @@
+{
+  "v": 1,
+  "name": "(lifted) cyber-Defense in Depth",
+  "subjects": [
+    {
+      "id": "layer-stack",
+      "type": "layer-stack-3d",
+      "args": {
+        "layers": 5,
+        "layerW": 2.4,
+        "layerD": 1.5,
+        "layerH": 0.28,
+        "gap": 0.45,
+        "taper": 1
+      },
+      "transform": {
+        "translate": [
+          -0.3,
+          1.4,
+          0
+        ],
+        "rotate": [
+          0.35,
+          0.5,
+          0
+        ]
+      },
+      "material": {
+        "hue": 0.57,
+        "sat": 0.55,
+        "value": 0.64,
+        "kind": "normal",
+        "roughness": 0.3,
+        "clearcoat": 0.45
+      }
+    }
+  ],
+  "overlay": [
+    {
+      "text": "DEFENSE IN DEPTH",
+      "anchor": [
+        0,
+        3.9,
+        0
+      ],
+      "role": "title"
+    },
+    {
+      "text": "Perimeter",
+      "anchor": [
+        3,
+        2.6,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "Network",
+      "anchor": [
+        3,
+        1.8800000000000001,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "Endpoint",
+      "anchor": [
+        3,
+        1.1600000000000001,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "Application",
+      "anchor": [
+        3,
+        0.43999999999999995,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "Data",
+      "anchor": [
+        3,
+        -0.2799999999999998,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    }
+  ],
+  "cameraSequence": {
+    "loop": false,
+    "shots": [
+      {
+        "duration": 0.01,
+        "pos": [
+          1,
+          2.1,
+          9.799999999999999
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 50,
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      },
+      {
+        "duration": 13,
+        "pos": [
+          0,
+          1.8,
+          8.2
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 46,
+        "transition": "blend",
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      }
+    ]
+  },
+  "defaults": {
+    "stage": {
+      "size": [
+        18,
+        9,
+        11
+      ]
+    }
+  }
+}

--- a/sdf-js/scenes/rec-cyber-3.json
+++ b/sdf-js/scenes/rec-cyber-3.json
@@ -1,0 +1,137 @@
+{
+  "v": 1,
+  "name": "(lifted) cyber-Threat Funnel",
+  "subjects": [
+    {
+      "id": "funnel",
+      "type": "funnel-3d",
+      "args": {
+        "stages": 4,
+        "topRadius": 1.15,
+        "bottomRadius": 0.28,
+        "stageHeight": 0.55,
+        "gap": 0.1
+      },
+      "transform": {
+        "translate": [
+          -0.3,
+          1.6,
+          0
+        ],
+        "rotate": [
+          0.12,
+          0,
+          0
+        ]
+      },
+      "material": {
+        "hue": 0.57,
+        "sat": 0.55,
+        "value": 0.64,
+        "kind": "normal",
+        "roughness": 0.3,
+        "clearcoat": 0.45
+      }
+    }
+  ],
+  "overlay": [
+    {
+      "text": "ATTACK FUNNEL",
+      "anchor": [
+        0,
+        3.9,
+        0
+      ],
+      "role": "title"
+    },
+    {
+      "text": "Attempts",
+      "anchor": [
+        3,
+        2.6,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "Detected",
+      "anchor": [
+        3,
+        1.8800000000000001,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "Contained",
+      "anchor": [
+        3,
+        1.1600000000000001,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "Breached",
+      "anchor": [
+        3,
+        0.43999999999999995,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    }
+  ],
+  "cameraSequence": {
+    "loop": false,
+    "shots": [
+      {
+        "duration": 0.01,
+        "pos": [
+          1,
+          2.1,
+          9.799999999999999
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 50,
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      },
+      {
+        "duration": 13,
+        "pos": [
+          0,
+          1.8,
+          8.2
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 46,
+        "transition": "blend",
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      }
+    ]
+  },
+  "defaults": {
+    "stage": {
+      "size": [
+        18,
+        9,
+        11
+      ]
+    }
+  }
+}

--- a/sdf-js/scenes/rec-cyber-4.json
+++ b/sdf-js/scenes/rec-cyber-4.json
@@ -1,0 +1,128 @@
+{
+  "v": 1,
+  "name": "(lifted) cyber-Maturity",
+  "subjects": [
+    {
+      "id": "pyramid",
+      "type": "pyramid-3d",
+      "args": {
+        "levels": 4
+      },
+      "transform": {
+        "translate": [
+          0,
+          0.6,
+          0
+        ]
+      },
+      "material": {
+        "hue": 0.57,
+        "sat": 0.55,
+        "value": 0.64,
+        "kind": "normal",
+        "roughness": 0.3,
+        "clearcoat": 0.45
+      }
+    }
+  ],
+  "overlay": [
+    {
+      "text": "SECURITY MATURITY",
+      "anchor": [
+        0,
+        3.9,
+        0
+      ],
+      "role": "title"
+    },
+    {
+      "text": "Adaptive",
+      "anchor": [
+        3,
+        2.6,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "Proactive",
+      "anchor": [
+        3,
+        1.8800000000000001,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "Reactive",
+      "anchor": [
+        3,
+        1.1600000000000001,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "Initial",
+      "anchor": [
+        3,
+        0.43999999999999995,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    }
+  ],
+  "cameraSequence": {
+    "loop": false,
+    "shots": [
+      {
+        "duration": 0.01,
+        "pos": [
+          1,
+          2.1,
+          9.799999999999999
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 50,
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      },
+      {
+        "duration": 13,
+        "pos": [
+          0,
+          1.8,
+          8.2
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 46,
+        "transition": "blend",
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      }
+    ]
+  },
+  "defaults": {
+    "stage": {
+      "size": [
+        18,
+        9,
+        11
+      ]
+    }
+  }
+}

--- a/sdf-js/scenes/rec-cyber-5.json
+++ b/sdf-js/scenes/rec-cyber-5.json
@@ -1,0 +1,128 @@
+{
+  "v": 1,
+  "name": "(lifted) cyber-Incident Response",
+  "subjects": [
+    {
+      "id": "progression",
+      "type": "progression-3d",
+      "args": {
+        "steps": 4
+      },
+      "transform": {
+        "translate": [
+          -1,
+          0.6,
+          0
+        ]
+      },
+      "material": {
+        "hue": 0.57,
+        "sat": 0.55,
+        "value": 0.64,
+        "kind": "normal",
+        "roughness": 0.3,
+        "clearcoat": 0.45
+      }
+    }
+  ],
+  "overlay": [
+    {
+      "text": "INCIDENT RESPONSE",
+      "anchor": [
+        0,
+        3.9,
+        0
+      ],
+      "role": "title"
+    },
+    {
+      "text": "Identify",
+      "anchor": [
+        3,
+        2.6,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "Contain",
+      "anchor": [
+        3,
+        1.8800000000000001,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "Eradicate",
+      "anchor": [
+        3,
+        1.1600000000000001,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "Recover",
+      "anchor": [
+        3,
+        0.43999999999999995,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    }
+  ],
+  "cameraSequence": {
+    "loop": false,
+    "shots": [
+      {
+        "duration": 0.01,
+        "pos": [
+          1,
+          2.1,
+          9.799999999999999
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 50,
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      },
+      {
+        "duration": 13,
+        "pos": [
+          0,
+          1.8,
+          8.2
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 46,
+        "transition": "blend",
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      }
+    ]
+  },
+  "defaults": {
+    "stage": {
+      "size": [
+        18,
+        9,
+        11
+      ]
+    }
+  }
+}

--- a/sdf-js/scenes/rec-journey-1.json
+++ b/sdf-js/scenes/rec-journey-1.json
@@ -1,0 +1,142 @@
+{
+  "v": 1,
+  "name": "(lifted) journey-Journey",
+  "subjects": [
+    {
+      "id": "timeline",
+      "type": "timeline-3d",
+      "args": {
+        "count": 5,
+        "axisLength": 4.2,
+        "axisRadius": 0.06,
+        "markerRadius": 0.2,
+        "stemHeight": 0.55
+      },
+      "transform": {
+        "translate": [
+          0,
+          1.4,
+          0
+        ]
+      },
+      "material": {
+        "hue": 0.57,
+        "sat": 0.55,
+        "value": 0.64,
+        "kind": "normal",
+        "roughness": 0.3,
+        "clearcoat": 0.45
+      }
+    }
+  ],
+  "overlay": [
+    {
+      "text": "CUSTOMER JOURNEY",
+      "anchor": [
+        0,
+        3.9,
+        0
+      ],
+      "role": "title"
+    },
+    {
+      "text": "Awareness",
+      "anchor": [
+        -2.1,
+        2.25,
+        0
+      ],
+      "role": "value",
+      "radius": 0.34
+    },
+    {
+      "text": "Consideration",
+      "anchor": [
+        -1.05,
+        2.25,
+        0
+      ],
+      "role": "value",
+      "radius": 0.34
+    },
+    {
+      "text": "Purchase",
+      "anchor": [
+        0,
+        2.25,
+        0
+      ],
+      "role": "value",
+      "radius": 0.34
+    },
+    {
+      "text": "Retention",
+      "anchor": [
+        1.0500000000000003,
+        2.25,
+        0
+      ],
+      "role": "value",
+      "radius": 0.34
+    },
+    {
+      "text": "Advocacy",
+      "anchor": [
+        2.1,
+        2.25,
+        0
+      ],
+      "role": "value",
+      "radius": 0.34
+    }
+  ],
+  "cameraSequence": {
+    "loop": false,
+    "shots": [
+      {
+        "duration": 0.01,
+        "pos": [
+          1,
+          2.1,
+          9.799999999999999
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 50,
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      },
+      {
+        "duration": 13,
+        "pos": [
+          0,
+          1.8,
+          8.2
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 46,
+        "transition": "blend",
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      }
+    ]
+  },
+  "defaults": {
+    "stage": {
+      "size": [
+        18,
+        9,
+        11
+      ]
+    }
+  }
+}

--- a/sdf-js/scenes/rec-journey-2.json
+++ b/sdf-js/scenes/rec-journey-2.json
@@ -1,0 +1,138 @@
+{
+  "v": 1,
+  "name": "(lifted) journey-Stages",
+  "subjects": [
+    {
+      "id": "progression",
+      "type": "progression-3d",
+      "args": {
+        "steps": 5
+      },
+      "transform": {
+        "translate": [
+          -1,
+          0.6,
+          0
+        ]
+      },
+      "material": {
+        "hue": 0.57,
+        "sat": 0.55,
+        "value": 0.64,
+        "kind": "normal",
+        "roughness": 0.3,
+        "clearcoat": 0.45
+      }
+    }
+  ],
+  "overlay": [
+    {
+      "text": "EXPERIENCE STAGES",
+      "anchor": [
+        0,
+        3.9,
+        0
+      ],
+      "role": "title"
+    },
+    {
+      "text": "Discover",
+      "anchor": [
+        3,
+        2.6,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "Evaluate",
+      "anchor": [
+        3,
+        1.8800000000000001,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "Buy",
+      "anchor": [
+        3,
+        1.1600000000000001,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "Use",
+      "anchor": [
+        3,
+        0.43999999999999995,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "Recommend",
+      "anchor": [
+        3,
+        -0.2799999999999998,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    }
+  ],
+  "cameraSequence": {
+    "loop": false,
+    "shots": [
+      {
+        "duration": 0.01,
+        "pos": [
+          1,
+          2.1,
+          9.799999999999999
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 50,
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      },
+      {
+        "duration": 13,
+        "pos": [
+          0,
+          1.8,
+          8.2
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 46,
+        "transition": "blend",
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      }
+    ]
+  },
+  "defaults": {
+    "stage": {
+      "size": [
+        18,
+        9,
+        11
+      ]
+    }
+  }
+}

--- a/sdf-js/scenes/rec-journey-3.json
+++ b/sdf-js/scenes/rec-journey-3.json
@@ -1,0 +1,138 @@
+{
+  "v": 1,
+  "name": "(lifted) journey-Touchpoints",
+  "subjects": [
+    {
+      "id": "radial-spoke",
+      "type": "radial-spoke-3d",
+      "args": {
+        "spokes": 5
+      },
+      "transform": {
+        "translate": [
+          0,
+          1.7,
+          0
+        ]
+      },
+      "material": {
+        "hue": 0.57,
+        "sat": 0.55,
+        "value": 0.64,
+        "kind": "normal",
+        "roughness": 0.3,
+        "clearcoat": 0.45
+      }
+    }
+  ],
+  "overlay": [
+    {
+      "text": "TOUCHPOINTS",
+      "anchor": [
+        0,
+        3.9,
+        0
+      ],
+      "role": "title"
+    },
+    {
+      "text": "Web 1",
+      "anchor": [
+        3,
+        2.6,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "Social 1",
+      "anchor": [
+        3,
+        1.8800000000000001,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "Store 1",
+      "anchor": [
+        3,
+        1.1600000000000001,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "Support 1",
+      "anchor": [
+        3,
+        0.43999999999999995,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "Email 1",
+      "anchor": [
+        3,
+        -0.2799999999999998,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    }
+  ],
+  "cameraSequence": {
+    "loop": false,
+    "shots": [
+      {
+        "duration": 0.01,
+        "pos": [
+          1,
+          2.1,
+          9.799999999999999
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 50,
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      },
+      {
+        "duration": 13,
+        "pos": [
+          0,
+          1.8,
+          8.2
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 46,
+        "transition": "blend",
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      }
+    ]
+  },
+  "defaults": {
+    "stage": {
+      "size": [
+        18,
+        9,
+        11
+      ]
+    }
+  }
+}

--- a/sdf-js/scenes/rec-journey-4.json
+++ b/sdf-js/scenes/rec-journey-4.json
@@ -1,0 +1,148 @@
+{
+  "v": 1,
+  "name": "(lifted) journey-Satisfaction",
+  "subjects": [
+    {
+      "id": "bar",
+      "type": "bar-3d",
+      "args": {
+        "values": [
+          0.8,
+          0.75,
+          0.95,
+          0.8999999999999999,
+          1
+        ],
+        "barWidth": 0.55,
+        "barDepth": 0.55,
+        "gap": 0.25,
+        "maxHeight": 2.2
+      },
+      "transform": {
+        "translate": [
+          0,
+          0.15,
+          0
+        ]
+      },
+      "material": {
+        "hue": 0.57,
+        "sat": 0.55,
+        "value": 0.64,
+        "kind": "normal",
+        "roughness": 0.3,
+        "clearcoat": 0.45
+      }
+    }
+  ],
+  "overlay": [
+    {
+      "text": "SATISFACTION BY STAGE",
+      "anchor": [
+        0,
+        3.9,
+        0
+      ],
+      "role": "title"
+    },
+    {
+      "text": "70%",
+      "anchor": [
+        -1.6,
+        2.16,
+        0.3
+      ],
+      "role": "value",
+      "radius": 0.32
+    },
+    {
+      "text": "65%",
+      "anchor": [
+        -0.8,
+        2.05,
+        0.3
+      ],
+      "role": "value",
+      "radius": 0.32
+    },
+    {
+      "text": "85%",
+      "anchor": [
+        0,
+        2.4899999999999998,
+        0.3
+      ],
+      "role": "value",
+      "radius": 0.32
+    },
+    {
+      "text": "80%",
+      "anchor": [
+        0.8000000000000003,
+        2.38,
+        0.3
+      ],
+      "role": "value",
+      "radius": 0.32
+    },
+    {
+      "text": "90%",
+      "anchor": [
+        1.6,
+        2.6,
+        0.3
+      ],
+      "role": "value",
+      "radius": 0.32
+    }
+  ],
+  "cameraSequence": {
+    "loop": false,
+    "shots": [
+      {
+        "duration": 0.01,
+        "pos": [
+          1,
+          2.1,
+          9.799999999999999
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 50,
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      },
+      {
+        "duration": 13,
+        "pos": [
+          0,
+          1.8,
+          8.2
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 46,
+        "transition": "blend",
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      }
+    ]
+  },
+  "defaults": {
+    "stage": {
+      "size": [
+        18,
+        9,
+        11
+      ]
+    }
+  }
+}

--- a/sdf-js/scenes/rec-journey-5.json
+++ b/sdf-js/scenes/rec-journey-5.json
@@ -1,0 +1,137 @@
+{
+  "v": 1,
+  "name": "(lifted) journey-Conversion Funnel",
+  "subjects": [
+    {
+      "id": "funnel",
+      "type": "funnel-3d",
+      "args": {
+        "stages": 4,
+        "topRadius": 1.15,
+        "bottomRadius": 0.28,
+        "stageHeight": 0.55,
+        "gap": 0.1
+      },
+      "transform": {
+        "translate": [
+          -0.3,
+          1.6,
+          0
+        ],
+        "rotate": [
+          0.12,
+          0,
+          0
+        ]
+      },
+      "material": {
+        "hue": 0.57,
+        "sat": 0.55,
+        "value": 0.64,
+        "kind": "normal",
+        "roughness": 0.3,
+        "clearcoat": 0.45
+      }
+    }
+  ],
+  "overlay": [
+    {
+      "text": "CONVERSION",
+      "anchor": [
+        0,
+        3.9,
+        0
+      ],
+      "role": "title"
+    },
+    {
+      "text": "Visitors",
+      "anchor": [
+        3,
+        2.6,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "Leads",
+      "anchor": [
+        3,
+        1.8800000000000001,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "Customers",
+      "anchor": [
+        3,
+        1.1600000000000001,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "Advocates",
+      "anchor": [
+        3,
+        0.43999999999999995,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    }
+  ],
+  "cameraSequence": {
+    "loop": false,
+    "shots": [
+      {
+        "duration": 0.01,
+        "pos": [
+          1,
+          2.1,
+          9.799999999999999
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 50,
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      },
+      {
+        "duration": 13,
+        "pos": [
+          0,
+          1.8,
+          8.2
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 46,
+        "transition": "blend",
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      }
+    ]
+  },
+  "defaults": {
+    "stage": {
+      "size": [
+        18,
+        9,
+        11
+      ]
+    }
+  }
+}

--- a/sdf-js/scenes/rec-pitch-1.json
+++ b/sdf-js/scenes/rec-pitch-1.json
@@ -1,0 +1,139 @@
+{
+  "v": 1,
+  "name": "(lifted) pitch-Ecosystem",
+  "subjects": [
+    {
+      "id": "sphere-network",
+      "type": "sphere-network-3d",
+      "args": {
+        "count": 5,
+        "arrangement": "sphere"
+      },
+      "transform": {
+        "translate": [
+          0,
+          1.8,
+          0
+        ]
+      },
+      "material": {
+        "hue": 0.57,
+        "sat": 0.55,
+        "value": 0.64,
+        "kind": "normal",
+        "roughness": 0.3,
+        "clearcoat": 0.45
+      }
+    }
+  ],
+  "overlay": [
+    {
+      "text": "STARTUP PITCH",
+      "anchor": [
+        0,
+        3.9,
+        0
+      ],
+      "role": "title"
+    },
+    {
+      "text": "Customers",
+      "anchor": [
+        3,
+        2.6,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "Market",
+      "anchor": [
+        3,
+        1.8800000000000001,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "Team",
+      "anchor": [
+        3,
+        1.1600000000000001,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "Investors",
+      "anchor": [
+        3,
+        0.43999999999999995,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "Partners",
+      "anchor": [
+        3,
+        -0.2799999999999998,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    }
+  ],
+  "cameraSequence": {
+    "loop": false,
+    "shots": [
+      {
+        "duration": 0.01,
+        "pos": [
+          1,
+          2.1,
+          9.799999999999999
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 50,
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      },
+      {
+        "duration": 13,
+        "pos": [
+          0,
+          1.8,
+          8.2
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 46,
+        "transition": "blend",
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      }
+    ]
+  },
+  "defaults": {
+    "stage": {
+      "size": [
+        18,
+        9,
+        11
+      ]
+    }
+  }
+}

--- a/sdf-js/scenes/rec-pitch-2.json
+++ b/sdf-js/scenes/rec-pitch-2.json
@@ -1,0 +1,137 @@
+{
+  "v": 1,
+  "name": "(lifted) pitch-Problem → Solution",
+  "subjects": [
+    {
+      "id": "funnel",
+      "type": "funnel-3d",
+      "args": {
+        "stages": 4,
+        "topRadius": 1.15,
+        "bottomRadius": 0.28,
+        "stageHeight": 0.55,
+        "gap": 0.1
+      },
+      "transform": {
+        "translate": [
+          -0.3,
+          1.6,
+          0
+        ],
+        "rotate": [
+          0.12,
+          0,
+          0
+        ]
+      },
+      "material": {
+        "hue": 0.57,
+        "sat": 0.55,
+        "value": 0.64,
+        "kind": "normal",
+        "roughness": 0.3,
+        "clearcoat": 0.45
+      }
+    }
+  ],
+  "overlay": [
+    {
+      "text": "PROBLEM → SOLUTION",
+      "anchor": [
+        0,
+        3.9,
+        0
+      ],
+      "role": "title"
+    },
+    {
+      "text": "Pain",
+      "anchor": [
+        3,
+        2.6,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "Insight",
+      "anchor": [
+        3,
+        1.8800000000000001,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "Solution",
+      "anchor": [
+        3,
+        1.1600000000000001,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "Wedge",
+      "anchor": [
+        3,
+        0.43999999999999995,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    }
+  ],
+  "cameraSequence": {
+    "loop": false,
+    "shots": [
+      {
+        "duration": 0.01,
+        "pos": [
+          1,
+          2.1,
+          9.799999999999999
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 50,
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      },
+      {
+        "duration": 13,
+        "pos": [
+          0,
+          1.8,
+          8.2
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 46,
+        "transition": "blend",
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      }
+    ]
+  },
+  "defaults": {
+    "stage": {
+      "size": [
+        18,
+        9,
+        11
+      ]
+    }
+  }
+}

--- a/sdf-js/scenes/rec-pitch-3.json
+++ b/sdf-js/scenes/rec-pitch-3.json
@@ -1,0 +1,118 @@
+{
+  "v": 1,
+  "name": "(lifted) pitch-Market Size",
+  "subjects": [
+    {
+      "id": "circle-stack",
+      "type": "circle-stack-3d",
+      "args": {
+        "count": 3
+      },
+      "transform": {
+        "translate": [
+          0,
+          1.4,
+          0
+        ]
+      },
+      "material": {
+        "hue": 0.57,
+        "sat": 0.55,
+        "value": 0.64,
+        "kind": "normal",
+        "roughness": 0.3,
+        "clearcoat": 0.45
+      }
+    }
+  ],
+  "overlay": [
+    {
+      "text": "TAM / SAM / SOM",
+      "anchor": [
+        0,
+        3.9,
+        0
+      ],
+      "role": "title"
+    },
+    {
+      "text": "TAM",
+      "anchor": [
+        3,
+        2.6,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "SAM",
+      "anchor": [
+        3,
+        1.8800000000000001,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "SOM",
+      "anchor": [
+        3,
+        1.1600000000000001,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    }
+  ],
+  "cameraSequence": {
+    "loop": false,
+    "shots": [
+      {
+        "duration": 0.01,
+        "pos": [
+          1,
+          2.1,
+          9.799999999999999
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 50,
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      },
+      {
+        "duration": 13,
+        "pos": [
+          0,
+          1.8,
+          8.2
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 46,
+        "transition": "blend",
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      }
+    ]
+  },
+  "defaults": {
+    "stage": {
+      "size": [
+        18,
+        9,
+        11
+      ]
+    }
+  }
+}

--- a/sdf-js/scenes/rec-pitch-4.json
+++ b/sdf-js/scenes/rec-pitch-4.json
@@ -1,0 +1,137 @@
+{
+  "v": 1,
+  "name": "(lifted) pitch-Traction",
+  "subjects": [
+    {
+      "id": "bar",
+      "type": "bar-3d",
+      "args": {
+        "values": [
+          0.175,
+          0.2875,
+          0.55,
+          1
+        ],
+        "barWidth": 0.55,
+        "barDepth": 0.55,
+        "gap": 0.25,
+        "maxHeight": 2.2
+      },
+      "transform": {
+        "translate": [
+          0,
+          0.15,
+          0
+        ]
+      },
+      "material": {
+        "hue": 0.57,
+        "sat": 0.55,
+        "value": 0.64,
+        "kind": "normal",
+        "roughness": 0.3,
+        "clearcoat": 0.45
+      }
+    }
+  ],
+  "overlay": [
+    {
+      "text": "TRACTION",
+      "anchor": [
+        0,
+        3.9,
+        0
+      ],
+      "role": "title"
+    },
+    {
+      "text": "10",
+      "anchor": [
+        -1.2000000000000002,
+        0.785,
+        0.3
+      ],
+      "role": "value",
+      "radius": 0.32
+    },
+    {
+      "text": "25",
+      "anchor": [
+        -0.40000000000000013,
+        1.0325,
+        0.3
+      ],
+      "role": "value",
+      "radius": 0.32
+    },
+    {
+      "text": "60",
+      "anchor": [
+        0.3999999999999999,
+        1.61,
+        0.3
+      ],
+      "role": "value",
+      "radius": 0.32
+    },
+    {
+      "text": "120",
+      "anchor": [
+        1.2000000000000002,
+        2.6,
+        0.3
+      ],
+      "role": "value",
+      "radius": 0.32
+    }
+  ],
+  "cameraSequence": {
+    "loop": false,
+    "shots": [
+      {
+        "duration": 0.01,
+        "pos": [
+          1,
+          2.1,
+          9.799999999999999
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 50,
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      },
+      {
+        "duration": 13,
+        "pos": [
+          0,
+          1.8,
+          8.2
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 46,
+        "transition": "blend",
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      }
+    ]
+  },
+  "defaults": {
+    "stage": {
+      "size": [
+        18,
+        9,
+        11
+      ]
+    }
+  }
+}

--- a/sdf-js/scenes/rec-pitch-5.json
+++ b/sdf-js/scenes/rec-pitch-5.json
@@ -1,0 +1,132 @@
+{
+  "v": 1,
+  "name": "(lifted) pitch-Roadmap",
+  "subjects": [
+    {
+      "id": "timeline",
+      "type": "timeline-3d",
+      "args": {
+        "count": 4,
+        "axisLength": 4.2,
+        "axisRadius": 0.06,
+        "markerRadius": 0.2,
+        "stemHeight": 0.55
+      },
+      "transform": {
+        "translate": [
+          0,
+          1.4,
+          0
+        ]
+      },
+      "material": {
+        "hue": 0.57,
+        "sat": 0.55,
+        "value": 0.64,
+        "kind": "normal",
+        "roughness": 0.3,
+        "clearcoat": 0.45
+      }
+    }
+  ],
+  "overlay": [
+    {
+      "text": "ROADMAP",
+      "anchor": [
+        0,
+        3.9,
+        0
+      ],
+      "role": "title"
+    },
+    {
+      "text": "Seed",
+      "anchor": [
+        -2.1,
+        2.25,
+        0
+      ],
+      "role": "value",
+      "radius": 0.34
+    },
+    {
+      "text": "Series A",
+      "anchor": [
+        -0.7,
+        2.25,
+        0
+      ],
+      "role": "value",
+      "radius": 0.34
+    },
+    {
+      "text": "Scale",
+      "anchor": [
+        0.7000000000000002,
+        2.25,
+        0
+      ],
+      "role": "value",
+      "radius": 0.34
+    },
+    {
+      "text": "Series B",
+      "anchor": [
+        2.1,
+        2.25,
+        0
+      ],
+      "role": "value",
+      "radius": 0.34
+    }
+  ],
+  "cameraSequence": {
+    "loop": false,
+    "shots": [
+      {
+        "duration": 0.01,
+        "pos": [
+          1,
+          2.1,
+          9.799999999999999
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 50,
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      },
+      {
+        "duration": 13,
+        "pos": [
+          0,
+          1.8,
+          8.2
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 46,
+        "transition": "blend",
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      }
+    ]
+  },
+  "defaults": {
+    "stage": {
+      "size": [
+        18,
+        9,
+        11
+      ]
+    }
+  }
+}

--- a/sdf-js/scripts/lift-rec-round2.mjs
+++ b/sdf-js/scripts/lift-rec-round2.mjs
@@ -1,0 +1,68 @@
+// lift-rec-round2.mjs — PL "recommendations" round 2 (5 templates). Data → twin map.
+import { writeFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+import { liftSceneData2dTo3d } from '../src/scene/lift-2d-to-3d.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const SCENES = resolve(__dirname, '../scenes');
+
+const DECKS = [
+  {
+    id: 'consulting', name: 'Consulting Toolbox', slides: [
+      { title: 'Toolbox', type: 'radial-spoke', args: { title: 'Consulting Toolbox', values: [1, 1, 1, 1, 1, 1], labels: ['SWOT', 'Porter 5F', 'BCG', 'Value Chain', 'McKinsey 7S', 'Ansoff'] } },
+      { title: '2x2 Matrix', type: 'matrix-grid', args: { title: 'Priority Matrix', rows: 2, cols: 2 } },
+      { title: 'Value Chain', type: 'progression', args: { title: 'Value Chain', steps: [{ label: 'Inbound' }, { label: 'Operations' }, { label: 'Outbound' }, { label: 'Marketing' }, { label: 'Service' }] } },
+      { title: 'Pyramid Principle', type: 'pyramid', args: { title: 'Pyramid Principle', layers: [{ label: 'Recommendation' }, { label: 'Arguments' }, { label: 'Evidence' }] } },
+      { title: 'Engagement Plan', type: 'timeline', args: { title: 'Engagement Plan', events: [{ label: 'Scope' }, { label: 'Analyze' }, { label: 'Recommend' }, { label: 'Implement' }] } },
+    ],
+  },
+  {
+    id: 'cyber', name: 'Cybersecurity', slides: [
+      { title: 'Threat Landscape', type: 'sphere-network', args: { title: 'Cybersecurity', hub: 'Assets', satellites: [{ label: 'Malware' }, { label: 'Phishing' }, { label: 'Ransomware' }, { label: 'Insider' }, { label: 'DDoS' }] } },
+      { title: 'Defense in Depth', type: 'layer-stack', args: { title: 'Defense in Depth', layers: [{ label: 'Perimeter' }, { label: 'Network' }, { label: 'Endpoint' }, { label: 'Application' }, { label: 'Data' }] } },
+      { title: 'Threat Funnel', type: 'funnel', args: { title: 'Attack Funnel', stages: [{ label: 'Attempts' }, { label: 'Detected' }, { label: 'Contained' }, { label: 'Breached' }] } },
+      { title: 'Maturity', type: 'pyramid', args: { title: 'Security Maturity', layers: [{ label: 'Adaptive' }, { label: 'Proactive' }, { label: 'Reactive' }, { label: 'Initial' }] } },
+      { title: 'Incident Response', type: 'progression', args: { title: 'Incident Response', steps: [{ label: 'Identify' }, { label: 'Contain' }, { label: 'Eradicate' }, { label: 'Recover' }] } },
+    ],
+  },
+  {
+    id: 'bizplan', name: 'Business Plan', slides: [
+      { title: 'Strategy Pyramid', type: 'pyramid', args: { title: 'Business Plan', layers: [{ label: 'Vision' }, { label: 'Strategy' }, { label: 'Tactics' }, { label: 'Operations' }] } },
+      { title: 'Milestones', type: 'timeline', args: { title: 'Milestones', events: [{ label: 'Found' }, { label: 'MVP' }, { label: 'Launch' }, { label: 'Scale' }, { label: 'Exit' }] } },
+      { title: 'Revenue Plan', type: 'bar', args: { title: 'Revenue Plan', values: [20, 45, 80, 130, 200], labels: ['Y1', 'Y2', 'Y3', 'Y4', 'Y5'], format: 'currency' } },
+      { title: 'Market Mix', type: 'pie', args: { title: 'Market Segments', values: [45, 30, 25], labels: ['Enterprise', 'SMB', 'Consumer'], format: 'percent' } },
+      { title: 'Sales Funnel', type: 'funnel', args: { title: 'Sales Funnel', stages: [{ label: 'Leads' }, { label: 'Qualified' }, { label: 'Proposal' }, { label: 'Closed' }] } },
+    ],
+  },
+  {
+    id: 'journey', name: 'Customer Journey / Experience Map', slides: [
+      { title: 'Journey', type: 'timeline', args: { title: 'Customer Journey', events: [{ label: 'Awareness' }, { label: 'Consideration' }, { label: 'Purchase' }, { label: 'Retention' }, { label: 'Advocacy' }] } },
+      { title: 'Stages', type: 'progression', args: { title: 'Experience Stages', steps: [{ label: 'Discover' }, { label: 'Evaluate' }, { label: 'Buy' }, { label: 'Use' }, { label: 'Recommend' }] } },
+      { title: 'Touchpoints', type: 'radial-spoke', args: { title: 'Touchpoints', values: [1, 1, 1, 1, 1], labels: ['Web', 'Social', 'Store', 'Support', 'Email'] } },
+      { title: 'Satisfaction', type: 'bar', args: { title: 'Satisfaction by Stage', values: [70, 65, 85, 80, 90], labels: ['Aware', 'Eval', 'Buy', 'Use', 'Refer'], format: 'percent' } },
+      { title: 'Conversion Funnel', type: 'funnel', args: { title: 'Conversion', stages: [{ label: 'Visitors' }, { label: 'Leads' }, { label: 'Customers' }, { label: 'Advocates' }] } },
+    ],
+  },
+  {
+    id: 'pitch', name: 'Startup Pitch Deck', slides: [
+      { title: 'Ecosystem', type: 'sphere-network', args: { title: 'Startup Pitch', hub: 'Product', satellites: [{ label: 'Customers' }, { label: 'Market' }, { label: 'Team' }, { label: 'Investors' }, { label: 'Partners' }] } },
+      { title: 'Problem → Solution', type: 'funnel', args: { title: 'Problem → Solution', stages: [{ label: 'Pain' }, { label: 'Insight' }, { label: 'Solution' }, { label: 'Wedge' }] } },
+      { title: 'Market Size', type: 'circle-stack', args: { title: 'TAM / SAM / SOM', layers: [{ label: 'TAM' }, { label: 'SAM' }, { label: 'SOM' }] } },
+      { title: 'Traction', type: 'bar', args: { title: 'Traction', values: [10, 25, 60, 120], labels: ['Q1', 'Q2', 'Q3', 'Q4'], format: 'number' } },
+      { title: 'Roadmap', type: 'timeline', args: { title: 'Roadmap', events: [{ label: 'Seed' }, { label: 'Series A' }, { label: 'Scale' }, { label: 'Series B' }] } },
+    ],
+  },
+];
+
+for (const deck of DECKS) {
+  const segments = [];
+  deck.slides.forEach((slide, i) => {
+    const scene = liftSceneData2dTo3d({ name: `${deck.id}-${slide.title}`, subjects: [{ type: slide.type, args: slide.args }] });
+    const file = `rec-${deck.id}-${i + 1}.json`;
+    writeFileSync(resolve(SCENES, file), `${JSON.stringify(scene, null, 2)}\n`);
+    segments.push({ file, title: slide.title, kind: 'slide', durationSec: 7 });
+  });
+  writeFileSync(resolve(SCENES, `deck-rec-${deck.id}.json`), `${JSON.stringify({ id: `deck-rec-${deck.id}`, name: deck.name, segments }, null, 2)}\n`);
+  console.log(`  ✓ ${deck.name.padEnd(34)} → ?deck=deck-rec-${deck.id}`);
+}


### PR DESCRIPTION
Round 2/5。5 个商业模板 → 3D 叙事 deck,纯数据 lift。

- `?deck=deck-rec-consulting` —— Consulting Toolbox
- `?deck=deck-rec-cyber` —— Cybersecurity
- `?deck=deck-rec-bizplan` —— Business Plan
- `?deck=deck-rec-journey` —— Customer Journey / Experience Map
- `?deck=deck-rec-pitch` —— Startup Pitch Deck

25 slide 全编译;matrix-grid 渲染验证。`npm test` 99/99。

🤖 Generated with [Claude Code](https://claude.com/claude-code)