### PR TITLE
feat(present): PL recommendations decks — round 3 (PM / Leadership / IT / Marketing / Strategy)

### DIFF
--- a/sdf-js/scenes/deck-rec-itstrategy.json
+++ b/sdf-js/scenes/deck-rec-itstrategy.json
@@ -1,0 +1,36 @@
+{
+  "id": "deck-rec-itstrategy",
+  "name": "IT Strategy",
+  "segments": [
+    {
+      "file": "rec-itstrategy-1.json",
+      "title": "IT Stack",
+      "kind": "slide",
+      "durationSec": 7
+    },
+    {
+      "file": "rec-itstrategy-2.json",
+      "title": "Roadmap",
+      "kind": "slide",
+      "durationSec": 7
+    },
+    {
+      "file": "rec-itstrategy-3.json",
+      "title": "Capabilities",
+      "kind": "slide",
+      "durationSec": 7
+    },
+    {
+      "file": "rec-itstrategy-4.json",
+      "title": "Maturity",
+      "kind": "slide",
+      "durationSec": 7
+    },
+    {
+      "file": "rec-itstrategy-5.json",
+      "title": "Portfolio",
+      "kind": "slide",
+      "durationSec": 7
+    }
+  ]
+}

--- a/sdf-js/scenes/deck-rec-leadership.json
+++ b/sdf-js/scenes/deck-rec-leadership.json
@@ -1,0 +1,36 @@
+{
+  "id": "deck-rec-leadership",
+  "name": "Leadership Toolbox",
+  "segments": [
+    {
+      "file": "rec-leadership-1.json",
+      "title": "Styles",
+      "kind": "slide",
+      "durationSec": 7
+    },
+    {
+      "file": "rec-leadership-2.json",
+      "title": "Situational",
+      "kind": "slide",
+      "durationSec": 7
+    },
+    {
+      "file": "rec-leadership-3.json",
+      "title": "Development",
+      "kind": "slide",
+      "durationSec": 7
+    },
+    {
+      "file": "rec-leadership-4.json",
+      "title": "Maturity",
+      "kind": "slide",
+      "durationSec": 7
+    },
+    {
+      "file": "rec-leadership-5.json",
+      "title": "Team Network",
+      "kind": "slide",
+      "durationSec": 7
+    }
+  ]
+}

--- a/sdf-js/scenes/deck-rec-marketing.json
+++ b/sdf-js/scenes/deck-rec-marketing.json
@@ -1,0 +1,36 @@
+{
+  "id": "deck-rec-marketing",
+  "name": "Marketing Toolbox",
+  "segments": [
+    {
+      "file": "rec-marketing-1.json",
+      "title": "Marketing Mix",
+      "kind": "slide",
+      "durationSec": 7
+    },
+    {
+      "file": "rec-marketing-2.json",
+      "title": "AIDA Funnel",
+      "kind": "slide",
+      "durationSec": 7
+    },
+    {
+      "file": "rec-marketing-3.json",
+      "title": "Channel Mix",
+      "kind": "slide",
+      "durationSec": 7
+    },
+    {
+      "file": "rec-marketing-4.json",
+      "title": "Campaign",
+      "kind": "slide",
+      "durationSec": 7
+    },
+    {
+      "file": "rec-marketing-5.json",
+      "title": "Segments",
+      "kind": "slide",
+      "durationSec": 7
+    }
+  ]
+}

--- a/sdf-js/scenes/deck-rec-pmtoolbox.json
+++ b/sdf-js/scenes/deck-rec-pmtoolbox.json
@@ -1,0 +1,36 @@
+{
+  "id": "deck-rec-pmtoolbox",
+  "name": "Project Management Toolbox",
+  "segments": [
+    {
+      "file": "rec-pmtoolbox-1.json",
+      "title": "PM Toolbox",
+      "kind": "slide",
+      "durationSec": 7
+    },
+    {
+      "file": "rec-pmtoolbox-2.json",
+      "title": "Schedule",
+      "kind": "slide",
+      "durationSec": 7
+    },
+    {
+      "file": "rec-pmtoolbox-3.json",
+      "title": "Phases",
+      "kind": "slide",
+      "durationSec": 7
+    },
+    {
+      "file": "rec-pmtoolbox-4.json",
+      "title": "Milestones",
+      "kind": "slide",
+      "durationSec": 7
+    },
+    {
+      "file": "rec-pmtoolbox-5.json",
+      "title": "Risk Matrix",
+      "kind": "slide",
+      "durationSec": 7
+    }
+  ]
+}

--- a/sdf-js/scenes/deck-rec-strategy.json
+++ b/sdf-js/scenes/deck-rec-strategy.json
@@ -1,0 +1,36 @@
+{
+  "id": "deck-rec-strategy",
+  "name": "Strategy Toolbox",
+  "segments": [
+    {
+      "file": "rec-strategy-1.json",
+      "title": "Frameworks",
+      "kind": "slide",
+      "durationSec": 7
+    },
+    {
+      "file": "rec-strategy-2.json",
+      "title": "SWOT",
+      "kind": "slide",
+      "durationSec": 7
+    },
+    {
+      "file": "rec-strategy-3.json",
+      "title": "Growth Options",
+      "kind": "slide",
+      "durationSec": 7
+    },
+    {
+      "file": "rec-strategy-4.json",
+      "title": "Strategy Pyramid",
+      "kind": "slide",
+      "durationSec": 7
+    },
+    {
+      "file": "rec-strategy-5.json",
+      "title": "Roadmap",
+      "kind": "slide",
+      "durationSec": 7
+    }
+  ]
+}

--- a/sdf-js/scenes/rec-itstrategy-1.json
+++ b/sdf-js/scenes/rec-itstrategy-1.json
@@ -1,0 +1,138 @@
+{
+  "v": 1,
+  "name": "(lifted) itstrategy-IT Stack",
+  "subjects": [
+    {
+      "id": "layer-stack",
+      "type": "layer-stack-3d",
+      "args": {
+        "layers": 4,
+        "layerW": 2.4,
+        "layerD": 1.5,
+        "layerH": 0.28,
+        "gap": 0.45,
+        "taper": 1
+      },
+      "transform": {
+        "translate": [
+          -0.3,
+          1.4,
+          0
+        ],
+        "rotate": [
+          0.35,
+          0.5,
+          0
+        ]
+      },
+      "material": {
+        "hue": 0.57,
+        "sat": 0.55,
+        "value": 0.64,
+        "kind": "normal",
+        "roughness": 0.3,
+        "clearcoat": 0.45
+      }
+    }
+  ],
+  "overlay": [
+    {
+      "text": "IT STRATEGY",
+      "anchor": [
+        0,
+        3.9,
+        0
+      ],
+      "role": "title"
+    },
+    {
+      "text": "Applications",
+      "anchor": [
+        3,
+        2.6,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "Data",
+      "anchor": [
+        3,
+        1.8800000000000001,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "Infrastructure",
+      "anchor": [
+        3,
+        1.1600000000000001,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "Security",
+      "anchor": [
+        3,
+        0.43999999999999995,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    }
+  ],
+  "cameraSequence": {
+    "loop": false,
+    "shots": [
+      {
+        "duration": 0.01,
+        "pos": [
+          1,
+          2.1,
+          9.799999999999999
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 50,
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      },
+      {
+        "duration": 13,
+        "pos": [
+          0,
+          1.8,
+          8.2
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 46,
+        "transition": "blend",
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      }
+    ]
+  },
+  "defaults": {
+    "stage": {
+      "size": [
+        18,
+        9,
+        11
+      ]
+    }
+  }
+}

--- a/sdf-js/scenes/rec-itstrategy-2.json
+++ b/sdf-js/scenes/rec-itstrategy-2.json
@@ -1,0 +1,132 @@
+{
+  "v": 1,
+  "name": "(lifted) itstrategy-Roadmap",
+  "subjects": [
+    {
+      "id": "timeline",
+      "type": "timeline-3d",
+      "args": {
+        "count": 4,
+        "axisLength": 4.2,
+        "axisRadius": 0.06,
+        "markerRadius": 0.2,
+        "stemHeight": 0.55
+      },
+      "transform": {
+        "translate": [
+          0,
+          1.4,
+          0
+        ]
+      },
+      "material": {
+        "hue": 0.57,
+        "sat": 0.55,
+        "value": 0.64,
+        "kind": "normal",
+        "roughness": 0.3,
+        "clearcoat": 0.45
+      }
+    }
+  ],
+  "overlay": [
+    {
+      "text": "IT ROADMAP",
+      "anchor": [
+        0,
+        3.9,
+        0
+      ],
+      "role": "title"
+    },
+    {
+      "text": "Assess",
+      "anchor": [
+        -2.1,
+        2.25,
+        0
+      ],
+      "role": "value",
+      "radius": 0.34
+    },
+    {
+      "text": "Modernize",
+      "anchor": [
+        -0.7,
+        2.25,
+        0
+      ],
+      "role": "value",
+      "radius": 0.34
+    },
+    {
+      "text": "Migrate",
+      "anchor": [
+        0.7000000000000002,
+        2.25,
+        0
+      ],
+      "role": "value",
+      "radius": 0.34
+    },
+    {
+      "text": "Optimize",
+      "anchor": [
+        2.1,
+        2.25,
+        0
+      ],
+      "role": "value",
+      "radius": 0.34
+    }
+  ],
+  "cameraSequence": {
+    "loop": false,
+    "shots": [
+      {
+        "duration": 0.01,
+        "pos": [
+          1,
+          2.1,
+          9.799999999999999
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 50,
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      },
+      {
+        "duration": 13,
+        "pos": [
+          0,
+          1.8,
+          8.2
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 46,
+        "transition": "blend",
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      }
+    ]
+  },
+  "defaults": {
+    "stage": {
+      "size": [
+        18,
+        9,
+        11
+      ]
+    }
+  }
+}

--- a/sdf-js/scenes/rec-itstrategy-3.json
+++ b/sdf-js/scenes/rec-itstrategy-3.json
@@ -1,0 +1,138 @@
+{
+  "v": 1,
+  "name": "(lifted) itstrategy-Capabilities",
+  "subjects": [
+    {
+      "id": "radial-spoke",
+      "type": "radial-spoke-3d",
+      "args": {
+        "spokes": 5
+      },
+      "transform": {
+        "translate": [
+          0,
+          1.7,
+          0
+        ]
+      },
+      "material": {
+        "hue": 0.57,
+        "sat": 0.55,
+        "value": 0.64,
+        "kind": "normal",
+        "roughness": 0.3,
+        "clearcoat": 0.45
+      }
+    }
+  ],
+  "overlay": [
+    {
+      "text": "IT CAPABILITIES",
+      "anchor": [
+        0,
+        3.9,
+        0
+      ],
+      "role": "title"
+    },
+    {
+      "text": "Cloud 1",
+      "anchor": [
+        3,
+        2.6,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "Data 1",
+      "anchor": [
+        3,
+        1.8800000000000001,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "Security 1",
+      "anchor": [
+        3,
+        1.1600000000000001,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "DevOps 1",
+      "anchor": [
+        3,
+        0.43999999999999995,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "AI 1",
+      "anchor": [
+        3,
+        -0.2799999999999998,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    }
+  ],
+  "cameraSequence": {
+    "loop": false,
+    "shots": [
+      {
+        "duration": 0.01,
+        "pos": [
+          1,
+          2.1,
+          9.799999999999999
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 50,
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      },
+      {
+        "duration": 13,
+        "pos": [
+          0,
+          1.8,
+          8.2
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 46,
+        "transition": "blend",
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      }
+    ]
+  },
+  "defaults": {
+    "stage": {
+      "size": [
+        18,
+        9,
+        11
+      ]
+    }
+  }
+}

--- a/sdf-js/scenes/rec-itstrategy-4.json
+++ b/sdf-js/scenes/rec-itstrategy-4.json
@@ -1,0 +1,128 @@
+{
+  "v": 1,
+  "name": "(lifted) itstrategy-Maturity",
+  "subjects": [
+    {
+      "id": "pyramid",
+      "type": "pyramid-3d",
+      "args": {
+        "levels": 4
+      },
+      "transform": {
+        "translate": [
+          0,
+          0.6,
+          0
+        ]
+      },
+      "material": {
+        "hue": 0.57,
+        "sat": 0.55,
+        "value": 0.64,
+        "kind": "normal",
+        "roughness": 0.3,
+        "clearcoat": 0.45
+      }
+    }
+  ],
+  "overlay": [
+    {
+      "text": "IT MATURITY",
+      "anchor": [
+        0,
+        3.9,
+        0
+      ],
+      "role": "title"
+    },
+    {
+      "text": "Optimized",
+      "anchor": [
+        3,
+        2.6,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "Managed",
+      "anchor": [
+        3,
+        1.8800000000000001,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "Defined",
+      "anchor": [
+        3,
+        1.1600000000000001,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "Ad-hoc",
+      "anchor": [
+        3,
+        0.43999999999999995,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    }
+  ],
+  "cameraSequence": {
+    "loop": false,
+    "shots": [
+      {
+        "duration": 0.01,
+        "pos": [
+          1,
+          2.1,
+          9.799999999999999
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 50,
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      },
+      {
+        "duration": 13,
+        "pos": [
+          0,
+          1.8,
+          8.2
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 46,
+        "transition": "blend",
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      }
+    ]
+  },
+  "defaults": {
+    "stage": {
+      "size": [
+        18,
+        9,
+        11
+      ]
+    }
+  }
+}

--- a/sdf-js/scenes/rec-itstrategy-5.json
+++ b/sdf-js/scenes/rec-itstrategy-5.json
@@ -1,0 +1,89 @@
+{
+  "v": 1,
+  "name": "(lifted) itstrategy-Portfolio",
+  "subjects": [
+    {
+      "id": "matrix-grid",
+      "type": "matrix-grid-3d",
+      "args": {
+        "rows": 2,
+        "cols": 2
+      },
+      "transform": {
+        "translate": [
+          0,
+          1.8,
+          0
+        ]
+      },
+      "material": {
+        "hue": 0.57,
+        "sat": 0.55,
+        "value": 0.64,
+        "kind": "normal",
+        "roughness": 0.3,
+        "clearcoat": 0.45
+      }
+    }
+  ],
+  "overlay": [
+    {
+      "text": "APP PORTFOLIO",
+      "anchor": [
+        0,
+        3.9,
+        0
+      ],
+      "role": "title"
+    }
+  ],
+  "cameraSequence": {
+    "loop": false,
+    "shots": [
+      {
+        "duration": 0.01,
+        "pos": [
+          1,
+          2.1,
+          9.799999999999999
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 50,
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      },
+      {
+        "duration": 13,
+        "pos": [
+          0,
+          1.8,
+          8.2
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 46,
+        "transition": "blend",
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      }
+    ]
+  },
+  "defaults": {
+    "stage": {
+      "size": [
+        18,
+        9,
+        11
+      ]
+    }
+  }
+}

--- a/sdf-js/scenes/rec-leadership-1.json
+++ b/sdf-js/scenes/rec-leadership-1.json
@@ -1,0 +1,138 @@
+{
+  "v": 1,
+  "name": "(lifted) leadership-Styles",
+  "subjects": [
+    {
+      "id": "radial-spoke",
+      "type": "radial-spoke-3d",
+      "args": {
+        "spokes": 5
+      },
+      "transform": {
+        "translate": [
+          0,
+          1.7,
+          0
+        ]
+      },
+      "material": {
+        "hue": 0.57,
+        "sat": 0.55,
+        "value": 0.64,
+        "kind": "normal",
+        "roughness": 0.3,
+        "clearcoat": 0.45
+      }
+    }
+  ],
+  "overlay": [
+    {
+      "text": "LEADERSHIP TOOLBOX",
+      "anchor": [
+        0,
+        3.9,
+        0
+      ],
+      "role": "title"
+    },
+    {
+      "text": "Visionary 1",
+      "anchor": [
+        3,
+        2.6,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "Coaching 1",
+      "anchor": [
+        3,
+        1.8800000000000001,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "Affiliative 1",
+      "anchor": [
+        3,
+        1.1600000000000001,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "Democratic 1",
+      "anchor": [
+        3,
+        0.43999999999999995,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "Commanding 1",
+      "anchor": [
+        3,
+        -0.2799999999999998,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    }
+  ],
+  "cameraSequence": {
+    "loop": false,
+    "shots": [
+      {
+        "duration": 0.01,
+        "pos": [
+          1,
+          2.1,
+          9.799999999999999
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 50,
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      },
+      {
+        "duration": 13,
+        "pos": [
+          0,
+          1.8,
+          8.2
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 46,
+        "transition": "blend",
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      }
+    ]
+  },
+  "defaults": {
+    "stage": {
+      "size": [
+        18,
+        9,
+        11
+      ]
+    }
+  }
+}

--- a/sdf-js/scenes/rec-leadership-2.json
+++ b/sdf-js/scenes/rec-leadership-2.json
@@ -1,0 +1,89 @@
+{
+  "v": 1,
+  "name": "(lifted) leadership-Situational",
+  "subjects": [
+    {
+      "id": "matrix-grid",
+      "type": "matrix-grid-3d",
+      "args": {
+        "rows": 2,
+        "cols": 2
+      },
+      "transform": {
+        "translate": [
+          0,
+          1.8,
+          0
+        ]
+      },
+      "material": {
+        "hue": 0.57,
+        "sat": 0.55,
+        "value": 0.64,
+        "kind": "normal",
+        "roughness": 0.3,
+        "clearcoat": 0.45
+      }
+    }
+  ],
+  "overlay": [
+    {
+      "text": "SITUATIONAL LEADERSHIP",
+      "anchor": [
+        0,
+        3.9,
+        0
+      ],
+      "role": "title"
+    }
+  ],
+  "cameraSequence": {
+    "loop": false,
+    "shots": [
+      {
+        "duration": 0.01,
+        "pos": [
+          1,
+          2.1,
+          9.799999999999999
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 50,
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      },
+      {
+        "duration": 13,
+        "pos": [
+          0,
+          1.8,
+          8.2
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 46,
+        "transition": "blend",
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      }
+    ]
+  },
+  "defaults": {
+    "stage": {
+      "size": [
+        18,
+        9,
+        11
+      ]
+    }
+  }
+}

--- a/sdf-js/scenes/rec-leadership-3.json
+++ b/sdf-js/scenes/rec-leadership-3.json
@@ -1,0 +1,128 @@
+{
+  "v": 1,
+  "name": "(lifted) leadership-Development",
+  "subjects": [
+    {
+      "id": "progression",
+      "type": "progression-3d",
+      "args": {
+        "steps": 4
+      },
+      "transform": {
+        "translate": [
+          -1,
+          0.6,
+          0
+        ]
+      },
+      "material": {
+        "hue": 0.57,
+        "sat": 0.55,
+        "value": 0.64,
+        "kind": "normal",
+        "roughness": 0.3,
+        "clearcoat": 0.45
+      }
+    }
+  ],
+  "overlay": [
+    {
+      "text": "LEADERSHIP DEVELOPMENT",
+      "anchor": [
+        0,
+        3.9,
+        0
+      ],
+      "role": "title"
+    },
+    {
+      "text": "Self",
+      "anchor": [
+        3,
+        2.6,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "Team",
+      "anchor": [
+        3,
+        1.8800000000000001,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "Org",
+      "anchor": [
+        3,
+        1.1600000000000001,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "Vision",
+      "anchor": [
+        3,
+        0.43999999999999995,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    }
+  ],
+  "cameraSequence": {
+    "loop": false,
+    "shots": [
+      {
+        "duration": 0.01,
+        "pos": [
+          1,
+          2.1,
+          9.799999999999999
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 50,
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      },
+      {
+        "duration": 13,
+        "pos": [
+          0,
+          1.8,
+          8.2
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 46,
+        "transition": "blend",
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      }
+    ]
+  },
+  "defaults": {
+    "stage": {
+      "size": [
+        18,
+        9,
+        11
+      ]
+    }
+  }
+}

--- a/sdf-js/scenes/rec-leadership-4.json
+++ b/sdf-js/scenes/rec-leadership-4.json
@@ -1,0 +1,128 @@
+{
+  "v": 1,
+  "name": "(lifted) leadership-Maturity",
+  "subjects": [
+    {
+      "id": "pyramid",
+      "type": "pyramid-3d",
+      "args": {
+        "levels": 4
+      },
+      "transform": {
+        "translate": [
+          0,
+          0.6,
+          0
+        ]
+      },
+      "material": {
+        "hue": 0.57,
+        "sat": 0.55,
+        "value": 0.64,
+        "kind": "normal",
+        "roughness": 0.3,
+        "clearcoat": 0.45
+      }
+    }
+  ],
+  "overlay": [
+    {
+      "text": "LEADERSHIP LEVELS",
+      "anchor": [
+        0,
+        3.9,
+        0
+      ],
+      "role": "title"
+    },
+    {
+      "text": "Executive",
+      "anchor": [
+        3,
+        2.6,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "Manager",
+      "anchor": [
+        3,
+        1.8800000000000001,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "Lead",
+      "anchor": [
+        3,
+        1.1600000000000001,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "Contributor",
+      "anchor": [
+        3,
+        0.43999999999999995,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    }
+  ],
+  "cameraSequence": {
+    "loop": false,
+    "shots": [
+      {
+        "duration": 0.01,
+        "pos": [
+          1,
+          2.1,
+          9.799999999999999
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 50,
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      },
+      {
+        "duration": 13,
+        "pos": [
+          0,
+          1.8,
+          8.2
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 46,
+        "transition": "blend",
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      }
+    ]
+  },
+  "defaults": {
+    "stage": {
+      "size": [
+        18,
+        9,
+        11
+      ]
+    }
+  }
+}

--- a/sdf-js/scenes/rec-leadership-5.json
+++ b/sdf-js/scenes/rec-leadership-5.json
@@ -1,0 +1,129 @@
+{
+  "v": 1,
+  "name": "(lifted) leadership-Team Network",
+  "subjects": [
+    {
+      "id": "sphere-network",
+      "type": "sphere-network-3d",
+      "args": {
+        "count": 4,
+        "arrangement": "sphere"
+      },
+      "transform": {
+        "translate": [
+          0,
+          1.8,
+          0
+        ]
+      },
+      "material": {
+        "hue": 0.57,
+        "sat": 0.55,
+        "value": 0.64,
+        "kind": "normal",
+        "roughness": 0.3,
+        "clearcoat": 0.45
+      }
+    }
+  ],
+  "overlay": [
+    {
+      "text": "TEAM",
+      "anchor": [
+        0,
+        3.9,
+        0
+      ],
+      "role": "title"
+    },
+    {
+      "text": "Eng",
+      "anchor": [
+        3,
+        2.6,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "Design",
+      "anchor": [
+        3,
+        1.8800000000000001,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "Product",
+      "anchor": [
+        3,
+        1.1600000000000001,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "Ops",
+      "anchor": [
+        3,
+        0.43999999999999995,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    }
+  ],
+  "cameraSequence": {
+    "loop": false,
+    "shots": [
+      {
+        "duration": 0.01,
+        "pos": [
+          1,
+          2.1,
+          9.799999999999999
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 50,
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      },
+      {
+        "duration": 13,
+        "pos": [
+          0,
+          1.8,
+          8.2
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 46,
+        "transition": "blend",
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      }
+    ]
+  },
+  "defaults": {
+    "stage": {
+      "size": [
+        18,
+        9,
+        11
+      ]
+    }
+  }
+}

--- a/sdf-js/scenes/rec-marketing-1.json
+++ b/sdf-js/scenes/rec-marketing-1.json
@@ -1,0 +1,128 @@
+{
+  "v": 1,
+  "name": "(lifted) marketing-Marketing Mix",
+  "subjects": [
+    {
+      "id": "radial-spoke",
+      "type": "radial-spoke-3d",
+      "args": {
+        "spokes": 4
+      },
+      "transform": {
+        "translate": [
+          0,
+          1.7,
+          0
+        ]
+      },
+      "material": {
+        "hue": 0.57,
+        "sat": 0.55,
+        "value": 0.64,
+        "kind": "normal",
+        "roughness": 0.3,
+        "clearcoat": 0.45
+      }
+    }
+  ],
+  "overlay": [
+    {
+      "text": "MARKETING TOOLBOX",
+      "anchor": [
+        0,
+        3.9,
+        0
+      ],
+      "role": "title"
+    },
+    {
+      "text": "Product 1",
+      "anchor": [
+        3,
+        2.6,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "Price 1",
+      "anchor": [
+        3,
+        1.8800000000000001,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "Place 1",
+      "anchor": [
+        3,
+        1.1600000000000001,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "Promotion 1",
+      "anchor": [
+        3,
+        0.43999999999999995,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    }
+  ],
+  "cameraSequence": {
+    "loop": false,
+    "shots": [
+      {
+        "duration": 0.01,
+        "pos": [
+          1,
+          2.1,
+          9.799999999999999
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 50,
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      },
+      {
+        "duration": 13,
+        "pos": [
+          0,
+          1.8,
+          8.2
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 46,
+        "transition": "blend",
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      }
+    ]
+  },
+  "defaults": {
+    "stage": {
+      "size": [
+        18,
+        9,
+        11
+      ]
+    }
+  }
+}

--- a/sdf-js/scenes/rec-marketing-2.json
+++ b/sdf-js/scenes/rec-marketing-2.json
@@ -1,0 +1,137 @@
+{
+  "v": 1,
+  "name": "(lifted) marketing-AIDA Funnel",
+  "subjects": [
+    {
+      "id": "funnel",
+      "type": "funnel-3d",
+      "args": {
+        "stages": 4,
+        "topRadius": 1.15,
+        "bottomRadius": 0.28,
+        "stageHeight": 0.55,
+        "gap": 0.1
+      },
+      "transform": {
+        "translate": [
+          -0.3,
+          1.6,
+          0
+        ],
+        "rotate": [
+          0.12,
+          0,
+          0
+        ]
+      },
+      "material": {
+        "hue": 0.57,
+        "sat": 0.55,
+        "value": 0.64,
+        "kind": "normal",
+        "roughness": 0.3,
+        "clearcoat": 0.45
+      }
+    }
+  ],
+  "overlay": [
+    {
+      "text": "AIDA",
+      "anchor": [
+        0,
+        3.9,
+        0
+      ],
+      "role": "title"
+    },
+    {
+      "text": "Attention",
+      "anchor": [
+        3,
+        2.6,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "Interest",
+      "anchor": [
+        3,
+        1.8800000000000001,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "Desire",
+      "anchor": [
+        3,
+        1.1600000000000001,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "Action",
+      "anchor": [
+        3,
+        0.43999999999999995,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    }
+  ],
+  "cameraSequence": {
+    "loop": false,
+    "shots": [
+      {
+        "duration": 0.01,
+        "pos": [
+          1,
+          2.1,
+          9.799999999999999
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 50,
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      },
+      {
+        "duration": 13,
+        "pos": [
+          0,
+          1.8,
+          8.2
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 46,
+        "transition": "blend",
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      }
+    ]
+  },
+  "defaults": {
+    "stage": {
+      "size": [
+        18,
+        9,
+        11
+      ]
+    }
+  }
+}

--- a/sdf-js/scenes/rec-marketing-3.json
+++ b/sdf-js/scenes/rec-marketing-3.json
@@ -1,0 +1,152 @@
+{
+  "v": 1,
+  "name": "(lifted) marketing-Channel Mix",
+  "subjects": [
+    {
+      "id": "pie",
+      "type": "pie-3d",
+      "args": {
+        "values": [
+          30,
+          25,
+          20,
+          15,
+          10
+        ],
+        "innerRadius": 0.55,
+        "outerRadius": 1.3,
+        "thickness": 0.45
+      },
+      "transform": {
+        "translate": [
+          0,
+          1.5,
+          0
+        ],
+        "rotate": [
+          1.2,
+          0,
+          0
+        ]
+      },
+      "material": {
+        "hue": 0.57,
+        "sat": 0.55,
+        "value": 0.64,
+        "kind": "normal",
+        "roughness": 0.3,
+        "clearcoat": 0.45
+      }
+    }
+  ],
+  "overlay": [
+    {
+      "text": "CHANNEL MIX",
+      "anchor": [
+        0,
+        3.9,
+        0
+      ],
+      "role": "title"
+    },
+    {
+      "text": "Search 30%",
+      "anchor": [
+        3,
+        2.6,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "Social 25%",
+      "anchor": [
+        3,
+        1.8800000000000001,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "Email 20%",
+      "anchor": [
+        3,
+        1.1600000000000001,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "Content 15%",
+      "anchor": [
+        3,
+        0.43999999999999995,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "Events 10%",
+      "anchor": [
+        3,
+        -0.2799999999999998,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    }
+  ],
+  "cameraSequence": {
+    "loop": false,
+    "shots": [
+      {
+        "duration": 0.01,
+        "pos": [
+          1,
+          2.1,
+          9.799999999999999
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 50,
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      },
+      {
+        "duration": 13,
+        "pos": [
+          0,
+          1.8,
+          8.2
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 46,
+        "transition": "blend",
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      }
+    ]
+  },
+  "defaults": {
+    "stage": {
+      "size": [
+        18,
+        9,
+        11
+      ]
+    }
+  }
+}

--- a/sdf-js/scenes/rec-marketing-4.json
+++ b/sdf-js/scenes/rec-marketing-4.json
@@ -1,0 +1,132 @@
+{
+  "v": 1,
+  "name": "(lifted) marketing-Campaign",
+  "subjects": [
+    {
+      "id": "timeline",
+      "type": "timeline-3d",
+      "args": {
+        "count": 4,
+        "axisLength": 4.2,
+        "axisRadius": 0.06,
+        "markerRadius": 0.2,
+        "stemHeight": 0.55
+      },
+      "transform": {
+        "translate": [
+          0,
+          1.4,
+          0
+        ]
+      },
+      "material": {
+        "hue": 0.57,
+        "sat": 0.55,
+        "value": 0.64,
+        "kind": "normal",
+        "roughness": 0.3,
+        "clearcoat": 0.45
+      }
+    }
+  ],
+  "overlay": [
+    {
+      "text": "CAMPAIGN CALENDAR",
+      "anchor": [
+        0,
+        3.9,
+        0
+      ],
+      "role": "title"
+    },
+    {
+      "text": "Tease",
+      "anchor": [
+        -2.1,
+        2.25,
+        0
+      ],
+      "role": "value",
+      "radius": 0.34
+    },
+    {
+      "text": "Launch",
+      "anchor": [
+        -0.7,
+        2.25,
+        0
+      ],
+      "role": "value",
+      "radius": 0.34
+    },
+    {
+      "text": "Sustain",
+      "anchor": [
+        0.7000000000000002,
+        2.25,
+        0
+      ],
+      "role": "value",
+      "radius": 0.34
+    },
+    {
+      "text": "Convert",
+      "anchor": [
+        2.1,
+        2.25,
+        0
+      ],
+      "role": "value",
+      "radius": 0.34
+    }
+  ],
+  "cameraSequence": {
+    "loop": false,
+    "shots": [
+      {
+        "duration": 0.01,
+        "pos": [
+          1,
+          2.1,
+          9.799999999999999
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 50,
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      },
+      {
+        "duration": 13,
+        "pos": [
+          0,
+          1.8,
+          8.2
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 46,
+        "transition": "blend",
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      }
+    ]
+  },
+  "defaults": {
+    "stage": {
+      "size": [
+        18,
+        9,
+        11
+      ]
+    }
+  }
+}

--- a/sdf-js/scenes/rec-marketing-5.json
+++ b/sdf-js/scenes/rec-marketing-5.json
@@ -1,0 +1,89 @@
+{
+  "v": 1,
+  "name": "(lifted) marketing-Segments",
+  "subjects": [
+    {
+      "id": "matrix-grid",
+      "type": "matrix-grid-3d",
+      "args": {
+        "rows": 2,
+        "cols": 3
+      },
+      "transform": {
+        "translate": [
+          0,
+          1.8,
+          0
+        ]
+      },
+      "material": {
+        "hue": 0.57,
+        "sat": 0.55,
+        "value": 0.64,
+        "kind": "normal",
+        "roughness": 0.3,
+        "clearcoat": 0.45
+      }
+    }
+  ],
+  "overlay": [
+    {
+      "text": "SEGMENT MATRIX",
+      "anchor": [
+        0,
+        3.9,
+        0
+      ],
+      "role": "title"
+    }
+  ],
+  "cameraSequence": {
+    "loop": false,
+    "shots": [
+      {
+        "duration": 0.01,
+        "pos": [
+          1,
+          2.1,
+          9.799999999999999
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 50,
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      },
+      {
+        "duration": 13,
+        "pos": [
+          0,
+          1.8,
+          8.2
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 46,
+        "transition": "blend",
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      }
+    ]
+  },
+  "defaults": {
+    "stage": {
+      "size": [
+        18,
+        9,
+        11
+      ]
+    }
+  }
+}

--- a/sdf-js/scenes/rec-pmtoolbox-1.json
+++ b/sdf-js/scenes/rec-pmtoolbox-1.json
@@ -1,0 +1,148 @@
+{
+  "v": 1,
+  "name": "(lifted) pmtoolbox-PM Toolbox",
+  "subjects": [
+    {
+      "id": "radial-spoke",
+      "type": "radial-spoke-3d",
+      "args": {
+        "spokes": 6
+      },
+      "transform": {
+        "translate": [
+          0,
+          1.7,
+          0
+        ]
+      },
+      "material": {
+        "hue": 0.57,
+        "sat": 0.55,
+        "value": 0.64,
+        "kind": "normal",
+        "roughness": 0.3,
+        "clearcoat": 0.45
+      }
+    }
+  ],
+  "overlay": [
+    {
+      "text": "PROJECT MANAGEMENT TOOLBOX",
+      "anchor": [
+        0,
+        3.9,
+        0
+      ],
+      "role": "title"
+    },
+    {
+      "text": "Charter 1",
+      "anchor": [
+        3,
+        2.6,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "WBS 1",
+      "anchor": [
+        3,
+        1.8800000000000001,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "Gantt 1",
+      "anchor": [
+        3,
+        1.1600000000000001,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "RACI 1",
+      "anchor": [
+        3,
+        0.43999999999999995,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "Risk 1",
+      "anchor": [
+        3,
+        -0.2799999999999998,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "Budget 1",
+      "anchor": [
+        3,
+        -0.9999999999999996,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    }
+  ],
+  "cameraSequence": {
+    "loop": false,
+    "shots": [
+      {
+        "duration": 0.01,
+        "pos": [
+          1,
+          2.1,
+          9.799999999999999
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 50,
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      },
+      {
+        "duration": 13,
+        "pos": [
+          0,
+          1.8,
+          8.2
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 46,
+        "transition": "blend",
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      }
+    ]
+  },
+  "defaults": {
+    "stage": {
+      "size": [
+        18,
+        9,
+        11
+      ]
+    }
+  }
+}

--- a/sdf-js/scenes/rec-pmtoolbox-2.json
+++ b/sdf-js/scenes/rec-pmtoolbox-2.json
@@ -1,0 +1,138 @@
+{
+  "v": 1,
+  "name": "(lifted) pmtoolbox-Schedule",
+  "subjects": [
+    {
+      "id": "gantt",
+      "type": "gantt-3d",
+      "args": {
+        "tasks": 5
+      },
+      "transform": {
+        "translate": [
+          0,
+          1.6,
+          0
+        ]
+      },
+      "material": {
+        "hue": 0.57,
+        "sat": 0.55,
+        "value": 0.64,
+        "kind": "normal",
+        "roughness": 0.3,
+        "clearcoat": 0.45
+      }
+    }
+  ],
+  "overlay": [
+    {
+      "text": "PROJECT SCHEDULE",
+      "anchor": [
+        0,
+        3.9,
+        0
+      ],
+      "role": "title"
+    },
+    {
+      "text": "Initiate",
+      "anchor": [
+        3,
+        2.6,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "Plan",
+      "anchor": [
+        3,
+        1.8800000000000001,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "Execute",
+      "anchor": [
+        3,
+        1.1600000000000001,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "Monitor",
+      "anchor": [
+        3,
+        0.43999999999999995,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "Close",
+      "anchor": [
+        3,
+        -0.2799999999999998,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    }
+  ],
+  "cameraSequence": {
+    "loop": false,
+    "shots": [
+      {
+        "duration": 0.01,
+        "pos": [
+          1,
+          2.1,
+          9.799999999999999
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 50,
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      },
+      {
+        "duration": 13,
+        "pos": [
+          0,
+          1.8,
+          8.2
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 46,
+        "transition": "blend",
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      }
+    ]
+  },
+  "defaults": {
+    "stage": {
+      "size": [
+        18,
+        9,
+        11
+      ]
+    }
+  }
+}

--- a/sdf-js/scenes/rec-pmtoolbox-3.json
+++ b/sdf-js/scenes/rec-pmtoolbox-3.json
@@ -1,0 +1,128 @@
+{
+  "v": 1,
+  "name": "(lifted) pmtoolbox-Phases",
+  "subjects": [
+    {
+      "id": "progression",
+      "type": "progression-3d",
+      "args": {
+        "steps": 4
+      },
+      "transform": {
+        "translate": [
+          -1,
+          0.6,
+          0
+        ]
+      },
+      "material": {
+        "hue": 0.57,
+        "sat": 0.55,
+        "value": 0.64,
+        "kind": "normal",
+        "roughness": 0.3,
+        "clearcoat": 0.45
+      }
+    }
+  ],
+  "overlay": [
+    {
+      "text": "PROJECT PHASES",
+      "anchor": [
+        0,
+        3.9,
+        0
+      ],
+      "role": "title"
+    },
+    {
+      "text": "Initiate",
+      "anchor": [
+        3,
+        2.6,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "Plan",
+      "anchor": [
+        3,
+        1.8800000000000001,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "Execute",
+      "anchor": [
+        3,
+        1.1600000000000001,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "Close",
+      "anchor": [
+        3,
+        0.43999999999999995,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    }
+  ],
+  "cameraSequence": {
+    "loop": false,
+    "shots": [
+      {
+        "duration": 0.01,
+        "pos": [
+          1,
+          2.1,
+          9.799999999999999
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 50,
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      },
+      {
+        "duration": 13,
+        "pos": [
+          0,
+          1.8,
+          8.2
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 46,
+        "transition": "blend",
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      }
+    ]
+  },
+  "defaults": {
+    "stage": {
+      "size": [
+        18,
+        9,
+        11
+      ]
+    }
+  }
+}

--- a/sdf-js/scenes/rec-pmtoolbox-4.json
+++ b/sdf-js/scenes/rec-pmtoolbox-4.json
@@ -1,0 +1,132 @@
+{
+  "v": 1,
+  "name": "(lifted) pmtoolbox-Milestones",
+  "subjects": [
+    {
+      "id": "timeline",
+      "type": "timeline-3d",
+      "args": {
+        "count": 4,
+        "axisLength": 4.2,
+        "axisRadius": 0.06,
+        "markerRadius": 0.2,
+        "stemHeight": 0.55
+      },
+      "transform": {
+        "translate": [
+          0,
+          1.4,
+          0
+        ]
+      },
+      "material": {
+        "hue": 0.57,
+        "sat": 0.55,
+        "value": 0.64,
+        "kind": "normal",
+        "roughness": 0.3,
+        "clearcoat": 0.45
+      }
+    }
+  ],
+  "overlay": [
+    {
+      "text": "MILESTONES",
+      "anchor": [
+        0,
+        3.9,
+        0
+      ],
+      "role": "title"
+    },
+    {
+      "text": "Charter",
+      "anchor": [
+        -2.1,
+        2.25,
+        0
+      ],
+      "role": "value",
+      "radius": 0.34
+    },
+    {
+      "text": "Baseline",
+      "anchor": [
+        -0.7,
+        2.25,
+        0
+      ],
+      "role": "value",
+      "radius": 0.34
+    },
+    {
+      "text": "Go-Live",
+      "anchor": [
+        0.7000000000000002,
+        2.25,
+        0
+      ],
+      "role": "value",
+      "radius": 0.34
+    },
+    {
+      "text": "Handover",
+      "anchor": [
+        2.1,
+        2.25,
+        0
+      ],
+      "role": "value",
+      "radius": 0.34
+    }
+  ],
+  "cameraSequence": {
+    "loop": false,
+    "shots": [
+      {
+        "duration": 0.01,
+        "pos": [
+          1,
+          2.1,
+          9.799999999999999
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 50,
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      },
+      {
+        "duration": 13,
+        "pos": [
+          0,
+          1.8,
+          8.2
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 46,
+        "transition": "blend",
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      }
+    ]
+  },
+  "defaults": {
+    "stage": {
+      "size": [
+        18,
+        9,
+        11
+      ]
+    }
+  }
+}

--- a/sdf-js/scenes/rec-pmtoolbox-5.json
+++ b/sdf-js/scenes/rec-pmtoolbox-5.json
@@ -1,0 +1,89 @@
+{
+  "v": 1,
+  "name": "(lifted) pmtoolbox-Risk Matrix",
+  "subjects": [
+    {
+      "id": "matrix-grid",
+      "type": "matrix-grid-3d",
+      "args": {
+        "rows": 3,
+        "cols": 3
+      },
+      "transform": {
+        "translate": [
+          0,
+          1.8,
+          0
+        ]
+      },
+      "material": {
+        "hue": 0.57,
+        "sat": 0.55,
+        "value": 0.64,
+        "kind": "normal",
+        "roughness": 0.3,
+        "clearcoat": 0.45
+      }
+    }
+  ],
+  "overlay": [
+    {
+      "text": "RISK MATRIX",
+      "anchor": [
+        0,
+        3.9,
+        0
+      ],
+      "role": "title"
+    }
+  ],
+  "cameraSequence": {
+    "loop": false,
+    "shots": [
+      {
+        "duration": 0.01,
+        "pos": [
+          1,
+          2.1,
+          9.799999999999999
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 50,
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      },
+      {
+        "duration": 13,
+        "pos": [
+          0,
+          1.8,
+          8.2
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 46,
+        "transition": "blend",
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      }
+    ]
+  },
+  "defaults": {
+    "stage": {
+      "size": [
+        18,
+        9,
+        11
+      ]
+    }
+  }
+}

--- a/sdf-js/scenes/rec-strategy-1.json
+++ b/sdf-js/scenes/rec-strategy-1.json
@@ -1,0 +1,148 @@
+{
+  "v": 1,
+  "name": "(lifted) strategy-Frameworks",
+  "subjects": [
+    {
+      "id": "radial-spoke",
+      "type": "radial-spoke-3d",
+      "args": {
+        "spokes": 6
+      },
+      "transform": {
+        "translate": [
+          0,
+          1.7,
+          0
+        ]
+      },
+      "material": {
+        "hue": 0.57,
+        "sat": 0.55,
+        "value": 0.64,
+        "kind": "normal",
+        "roughness": 0.3,
+        "clearcoat": 0.45
+      }
+    }
+  ],
+  "overlay": [
+    {
+      "text": "STRATEGY TOOLBOX",
+      "anchor": [
+        0,
+        3.9,
+        0
+      ],
+      "role": "title"
+    },
+    {
+      "text": "SWOT 1",
+      "anchor": [
+        3,
+        2.6,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "PESTLE 1",
+      "anchor": [
+        3,
+        1.8800000000000001,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "Porter 1",
+      "anchor": [
+        3,
+        1.1600000000000001,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "Ansoff 1",
+      "anchor": [
+        3,
+        0.43999999999999995,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "BCG 1",
+      "anchor": [
+        3,
+        -0.2799999999999998,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "Blue Ocean 1",
+      "anchor": [
+        3,
+        -0.9999999999999996,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    }
+  ],
+  "cameraSequence": {
+    "loop": false,
+    "shots": [
+      {
+        "duration": 0.01,
+        "pos": [
+          1,
+          2.1,
+          9.799999999999999
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 50,
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      },
+      {
+        "duration": 13,
+        "pos": [
+          0,
+          1.8,
+          8.2
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 46,
+        "transition": "blend",
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      }
+    ]
+  },
+  "defaults": {
+    "stage": {
+      "size": [
+        18,
+        9,
+        11
+      ]
+    }
+  }
+}

--- a/sdf-js/scenes/rec-strategy-2.json
+++ b/sdf-js/scenes/rec-strategy-2.json
@@ -1,0 +1,89 @@
+{
+  "v": 1,
+  "name": "(lifted) strategy-SWOT",
+  "subjects": [
+    {
+      "id": "matrix-grid",
+      "type": "matrix-grid-3d",
+      "args": {
+        "rows": 2,
+        "cols": 2
+      },
+      "transform": {
+        "translate": [
+          0,
+          1.8,
+          0
+        ]
+      },
+      "material": {
+        "hue": 0.57,
+        "sat": 0.55,
+        "value": 0.64,
+        "kind": "normal",
+        "roughness": 0.3,
+        "clearcoat": 0.45
+      }
+    }
+  ],
+  "overlay": [
+    {
+      "text": "SWOT",
+      "anchor": [
+        0,
+        3.9,
+        0
+      ],
+      "role": "title"
+    }
+  ],
+  "cameraSequence": {
+    "loop": false,
+    "shots": [
+      {
+        "duration": 0.01,
+        "pos": [
+          1,
+          2.1,
+          9.799999999999999
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 50,
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      },
+      {
+        "duration": 13,
+        "pos": [
+          0,
+          1.8,
+          8.2
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 46,
+        "transition": "blend",
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      }
+    ]
+  },
+  "defaults": {
+    "stage": {
+      "size": [
+        18,
+        9,
+        11
+      ]
+    }
+  }
+}

--- a/sdf-js/scenes/rec-strategy-3.json
+++ b/sdf-js/scenes/rec-strategy-3.json
@@ -1,0 +1,137 @@
+{
+  "v": 1,
+  "name": "(lifted) strategy-Growth Options",
+  "subjects": [
+    {
+      "id": "circle-segmented",
+      "type": "circle-segmented-3d",
+      "args": {
+        "segments": 4,
+        "radius": 0.8,
+        "innerRatio": 0.55,
+        "thickness": 0.2,
+        "gapWidth": 0.12
+      },
+      "transform": {
+        "translate": [
+          0,
+          1.6,
+          0
+        ],
+        "rotate": [
+          1.5708,
+          0,
+          0
+        ]
+      },
+      "material": {
+        "hue": 0.57,
+        "sat": 0.55,
+        "value": 0.64,
+        "kind": "normal",
+        "roughness": 0.3,
+        "clearcoat": 0.45
+      }
+    }
+  ],
+  "overlay": [
+    {
+      "text": "ANSOFF MATRIX",
+      "anchor": [
+        0,
+        3.9,
+        0
+      ],
+      "role": "title"
+    },
+    {
+      "text": "Penetration",
+      "anchor": [
+        3,
+        2.6,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "Development",
+      "anchor": [
+        3,
+        1.8800000000000001,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "Product",
+      "anchor": [
+        3,
+        1.1600000000000001,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "Diversify",
+      "anchor": [
+        3,
+        0.43999999999999995,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    }
+  ],
+  "cameraSequence": {
+    "loop": false,
+    "shots": [
+      {
+        "duration": 0.01,
+        "pos": [
+          1,
+          2.1,
+          9.799999999999999
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 50,
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      },
+      {
+        "duration": 13,
+        "pos": [
+          0,
+          1.8,
+          8.2
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 46,
+        "transition": "blend",
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      }
+    ]
+  },
+  "defaults": {
+    "stage": {
+      "size": [
+        18,
+        9,
+        11
+      ]
+    }
+  }
+}

--- a/sdf-js/scenes/rec-strategy-4.json
+++ b/sdf-js/scenes/rec-strategy-4.json
@@ -1,0 +1,128 @@
+{
+  "v": 1,
+  "name": "(lifted) strategy-Strategy Pyramid",
+  "subjects": [
+    {
+      "id": "pyramid",
+      "type": "pyramid-3d",
+      "args": {
+        "levels": 4
+      },
+      "transform": {
+        "translate": [
+          0,
+          0.6,
+          0
+        ]
+      },
+      "material": {
+        "hue": 0.57,
+        "sat": 0.55,
+        "value": 0.64,
+        "kind": "normal",
+        "roughness": 0.3,
+        "clearcoat": 0.45
+      }
+    }
+  ],
+  "overlay": [
+    {
+      "text": "STRATEGY PYRAMID",
+      "anchor": [
+        0,
+        3.9,
+        0
+      ],
+      "role": "title"
+    },
+    {
+      "text": "Mission",
+      "anchor": [
+        3,
+        2.6,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "Objectives",
+      "anchor": [
+        3,
+        1.8800000000000001,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "Strategy",
+      "anchor": [
+        3,
+        1.1600000000000001,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "Tactics",
+      "anchor": [
+        3,
+        0.43999999999999995,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    }
+  ],
+  "cameraSequence": {
+    "loop": false,
+    "shots": [
+      {
+        "duration": 0.01,
+        "pos": [
+          1,
+          2.1,
+          9.799999999999999
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 50,
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      },
+      {
+        "duration": 13,
+        "pos": [
+          0,
+          1.8,
+          8.2
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 46,
+        "transition": "blend",
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      }
+    ]
+  },
+  "defaults": {
+    "stage": {
+      "size": [
+        18,
+        9,
+        11
+      ]
+    }
+  }
+}

--- a/sdf-js/scenes/rec-strategy-5.json
+++ b/sdf-js/scenes/rec-strategy-5.json
@@ -1,0 +1,132 @@
+{
+  "v": 1,
+  "name": "(lifted) strategy-Roadmap",
+  "subjects": [
+    {
+      "id": "timeline",
+      "type": "timeline-3d",
+      "args": {
+        "count": 4,
+        "axisLength": 4.2,
+        "axisRadius": 0.06,
+        "markerRadius": 0.2,
+        "stemHeight": 0.55
+      },
+      "transform": {
+        "translate": [
+          0,
+          1.4,
+          0
+        ]
+      },
+      "material": {
+        "hue": 0.57,
+        "sat": 0.55,
+        "value": 0.64,
+        "kind": "normal",
+        "roughness": 0.3,
+        "clearcoat": 0.45
+      }
+    }
+  ],
+  "overlay": [
+    {
+      "text": "STRATEGIC ROADMAP",
+      "anchor": [
+        0,
+        3.9,
+        0
+      ],
+      "role": "title"
+    },
+    {
+      "text": "Now",
+      "anchor": [
+        -2.1,
+        2.25,
+        0
+      ],
+      "role": "value",
+      "radius": 0.34
+    },
+    {
+      "text": "Next",
+      "anchor": [
+        -0.7,
+        2.25,
+        0
+      ],
+      "role": "value",
+      "radius": 0.34
+    },
+    {
+      "text": "Later",
+      "anchor": [
+        0.7000000000000002,
+        2.25,
+        0
+      ],
+      "role": "value",
+      "radius": 0.34
+    },
+    {
+      "text": "Vision",
+      "anchor": [
+        2.1,
+        2.25,
+        0
+      ],
+      "role": "value",
+      "radius": 0.34
+    }
+  ],
+  "cameraSequence": {
+    "loop": false,
+    "shots": [
+      {
+        "duration": 0.01,
+        "pos": [
+          1,
+          2.1,
+          9.799999999999999
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 50,
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      },
+      {
+        "duration": 13,
+        "pos": [
+          0,
+          1.8,
+          8.2
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 46,
+        "transition": "blend",
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      }
+    ]
+  },
+  "defaults": {
+    "stage": {
+      "size": [
+        18,
+        9,
+        11
+      ]
+    }
+  }
+}

--- a/sdf-js/scripts/lift-rec-round3.mjs
+++ b/sdf-js/scripts/lift-rec-round3.mjs
@@ -1,0 +1,68 @@
+// lift-rec-round3.mjs — PL "recommendations" round 3 (5 templates). Data → twin map.
+import { writeFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+import { liftSceneData2dTo3d } from '../src/scene/lift-2d-to-3d.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const SCENES = resolve(__dirname, '../scenes');
+
+const DECKS = [
+  {
+    id: 'pmtoolbox', name: 'Project Management Toolbox', slides: [
+      { title: 'PM Toolbox', type: 'radial-spoke', args: { title: 'Project Management Toolbox', values: [1, 1, 1, 1, 1, 1], labels: ['Charter', 'WBS', 'Gantt', 'RACI', 'Risk', 'Budget'] } },
+      { title: 'Schedule', type: 'gantt', args: { title: 'Project Schedule', tasks: [{ label: 'Initiate' }, { label: 'Plan' }, { label: 'Execute' }, { label: 'Monitor' }, { label: 'Close' }] } },
+      { title: 'Phases', type: 'progression', args: { title: 'Project Phases', steps: [{ label: 'Initiate' }, { label: 'Plan' }, { label: 'Execute' }, { label: 'Close' }] } },
+      { title: 'Milestones', type: 'timeline', args: { title: 'Milestones', events: [{ label: 'Charter' }, { label: 'Baseline' }, { label: 'Go-Live' }, { label: 'Handover' }] } },
+      { title: 'Risk Matrix', type: 'matrix-grid', args: { title: 'Risk Matrix', rows: 3, cols: 3 } },
+    ],
+  },
+  {
+    id: 'leadership', name: 'Leadership Toolbox', slides: [
+      { title: 'Styles', type: 'radial-spoke', args: { title: 'Leadership Toolbox', values: [1, 1, 1, 1, 1], labels: ['Visionary', 'Coaching', 'Affiliative', 'Democratic', 'Commanding'] } },
+      { title: 'Situational', type: 'matrix-grid', args: { title: 'Situational Leadership', rows: 2, cols: 2 } },
+      { title: 'Development', type: 'progression', args: { title: 'Leadership Development', steps: [{ label: 'Self' }, { label: 'Team' }, { label: 'Org' }, { label: 'Vision' }] } },
+      { title: 'Maturity', type: 'pyramid', args: { title: 'Leadership Levels', layers: [{ label: 'Executive' }, { label: 'Manager' }, { label: 'Lead' }, { label: 'Contributor' }] } },
+      { title: 'Team Network', type: 'sphere-network', args: { title: 'Team', hub: 'Leader', satellites: [{ label: 'Eng' }, { label: 'Design' }, { label: 'Product' }, { label: 'Ops' }] } },
+    ],
+  },
+  {
+    id: 'itstrategy', name: 'IT Strategy', slides: [
+      { title: 'IT Stack', type: 'layer-stack', args: { title: 'IT Strategy', layers: [{ label: 'Applications' }, { label: 'Data' }, { label: 'Infrastructure' }, { label: 'Security' }] } },
+      { title: 'Roadmap', type: 'timeline', args: { title: 'IT Roadmap', events: [{ label: 'Assess' }, { label: 'Modernize' }, { label: 'Migrate' }, { label: 'Optimize' }] } },
+      { title: 'Capabilities', type: 'radial-spoke', args: { title: 'IT Capabilities', values: [1, 1, 1, 1, 1], labels: ['Cloud', 'Data', 'Security', 'DevOps', 'AI'] } },
+      { title: 'Maturity', type: 'pyramid', args: { title: 'IT Maturity', layers: [{ label: 'Optimized' }, { label: 'Managed' }, { label: 'Defined' }, { label: 'Ad-hoc' }] } },
+      { title: 'Portfolio', type: 'matrix-grid', args: { title: 'App Portfolio', rows: 2, cols: 2 } },
+    ],
+  },
+  {
+    id: 'marketing', name: 'Marketing Toolbox', slides: [
+      { title: 'Marketing Mix', type: 'radial-spoke', args: { title: 'Marketing Toolbox', values: [1, 1, 1, 1], labels: ['Product', 'Price', 'Place', 'Promotion'] } },
+      { title: 'AIDA Funnel', type: 'funnel', args: { title: 'AIDA', stages: [{ label: 'Attention' }, { label: 'Interest' }, { label: 'Desire' }, { label: 'Action' }] } },
+      { title: 'Channel Mix', type: 'pie', args: { title: 'Channel Mix', values: [30, 25, 20, 15, 10], labels: ['Search', 'Social', 'Email', 'Content', 'Events'], format: 'percent' } },
+      { title: 'Campaign', type: 'timeline', args: { title: 'Campaign Calendar', events: [{ label: 'Tease' }, { label: 'Launch' }, { label: 'Sustain' }, { label: 'Convert' }] } },
+      { title: 'Segments', type: 'matrix-grid', args: { title: 'Segment Matrix', rows: 2, cols: 3 } },
+    ],
+  },
+  {
+    id: 'strategy', name: 'Strategy Toolbox', slides: [
+      { title: 'Frameworks', type: 'radial-spoke', args: { title: 'Strategy Toolbox', values: [1, 1, 1, 1, 1, 1], labels: ['SWOT', 'PESTLE', 'Porter', 'Ansoff', 'BCG', 'Blue Ocean'] } },
+      { title: 'SWOT', type: 'matrix-grid', args: { title: 'SWOT', rows: 2, cols: 2 } },
+      { title: 'Growth Options', type: 'circle-segmented', args: { title: 'Ansoff Matrix', segments: 4, labels: ['Penetration', 'Development', 'Product', 'Diversify'] } },
+      { title: 'Strategy Pyramid', type: 'pyramid', args: { title: 'Strategy Pyramid', layers: [{ label: 'Mission' }, { label: 'Objectives' }, { label: 'Strategy' }, { label: 'Tactics' }] } },
+      { title: 'Roadmap', type: 'timeline', args: { title: 'Strategic Roadmap', events: [{ label: 'Now' }, { label: 'Next' }, { label: 'Later' }, { label: 'Vision' }] } },
+    ],
+  },
+];
+
+for (const deck of DECKS) {
+  const segments = [];
+  deck.slides.forEach((slide, i) => {
+    const scene = liftSceneData2dTo3d({ name: `${deck.id}-${slide.title}`, subjects: [{ type: slide.type, args: slide.args }] });
+    const file = `rec-${deck.id}-${i + 1}.json`;
+    writeFileSync(resolve(SCENES, file), `${JSON.stringify(scene, null, 2)}\n`);
+    segments.push({ file, title: slide.title, kind: 'slide', durationSec: 7 });
+  });
+  writeFileSync(resolve(SCENES, `deck-rec-${deck.id}.json`), `${JSON.stringify({ id: `deck-rec-${deck.id}`, name: deck.name, segments }, null, 2)}\n`);
+  console.log(`  ✓ ${deck.name.padEnd(32)} → ?deck=deck-rec-${deck.id}`);
+}


### PR DESCRIPTION
Round 3/5。5 个工具箱/战略模板 → 3D deck,纯数据 lift。

- `?deck=deck-rec-pmtoolbox` —— Project Management Toolbox
- `?deck=deck-rec-leadership` —— Leadership Toolbox
- `?deck=deck-rec-itstrategy` —— IT Strategy
- `?deck=deck-rec-marketing` —— Marketing Toolbox
- `?deck=deck-rec-strategy` —— Strategy Toolbox

25 slide 全编译(原子均已在 round 1-2 渲染验证)。`npm test` 99/99。

🤖 Generated with [Claude Code](https://claude.com/claude-code)