### PR TITLE
feat(present): PL recommendations decks — round 5 / final (Flow / Timelines / Mountain / Icons)

### DIFF
--- a/sdf-js/scenes/deck-rec-flowchart.json
+++ b/sdf-js/scenes/deck-rec-flowchart.json
@@ -1,0 +1,36 @@
+{
+  "id": "deck-rec-flowchart",
+  "name": "Flow Chart Toolbox",
+  "segments": [
+    {
+      "file": "rec-flowchart-1.json",
+      "title": "Process Flow",
+      "kind": "slide",
+      "durationSec": 7
+    },
+    {
+      "file": "rec-flowchart-2.json",
+      "title": "Workflow",
+      "kind": "slide",
+      "durationSec": 7
+    },
+    {
+      "file": "rec-flowchart-3.json",
+      "title": "Decision Tree",
+      "kind": "slide",
+      "durationSec": 7
+    },
+    {
+      "file": "rec-flowchart-4.json",
+      "title": "Stages",
+      "kind": "slide",
+      "durationSec": 7
+    },
+    {
+      "file": "rec-flowchart-5.json",
+      "title": "Cycle",
+      "kind": "slide",
+      "durationSec": 7
+    }
+  ]
+}

--- a/sdf-js/scenes/deck-rec-icons.json
+++ b/sdf-js/scenes/deck-rec-icons.json
@@ -1,0 +1,36 @@
+{
+  "id": "deck-rec-icons",
+  "name": "Line Icons - Business",
+  "segments": [
+    {
+      "file": "rec-icons-1.json",
+      "title": "Categories",
+      "kind": "slide",
+      "durationSec": 7
+    },
+    {
+      "file": "rec-icons-2.json",
+      "title": "Icon Grid",
+      "kind": "slide",
+      "durationSec": 7
+    },
+    {
+      "file": "rec-icons-3.json",
+      "title": "Concept Tiles",
+      "kind": "slide",
+      "durationSec": 7
+    },
+    {
+      "file": "rec-icons-4.json",
+      "title": "Themes",
+      "kind": "slide",
+      "durationSec": 7
+    },
+    {
+      "file": "rec-icons-5.json",
+      "title": "Toolkit",
+      "kind": "slide",
+      "durationSec": 7
+    }
+  ]
+}

--- a/sdf-js/scenes/deck-rec-mountain.json
+++ b/sdf-js/scenes/deck-rec-mountain.json
@@ -1,0 +1,36 @@
+{
+  "id": "deck-rec-mountain",
+  "name": "Mountain Path – Graphics",
+  "segments": [
+    {
+      "file": "rec-mountain-1.json",
+      "title": "The Summit",
+      "kind": "slide",
+      "durationSec": 7
+    },
+    {
+      "file": "rec-mountain-2.json",
+      "title": "The Climb",
+      "kind": "slide",
+      "durationSec": 7
+    },
+    {
+      "file": "rec-mountain-3.json",
+      "title": "Milestones",
+      "kind": "slide",
+      "durationSec": 7
+    },
+    {
+      "file": "rec-mountain-4.json",
+      "title": "Elevation Tiers",
+      "kind": "slide",
+      "durationSec": 7
+    },
+    {
+      "file": "rec-mountain-5.json",
+      "title": "Goal Path",
+      "kind": "slide",
+      "durationSec": 7
+    }
+  ]
+}

--- a/sdf-js/scenes/deck-rec-timelines.json
+++ b/sdf-js/scenes/deck-rec-timelines.json
@@ -1,0 +1,36 @@
+{
+  "id": "deck-rec-timelines",
+  "name": "Project Timelines 2026",
+  "segments": [
+    {
+      "file": "rec-timelines-1.json",
+      "title": "2026 Timeline",
+      "kind": "slide",
+      "durationSec": 7
+    },
+    {
+      "file": "rec-timelines-2.json",
+      "title": "Roadmap",
+      "kind": "slide",
+      "durationSec": 7
+    },
+    {
+      "file": "rec-timelines-3.json",
+      "title": "Gantt",
+      "kind": "slide",
+      "durationSec": 7
+    },
+    {
+      "file": "rec-timelines-4.json",
+      "title": "Milestones",
+      "kind": "slide",
+      "durationSec": 7
+    },
+    {
+      "file": "rec-timelines-5.json",
+      "title": "Phases",
+      "kind": "slide",
+      "durationSec": 7
+    }
+  ]
+}

--- a/sdf-js/scenes/rec-flowchart-1.json
+++ b/sdf-js/scenes/rec-flowchart-1.json
@@ -1,0 +1,128 @@
+{
+  "v": 1,
+  "name": "(lifted) flowchart-Process Flow",
+  "subjects": [
+    {
+      "id": "flow-chart",
+      "type": "flow-chart-3d",
+      "args": {
+        "steps": 4
+      },
+      "transform": {
+        "translate": [
+          0,
+          1.6,
+          0
+        ]
+      },
+      "material": {
+        "hue": 0.57,
+        "sat": 0.55,
+        "value": 0.64,
+        "kind": "normal",
+        "roughness": 0.3,
+        "clearcoat": 0.45
+      }
+    }
+  ],
+  "overlay": [
+    {
+      "text": "FLOW CHART TOOLBOX",
+      "anchor": [
+        0,
+        3.9,
+        0
+      ],
+      "role": "title"
+    },
+    {
+      "text": "Start",
+      "anchor": [
+        3,
+        2.6,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "Process",
+      "anchor": [
+        3,
+        1.8800000000000001,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "Decision",
+      "anchor": [
+        3,
+        1.1600000000000001,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "End",
+      "anchor": [
+        3,
+        0.43999999999999995,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    }
+  ],
+  "cameraSequence": {
+    "loop": false,
+    "shots": [
+      {
+        "duration": 0.01,
+        "pos": [
+          1,
+          2.1,
+          9.799999999999999
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 50,
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      },
+      {
+        "duration": 13,
+        "pos": [
+          0,
+          1.8,
+          8.2
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 46,
+        "transition": "blend",
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      }
+    ]
+  },
+  "defaults": {
+    "stage": {
+      "size": [
+        18,
+        9,
+        11
+      ]
+    }
+  }
+}

--- a/sdf-js/scenes/rec-flowchart-2.json
+++ b/sdf-js/scenes/rec-flowchart-2.json
@@ -1,0 +1,138 @@
+{
+  "v": 1,
+  "name": "(lifted) flowchart-Workflow",
+  "subjects": [
+    {
+      "id": "flow-chart",
+      "type": "flow-chart-3d",
+      "args": {
+        "steps": 5
+      },
+      "transform": {
+        "translate": [
+          0,
+          1.6,
+          0
+        ]
+      },
+      "material": {
+        "hue": 0.57,
+        "sat": 0.55,
+        "value": 0.64,
+        "kind": "normal",
+        "roughness": 0.3,
+        "clearcoat": 0.45
+      }
+    }
+  ],
+  "overlay": [
+    {
+      "text": "WORKFLOW",
+      "anchor": [
+        0,
+        3.9,
+        0
+      ],
+      "role": "title"
+    },
+    {
+      "text": "Intake",
+      "anchor": [
+        3,
+        2.6,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "Review",
+      "anchor": [
+        3,
+        1.8800000000000001,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "Approve",
+      "anchor": [
+        3,
+        1.1600000000000001,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "Execute",
+      "anchor": [
+        3,
+        0.43999999999999995,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "Close",
+      "anchor": [
+        3,
+        -0.2799999999999998,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    }
+  ],
+  "cameraSequence": {
+    "loop": false,
+    "shots": [
+      {
+        "duration": 0.01,
+        "pos": [
+          1,
+          2.1,
+          9.799999999999999
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 50,
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      },
+      {
+        "duration": 13,
+        "pos": [
+          0,
+          1.8,
+          8.2
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 46,
+        "transition": "blend",
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      }
+    ]
+  },
+  "defaults": {
+    "stage": {
+      "size": [
+        18,
+        9,
+        11
+      ]
+    }
+  }
+}

--- a/sdf-js/scenes/rec-flowchart-3.json
+++ b/sdf-js/scenes/rec-flowchart-3.json
@@ -1,0 +1,89 @@
+{
+  "v": 1,
+  "name": "(lifted) flowchart-Decision Tree",
+  "subjects": [
+    {
+      "id": "tree-diagram",
+      "type": "tree-diagram-3d",
+      "args": {
+        "levels": 3,
+        "branching": 2
+      },
+      "transform": {
+        "translate": [
+          0,
+          2.8,
+          0
+        ]
+      },
+      "material": {
+        "hue": 0.57,
+        "sat": 0.55,
+        "value": 0.64,
+        "kind": "normal",
+        "roughness": 0.3,
+        "clearcoat": 0.45
+      }
+    }
+  ],
+  "overlay": [
+    {
+      "text": "DECISION TREE",
+      "anchor": [
+        0,
+        3.9,
+        0
+      ],
+      "role": "title"
+    }
+  ],
+  "cameraSequence": {
+    "loop": false,
+    "shots": [
+      {
+        "duration": 0.01,
+        "pos": [
+          1,
+          2.1,
+          9.799999999999999
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 50,
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      },
+      {
+        "duration": 13,
+        "pos": [
+          0,
+          1.8,
+          8.2
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 46,
+        "transition": "blend",
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      }
+    ]
+  },
+  "defaults": {
+    "stage": {
+      "size": [
+        18,
+        9,
+        11
+      ]
+    }
+  }
+}

--- a/sdf-js/scenes/rec-flowchart-4.json
+++ b/sdf-js/scenes/rec-flowchart-4.json
@@ -1,0 +1,128 @@
+{
+  "v": 1,
+  "name": "(lifted) flowchart-Stages",
+  "subjects": [
+    {
+      "id": "progression",
+      "type": "progression-3d",
+      "args": {
+        "steps": 4
+      },
+      "transform": {
+        "translate": [
+          -1,
+          0.6,
+          0
+        ]
+      },
+      "material": {
+        "hue": 0.57,
+        "sat": 0.55,
+        "value": 0.64,
+        "kind": "normal",
+        "roughness": 0.3,
+        "clearcoat": 0.45
+      }
+    }
+  ],
+  "overlay": [
+    {
+      "text": "STAGES",
+      "anchor": [
+        0,
+        3.9,
+        0
+      ],
+      "role": "title"
+    },
+    {
+      "text": "Define",
+      "anchor": [
+        3,
+        2.6,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "Map",
+      "anchor": [
+        3,
+        1.8800000000000001,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "Analyze",
+      "anchor": [
+        3,
+        1.1600000000000001,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "Improve",
+      "anchor": [
+        3,
+        0.43999999999999995,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    }
+  ],
+  "cameraSequence": {
+    "loop": false,
+    "shots": [
+      {
+        "duration": 0.01,
+        "pos": [
+          1,
+          2.1,
+          9.799999999999999
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 50,
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      },
+      {
+        "duration": 13,
+        "pos": [
+          0,
+          1.8,
+          8.2
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 46,
+        "transition": "blend",
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      }
+    ]
+  },
+  "defaults": {
+    "stage": {
+      "size": [
+        18,
+        9,
+        11
+      ]
+    }
+  }
+}

--- a/sdf-js/scenes/rec-flowchart-5.json
+++ b/sdf-js/scenes/rec-flowchart-5.json
@@ -1,0 +1,133 @@
+{
+  "v": 1,
+  "name": "(lifted) flowchart-Cycle",
+  "subjects": [
+    {
+      "id": "circle-loop",
+      "type": "circle-loop-3d",
+      "args": {
+        "segments": 4
+      },
+      "transform": {
+        "translate": [
+          0,
+          1.6,
+          0
+        ],
+        "rotate": [
+          1.5708,
+          0,
+          0
+        ]
+      },
+      "material": {
+        "hue": 0.57,
+        "sat": 0.55,
+        "value": 0.64,
+        "kind": "normal",
+        "roughness": 0.3,
+        "clearcoat": 0.45
+      }
+    }
+  ],
+  "overlay": [
+    {
+      "text": "PROCESS CYCLE",
+      "anchor": [
+        0,
+        3.9,
+        0
+      ],
+      "role": "title"
+    },
+    {
+      "text": "Plan",
+      "anchor": [
+        3,
+        2.6,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "Do",
+      "anchor": [
+        3,
+        1.8800000000000001,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "Check",
+      "anchor": [
+        3,
+        1.1600000000000001,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "Act",
+      "anchor": [
+        3,
+        0.43999999999999995,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    }
+  ],
+  "cameraSequence": {
+    "loop": false,
+    "shots": [
+      {
+        "duration": 0.01,
+        "pos": [
+          1,
+          2.1,
+          9.799999999999999
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 50,
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      },
+      {
+        "duration": 13,
+        "pos": [
+          0,
+          1.8,
+          8.2
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 46,
+        "transition": "blend",
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      }
+    ]
+  },
+  "defaults": {
+    "stage": {
+      "size": [
+        18,
+        9,
+        11
+      ]
+    }
+  }
+}

--- a/sdf-js/scenes/rec-icons-1.json
+++ b/sdf-js/scenes/rec-icons-1.json
@@ -1,0 +1,148 @@
+{
+  "v": 1,
+  "name": "(lifted) icons-Categories",
+  "subjects": [
+    {
+      "id": "radial-spoke",
+      "type": "radial-spoke-3d",
+      "args": {
+        "spokes": 6
+      },
+      "transform": {
+        "translate": [
+          0,
+          1.7,
+          0
+        ]
+      },
+      "material": {
+        "hue": 0.57,
+        "sat": 0.55,
+        "value": 0.64,
+        "kind": "normal",
+        "roughness": 0.3,
+        "clearcoat": 0.45
+      }
+    }
+  ],
+  "overlay": [
+    {
+      "text": "BUSINESS ICONS",
+      "anchor": [
+        0,
+        3.9,
+        0
+      ],
+      "role": "title"
+    },
+    {
+      "text": "Finance 1",
+      "anchor": [
+        3,
+        2.6,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "People 1",
+      "anchor": [
+        3,
+        1.8800000000000001,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "Growth 1",
+      "anchor": [
+        3,
+        1.1600000000000001,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "Tech 1",
+      "anchor": [
+        3,
+        0.43999999999999995,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "Strategy 1",
+      "anchor": [
+        3,
+        -0.2799999999999998,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "Ops 1",
+      "anchor": [
+        3,
+        -0.9999999999999996,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    }
+  ],
+  "cameraSequence": {
+    "loop": false,
+    "shots": [
+      {
+        "duration": 0.01,
+        "pos": [
+          1,
+          2.1,
+          9.799999999999999
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 50,
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      },
+      {
+        "duration": 13,
+        "pos": [
+          0,
+          1.8,
+          8.2
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 46,
+        "transition": "blend",
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      }
+    ]
+  },
+  "defaults": {
+    "stage": {
+      "size": [
+        18,
+        9,
+        11
+      ]
+    }
+  }
+}

--- a/sdf-js/scenes/rec-icons-2.json
+++ b/sdf-js/scenes/rec-icons-2.json
@@ -1,0 +1,93 @@
+{
+  "v": 1,
+  "name": "(lifted) icons-Icon Grid",
+  "subjects": [
+    {
+      "id": "cube-grid",
+      "type": "cube-3d",
+      "args": {
+        "arrangement": "grid",
+        "count": 9,
+        "cubeSize": 0.5,
+        "spacing": 0.2,
+        "material": "solid",
+        "colors": null
+      },
+      "transform": {
+        "translate": [
+          0,
+          1.6,
+          0
+        ]
+      },
+      "material": {
+        "hue": 0.57,
+        "sat": 0.55,
+        "value": 0.64,
+        "kind": "normal",
+        "roughness": 0.3,
+        "clearcoat": 0.45
+      }
+    }
+  ],
+  "overlay": [
+    {
+      "text": "ICON SET",
+      "anchor": [
+        0,
+        3.9,
+        0
+      ],
+      "role": "title"
+    }
+  ],
+  "cameraSequence": {
+    "loop": false,
+    "shots": [
+      {
+        "duration": 0.01,
+        "pos": [
+          1,
+          2.1,
+          9.799999999999999
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 50,
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      },
+      {
+        "duration": 13,
+        "pos": [
+          0,
+          1.8,
+          8.2
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 46,
+        "transition": "blend",
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      }
+    ]
+  },
+  "defaults": {
+    "stage": {
+      "size": [
+        18,
+        9,
+        11
+      ]
+    }
+  }
+}

--- a/sdf-js/scenes/rec-icons-3.json
+++ b/sdf-js/scenes/rec-icons-3.json
@@ -1,0 +1,89 @@
+{
+  "v": 1,
+  "name": "(lifted) icons-Concept Tiles",
+  "subjects": [
+    {
+      "id": "matrix-grid",
+      "type": "matrix-grid-3d",
+      "args": {
+        "rows": 2,
+        "cols": 4
+      },
+      "transform": {
+        "translate": [
+          0,
+          1.8,
+          0
+        ]
+      },
+      "material": {
+        "hue": 0.57,
+        "sat": 0.55,
+        "value": 0.64,
+        "kind": "normal",
+        "roughness": 0.3,
+        "clearcoat": 0.45
+      }
+    }
+  ],
+  "overlay": [
+    {
+      "text": "CONCEPT TILES",
+      "anchor": [
+        0,
+        3.9,
+        0
+      ],
+      "role": "title"
+    }
+  ],
+  "cameraSequence": {
+    "loop": false,
+    "shots": [
+      {
+        "duration": 0.01,
+        "pos": [
+          1,
+          2.1,
+          9.799999999999999
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 50,
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      },
+      {
+        "duration": 13,
+        "pos": [
+          0,
+          1.8,
+          8.2
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 46,
+        "transition": "blend",
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      }
+    ]
+  },
+  "defaults": {
+    "stage": {
+      "size": [
+        18,
+        9,
+        11
+      ]
+    }
+  }
+}

--- a/sdf-js/scenes/rec-icons-4.json
+++ b/sdf-js/scenes/rec-icons-4.json
@@ -1,0 +1,157 @@
+{
+  "v": 1,
+  "name": "(lifted) icons-Themes",
+  "subjects": [
+    {
+      "id": "circle-segmented",
+      "type": "circle-segmented-3d",
+      "args": {
+        "segments": 6,
+        "radius": 0.8,
+        "innerRatio": 0.55,
+        "thickness": 0.2,
+        "gapWidth": 0.12
+      },
+      "transform": {
+        "translate": [
+          0,
+          1.6,
+          0
+        ],
+        "rotate": [
+          1.5708,
+          0,
+          0
+        ]
+      },
+      "material": {
+        "hue": 0.57,
+        "sat": 0.55,
+        "value": 0.64,
+        "kind": "normal",
+        "roughness": 0.3,
+        "clearcoat": 0.45
+      }
+    }
+  ],
+  "overlay": [
+    {
+      "text": "THEMES",
+      "anchor": [
+        0,
+        3.9,
+        0
+      ],
+      "role": "title"
+    },
+    {
+      "text": "$",
+      "anchor": [
+        3,
+        2.6,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "%",
+      "anchor": [
+        3,
+        1.8800000000000001,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "↑",
+      "anchor": [
+        3,
+        1.1600000000000001,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "★",
+      "anchor": [
+        3,
+        0.43999999999999995,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "✓",
+      "anchor": [
+        3,
+        -0.2799999999999998,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "◆",
+      "anchor": [
+        3,
+        -0.9999999999999996,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    }
+  ],
+  "cameraSequence": {
+    "loop": false,
+    "shots": [
+      {
+        "duration": 0.01,
+        "pos": [
+          1,
+          2.1,
+          9.799999999999999
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 50,
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      },
+      {
+        "duration": 13,
+        "pos": [
+          0,
+          1.8,
+          8.2
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 46,
+        "transition": "blend",
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      }
+    ]
+  },
+  "defaults": {
+    "stage": {
+      "size": [
+        18,
+        9,
+        11
+      ]
+    }
+  }
+}

--- a/sdf-js/scenes/rec-icons-5.json
+++ b/sdf-js/scenes/rec-icons-5.json
@@ -1,0 +1,128 @@
+{
+  "v": 1,
+  "name": "(lifted) icons-Toolkit",
+  "subjects": [
+    {
+      "id": "radial-spoke",
+      "type": "radial-spoke-3d",
+      "args": {
+        "spokes": 4
+      },
+      "transform": {
+        "translate": [
+          0,
+          1.7,
+          0
+        ]
+      },
+      "material": {
+        "hue": 0.57,
+        "sat": 0.55,
+        "value": 0.64,
+        "kind": "normal",
+        "roughness": 0.3,
+        "clearcoat": 0.45
+      }
+    }
+  ],
+  "overlay": [
+    {
+      "text": "TOOLKIT",
+      "anchor": [
+        0,
+        3.9,
+        0
+      ],
+      "role": "title"
+    },
+    {
+      "text": "Charts 1",
+      "anchor": [
+        3,
+        2.6,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "Flows 1",
+      "anchor": [
+        3,
+        1.8800000000000001,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "Maps 1",
+      "anchor": [
+        3,
+        1.1600000000000001,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "KPIs 1",
+      "anchor": [
+        3,
+        0.43999999999999995,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    }
+  ],
+  "cameraSequence": {
+    "loop": false,
+    "shots": [
+      {
+        "duration": 0.01,
+        "pos": [
+          1,
+          2.1,
+          9.799999999999999
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 50,
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      },
+      {
+        "duration": 13,
+        "pos": [
+          0,
+          1.8,
+          8.2
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 46,
+        "transition": "blend",
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      }
+    ]
+  },
+  "defaults": {
+    "stage": {
+      "size": [
+        18,
+        9,
+        11
+      ]
+    }
+  }
+}

--- a/sdf-js/scenes/rec-mountain-1.json
+++ b/sdf-js/scenes/rec-mountain-1.json
@@ -1,0 +1,128 @@
+{
+  "v": 1,
+  "name": "(lifted) mountain-The Summit",
+  "subjects": [
+    {
+      "id": "pyramid",
+      "type": "pyramid-3d",
+      "args": {
+        "levels": 4
+      },
+      "transform": {
+        "translate": [
+          0,
+          0.6,
+          0
+        ]
+      },
+      "material": {
+        "hue": 0.57,
+        "sat": 0.55,
+        "value": 0.64,
+        "kind": "normal",
+        "roughness": 0.3,
+        "clearcoat": 0.45
+      }
+    }
+  ],
+  "overlay": [
+    {
+      "text": "MOUNTAIN PATH",
+      "anchor": [
+        0,
+        3.9,
+        0
+      ],
+      "role": "title"
+    },
+    {
+      "text": "Summit",
+      "anchor": [
+        3,
+        2.6,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "Ridge",
+      "anchor": [
+        3,
+        1.8800000000000001,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "Ascent",
+      "anchor": [
+        3,
+        1.1600000000000001,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "Base Camp",
+      "anchor": [
+        3,
+        0.43999999999999995,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    }
+  ],
+  "cameraSequence": {
+    "loop": false,
+    "shots": [
+      {
+        "duration": 0.01,
+        "pos": [
+          1,
+          2.1,
+          9.799999999999999
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 50,
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      },
+      {
+        "duration": 13,
+        "pos": [
+          0,
+          1.8,
+          8.2
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 46,
+        "transition": "blend",
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      }
+    ]
+  },
+  "defaults": {
+    "stage": {
+      "size": [
+        18,
+        9,
+        11
+      ]
+    }
+  }
+}

--- a/sdf-js/scenes/rec-mountain-2.json
+++ b/sdf-js/scenes/rec-mountain-2.json
@@ -1,0 +1,128 @@
+{
+  "v": 1,
+  "name": "(lifted) mountain-The Climb",
+  "subjects": [
+    {
+      "id": "progression",
+      "type": "progression-3d",
+      "args": {
+        "steps": 4
+      },
+      "transform": {
+        "translate": [
+          -1,
+          0.6,
+          0
+        ]
+      },
+      "material": {
+        "hue": 0.57,
+        "sat": 0.55,
+        "value": 0.64,
+        "kind": "normal",
+        "roughness": 0.3,
+        "clearcoat": 0.45
+      }
+    }
+  ],
+  "overlay": [
+    {
+      "text": "THE CLIMB",
+      "anchor": [
+        0,
+        3.9,
+        0
+      ],
+      "role": "title"
+    },
+    {
+      "text": "Base Camp",
+      "anchor": [
+        3,
+        2.6,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "Ascent",
+      "anchor": [
+        3,
+        1.8800000000000001,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "Ridge",
+      "anchor": [
+        3,
+        1.1600000000000001,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "Summit",
+      "anchor": [
+        3,
+        0.43999999999999995,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    }
+  ],
+  "cameraSequence": {
+    "loop": false,
+    "shots": [
+      {
+        "duration": 0.01,
+        "pos": [
+          1,
+          2.1,
+          9.799999999999999
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 50,
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      },
+      {
+        "duration": 13,
+        "pos": [
+          0,
+          1.8,
+          8.2
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 46,
+        "transition": "blend",
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      }
+    ]
+  },
+  "defaults": {
+    "stage": {
+      "size": [
+        18,
+        9,
+        11
+      ]
+    }
+  }
+}

--- a/sdf-js/scenes/rec-mountain-3.json
+++ b/sdf-js/scenes/rec-mountain-3.json
@@ -1,0 +1,132 @@
+{
+  "v": 1,
+  "name": "(lifted) mountain-Milestones",
+  "subjects": [
+    {
+      "id": "timeline",
+      "type": "timeline-3d",
+      "args": {
+        "count": 4,
+        "axisLength": 4.2,
+        "axisRadius": 0.06,
+        "markerRadius": 0.2,
+        "stemHeight": 0.55
+      },
+      "transform": {
+        "translate": [
+          0,
+          1.4,
+          0
+        ]
+      },
+      "material": {
+        "hue": 0.57,
+        "sat": 0.55,
+        "value": 0.64,
+        "kind": "normal",
+        "roughness": 0.3,
+        "clearcoat": 0.45
+      }
+    }
+  ],
+  "overlay": [
+    {
+      "text": "JOURNEY MILESTONES",
+      "anchor": [
+        0,
+        3.9,
+        0
+      ],
+      "role": "title"
+    },
+    {
+      "text": "Start",
+      "anchor": [
+        -2.1,
+        2.25,
+        0
+      ],
+      "role": "value",
+      "radius": 0.34
+    },
+    {
+      "text": "Camp 1",
+      "anchor": [
+        -0.7,
+        2.25,
+        0
+      ],
+      "role": "value",
+      "radius": 0.34
+    },
+    {
+      "text": "Camp 2",
+      "anchor": [
+        0.7000000000000002,
+        2.25,
+        0
+      ],
+      "role": "value",
+      "radius": 0.34
+    },
+    {
+      "text": "Peak",
+      "anchor": [
+        2.1,
+        2.25,
+        0
+      ],
+      "role": "value",
+      "radius": 0.34
+    }
+  ],
+  "cameraSequence": {
+    "loop": false,
+    "shots": [
+      {
+        "duration": 0.01,
+        "pos": [
+          1,
+          2.1,
+          9.799999999999999
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 50,
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      },
+      {
+        "duration": 13,
+        "pos": [
+          0,
+          1.8,
+          8.2
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 46,
+        "transition": "blend",
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      }
+    ]
+  },
+  "defaults": {
+    "stage": {
+      "size": [
+        18,
+        9,
+        11
+      ]
+    }
+  }
+}

--- a/sdf-js/scenes/rec-mountain-4.json
+++ b/sdf-js/scenes/rec-mountain-4.json
@@ -1,0 +1,128 @@
+{
+  "v": 1,
+  "name": "(lifted) mountain-Elevation Tiers",
+  "subjects": [
+    {
+      "id": "circle-stack",
+      "type": "circle-stack-3d",
+      "args": {
+        "count": 4
+      },
+      "transform": {
+        "translate": [
+          0,
+          1.4,
+          0
+        ]
+      },
+      "material": {
+        "hue": 0.57,
+        "sat": 0.55,
+        "value": 0.64,
+        "kind": "normal",
+        "roughness": 0.3,
+        "clearcoat": 0.45
+      }
+    }
+  ],
+  "overlay": [
+    {
+      "text": "ELEVATION",
+      "anchor": [
+        0,
+        3.9,
+        0
+      ],
+      "role": "title"
+    },
+    {
+      "text": "Peak",
+      "anchor": [
+        3,
+        2.6,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "High",
+      "anchor": [
+        3,
+        1.8800000000000001,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "Mid",
+      "anchor": [
+        3,
+        1.1600000000000001,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "Foot",
+      "anchor": [
+        3,
+        0.43999999999999995,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    }
+  ],
+  "cameraSequence": {
+    "loop": false,
+    "shots": [
+      {
+        "duration": 0.01,
+        "pos": [
+          1,
+          2.1,
+          9.799999999999999
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 50,
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      },
+      {
+        "duration": 13,
+        "pos": [
+          0,
+          1.8,
+          8.2
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 46,
+        "transition": "blend",
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      }
+    ]
+  },
+  "defaults": {
+    "stage": {
+      "size": [
+        18,
+        9,
+        11
+      ]
+    }
+  }
+}

--- a/sdf-js/scenes/rec-mountain-5.json
+++ b/sdf-js/scenes/rec-mountain-5.json
@@ -1,0 +1,137 @@
+{
+  "v": 1,
+  "name": "(lifted) mountain-Goal Path",
+  "subjects": [
+    {
+      "id": "funnel",
+      "type": "funnel-3d",
+      "args": {
+        "stages": 4,
+        "topRadius": 1.15,
+        "bottomRadius": 0.28,
+        "stageHeight": 0.55,
+        "gap": 0.1
+      },
+      "transform": {
+        "translate": [
+          -0.3,
+          1.6,
+          0
+        ],
+        "rotate": [
+          0.12,
+          0,
+          0
+        ]
+      },
+      "material": {
+        "hue": 0.57,
+        "sat": 0.55,
+        "value": 0.64,
+        "kind": "normal",
+        "roughness": 0.3,
+        "clearcoat": 0.45
+      }
+    }
+  ],
+  "overlay": [
+    {
+      "text": "FOCUS TO SUMMIT",
+      "anchor": [
+        0,
+        3.9,
+        0
+      ],
+      "role": "title"
+    },
+    {
+      "text": "Vision",
+      "anchor": [
+        3,
+        2.6,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "Plan",
+      "anchor": [
+        3,
+        1.8800000000000001,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "Effort",
+      "anchor": [
+        3,
+        1.1600000000000001,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "Summit",
+      "anchor": [
+        3,
+        0.43999999999999995,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    }
+  ],
+  "cameraSequence": {
+    "loop": false,
+    "shots": [
+      {
+        "duration": 0.01,
+        "pos": [
+          1,
+          2.1,
+          9.799999999999999
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 50,
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      },
+      {
+        "duration": 13,
+        "pos": [
+          0,
+          1.8,
+          8.2
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 46,
+        "transition": "blend",
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      }
+    ]
+  },
+  "defaults": {
+    "stage": {
+      "size": [
+        18,
+        9,
+        11
+      ]
+    }
+  }
+}

--- a/sdf-js/scenes/rec-timelines-1.json
+++ b/sdf-js/scenes/rec-timelines-1.json
@@ -1,0 +1,132 @@
+{
+  "v": 1,
+  "name": "(lifted) timelines-2026 Timeline",
+  "subjects": [
+    {
+      "id": "timeline",
+      "type": "timeline-3d",
+      "args": {
+        "count": 4,
+        "axisLength": 4.2,
+        "axisRadius": 0.06,
+        "markerRadius": 0.2,
+        "stemHeight": 0.55
+      },
+      "transform": {
+        "translate": [
+          0,
+          1.4,
+          0
+        ]
+      },
+      "material": {
+        "hue": 0.57,
+        "sat": 0.55,
+        "value": 0.64,
+        "kind": "normal",
+        "roughness": 0.3,
+        "clearcoat": 0.45
+      }
+    }
+  ],
+  "overlay": [
+    {
+      "text": "PROJECT TIMELINES 2026",
+      "anchor": [
+        0,
+        3.9,
+        0
+      ],
+      "role": "title"
+    },
+    {
+      "text": "Q1",
+      "anchor": [
+        -2.1,
+        2.25,
+        0
+      ],
+      "role": "value",
+      "radius": 0.34
+    },
+    {
+      "text": "Q2",
+      "anchor": [
+        -0.7,
+        2.25,
+        0
+      ],
+      "role": "value",
+      "radius": 0.34
+    },
+    {
+      "text": "Q3",
+      "anchor": [
+        0.7000000000000002,
+        2.25,
+        0
+      ],
+      "role": "value",
+      "radius": 0.34
+    },
+    {
+      "text": "Q4",
+      "anchor": [
+        2.1,
+        2.25,
+        0
+      ],
+      "role": "value",
+      "radius": 0.34
+    }
+  ],
+  "cameraSequence": {
+    "loop": false,
+    "shots": [
+      {
+        "duration": 0.01,
+        "pos": [
+          1,
+          2.1,
+          9.799999999999999
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 50,
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      },
+      {
+        "duration": 13,
+        "pos": [
+          0,
+          1.8,
+          8.2
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 46,
+        "transition": "blend",
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      }
+    ]
+  },
+  "defaults": {
+    "stage": {
+      "size": [
+        18,
+        9,
+        11
+      ]
+    }
+  }
+}

--- a/sdf-js/scenes/rec-timelines-2.json
+++ b/sdf-js/scenes/rec-timelines-2.json
@@ -1,0 +1,142 @@
+{
+  "v": 1,
+  "name": "(lifted) timelines-Roadmap",
+  "subjects": [
+    {
+      "id": "timeline",
+      "type": "timeline-3d",
+      "args": {
+        "count": 5,
+        "axisLength": 4.2,
+        "axisRadius": 0.06,
+        "markerRadius": 0.2,
+        "stemHeight": 0.55
+      },
+      "transform": {
+        "translate": [
+          0,
+          1.4,
+          0
+        ]
+      },
+      "material": {
+        "hue": 0.57,
+        "sat": 0.55,
+        "value": 0.64,
+        "kind": "normal",
+        "roughness": 0.3,
+        "clearcoat": 0.45
+      }
+    }
+  ],
+  "overlay": [
+    {
+      "text": "ROADMAP",
+      "anchor": [
+        0,
+        3.9,
+        0
+      ],
+      "role": "title"
+    },
+    {
+      "text": "Jan",
+      "anchor": [
+        -2.1,
+        2.25,
+        0
+      ],
+      "role": "value",
+      "radius": 0.34
+    },
+    {
+      "text": "Apr",
+      "anchor": [
+        -1.05,
+        2.25,
+        0
+      ],
+      "role": "value",
+      "radius": 0.34
+    },
+    {
+      "text": "Jul",
+      "anchor": [
+        0,
+        2.25,
+        0
+      ],
+      "role": "value",
+      "radius": 0.34
+    },
+    {
+      "text": "Oct",
+      "anchor": [
+        1.0500000000000003,
+        2.25,
+        0
+      ],
+      "role": "value",
+      "radius": 0.34
+    },
+    {
+      "text": "Dec",
+      "anchor": [
+        2.1,
+        2.25,
+        0
+      ],
+      "role": "value",
+      "radius": 0.34
+    }
+  ],
+  "cameraSequence": {
+    "loop": false,
+    "shots": [
+      {
+        "duration": 0.01,
+        "pos": [
+          1,
+          2.1,
+          9.799999999999999
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 50,
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      },
+      {
+        "duration": 13,
+        "pos": [
+          0,
+          1.8,
+          8.2
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 46,
+        "transition": "blend",
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      }
+    ]
+  },
+  "defaults": {
+    "stage": {
+      "size": [
+        18,
+        9,
+        11
+      ]
+    }
+  }
+}

--- a/sdf-js/scenes/rec-timelines-3.json
+++ b/sdf-js/scenes/rec-timelines-3.json
@@ -1,0 +1,128 @@
+{
+  "v": 1,
+  "name": "(lifted) timelines-Gantt",
+  "subjects": [
+    {
+      "id": "gantt",
+      "type": "gantt-3d",
+      "args": {
+        "tasks": 4
+      },
+      "transform": {
+        "translate": [
+          0,
+          1.6,
+          0
+        ]
+      },
+      "material": {
+        "hue": 0.57,
+        "sat": 0.55,
+        "value": 0.64,
+        "kind": "normal",
+        "roughness": 0.3,
+        "clearcoat": 0.45
+      }
+    }
+  ],
+  "overlay": [
+    {
+      "text": "GANTT 2026",
+      "anchor": [
+        0,
+        3.9,
+        0
+      ],
+      "role": "title"
+    },
+    {
+      "text": "Phase 1",
+      "anchor": [
+        3,
+        2.6,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "Phase 2",
+      "anchor": [
+        3,
+        1.8800000000000001,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "Phase 3",
+      "anchor": [
+        3,
+        1.1600000000000001,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "Phase 4",
+      "anchor": [
+        3,
+        0.43999999999999995,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    }
+  ],
+  "cameraSequence": {
+    "loop": false,
+    "shots": [
+      {
+        "duration": 0.01,
+        "pos": [
+          1,
+          2.1,
+          9.799999999999999
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 50,
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      },
+      {
+        "duration": 13,
+        "pos": [
+          0,
+          1.8,
+          8.2
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 46,
+        "transition": "blend",
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      }
+    ]
+  },
+  "defaults": {
+    "stage": {
+      "size": [
+        18,
+        9,
+        11
+      ]
+    }
+  }
+}

--- a/sdf-js/scenes/rec-timelines-4.json
+++ b/sdf-js/scenes/rec-timelines-4.json
@@ -1,0 +1,128 @@
+{
+  "v": 1,
+  "name": "(lifted) timelines-Milestones",
+  "subjects": [
+    {
+      "id": "progression",
+      "type": "progression-3d",
+      "args": {
+        "steps": 4
+      },
+      "transform": {
+        "translate": [
+          -1,
+          0.6,
+          0
+        ]
+      },
+      "material": {
+        "hue": 0.57,
+        "sat": 0.55,
+        "value": 0.64,
+        "kind": "normal",
+        "roughness": 0.3,
+        "clearcoat": 0.45
+      }
+    }
+  ],
+  "overlay": [
+    {
+      "text": "MILESTONES",
+      "anchor": [
+        0,
+        3.9,
+        0
+      ],
+      "role": "title"
+    },
+    {
+      "text": "Plan",
+      "anchor": [
+        3,
+        2.6,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "Build",
+      "anchor": [
+        3,
+        1.8800000000000001,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "Ship",
+      "anchor": [
+        3,
+        1.1600000000000001,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "Scale",
+      "anchor": [
+        3,
+        0.43999999999999995,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    }
+  ],
+  "cameraSequence": {
+    "loop": false,
+    "shots": [
+      {
+        "duration": 0.01,
+        "pos": [
+          1,
+          2.1,
+          9.799999999999999
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 50,
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      },
+      {
+        "duration": 13,
+        "pos": [
+          0,
+          1.8,
+          8.2
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 46,
+        "transition": "blend",
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      }
+    ]
+  },
+  "defaults": {
+    "stage": {
+      "size": [
+        18,
+        9,
+        11
+      ]
+    }
+  }
+}

--- a/sdf-js/scenes/rec-timelines-5.json
+++ b/sdf-js/scenes/rec-timelines-5.json
@@ -1,0 +1,138 @@
+{
+  "v": 1,
+  "name": "(lifted) timelines-Phases",
+  "subjects": [
+    {
+      "id": "layer-stack",
+      "type": "layer-stack-3d",
+      "args": {
+        "layers": 4,
+        "layerW": 2.4,
+        "layerD": 1.5,
+        "layerH": 0.28,
+        "gap": 0.45,
+        "taper": 1
+      },
+      "transform": {
+        "translate": [
+          -0.3,
+          1.4,
+          0
+        ],
+        "rotate": [
+          0.35,
+          0.5,
+          0
+        ]
+      },
+      "material": {
+        "hue": 0.57,
+        "sat": 0.55,
+        "value": 0.64,
+        "kind": "normal",
+        "roughness": 0.3,
+        "clearcoat": 0.45
+      }
+    }
+  ],
+  "overlay": [
+    {
+      "text": "PROGRAM PHASES",
+      "anchor": [
+        0,
+        3.9,
+        0
+      ],
+      "role": "title"
+    },
+    {
+      "text": "Discovery",
+      "anchor": [
+        3,
+        2.6,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "Delivery",
+      "anchor": [
+        3,
+        1.8800000000000001,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "Adoption",
+      "anchor": [
+        3,
+        1.1600000000000001,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    },
+    {
+      "text": "Value",
+      "anchor": [
+        3,
+        0.43999999999999995,
+        0
+      ],
+      "role": "card",
+      "align": "left"
+    }
+  ],
+  "cameraSequence": {
+    "loop": false,
+    "shots": [
+      {
+        "duration": 0.01,
+        "pos": [
+          1,
+          2.1,
+          9.799999999999999
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 50,
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      },
+      {
+        "duration": 13,
+        "pos": [
+          0,
+          1.8,
+          8.2
+        ],
+        "target": [
+          0,
+          1.6,
+          0
+        ],
+        "fov": 46,
+        "transition": "blend",
+        "aperture": 0,
+        "focalDistance": 8.2,
+        "ease": "smooth"
+      }
+    ]
+  },
+  "defaults": {
+    "stage": {
+      "size": [
+        18,
+        9,
+        11
+      ]
+    }
+  }
+}

--- a/sdf-js/scripts/lift-rec-round5.mjs
+++ b/sdf-js/scripts/lift-rec-round5.mjs
@@ -1,0 +1,62 @@
+// lift-rec-round5.mjs — PL "recommendations" round 5 (final 4 templates). Data → twin map.
+// Note: Mountain Path (metaphor graphic) and Line Icons (icon set) have no dedicated
+// atom — represented with the closest structural analogs (climb=progression/pyramid,
+// icons=grid tiles). This is the real-world test surfacing a coverage gap, on purpose.
+import { writeFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+import { liftSceneData2dTo3d } from '../src/scene/lift-2d-to-3d.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const SCENES = resolve(__dirname, '../scenes');
+
+const DECKS = [
+  {
+    id: 'flowchart', name: 'Flow Chart Toolbox', slides: [
+      { title: 'Process Flow', type: 'flow-chart', args: { title: 'Flow Chart Toolbox', steps: [{ label: 'Start' }, { label: 'Process' }, { label: 'Decision' }, { label: 'End' }] } },
+      { title: 'Workflow', type: 'flow-chart', args: { title: 'Workflow', steps: [{ label: 'Intake' }, { label: 'Review' }, { label: 'Approve' }, { label: 'Execute' }, { label: 'Close' }] } },
+      { title: 'Decision Tree', type: 'tree-diagram', args: { title: 'Decision Tree', root: { label: 'Q', children: [{ label: 'Yes', children: [{ label: 'A1' }, { label: 'A2' }] }, { label: 'No', children: [{ label: 'B1' }, { label: 'B2' }] }] } } },
+      { title: 'Stages', type: 'progression', args: { title: 'Stages', steps: [{ label: 'Define' }, { label: 'Map' }, { label: 'Analyze' }, { label: 'Improve' }] } },
+      { title: 'Cycle', type: 'circle-loop', args: { title: 'Process Cycle', segments: 4, labels: ['Plan', 'Do', 'Check', 'Act'] } },
+    ],
+  },
+  {
+    id: 'timelines', name: 'Project Timelines 2026', slides: [
+      { title: '2026 Timeline', type: 'timeline', args: { title: 'Project Timelines 2026', events: [{ label: 'Q1' }, { label: 'Q2' }, { label: 'Q3' }, { label: 'Q4' }] } },
+      { title: 'Roadmap', type: 'timeline', args: { title: 'Roadmap', events: [{ label: 'Jan' }, { label: 'Apr' }, { label: 'Jul' }, { label: 'Oct' }, { label: 'Dec' }] } },
+      { title: 'Gantt', type: 'gantt', args: { title: 'Gantt 2026', tasks: [{ label: 'Phase 1' }, { label: 'Phase 2' }, { label: 'Phase 3' }, { label: 'Phase 4' }] } },
+      { title: 'Milestones', type: 'progression', args: { title: 'Milestones', steps: [{ label: 'Plan' }, { label: 'Build' }, { label: 'Ship' }, { label: 'Scale' }] } },
+      { title: 'Phases', type: 'layer-stack', args: { title: 'Program Phases', layers: [{ label: 'Discovery' }, { label: 'Delivery' }, { label: 'Adoption' }, { label: 'Value' }] } },
+    ],
+  },
+  {
+    id: 'mountain', name: 'Mountain Path – Graphics', slides: [
+      { title: 'The Summit', type: 'pyramid', args: { title: 'Mountain Path', layers: [{ label: 'Summit' }, { label: 'Ridge' }, { label: 'Ascent' }, { label: 'Base Camp' }] } },
+      { title: 'The Climb', type: 'progression', args: { title: 'The Climb', steps: [{ label: 'Base Camp' }, { label: 'Ascent' }, { label: 'Ridge' }, { label: 'Summit' }] } },
+      { title: 'Milestones', type: 'timeline', args: { title: 'Journey Milestones', events: [{ label: 'Start' }, { label: 'Camp 1' }, { label: 'Camp 2' }, { label: 'Peak' }] } },
+      { title: 'Elevation Tiers', type: 'circle-stack', args: { title: 'Elevation', layers: [{ label: 'Peak' }, { label: 'High' }, { label: 'Mid' }, { label: 'Foot' }] } },
+      { title: 'Goal Path', type: 'funnel', args: { title: 'Focus to Summit', stages: [{ label: 'Vision' }, { label: 'Plan' }, { label: 'Effort' }, { label: 'Summit' }] } },
+    ],
+  },
+  {
+    id: 'icons', name: 'Line Icons - Business', slides: [
+      { title: 'Categories', type: 'radial-spoke', args: { title: 'Business Icons', values: [1, 1, 1, 1, 1, 1], labels: ['Finance', 'People', 'Growth', 'Tech', 'Strategy', 'Ops'] } },
+      { title: 'Icon Grid', type: 'cube-grid', args: { title: 'Icon Set', size: 3 } },
+      { title: 'Concept Tiles', type: 'matrix-grid', args: { title: 'Concept Tiles', rows: 2, cols: 4 } },
+      { title: 'Themes', type: 'circle-segmented', args: { title: 'Themes', segments: 6, labels: ['$', '%', '↑', '★', '✓', '◆'] } },
+      { title: 'Toolkit', type: 'radial-spoke', args: { title: 'Toolkit', values: [1, 1, 1, 1], labels: ['Charts', 'Flows', 'Maps', 'KPIs'] } },
+    ],
+  },
+];
+
+for (const deck of DECKS) {
+  const segments = [];
+  deck.slides.forEach((slide, i) => {
+    const scene = liftSceneData2dTo3d({ name: `${deck.id}-${slide.title}`, subjects: [{ type: slide.type, args: slide.args }] });
+    const file = `rec-${deck.id}-${i + 1}.json`;
+    writeFileSync(resolve(SCENES, file), `${JSON.stringify(scene, null, 2)}\n`);
+    segments.push({ file, title: slide.title, kind: 'slide', durationSec: 7 });
+  });
+  writeFileSync(resolve(SCENES, `deck-rec-${deck.id}.json`), `${JSON.stringify({ id: `deck-rec-${deck.id}`, name: deck.name, segments }, null, 2)}\n`);
+  console.log(`  ✓ ${deck.name.padEnd(34)} → ?deck=deck-rec-${deck.id}`);
+}


### PR DESCRIPTION
Round 5/5 —— **收尾全部 23 个**。纯数据 lift。

- `?deck=deck-rec-flowchart` —— Flow Chart Toolbox
- `?deck=deck-rec-timelines` —— Project Timelines 2026
- `?deck=deck-rec-mountain` —— Mountain Path – Graphics
- `?deck=deck-rec-icons` —— Line Icons - Business

20 slide 全编译;flow-chart 渲染验证。`npm test` 99/99。

**已知缺口(留给打磨轮)**:Mountain Path / Line Icons 没有专属原子(隐喻图/图标集)→ 用结构近似表达;cube-grid 的 grid 排布渲成一行而非 NxN,需修。

**至此 23 个 recommendations 全部实现(rounds 1-5,共 115 slide / 23 deck)。**

🤖 Generated with [Claude Code](https://claude.com/claude-code)