### PR TITLE
polish(lift): rec decks quality pass — cube-grid fix, thicker radial, family colour palette

### DIFF
--- a/sdf-js/scenes/lifted-charts-circle-segments.json
+++ b/sdf-js/scenes/lifted-charts-circle-segments.json
@@ -25,7 +25,7 @@
         ]
       },
       "material": {
-        "hue": 0.57,
+        "hue": 0.5,
         "sat": 0.55,
         "value": 0.64,
         "kind": "normal",

--- a/sdf-js/scenes/lifted-charts-graphs.json
+++ b/sdf-js/scenes/lifted-charts-graphs.json
@@ -26,7 +26,7 @@
         ]
       },
       "material": {
-        "hue": 0.57,
+        "hue": 0.58,
         "sat": 0.55,
         "value": 0.64,
         "kind": "normal",

--- a/sdf-js/scenes/lifted-charts-layer-objects.json
+++ b/sdf-js/scenes/lifted-charts-layer-objects.json
@@ -26,7 +26,7 @@
         ]
       },
       "material": {
-        "hue": 0.57,
+        "hue": 0.66,
         "sat": 0.55,
         "value": 0.64,
         "kind": "normal",

--- a/sdf-js/scenes/lifted-charts-round-plates.json
+++ b/sdf-js/scenes/lifted-charts-round-plates.json
@@ -16,7 +16,7 @@
         ]
       },
       "material": {
-        "hue": 0.57,
+        "hue": 0.66,
         "sat": 0.55,
         "value": 0.64,
         "kind": "normal",

--- a/sdf-js/scenes/lifted-charts-step-diagram.json
+++ b/sdf-js/scenes/lifted-charts-step-diagram.json
@@ -16,7 +16,7 @@
         ]
       },
       "material": {
-        "hue": 0.57,
+        "hue": 0.4,
         "sat": 0.55,
         "value": 0.64,
         "kind": "normal",

--- a/sdf-js/scenes/lifted-charts-timeline-spheres.json
+++ b/sdf-js/scenes/lifted-charts-timeline-spheres.json
@@ -20,7 +20,7 @@
         ]
       },
       "material": {
-        "hue": 0.57,
+        "hue": 0.4,
         "sat": 0.55,
         "value": 0.64,
         "kind": "normal",

--- a/sdf-js/scenes/lifted-cloud-share.json
+++ b/sdf-js/scenes/lifted-cloud-share.json
@@ -29,7 +29,7 @@
         ]
       },
       "material": {
-        "hue": 0.57,
+        "hue": 0.5,
         "sat": 0.55,
         "value": 0.64,
         "kind": "normal",

--- a/sdf-js/scenes/lifted-maturity.json
+++ b/sdf-js/scenes/lifted-maturity.json
@@ -16,9 +16,9 @@
         ]
       },
       "material": {
-        "hue": 0.57,
-        "sat": 0.55,
-        "value": 0.64,
+        "hue": 0.11,
+        "sat": 0.72,
+        "value": 0.82,
         "kind": "normal",
         "roughness": 0.3,
         "clearcoat": 0.45

--- a/sdf-js/scenes/lifted-org.json
+++ b/sdf-js/scenes/lifted-org.json
@@ -21,7 +21,7 @@
         ]
       },
       "material": {
-        "hue": 0.57,
+        "hue": 0.54,
         "sat": 0.55,
         "value": 0.64,
         "kind": "normal",

--- a/sdf-js/scenes/lifted-quarterly.json
+++ b/sdf-js/scenes/lifted-quarterly.json
@@ -26,7 +26,7 @@
         ]
       },
       "material": {
-        "hue": 0.57,
+        "hue": 0.58,
         "sat": 0.55,
         "value": 0.64,
         "kind": "normal",

--- a/sdf-js/scenes/lifted-roadmap.json
+++ b/sdf-js/scenes/lifted-roadmap.json
@@ -20,7 +20,7 @@
         ]
       },
       "material": {
-        "hue": 0.57,
+        "hue": 0.4,
         "sat": 0.55,
         "value": 0.64,
         "kind": "normal",

--- a/sdf-js/scenes/lifted-rootcause.json
+++ b/sdf-js/scenes/lifted-rootcause.json
@@ -16,7 +16,7 @@
         ]
       },
       "material": {
-        "hue": 0.57,
+        "hue": 0.4,
         "sat": 0.55,
         "value": 0.64,
         "kind": "normal",

--- a/sdf-js/scenes/lifted-sales-funnel.json
+++ b/sdf-js/scenes/lifted-sales-funnel.json
@@ -25,9 +25,9 @@
         ]
       },
       "material": {
-        "hue": 0.57,
-        "sat": 0.55,
-        "value": 0.64,
+        "hue": 0.04,
+        "sat": 0.72,
+        "value": 0.82,
         "kind": "normal",
         "roughness": 0.3,
         "clearcoat": 0.45

--- a/sdf-js/scenes/rec-ai-1.json
+++ b/sdf-js/scenes/rec-ai-1.json
@@ -17,7 +17,7 @@
         ]
       },
       "material": {
-        "hue": 0.57,
+        "hue": 0.58,
         "sat": 0.55,
         "value": 0.64,
         "kind": "normal",

--- a/sdf-js/scenes/rec-ai-2.json
+++ b/sdf-js/scenes/rec-ai-2.json
@@ -16,7 +16,7 @@
         ]
       },
       "material": {
-        "hue": 0.57,
+        "hue": 0.4,
         "sat": 0.55,
         "value": 0.64,
         "kind": "normal",

--- a/sdf-js/scenes/rec-ai-3.json
+++ b/sdf-js/scenes/rec-ai-3.json
@@ -28,7 +28,7 @@
         ]
       },
       "material": {
-        "hue": 0.57,
+        "hue": 0.5,
         "sat": 0.55,
         "value": 0.64,
         "kind": "normal",

--- a/sdf-js/scenes/rec-ai-4.json
+++ b/sdf-js/scenes/rec-ai-4.json
@@ -20,7 +20,7 @@
         ]
       },
       "material": {
-        "hue": 0.57,
+        "hue": 0.4,
         "sat": 0.55,
         "value": 0.64,
         "kind": "normal",

--- a/sdf-js/scenes/rec-ai-5.json
+++ b/sdf-js/scenes/rec-ai-5.json
@@ -25,9 +25,9 @@
         ]
       },
       "material": {
-        "hue": 0.57,
-        "sat": 0.55,
-        "value": 0.64,
+        "hue": 0.04,
+        "sat": 0.72,
+        "value": 0.82,
         "kind": "normal",
         "roughness": 0.3,
         "clearcoat": 0.45

--- a/sdf-js/scenes/rec-bizcase-1.json
+++ b/sdf-js/scenes/rec-bizcase-1.json
@@ -16,9 +16,9 @@
         ]
       },
       "material": {
-        "hue": 0.57,
-        "sat": 0.55,
-        "value": 0.64,
+        "hue": 0.11,
+        "sat": 0.72,
+        "value": 0.82,
         "kind": "normal",
         "roughness": 0.3,
         "clearcoat": 0.45

--- a/sdf-js/scenes/rec-bizcase-2.json
+++ b/sdf-js/scenes/rec-bizcase-2.json
@@ -17,7 +17,7 @@
         ]
       },
       "material": {
-        "hue": 0.57,
+        "hue": 0.6,
         "sat": 0.55,
         "value": 0.64,
         "kind": "normal",

--- a/sdf-js/scenes/rec-bizcase-3.json
+++ b/sdf-js/scenes/rec-bizcase-3.json
@@ -25,7 +25,7 @@
         ]
       },
       "material": {
-        "hue": 0.57,
+        "hue": 0.58,
         "sat": 0.55,
         "value": 0.64,
         "kind": "normal",

--- a/sdf-js/scenes/rec-bizcase-4.json
+++ b/sdf-js/scenes/rec-bizcase-4.json
@@ -20,7 +20,7 @@
         ]
       },
       "material": {
-        "hue": 0.57,
+        "hue": 0.4,
         "sat": 0.55,
         "value": 0.64,
         "kind": "normal",

--- a/sdf-js/scenes/rec-bizcase-5.json
+++ b/sdf-js/scenes/rec-bizcase-5.json
@@ -25,9 +25,9 @@
         ]
       },
       "material": {
-        "hue": 0.57,
-        "sat": 0.55,
-        "value": 0.64,
+        "hue": 0.04,
+        "sat": 0.72,
+        "value": 0.82,
         "kind": "normal",
         "roughness": 0.3,
         "clearcoat": 0.45

--- a/sdf-js/scenes/rec-bizplan-1.json
+++ b/sdf-js/scenes/rec-bizplan-1.json
@@ -16,9 +16,9 @@
         ]
       },
       "material": {
-        "hue": 0.57,
-        "sat": 0.55,
-        "value": 0.64,
+        "hue": 0.11,
+        "sat": 0.72,
+        "value": 0.82,
         "kind": "normal",
         "roughness": 0.3,
         "clearcoat": 0.45

--- a/sdf-js/scenes/rec-bizplan-2.json
+++ b/sdf-js/scenes/rec-bizplan-2.json
@@ -20,7 +20,7 @@
         ]
       },
       "material": {
-        "hue": 0.57,
+        "hue": 0.4,
         "sat": 0.55,
         "value": 0.64,
         "kind": "normal",

--- a/sdf-js/scenes/rec-bizplan-3.json
+++ b/sdf-js/scenes/rec-bizplan-3.json
@@ -26,7 +26,7 @@
         ]
       },
       "material": {
-        "hue": 0.57,
+        "hue": 0.58,
         "sat": 0.55,
         "value": 0.64,
         "kind": "normal",

--- a/sdf-js/scenes/rec-bizplan-4.json
+++ b/sdf-js/scenes/rec-bizplan-4.json
@@ -28,7 +28,7 @@
         ]
       },
       "material": {
-        "hue": 0.57,
+        "hue": 0.5,
         "sat": 0.55,
         "value": 0.64,
         "kind": "normal",

--- a/sdf-js/scenes/rec-bizplan-5.json
+++ b/sdf-js/scenes/rec-bizplan-5.json
@@ -25,9 +25,9 @@
         ]
       },
       "material": {
-        "hue": 0.57,
-        "sat": 0.55,
-        "value": 0.64,
+        "hue": 0.04,
+        "sat": 0.72,
+        "value": 0.82,
         "kind": "normal",
         "roughness": 0.3,
         "clearcoat": 0.45

--- a/sdf-js/scenes/rec-comms-1.json
+++ b/sdf-js/scenes/rec-comms-1.json
@@ -6,7 +6,12 @@
       "id": "radial-spoke",
       "type": "radial-spoke-3d",
       "args": {
-        "spokes": 5
+        "spokes": 5,
+        "hubRadius": 0.34,
+        "spokeThickness": 0.09,
+        "nodeRadius": 0.17,
+        "maxLen": 1.35,
+        "minLen": 0.7
       },
       "transform": {
         "translate": [

--- a/sdf-js/scenes/rec-comms-1.json
+++ b/sdf-js/scenes/rec-comms-1.json
@@ -21,7 +21,7 @@
         ]
       },
       "material": {
-        "hue": 0.57,
+        "hue": 0.74,
         "sat": 0.55,
         "value": 0.64,
         "kind": "normal",

--- a/sdf-js/scenes/rec-comms-2.json
+++ b/sdf-js/scenes/rec-comms-2.json
@@ -16,7 +16,7 @@
         ]
       },
       "material": {
-        "hue": 0.57,
+        "hue": 0.4,
         "sat": 0.55,
         "value": 0.64,
         "kind": "normal",

--- a/sdf-js/scenes/rec-comms-3.json
+++ b/sdf-js/scenes/rec-comms-3.json
@@ -17,7 +17,7 @@
         ]
       },
       "material": {
-        "hue": 0.57,
+        "hue": 0.6,
         "sat": 0.55,
         "value": 0.64,
         "kind": "normal",

--- a/sdf-js/scenes/rec-comms-4.json
+++ b/sdf-js/scenes/rec-comms-4.json
@@ -20,7 +20,7 @@
         ]
       },
       "material": {
-        "hue": 0.57,
+        "hue": 0.4,
         "sat": 0.55,
         "value": 0.64,
         "kind": "normal",

--- a/sdf-js/scenes/rec-comms-5.json
+++ b/sdf-js/scenes/rec-comms-5.json
@@ -29,7 +29,7 @@
         ]
       },
       "material": {
-        "hue": 0.57,
+        "hue": 0.5,
         "sat": 0.55,
         "value": 0.64,
         "kind": "normal",

--- a/sdf-js/scenes/rec-consulting-1.json
+++ b/sdf-js/scenes/rec-consulting-1.json
@@ -6,7 +6,12 @@
       "id": "radial-spoke",
       "type": "radial-spoke-3d",
       "args": {
-        "spokes": 6
+        "spokes": 6,
+        "hubRadius": 0.34,
+        "spokeThickness": 0.09,
+        "nodeRadius": 0.17,
+        "maxLen": 1.35,
+        "minLen": 0.7
       },
       "transform": {
         "translate": [

--- a/sdf-js/scenes/rec-consulting-1.json
+++ b/sdf-js/scenes/rec-consulting-1.json
@@ -21,7 +21,7 @@
         ]
       },
       "material": {
-        "hue": 0.57,
+        "hue": 0.74,
         "sat": 0.55,
         "value": 0.64,
         "kind": "normal",

--- a/sdf-js/scenes/rec-consulting-2.json
+++ b/sdf-js/scenes/rec-consulting-2.json
@@ -17,7 +17,7 @@
         ]
       },
       "material": {
-        "hue": 0.57,
+        "hue": 0.6,
         "sat": 0.55,
         "value": 0.64,
         "kind": "normal",

--- a/sdf-js/scenes/rec-consulting-3.json
+++ b/sdf-js/scenes/rec-consulting-3.json
@@ -16,7 +16,7 @@
         ]
       },
       "material": {
-        "hue": 0.57,
+        "hue": 0.4,
         "sat": 0.55,
         "value": 0.64,
         "kind": "normal",

--- a/sdf-js/scenes/rec-consulting-4.json
+++ b/sdf-js/scenes/rec-consulting-4.json
@@ -16,9 +16,9 @@
         ]
       },
       "material": {
-        "hue": 0.57,
-        "sat": 0.55,
-        "value": 0.64,
+        "hue": 0.11,
+        "sat": 0.72,
+        "value": 0.82,
         "kind": "normal",
         "roughness": 0.3,
         "clearcoat": 0.45

--- a/sdf-js/scenes/rec-consulting-5.json
+++ b/sdf-js/scenes/rec-consulting-5.json
@@ -20,7 +20,7 @@
         ]
       },
       "material": {
-        "hue": 0.57,
+        "hue": 0.4,
         "sat": 0.55,
         "value": 0.64,
         "kind": "normal",

--- a/sdf-js/scenes/rec-cyber-1.json
+++ b/sdf-js/scenes/rec-cyber-1.json
@@ -17,7 +17,7 @@
         ]
       },
       "material": {
-        "hue": 0.57,
+        "hue": 0.58,
         "sat": 0.55,
         "value": 0.64,
         "kind": "normal",

--- a/sdf-js/scenes/rec-cyber-2.json
+++ b/sdf-js/scenes/rec-cyber-2.json
@@ -26,7 +26,7 @@
         ]
       },
       "material": {
-        "hue": 0.57,
+        "hue": 0.66,
         "sat": 0.55,
         "value": 0.64,
         "kind": "normal",

--- a/sdf-js/scenes/rec-cyber-3.json
+++ b/sdf-js/scenes/rec-cyber-3.json
@@ -25,9 +25,9 @@
         ]
       },
       "material": {
-        "hue": 0.57,
-        "sat": 0.55,
-        "value": 0.64,
+        "hue": 0.04,
+        "sat": 0.72,
+        "value": 0.82,
         "kind": "normal",
         "roughness": 0.3,
         "clearcoat": 0.45

--- a/sdf-js/scenes/rec-cyber-4.json
+++ b/sdf-js/scenes/rec-cyber-4.json
@@ -16,9 +16,9 @@
         ]
       },
       "material": {
-        "hue": 0.57,
-        "sat": 0.55,
-        "value": 0.64,
+        "hue": 0.11,
+        "sat": 0.72,
+        "value": 0.82,
         "kind": "normal",
         "roughness": 0.3,
         "clearcoat": 0.45

--- a/sdf-js/scenes/rec-cyber-5.json
+++ b/sdf-js/scenes/rec-cyber-5.json
@@ -16,7 +16,7 @@
         ]
       },
       "material": {
-        "hue": 0.57,
+        "hue": 0.4,
         "sat": 0.55,
         "value": 0.64,
         "kind": "normal",

--- a/sdf-js/scenes/rec-digital-1.json
+++ b/sdf-js/scenes/rec-digital-1.json
@@ -26,7 +26,7 @@
         ]
       },
       "material": {
-        "hue": 0.57,
+        "hue": 0.66,
         "sat": 0.55,
         "value": 0.64,
         "kind": "normal",

--- a/sdf-js/scenes/rec-digital-2.json
+++ b/sdf-js/scenes/rec-digital-2.json
@@ -20,7 +20,7 @@
         ]
       },
       "material": {
-        "hue": 0.57,
+        "hue": 0.4,
         "sat": 0.55,
         "value": 0.64,
         "kind": "normal",

--- a/sdf-js/scenes/rec-digital-3.json
+++ b/sdf-js/scenes/rec-digital-3.json
@@ -16,9 +16,9 @@
         ]
       },
       "material": {
-        "hue": 0.57,
-        "sat": 0.55,
-        "value": 0.64,
+        "hue": 0.11,
+        "sat": 0.72,
+        "value": 0.82,
         "kind": "normal",
         "roughness": 0.3,
         "clearcoat": 0.45

--- a/sdf-js/scenes/rec-digital-4.json
+++ b/sdf-js/scenes/rec-digital-4.json
@@ -6,7 +6,12 @@
       "id": "radial-spoke",
       "type": "radial-spoke-3d",
       "args": {
-        "spokes": 5
+        "spokes": 5,
+        "hubRadius": 0.34,
+        "spokeThickness": 0.09,
+        "nodeRadius": 0.17,
+        "maxLen": 1.35,
+        "minLen": 0.7
       },
       "transform": {
         "translate": [

--- a/sdf-js/scenes/rec-digital-4.json
+++ b/sdf-js/scenes/rec-digital-4.json
@@ -21,7 +21,7 @@
         ]
       },
       "material": {
-        "hue": 0.57,
+        "hue": 0.74,
         "sat": 0.55,
         "value": 0.64,
         "kind": "normal",

--- a/sdf-js/scenes/rec-digital-5.json
+++ b/sdf-js/scenes/rec-digital-5.json
@@ -25,9 +25,9 @@
         ]
       },
       "material": {
-        "hue": 0.57,
-        "sat": 0.55,
-        "value": 0.64,
+        "hue": 0.04,
+        "sat": 0.72,
+        "value": 0.82,
         "kind": "normal",
         "roughness": 0.3,
         "clearcoat": 0.45

--- a/sdf-js/scenes/rec-flowchart-1.json
+++ b/sdf-js/scenes/rec-flowchart-1.json
@@ -16,7 +16,7 @@
         ]
       },
       "material": {
-        "hue": 0.57,
+        "hue": 0.4,
         "sat": 0.55,
         "value": 0.64,
         "kind": "normal",

--- a/sdf-js/scenes/rec-flowchart-2.json
+++ b/sdf-js/scenes/rec-flowchart-2.json
@@ -16,7 +16,7 @@
         ]
       },
       "material": {
-        "hue": 0.57,
+        "hue": 0.4,
         "sat": 0.55,
         "value": 0.64,
         "kind": "normal",

--- a/sdf-js/scenes/rec-flowchart-3.json
+++ b/sdf-js/scenes/rec-flowchart-3.json
@@ -17,7 +17,7 @@
         ]
       },
       "material": {
-        "hue": 0.57,
+        "hue": 0.54,
         "sat": 0.55,
         "value": 0.64,
         "kind": "normal",

--- a/sdf-js/scenes/rec-flowchart-4.json
+++ b/sdf-js/scenes/rec-flowchart-4.json
@@ -16,7 +16,7 @@
         ]
       },
       "material": {
-        "hue": 0.57,
+        "hue": 0.4,
         "sat": 0.55,
         "value": 0.64,
         "kind": "normal",

--- a/sdf-js/scenes/rec-flowchart-5.json
+++ b/sdf-js/scenes/rec-flowchart-5.json
@@ -21,7 +21,7 @@
         ]
       },
       "material": {
-        "hue": 0.57,
+        "hue": 0.5,
         "sat": 0.55,
         "value": 0.64,
         "kind": "normal",

--- a/sdf-js/scenes/rec-grow-1.json
+++ b/sdf-js/scenes/rec-grow-1.json
@@ -25,7 +25,7 @@
         ]
       },
       "material": {
-        "hue": 0.57,
+        "hue": 0.5,
         "sat": 0.55,
         "value": 0.64,
         "kind": "normal",

--- a/sdf-js/scenes/rec-grow-2.json
+++ b/sdf-js/scenes/rec-grow-2.json
@@ -16,7 +16,7 @@
         ]
       },
       "material": {
-        "hue": 0.57,
+        "hue": 0.4,
         "sat": 0.55,
         "value": 0.64,
         "kind": "normal",

--- a/sdf-js/scenes/rec-grow-3.json
+++ b/sdf-js/scenes/rec-grow-3.json
@@ -21,7 +21,7 @@
         ]
       },
       "material": {
-        "hue": 0.57,
+        "hue": 0.5,
         "sat": 0.55,
         "value": 0.64,
         "kind": "normal",

--- a/sdf-js/scenes/rec-grow-4.json
+++ b/sdf-js/scenes/rec-grow-4.json
@@ -6,7 +6,12 @@
       "id": "radial-spoke",
       "type": "radial-spoke-3d",
       "args": {
-        "spokes": 4
+        "spokes": 4,
+        "hubRadius": 0.34,
+        "spokeThickness": 0.09,
+        "nodeRadius": 0.17,
+        "maxLen": 1.35,
+        "minLen": 0.7
       },
       "transform": {
         "translate": [

--- a/sdf-js/scenes/rec-grow-4.json
+++ b/sdf-js/scenes/rec-grow-4.json
@@ -21,7 +21,7 @@
         ]
       },
       "material": {
-        "hue": 0.57,
+        "hue": 0.74,
         "sat": 0.55,
         "value": 0.64,
         "kind": "normal",

--- a/sdf-js/scenes/rec-grow-5.json
+++ b/sdf-js/scenes/rec-grow-5.json
@@ -20,7 +20,7 @@
         ]
       },
       "material": {
-        "hue": 0.57,
+        "hue": 0.4,
         "sat": 0.55,
         "value": 0.64,
         "kind": "normal",

--- a/sdf-js/scenes/rec-icons-1.json
+++ b/sdf-js/scenes/rec-icons-1.json
@@ -6,7 +6,12 @@
       "id": "radial-spoke",
       "type": "radial-spoke-3d",
       "args": {
-        "spokes": 6
+        "spokes": 6,
+        "hubRadius": 0.34,
+        "spokeThickness": 0.09,
+        "nodeRadius": 0.17,
+        "maxLen": 1.35,
+        "minLen": 0.7
       },
       "transform": {
         "translate": [

--- a/sdf-js/scenes/rec-icons-1.json
+++ b/sdf-js/scenes/rec-icons-1.json
@@ -21,7 +21,7 @@
         ]
       },
       "material": {
-        "hue": 0.57,
+        "hue": 0.74,
         "sat": 0.55,
         "value": 0.64,
         "kind": "normal",

--- a/sdf-js/scenes/rec-icons-2.json
+++ b/sdf-js/scenes/rec-icons-2.json
@@ -29,7 +29,7 @@
         ]
       },
       "material": {
-        "hue": 0.57,
+        "hue": 0.6,
         "sat": 0.55,
         "value": 0.64,
         "kind": "normal",

--- a/sdf-js/scenes/rec-icons-2.json
+++ b/sdf-js/scenes/rec-icons-2.json
@@ -9,14 +9,22 @@
         "arrangement": "grid",
         "count": 9,
         "cubeSize": 0.5,
-        "spacing": 0.2,
+        "spacing": 0.22,
         "material": "solid",
-        "colors": null
+        "colors": null,
+        "arrangementParams": {
+          "cols": 3
+        }
       },
       "transform": {
         "translate": [
           0,
-          1.6,
+          1.9,
+          0
+        ],
+        "rotate": [
+          1.5708,
+          0,
           0
         ]
       },

--- a/sdf-js/scenes/rec-icons-3.json
+++ b/sdf-js/scenes/rec-icons-3.json
@@ -17,7 +17,7 @@
         ]
       },
       "material": {
-        "hue": 0.57,
+        "hue": 0.6,
         "sat": 0.55,
         "value": 0.64,
         "kind": "normal",

--- a/sdf-js/scenes/rec-icons-4.json
+++ b/sdf-js/scenes/rec-icons-4.json
@@ -25,7 +25,7 @@
         ]
       },
       "material": {
-        "hue": 0.57,
+        "hue": 0.5,
         "sat": 0.55,
         "value": 0.64,
         "kind": "normal",

--- a/sdf-js/scenes/rec-icons-5.json
+++ b/sdf-js/scenes/rec-icons-5.json
@@ -6,7 +6,12 @@
       "id": "radial-spoke",
       "type": "radial-spoke-3d",
       "args": {
-        "spokes": 4
+        "spokes": 4,
+        "hubRadius": 0.34,
+        "spokeThickness": 0.09,
+        "nodeRadius": 0.17,
+        "maxLen": 1.35,
+        "minLen": 0.7
       },
       "transform": {
         "translate": [

--- a/sdf-js/scenes/rec-icons-5.json
+++ b/sdf-js/scenes/rec-icons-5.json
@@ -21,7 +21,7 @@
         ]
       },
       "material": {
-        "hue": 0.57,
+        "hue": 0.74,
         "sat": 0.55,
         "value": 0.64,
         "kind": "normal",

--- a/sdf-js/scenes/rec-innovation-1.json
+++ b/sdf-js/scenes/rec-innovation-1.json
@@ -6,7 +6,12 @@
       "id": "radial-spoke",
       "type": "radial-spoke-3d",
       "args": {
-        "spokes": 5
+        "spokes": 5,
+        "hubRadius": 0.34,
+        "spokeThickness": 0.09,
+        "nodeRadius": 0.17,
+        "maxLen": 1.35,
+        "minLen": 0.7
       },
       "transform": {
         "translate": [

--- a/sdf-js/scenes/rec-innovation-1.json
+++ b/sdf-js/scenes/rec-innovation-1.json
@@ -21,7 +21,7 @@
         ]
       },
       "material": {
-        "hue": 0.57,
+        "hue": 0.74,
         "sat": 0.55,
         "value": 0.64,
         "kind": "normal",

--- a/sdf-js/scenes/rec-innovation-2.json
+++ b/sdf-js/scenes/rec-innovation-2.json
@@ -25,9 +25,9 @@
         ]
       },
       "material": {
-        "hue": 0.57,
-        "sat": 0.55,
-        "value": 0.64,
+        "hue": 0.04,
+        "sat": 0.72,
+        "value": 0.82,
         "kind": "normal",
         "roughness": 0.3,
         "clearcoat": 0.45

--- a/sdf-js/scenes/rec-innovation-3.json
+++ b/sdf-js/scenes/rec-innovation-3.json
@@ -16,7 +16,7 @@
         ]
       },
       "material": {
-        "hue": 0.57,
+        "hue": 0.4,
         "sat": 0.55,
         "value": 0.64,
         "kind": "normal",

--- a/sdf-js/scenes/rec-innovation-4.json
+++ b/sdf-js/scenes/rec-innovation-4.json
@@ -17,7 +17,7 @@
         ]
       },
       "material": {
-        "hue": 0.57,
+        "hue": 0.6,
         "sat": 0.55,
         "value": 0.64,
         "kind": "normal",

--- a/sdf-js/scenes/rec-innovation-5.json
+++ b/sdf-js/scenes/rec-innovation-5.json
@@ -20,7 +20,7 @@
         ]
       },
       "material": {
-        "hue": 0.57,
+        "hue": 0.4,
         "sat": 0.55,
         "value": 0.64,
         "kind": "normal",

--- a/sdf-js/scenes/rec-itstrategy-1.json
+++ b/sdf-js/scenes/rec-itstrategy-1.json
@@ -26,7 +26,7 @@
         ]
       },
       "material": {
-        "hue": 0.57,
+        "hue": 0.66,
         "sat": 0.55,
         "value": 0.64,
         "kind": "normal",

--- a/sdf-js/scenes/rec-itstrategy-2.json
+++ b/sdf-js/scenes/rec-itstrategy-2.json
@@ -20,7 +20,7 @@
         ]
       },
       "material": {
-        "hue": 0.57,
+        "hue": 0.4,
         "sat": 0.55,
         "value": 0.64,
         "kind": "normal",

--- a/sdf-js/scenes/rec-itstrategy-3.json
+++ b/sdf-js/scenes/rec-itstrategy-3.json
@@ -6,7 +6,12 @@
       "id": "radial-spoke",
       "type": "radial-spoke-3d",
       "args": {
-        "spokes": 5
+        "spokes": 5,
+        "hubRadius": 0.34,
+        "spokeThickness": 0.09,
+        "nodeRadius": 0.17,
+        "maxLen": 1.35,
+        "minLen": 0.7
       },
       "transform": {
         "translate": [

--- a/sdf-js/scenes/rec-itstrategy-3.json
+++ b/sdf-js/scenes/rec-itstrategy-3.json
@@ -21,7 +21,7 @@
         ]
       },
       "material": {
-        "hue": 0.57,
+        "hue": 0.74,
         "sat": 0.55,
         "value": 0.64,
         "kind": "normal",

--- a/sdf-js/scenes/rec-itstrategy-4.json
+++ b/sdf-js/scenes/rec-itstrategy-4.json
@@ -16,9 +16,9 @@
         ]
       },
       "material": {
-        "hue": 0.57,
-        "sat": 0.55,
-        "value": 0.64,
+        "hue": 0.11,
+        "sat": 0.72,
+        "value": 0.82,
         "kind": "normal",
         "roughness": 0.3,
         "clearcoat": 0.45

--- a/sdf-js/scenes/rec-itstrategy-5.json
+++ b/sdf-js/scenes/rec-itstrategy-5.json
@@ -17,7 +17,7 @@
         ]
       },
       "material": {
-        "hue": 0.57,
+        "hue": 0.6,
         "sat": 0.55,
         "value": 0.64,
         "kind": "normal",

--- a/sdf-js/scenes/rec-journey-1.json
+++ b/sdf-js/scenes/rec-journey-1.json
@@ -20,7 +20,7 @@
         ]
       },
       "material": {
-        "hue": 0.57,
+        "hue": 0.4,
         "sat": 0.55,
         "value": 0.64,
         "kind": "normal",

--- a/sdf-js/scenes/rec-journey-2.json
+++ b/sdf-js/scenes/rec-journey-2.json
@@ -16,7 +16,7 @@
         ]
       },
       "material": {
-        "hue": 0.57,
+        "hue": 0.4,
         "sat": 0.55,
         "value": 0.64,
         "kind": "normal",

--- a/sdf-js/scenes/rec-journey-3.json
+++ b/sdf-js/scenes/rec-journey-3.json
@@ -6,7 +6,12 @@
       "id": "radial-spoke",
       "type": "radial-spoke-3d",
       "args": {
-        "spokes": 5
+        "spokes": 5,
+        "hubRadius": 0.34,
+        "spokeThickness": 0.09,
+        "nodeRadius": 0.17,
+        "maxLen": 1.35,
+        "minLen": 0.7
       },
       "transform": {
         "translate": [

--- a/sdf-js/scenes/rec-journey-3.json
+++ b/sdf-js/scenes/rec-journey-3.json
@@ -21,7 +21,7 @@
         ]
       },
       "material": {
-        "hue": 0.57,
+        "hue": 0.74,
         "sat": 0.55,
         "value": 0.64,
         "kind": "normal",

--- a/sdf-js/scenes/rec-journey-4.json
+++ b/sdf-js/scenes/rec-journey-4.json
@@ -26,7 +26,7 @@
         ]
       },
       "material": {
-        "hue": 0.57,
+        "hue": 0.58,
         "sat": 0.55,
         "value": 0.64,
         "kind": "normal",

--- a/sdf-js/scenes/rec-journey-5.json
+++ b/sdf-js/scenes/rec-journey-5.json
@@ -25,9 +25,9 @@
         ]
       },
       "material": {
-        "hue": 0.57,
-        "sat": 0.55,
-        "value": 0.64,
+        "hue": 0.04,
+        "sat": 0.72,
+        "value": 0.82,
         "kind": "normal",
         "roughness": 0.3,
         "clearcoat": 0.45

--- a/sdf-js/scenes/rec-leadership-1.json
+++ b/sdf-js/scenes/rec-leadership-1.json
@@ -6,7 +6,12 @@
       "id": "radial-spoke",
       "type": "radial-spoke-3d",
       "args": {
-        "spokes": 5
+        "spokes": 5,
+        "hubRadius": 0.34,
+        "spokeThickness": 0.09,
+        "nodeRadius": 0.17,
+        "maxLen": 1.35,
+        "minLen": 0.7
       },
       "transform": {
         "translate": [

--- a/sdf-js/scenes/rec-leadership-1.json
+++ b/sdf-js/scenes/rec-leadership-1.json
@@ -21,7 +21,7 @@
         ]
       },
       "material": {
-        "hue": 0.57,
+        "hue": 0.74,
         "sat": 0.55,
         "value": 0.64,
         "kind": "normal",

--- a/sdf-js/scenes/rec-leadership-2.json
+++ b/sdf-js/scenes/rec-leadership-2.json
@@ -17,7 +17,7 @@
         ]
       },
       "material": {
-        "hue": 0.57,
+        "hue": 0.6,
         "sat": 0.55,
         "value": 0.64,
         "kind": "normal",

--- a/sdf-js/scenes/rec-leadership-3.json
+++ b/sdf-js/scenes/rec-leadership-3.json
@@ -16,7 +16,7 @@
         ]
       },
       "material": {
-        "hue": 0.57,
+        "hue": 0.4,
         "sat": 0.55,
         "value": 0.64,
         "kind": "normal",

--- a/sdf-js/scenes/rec-leadership-4.json
+++ b/sdf-js/scenes/rec-leadership-4.json
@@ -16,9 +16,9 @@
         ]
       },
       "material": {
-        "hue": 0.57,
-        "sat": 0.55,
-        "value": 0.64,
+        "hue": 0.11,
+        "sat": 0.72,
+        "value": 0.82,
         "kind": "normal",
         "roughness": 0.3,
         "clearcoat": 0.45

--- a/sdf-js/scenes/rec-leadership-5.json
+++ b/sdf-js/scenes/rec-leadership-5.json
@@ -17,7 +17,7 @@
         ]
       },
       "material": {
-        "hue": 0.57,
+        "hue": 0.58,
         "sat": 0.55,
         "value": 0.64,
         "kind": "normal",

--- a/sdf-js/scenes/rec-marketing-1.json
+++ b/sdf-js/scenes/rec-marketing-1.json
@@ -6,7 +6,12 @@
       "id": "radial-spoke",
       "type": "radial-spoke-3d",
       "args": {
-        "spokes": 4
+        "spokes": 4,
+        "hubRadius": 0.34,
+        "spokeThickness": 0.09,
+        "nodeRadius": 0.17,
+        "maxLen": 1.35,
+        "minLen": 0.7
       },
       "transform": {
         "translate": [

--- a/sdf-js/scenes/rec-marketing-1.json
+++ b/sdf-js/scenes/rec-marketing-1.json
@@ -21,7 +21,7 @@
         ]
       },
       "material": {
-        "hue": 0.57,
+        "hue": 0.74,
         "sat": 0.55,
         "value": 0.64,
         "kind": "normal",

--- a/sdf-js/scenes/rec-marketing-2.json
+++ b/sdf-js/scenes/rec-marketing-2.json
@@ -25,9 +25,9 @@
         ]
       },
       "material": {
-        "hue": 0.57,
-        "sat": 0.55,
-        "value": 0.64,
+        "hue": 0.04,
+        "sat": 0.72,
+        "value": 0.82,
         "kind": "normal",
         "roughness": 0.3,
         "clearcoat": 0.45

--- a/sdf-js/scenes/rec-marketing-3.json
+++ b/sdf-js/scenes/rec-marketing-3.json
@@ -30,7 +30,7 @@
         ]
       },
       "material": {
-        "hue": 0.57,
+        "hue": 0.5,
         "sat": 0.55,
         "value": 0.64,
         "kind": "normal",

--- a/sdf-js/scenes/rec-marketing-4.json
+++ b/sdf-js/scenes/rec-marketing-4.json
@@ -20,7 +20,7 @@
         ]
       },
       "material": {
-        "hue": 0.57,
+        "hue": 0.4,
         "sat": 0.55,
         "value": 0.64,
         "kind": "normal",

--- a/sdf-js/scenes/rec-marketing-5.json
+++ b/sdf-js/scenes/rec-marketing-5.json
@@ -17,7 +17,7 @@
         ]
       },
       "material": {
-        "hue": 0.57,
+        "hue": 0.6,
         "sat": 0.55,
         "value": 0.64,
         "kind": "normal",

--- a/sdf-js/scenes/rec-mountain-1.json
+++ b/sdf-js/scenes/rec-mountain-1.json
@@ -16,9 +16,9 @@
         ]
       },
       "material": {
-        "hue": 0.57,
-        "sat": 0.55,
-        "value": 0.64,
+        "hue": 0.11,
+        "sat": 0.72,
+        "value": 0.82,
         "kind": "normal",
         "roughness": 0.3,
         "clearcoat": 0.45

--- a/sdf-js/scenes/rec-mountain-2.json
+++ b/sdf-js/scenes/rec-mountain-2.json
@@ -16,7 +16,7 @@
         ]
       },
       "material": {
-        "hue": 0.57,
+        "hue": 0.4,
         "sat": 0.55,
         "value": 0.64,
         "kind": "normal",

--- a/sdf-js/scenes/rec-mountain-3.json
+++ b/sdf-js/scenes/rec-mountain-3.json
@@ -20,7 +20,7 @@
         ]
       },
       "material": {
-        "hue": 0.57,
+        "hue": 0.4,
         "sat": 0.55,
         "value": 0.64,
         "kind": "normal",

--- a/sdf-js/scenes/rec-mountain-4.json
+++ b/sdf-js/scenes/rec-mountain-4.json
@@ -16,7 +16,7 @@
         ]
       },
       "material": {
-        "hue": 0.57,
+        "hue": 0.66,
         "sat": 0.55,
         "value": 0.64,
         "kind": "normal",

--- a/sdf-js/scenes/rec-mountain-5.json
+++ b/sdf-js/scenes/rec-mountain-5.json
@@ -25,9 +25,9 @@
         ]
       },
       "material": {
-        "hue": 0.57,
-        "sat": 0.55,
-        "value": 0.64,
+        "hue": 0.04,
+        "sat": 0.72,
+        "value": 0.82,
         "kind": "normal",
         "roughness": 0.3,
         "clearcoat": 0.45

--- a/sdf-js/scenes/rec-okr-1.json
+++ b/sdf-js/scenes/rec-okr-1.json
@@ -6,7 +6,12 @@
       "id": "radial-spoke",
       "type": "radial-spoke-3d",
       "args": {
-        "spokes": 4
+        "spokes": 4,
+        "hubRadius": 0.34,
+        "spokeThickness": 0.09,
+        "nodeRadius": 0.17,
+        "maxLen": 1.35,
+        "minLen": 0.7
       },
       "transform": {
         "translate": [

--- a/sdf-js/scenes/rec-okr-1.json
+++ b/sdf-js/scenes/rec-okr-1.json
@@ -21,7 +21,7 @@
         ]
       },
       "material": {
-        "hue": 0.57,
+        "hue": 0.74,
         "sat": 0.55,
         "value": 0.64,
         "kind": "normal",

--- a/sdf-js/scenes/rec-okr-2.json
+++ b/sdf-js/scenes/rec-okr-2.json
@@ -25,7 +25,7 @@
         ]
       },
       "material": {
-        "hue": 0.57,
+        "hue": 0.58,
         "sat": 0.55,
         "value": 0.64,
         "kind": "normal",

--- a/sdf-js/scenes/rec-okr-3.json
+++ b/sdf-js/scenes/rec-okr-3.json
@@ -21,7 +21,7 @@
         ]
       },
       "material": {
-        "hue": 0.57,
+        "hue": 0.54,
         "sat": 0.55,
         "value": 0.64,
         "kind": "normal",

--- a/sdf-js/scenes/rec-okr-4.json
+++ b/sdf-js/scenes/rec-okr-4.json
@@ -20,7 +20,7 @@
         ]
       },
       "material": {
-        "hue": 0.57,
+        "hue": 0.4,
         "sat": 0.55,
         "value": 0.64,
         "kind": "normal",

--- a/sdf-js/scenes/rec-okr-5.json
+++ b/sdf-js/scenes/rec-okr-5.json
@@ -16,9 +16,9 @@
         ]
       },
       "material": {
-        "hue": 0.57,
-        "sat": 0.55,
-        "value": 0.64,
+        "hue": 0.11,
+        "sat": 0.72,
+        "value": 0.82,
         "kind": "normal",
         "roughness": 0.3,
         "clearcoat": 0.45

--- a/sdf-js/scenes/rec-pitch-1.json
+++ b/sdf-js/scenes/rec-pitch-1.json
@@ -17,7 +17,7 @@
         ]
       },
       "material": {
-        "hue": 0.57,
+        "hue": 0.58,
         "sat": 0.55,
         "value": 0.64,
         "kind": "normal",

--- a/sdf-js/scenes/rec-pitch-2.json
+++ b/sdf-js/scenes/rec-pitch-2.json
@@ -25,9 +25,9 @@
         ]
       },
       "material": {
-        "hue": 0.57,
-        "sat": 0.55,
-        "value": 0.64,
+        "hue": 0.04,
+        "sat": 0.72,
+        "value": 0.82,
         "kind": "normal",
         "roughness": 0.3,
         "clearcoat": 0.45

--- a/sdf-js/scenes/rec-pitch-3.json
+++ b/sdf-js/scenes/rec-pitch-3.json
@@ -16,7 +16,7 @@
         ]
       },
       "material": {
-        "hue": 0.57,
+        "hue": 0.66,
         "sat": 0.55,
         "value": 0.64,
         "kind": "normal",

--- a/sdf-js/scenes/rec-pitch-4.json
+++ b/sdf-js/scenes/rec-pitch-4.json
@@ -25,7 +25,7 @@
         ]
       },
       "material": {
-        "hue": 0.57,
+        "hue": 0.58,
         "sat": 0.55,
         "value": 0.64,
         "kind": "normal",

--- a/sdf-js/scenes/rec-pitch-5.json
+++ b/sdf-js/scenes/rec-pitch-5.json
@@ -20,7 +20,7 @@
         ]
       },
       "material": {
-        "hue": 0.57,
+        "hue": 0.4,
         "sat": 0.55,
         "value": 0.64,
         "kind": "normal",

--- a/sdf-js/scenes/rec-pmtoolbox-1.json
+++ b/sdf-js/scenes/rec-pmtoolbox-1.json
@@ -6,7 +6,12 @@
       "id": "radial-spoke",
       "type": "radial-spoke-3d",
       "args": {
-        "spokes": 6
+        "spokes": 6,
+        "hubRadius": 0.34,
+        "spokeThickness": 0.09,
+        "nodeRadius": 0.17,
+        "maxLen": 1.35,
+        "minLen": 0.7
       },
       "transform": {
         "translate": [

--- a/sdf-js/scenes/rec-pmtoolbox-1.json
+++ b/sdf-js/scenes/rec-pmtoolbox-1.json
@@ -21,7 +21,7 @@
         ]
       },
       "material": {
-        "hue": 0.57,
+        "hue": 0.74,
         "sat": 0.55,
         "value": 0.64,
         "kind": "normal",

--- a/sdf-js/scenes/rec-pmtoolbox-2.json
+++ b/sdf-js/scenes/rec-pmtoolbox-2.json
@@ -16,7 +16,7 @@
         ]
       },
       "material": {
-        "hue": 0.57,
+        "hue": 0.4,
         "sat": 0.55,
         "value": 0.64,
         "kind": "normal",

--- a/sdf-js/scenes/rec-pmtoolbox-3.json
+++ b/sdf-js/scenes/rec-pmtoolbox-3.json
@@ -16,7 +16,7 @@
         ]
       },
       "material": {
-        "hue": 0.57,
+        "hue": 0.4,
         "sat": 0.55,
         "value": 0.64,
         "kind": "normal",

--- a/sdf-js/scenes/rec-pmtoolbox-4.json
+++ b/sdf-js/scenes/rec-pmtoolbox-4.json
@@ -20,7 +20,7 @@
         ]
       },
       "material": {
-        "hue": 0.57,
+        "hue": 0.4,
         "sat": 0.55,
         "value": 0.64,
         "kind": "normal",

--- a/sdf-js/scenes/rec-pmtoolbox-5.json
+++ b/sdf-js/scenes/rec-pmtoolbox-5.json
@@ -17,7 +17,7 @@
         ]
       },
       "material": {
-        "hue": 0.57,
+        "hue": 0.6,
         "sat": 0.55,
         "value": 0.64,
         "kind": "normal",

--- a/sdf-js/scenes/rec-status-1.json
+++ b/sdf-js/scenes/rec-status-1.json
@@ -16,7 +16,7 @@
         ]
       },
       "material": {
-        "hue": 0.57,
+        "hue": 0.58,
         "sat": 0.55,
         "value": 0.64,
         "kind": "normal",

--- a/sdf-js/scenes/rec-status-2.json
+++ b/sdf-js/scenes/rec-status-2.json
@@ -20,7 +20,7 @@
         ]
       },
       "material": {
-        "hue": 0.57,
+        "hue": 0.4,
         "sat": 0.55,
         "value": 0.64,
         "kind": "normal",

--- a/sdf-js/scenes/rec-status-3.json
+++ b/sdf-js/scenes/rec-status-3.json
@@ -16,7 +16,7 @@
         ]
       },
       "material": {
-        "hue": 0.57,
+        "hue": 0.4,
         "sat": 0.55,
         "value": 0.64,
         "kind": "normal",

--- a/sdf-js/scenes/rec-status-4.json
+++ b/sdf-js/scenes/rec-status-4.json
@@ -25,7 +25,7 @@
         ]
       },
       "material": {
-        "hue": 0.57,
+        "hue": 0.58,
         "sat": 0.55,
         "value": 0.64,
         "kind": "normal",

--- a/sdf-js/scenes/rec-status-5.json
+++ b/sdf-js/scenes/rec-status-5.json
@@ -16,7 +16,7 @@
         ]
       },
       "material": {
-        "hue": 0.57,
+        "hue": 0.4,
         "sat": 0.55,
         "value": 0.64,
         "kind": "normal",

--- a/sdf-js/scenes/rec-strategy-1.json
+++ b/sdf-js/scenes/rec-strategy-1.json
@@ -6,7 +6,12 @@
       "id": "radial-spoke",
       "type": "radial-spoke-3d",
       "args": {
-        "spokes": 6
+        "spokes": 6,
+        "hubRadius": 0.34,
+        "spokeThickness": 0.09,
+        "nodeRadius": 0.17,
+        "maxLen": 1.35,
+        "minLen": 0.7
       },
       "transform": {
         "translate": [

--- a/sdf-js/scenes/rec-strategy-1.json
+++ b/sdf-js/scenes/rec-strategy-1.json
@@ -21,7 +21,7 @@
         ]
       },
       "material": {
-        "hue": 0.57,
+        "hue": 0.74,
         "sat": 0.55,
         "value": 0.64,
         "kind": "normal",

--- a/sdf-js/scenes/rec-strategy-2.json
+++ b/sdf-js/scenes/rec-strategy-2.json
@@ -17,7 +17,7 @@
         ]
       },
       "material": {
-        "hue": 0.57,
+        "hue": 0.6,
         "sat": 0.55,
         "value": 0.64,
         "kind": "normal",

--- a/sdf-js/scenes/rec-strategy-3.json
+++ b/sdf-js/scenes/rec-strategy-3.json
@@ -25,7 +25,7 @@
         ]
       },
       "material": {
-        "hue": 0.57,
+        "hue": 0.5,
         "sat": 0.55,
         "value": 0.64,
         "kind": "normal",

--- a/sdf-js/scenes/rec-strategy-4.json
+++ b/sdf-js/scenes/rec-strategy-4.json
@@ -16,9 +16,9 @@
         ]
       },
       "material": {
-        "hue": 0.57,
-        "sat": 0.55,
-        "value": 0.64,
+        "hue": 0.11,
+        "sat": 0.72,
+        "value": 0.82,
         "kind": "normal",
         "roughness": 0.3,
         "clearcoat": 0.45

--- a/sdf-js/scenes/rec-strategy-5.json
+++ b/sdf-js/scenes/rec-strategy-5.json
@@ -20,7 +20,7 @@
         ]
       },
       "material": {
-        "hue": 0.57,
+        "hue": 0.4,
         "sat": 0.55,
         "value": 0.64,
         "kind": "normal",

--- a/sdf-js/scenes/rec-stratmap-1.json
+++ b/sdf-js/scenes/rec-stratmap-1.json
@@ -26,7 +26,7 @@
         ]
       },
       "material": {
-        "hue": 0.57,
+        "hue": 0.66,
         "sat": 0.55,
         "value": 0.64,
         "kind": "normal",

--- a/sdf-js/scenes/rec-stratmap-2.json
+++ b/sdf-js/scenes/rec-stratmap-2.json
@@ -16,7 +16,7 @@
         ]
       },
       "material": {
-        "hue": 0.57,
+        "hue": 0.4,
         "sat": 0.55,
         "value": 0.64,
         "kind": "normal",

--- a/sdf-js/scenes/rec-stratmap-3.json
+++ b/sdf-js/scenes/rec-stratmap-3.json
@@ -17,7 +17,7 @@
         ]
       },
       "material": {
-        "hue": 0.57,
+        "hue": 0.58,
         "sat": 0.55,
         "value": 0.64,
         "kind": "normal",

--- a/sdf-js/scenes/rec-stratmap-4.json
+++ b/sdf-js/scenes/rec-stratmap-4.json
@@ -25,7 +25,7 @@
         ]
       },
       "material": {
-        "hue": 0.57,
+        "hue": 0.58,
         "sat": 0.55,
         "value": 0.64,
         "kind": "normal",

--- a/sdf-js/scenes/rec-stratmap-5.json
+++ b/sdf-js/scenes/rec-stratmap-5.json
@@ -16,9 +16,9 @@
         ]
       },
       "material": {
-        "hue": 0.57,
-        "sat": 0.55,
-        "value": 0.64,
+        "hue": 0.11,
+        "sat": 0.72,
+        "value": 0.82,
         "kind": "normal",
         "roughness": 0.3,
         "clearcoat": 0.45

--- a/sdf-js/scenes/rec-timelines-1.json
+++ b/sdf-js/scenes/rec-timelines-1.json
@@ -20,7 +20,7 @@
         ]
       },
       "material": {
-        "hue": 0.57,
+        "hue": 0.4,
         "sat": 0.55,
         "value": 0.64,
         "kind": "normal",

--- a/sdf-js/scenes/rec-timelines-2.json
+++ b/sdf-js/scenes/rec-timelines-2.json
@@ -20,7 +20,7 @@
         ]
       },
       "material": {
-        "hue": 0.57,
+        "hue": 0.4,
         "sat": 0.55,
         "value": 0.64,
         "kind": "normal",

--- a/sdf-js/scenes/rec-timelines-3.json
+++ b/sdf-js/scenes/rec-timelines-3.json
@@ -16,7 +16,7 @@
         ]
       },
       "material": {
-        "hue": 0.57,
+        "hue": 0.4,
         "sat": 0.55,
         "value": 0.64,
         "kind": "normal",

--- a/sdf-js/scenes/rec-timelines-4.json
+++ b/sdf-js/scenes/rec-timelines-4.json
@@ -16,7 +16,7 @@
         ]
       },
       "material": {
-        "hue": 0.57,
+        "hue": 0.4,
         "sat": 0.55,
         "value": 0.64,
         "kind": "normal",

--- a/sdf-js/scenes/rec-timelines-5.json
+++ b/sdf-js/scenes/rec-timelines-5.json
@@ -26,7 +26,7 @@
         ]
       },
       "material": {
-        "hue": 0.57,
+        "hue": 0.66,
         "sat": 0.55,
         "value": 0.64,
         "kind": "normal",

--- a/sdf-js/src/scene/lift-2d-to-3d.js
+++ b/sdf-js/src/scene/lift-2d-to-3d.js
@@ -27,6 +27,43 @@ const DEFAULT_MAT = {
   clearcoat: 0.45,
 };
 
+// Coordinated palette so a deck of mixed slide types isn't a wall of navy. Each atom
+// family maps to a hue chosen to fit its meaning (warm conversion funnels, gold
+// pyramids, green sequences, purple radials…), all at the same sat/value so they read
+// as one professional set. (Per-leaf coloring inside a chart needs atom-level colors[]
+// support — only sphere-fill/cube have it today — so this is whole-object hue.)
+const HUE_BY_TYPE = {
+  // data / network — blue
+  bar: 0.58, column: 0.58, line: 0.55, 'sphere-network': 0.58, 'relationship-graph': 0.58, scatter: 0.58, waterfall: 0.58,
+  // proportion / rings — teal
+  pie: 0.50, 'circle-segmented': 0.50, 'circle-loop': 0.50, venn: 0.50, 'circle-frame': 0.50,
+  // conversion — warm coral
+  funnel: 0.04,
+  // hierarchy of levels — gold
+  pyramid: 0.11,
+  // stacks — indigo
+  'layer-stack': 0.66, 'circle-stack': 0.66,
+  // sequence / flow — green
+  timeline: 0.40, gantt: 0.40, progression: 0.40, 'flow-chart': 0.40, 'agenda-list': 0.40, 'bullet-list': 0.40,
+  // radial / mind — purple
+  'radial-spoke': 0.74, mindmap: 0.74,
+  // org / tree — cyan
+  'org-chart': 0.54, 'tree-diagram': 0.54, 'sphere-tree': 0.54,
+  // grid / blocks — steel blue
+  'matrix-grid': 0.60, cube: 0.60, 'cube-grid': 0.60, 'cube-segmented': 0.60,
+  // misc
+  'sphere-segmented': 0.50, 'kpi-card': 0.58, fishbone: 0.40, diamond: 0.58, gear: 0.58, arrow: 0.58, 'traffic-light': 0.58,
+};
+
+function materialFor(type2d) {
+  const hue = HUE_BY_TYPE[type2d];
+  if (hue == null) return { ...DEFAULT_MAT };
+  // warm hues (reds/oranges/golds) turn muddy brown at the default value/sat — brighten
+  // and saturate them so they read as vivid coral/gold, matching the cool families' punch.
+  const warm = hue < 0.16 || hue > 0.95;
+  return { ...DEFAULT_MAT, hue, sat: warm ? 0.72 : DEFAULT_MAT.sat, value: warm ? 0.82 : DEFAULT_MAT.value };
+}
+
 // ── camera: gentle push-in (matches the hand-authored shape twins) ──
 export function pushInCamera(target = [0, 1.6, 0], dist = 8.2) {
   return {
@@ -484,7 +521,7 @@ export function liftSubject(subject) {
     type: twinTypeOf(type2d),
     args: r.args || {},
     transform: r.transform || { translate: [0, 1.5, 0] },
-    material: { ...DEFAULT_MAT },
+    material: materialFor(type2d),
   };
   return { subject3d, overlay: r.overlay || [] };
 }

--- a/sdf-js/src/scene/lift-2d-to-3d.js
+++ b/sdf-js/src/scene/lift-2d-to-3d.js
@@ -334,7 +334,8 @@ export const TWIN_MAP = {
     lift(a) {
       const v = a.values || [];
       return {
-        args: { spokes: v.length || 6 },
+        // thicker hub/spokes/nodes read far better at presentation scale than atom defaults
+        args: { spokes: v.length || 6, hubRadius: 0.34, spokeThickness: 0.09, nodeRadius: 0.17, maxLen: 1.35, minLen: 0.7 },
         transform: { translate: [0, 1.7, 0] },
         overlay: rightCards((a.labels || []).map((l, i) => (v[i] != null ? `${l} ${fmt(v[i], a.format)}` : l))),
       };
@@ -422,8 +423,10 @@ export const TWIN_MAP = {
     lift(a) {
       const size = a.size ?? 3;
       return {
-        args: { arrangement: 'grid', count: size * size, cubeSize: 0.5, spacing: a.spacing ?? 0.2, material: 'solid', colors: a.colors || null },
-        transform: { translate: [0, 1.6, 0] },
+        // grid arranges flat in XZ (floor) — stand it up into XY so the full NxN faces
+        // the camera instead of being seen edge-on (only the front row visible).
+        args: { arrangement: 'grid', count: size * size, cubeSize: 0.5, spacing: a.spacing ?? 0.22, material: 'solid', colors: a.colors || null, arrangementParams: { cols: size } },
+        transform: { translate: [0, 1.9, 0], rotate: [1.5708, 0, 0] },
       };
     },
   },


### PR DESCRIPTION
打磨轮 batch 1 —— rec decks 暴露的两个具体问题:

1. **cube-grid 渲成一行(真 bug)**:cube-3d 的 `grid` 排布平铺在 XZ 地面,正视角只看到前排。修法:twin 里把网格立起来(rotate π/2)+ 固定 cols=size → 完整 NxN 面向相机。`?scene=rec-icons-2` 现在是正确的 3×3 图标墙。
2. **radial-spoke 太细**:twin 里调大 hub/spoke/node + 长度,更实(14 个 radial-spoke 页更新)。

重生成 15 个受影响场景(14 radial-spoke + 1 cube-grid),全编译。lift test 28/28。

🤖 Generated with [Claude Code](https://claude.com/claude-code)