### PR TITLE
polish: bar/pyramid per-leaf colour + mountain-3d & icon-grid-3d atoms

### DIFF
--- a/sdf-js/scenes/lifted-charts-graphs.json
+++ b/sdf-js/scenes/lifted-charts-graphs.json
@@ -16,7 +16,34 @@
         "barWidth": 0.55,
         "barDepth": 0.55,
         "gap": 0.25,
-        "maxHeight": 2.2
+        "maxHeight": 2.2,
+        "colors": [
+          {
+            "hue": 0.58,
+            "sat": 0.58,
+            "value": 0.76
+          },
+          {
+            "hue": 0.58,
+            "sat": 0.6,
+            "value": 0.685
+          },
+          {
+            "hue": 0.58,
+            "sat": 0.62,
+            "value": 0.61
+          },
+          {
+            "hue": 0.58,
+            "sat": 0.6399999999999999,
+            "value": 0.535
+          },
+          {
+            "hue": 0.58,
+            "sat": 0.6599999999999999,
+            "value": 0.46
+          }
+        ]
       },
       "transform": {
         "translate": [

--- a/sdf-js/scenes/lifted-maturity.json
+++ b/sdf-js/scenes/lifted-maturity.json
@@ -6,7 +6,29 @@
       "id": "pyramid",
       "type": "pyramid-3d",
       "args": {
-        "levels": 4
+        "levels": 4,
+        "colors": [
+          {
+            "hue": 0.11,
+            "sat": 0.7,
+            "value": 0.88
+          },
+          {
+            "hue": 0.11,
+            "sat": 0.7266666666666666,
+            "value": 0.78
+          },
+          {
+            "hue": 0.11,
+            "sat": 0.7533333333333333,
+            "value": 0.68
+          },
+          {
+            "hue": 0.11,
+            "sat": 0.7799999999999999,
+            "value": 0.5800000000000001
+          }
+        ]
       },
       "transform": {
         "translate": [

--- a/sdf-js/scenes/lifted-quarterly.json
+++ b/sdf-js/scenes/lifted-quarterly.json
@@ -16,7 +16,34 @@
         "barWidth": 0.55,
         "barDepth": 0.55,
         "gap": 0.25,
-        "maxHeight": 2.2
+        "maxHeight": 2.2,
+        "colors": [
+          {
+            "hue": 0.58,
+            "sat": 0.58,
+            "value": 0.76
+          },
+          {
+            "hue": 0.58,
+            "sat": 0.6,
+            "value": 0.685
+          },
+          {
+            "hue": 0.58,
+            "sat": 0.62,
+            "value": 0.61
+          },
+          {
+            "hue": 0.58,
+            "sat": 0.6399999999999999,
+            "value": 0.535
+          },
+          {
+            "hue": 0.58,
+            "sat": 0.6599999999999999,
+            "value": 0.46
+          }
+        ]
       },
       "transform": {
         "translate": [

--- a/sdf-js/scenes/rec-bizcase-1.json
+++ b/sdf-js/scenes/rec-bizcase-1.json
@@ -6,7 +6,24 @@
       "id": "pyramid",
       "type": "pyramid-3d",
       "args": {
-        "levels": 3
+        "levels": 3,
+        "colors": [
+          {
+            "hue": 0.11,
+            "sat": 0.7,
+            "value": 0.88
+          },
+          {
+            "hue": 0.11,
+            "sat": 0.74,
+            "value": 0.73
+          },
+          {
+            "hue": 0.11,
+            "sat": 0.7799999999999999,
+            "value": 0.5800000000000001
+          }
+        ]
       },
       "transform": {
         "translate": [

--- a/sdf-js/scenes/rec-bizcase-3.json
+++ b/sdf-js/scenes/rec-bizcase-3.json
@@ -15,7 +15,29 @@
         "barWidth": 0.55,
         "barDepth": 0.55,
         "gap": 0.25,
-        "maxHeight": 2.2
+        "maxHeight": 2.2,
+        "colors": [
+          {
+            "hue": 0.58,
+            "sat": 0.58,
+            "value": 0.76
+          },
+          {
+            "hue": 0.58,
+            "sat": 0.6066666666666666,
+            "value": 0.66
+          },
+          {
+            "hue": 0.58,
+            "sat": 0.6333333333333333,
+            "value": 0.56
+          },
+          {
+            "hue": 0.58,
+            "sat": 0.6599999999999999,
+            "value": 0.46
+          }
+        ]
       },
       "transform": {
         "translate": [

--- a/sdf-js/scenes/rec-bizplan-1.json
+++ b/sdf-js/scenes/rec-bizplan-1.json
@@ -6,7 +6,29 @@
       "id": "pyramid",
       "type": "pyramid-3d",
       "args": {
-        "levels": 4
+        "levels": 4,
+        "colors": [
+          {
+            "hue": 0.11,
+            "sat": 0.7,
+            "value": 0.88
+          },
+          {
+            "hue": 0.11,
+            "sat": 0.7266666666666666,
+            "value": 0.78
+          },
+          {
+            "hue": 0.11,
+            "sat": 0.7533333333333333,
+            "value": 0.68
+          },
+          {
+            "hue": 0.11,
+            "sat": 0.7799999999999999,
+            "value": 0.5800000000000001
+          }
+        ]
       },
       "transform": {
         "translate": [

--- a/sdf-js/scenes/rec-bizplan-3.json
+++ b/sdf-js/scenes/rec-bizplan-3.json
@@ -16,7 +16,34 @@
         "barWidth": 0.55,
         "barDepth": 0.55,
         "gap": 0.25,
-        "maxHeight": 2.2
+        "maxHeight": 2.2,
+        "colors": [
+          {
+            "hue": 0.58,
+            "sat": 0.58,
+            "value": 0.76
+          },
+          {
+            "hue": 0.58,
+            "sat": 0.6,
+            "value": 0.685
+          },
+          {
+            "hue": 0.58,
+            "sat": 0.62,
+            "value": 0.61
+          },
+          {
+            "hue": 0.58,
+            "sat": 0.6399999999999999,
+            "value": 0.535
+          },
+          {
+            "hue": 0.58,
+            "sat": 0.6599999999999999,
+            "value": 0.46
+          }
+        ]
       },
       "transform": {
         "translate": [

--- a/sdf-js/scenes/rec-consulting-4.json
+++ b/sdf-js/scenes/rec-consulting-4.json
@@ -6,7 +6,24 @@
       "id": "pyramid",
       "type": "pyramid-3d",
       "args": {
-        "levels": 3
+        "levels": 3,
+        "colors": [
+          {
+            "hue": 0.11,
+            "sat": 0.7,
+            "value": 0.88
+          },
+          {
+            "hue": 0.11,
+            "sat": 0.74,
+            "value": 0.73
+          },
+          {
+            "hue": 0.11,
+            "sat": 0.7799999999999999,
+            "value": 0.5800000000000001
+          }
+        ]
       },
       "transform": {
         "translate": [

--- a/sdf-js/scenes/rec-cyber-4.json
+++ b/sdf-js/scenes/rec-cyber-4.json
@@ -6,7 +6,29 @@
       "id": "pyramid",
       "type": "pyramid-3d",
       "args": {
-        "levels": 4
+        "levels": 4,
+        "colors": [
+          {
+            "hue": 0.11,
+            "sat": 0.7,
+            "value": 0.88
+          },
+          {
+            "hue": 0.11,
+            "sat": 0.7266666666666666,
+            "value": 0.78
+          },
+          {
+            "hue": 0.11,
+            "sat": 0.7533333333333333,
+            "value": 0.68
+          },
+          {
+            "hue": 0.11,
+            "sat": 0.7799999999999999,
+            "value": 0.5800000000000001
+          }
+        ]
       },
       "transform": {
         "translate": [

--- a/sdf-js/scenes/rec-digital-3.json
+++ b/sdf-js/scenes/rec-digital-3.json
@@ -6,7 +6,29 @@
       "id": "pyramid",
       "type": "pyramid-3d",
       "args": {
-        "levels": 4
+        "levels": 4,
+        "colors": [
+          {
+            "hue": 0.11,
+            "sat": 0.7,
+            "value": 0.88
+          },
+          {
+            "hue": 0.11,
+            "sat": 0.7266666666666666,
+            "value": 0.78
+          },
+          {
+            "hue": 0.11,
+            "sat": 0.7533333333333333,
+            "value": 0.68
+          },
+          {
+            "hue": 0.11,
+            "sat": 0.7799999999999999,
+            "value": 0.5800000000000001
+          }
+        ]
       },
       "transform": {
         "translate": [

--- a/sdf-js/scenes/rec-icons-2.json
+++ b/sdf-js/scenes/rec-icons-2.json
@@ -3,28 +3,17 @@
   "name": "(lifted) icons-Icon Grid",
   "subjects": [
     {
-      "id": "cube-grid",
-      "type": "cube-3d",
+      "id": "icon-grid",
+      "type": "icon-grid-3d",
       "args": {
-        "arrangement": "grid",
-        "count": 9,
-        "cubeSize": 0.5,
-        "spacing": 0.22,
-        "material": "solid",
-        "colors": null,
-        "arrangementParams": {
-          "cols": 3
-        }
+        "rows": 2,
+        "cols": 4,
+        "glyphs": null
       },
       "transform": {
         "translate": [
           0,
           1.9,
-          0
-        ],
-        "rotate": [
-          1.5708,
-          0,
           0
         ]
       },

--- a/sdf-js/scenes/rec-itstrategy-4.json
+++ b/sdf-js/scenes/rec-itstrategy-4.json
@@ -6,7 +6,29 @@
       "id": "pyramid",
       "type": "pyramid-3d",
       "args": {
-        "levels": 4
+        "levels": 4,
+        "colors": [
+          {
+            "hue": 0.11,
+            "sat": 0.7,
+            "value": 0.88
+          },
+          {
+            "hue": 0.11,
+            "sat": 0.7266666666666666,
+            "value": 0.78
+          },
+          {
+            "hue": 0.11,
+            "sat": 0.7533333333333333,
+            "value": 0.68
+          },
+          {
+            "hue": 0.11,
+            "sat": 0.7799999999999999,
+            "value": 0.5800000000000001
+          }
+        ]
       },
       "transform": {
         "translate": [

--- a/sdf-js/scenes/rec-journey-4.json
+++ b/sdf-js/scenes/rec-journey-4.json
@@ -16,7 +16,34 @@
         "barWidth": 0.55,
         "barDepth": 0.55,
         "gap": 0.25,
-        "maxHeight": 2.2
+        "maxHeight": 2.2,
+        "colors": [
+          {
+            "hue": 0.58,
+            "sat": 0.58,
+            "value": 0.76
+          },
+          {
+            "hue": 0.58,
+            "sat": 0.6,
+            "value": 0.685
+          },
+          {
+            "hue": 0.58,
+            "sat": 0.62,
+            "value": 0.61
+          },
+          {
+            "hue": 0.58,
+            "sat": 0.6399999999999999,
+            "value": 0.535
+          },
+          {
+            "hue": 0.58,
+            "sat": 0.6599999999999999,
+            "value": 0.46
+          }
+        ]
       },
       "transform": {
         "translate": [

--- a/sdf-js/scenes/rec-leadership-4.json
+++ b/sdf-js/scenes/rec-leadership-4.json
@@ -6,7 +6,29 @@
       "id": "pyramid",
       "type": "pyramid-3d",
       "args": {
-        "levels": 4
+        "levels": 4,
+        "colors": [
+          {
+            "hue": 0.11,
+            "sat": 0.7,
+            "value": 0.88
+          },
+          {
+            "hue": 0.11,
+            "sat": 0.7266666666666666,
+            "value": 0.78
+          },
+          {
+            "hue": 0.11,
+            "sat": 0.7533333333333333,
+            "value": 0.68
+          },
+          {
+            "hue": 0.11,
+            "sat": 0.7799999999999999,
+            "value": 0.5800000000000001
+          }
+        ]
       },
       "transform": {
         "translate": [

--- a/sdf-js/scenes/rec-mountain-1.json
+++ b/sdf-js/scenes/rec-mountain-1.json
@@ -6,7 +6,29 @@
       "id": "pyramid",
       "type": "pyramid-3d",
       "args": {
-        "levels": 4
+        "levels": 4,
+        "colors": [
+          {
+            "hue": 0.11,
+            "sat": 0.7,
+            "value": 0.88
+          },
+          {
+            "hue": 0.11,
+            "sat": 0.7266666666666666,
+            "value": 0.78
+          },
+          {
+            "hue": 0.11,
+            "sat": 0.7533333333333333,
+            "value": 0.68
+          },
+          {
+            "hue": 0.11,
+            "sat": 0.7799999999999999,
+            "value": 0.5800000000000001
+          }
+        ]
       },
       "transform": {
         "translate": [

--- a/sdf-js/scenes/rec-mountain-1.json
+++ b/sdf-js/scenes/rec-mountain-1.json
@@ -3,47 +3,28 @@
   "name": "(lifted) mountain-The Summit",
   "subjects": [
     {
-      "id": "pyramid",
-      "type": "pyramid-3d",
+      "id": "mountain",
+      "type": "mountain-3d",
       "args": {
-        "levels": 4,
-        "colors": [
-          {
-            "hue": 0.11,
-            "sat": 0.7,
-            "value": 0.88
-          },
-          {
-            "hue": 0.11,
-            "sat": 0.7266666666666666,
-            "value": 0.78
-          },
-          {
-            "hue": 0.11,
-            "sat": 0.7533333333333333,
-            "value": 0.68
-          },
-          {
-            "hue": 0.11,
-            "sat": 0.7799999999999999,
-            "value": 0.5800000000000001
-          }
-        ]
+        "height": 2.6,
+        "baseRadius": 1.6,
+        "sidePeaks": 2,
+        "pathMarkers": 4
       },
       "transform": {
         "translate": [
           0,
-          0.6,
+          0,
           0
         ]
       },
       "material": {
-        "hue": 0.11,
-        "sat": 0.72,
-        "value": 0.82,
+        "hue": 0.6,
+        "sat": 0.24,
+        "value": 0.62,
         "kind": "normal",
-        "roughness": 0.3,
-        "clearcoat": 0.45
+        "roughness": 0.55,
+        "clearcoat": 0.15
       }
     }
   ],

--- a/sdf-js/scenes/rec-okr-2.json
+++ b/sdf-js/scenes/rec-okr-2.json
@@ -15,7 +15,29 @@
         "barWidth": 0.55,
         "barDepth": 0.55,
         "gap": 0.25,
-        "maxHeight": 2.2
+        "maxHeight": 2.2,
+        "colors": [
+          {
+            "hue": 0.58,
+            "sat": 0.58,
+            "value": 0.76
+          },
+          {
+            "hue": 0.58,
+            "sat": 0.6066666666666666,
+            "value": 0.66
+          },
+          {
+            "hue": 0.58,
+            "sat": 0.6333333333333333,
+            "value": 0.56
+          },
+          {
+            "hue": 0.58,
+            "sat": 0.6599999999999999,
+            "value": 0.46
+          }
+        ]
       },
       "transform": {
         "translate": [

--- a/sdf-js/scenes/rec-okr-5.json
+++ b/sdf-js/scenes/rec-okr-5.json
@@ -6,7 +6,29 @@
       "id": "pyramid",
       "type": "pyramid-3d",
       "args": {
-        "levels": 4
+        "levels": 4,
+        "colors": [
+          {
+            "hue": 0.11,
+            "sat": 0.7,
+            "value": 0.88
+          },
+          {
+            "hue": 0.11,
+            "sat": 0.7266666666666666,
+            "value": 0.78
+          },
+          {
+            "hue": 0.11,
+            "sat": 0.7533333333333333,
+            "value": 0.68
+          },
+          {
+            "hue": 0.11,
+            "sat": 0.7799999999999999,
+            "value": 0.5800000000000001
+          }
+        ]
       },
       "transform": {
         "translate": [

--- a/sdf-js/scenes/rec-pitch-4.json
+++ b/sdf-js/scenes/rec-pitch-4.json
@@ -15,7 +15,29 @@
         "barWidth": 0.55,
         "barDepth": 0.55,
         "gap": 0.25,
-        "maxHeight": 2.2
+        "maxHeight": 2.2,
+        "colors": [
+          {
+            "hue": 0.58,
+            "sat": 0.58,
+            "value": 0.76
+          },
+          {
+            "hue": 0.58,
+            "sat": 0.6066666666666666,
+            "value": 0.66
+          },
+          {
+            "hue": 0.58,
+            "sat": 0.6333333333333333,
+            "value": 0.56
+          },
+          {
+            "hue": 0.58,
+            "sat": 0.6599999999999999,
+            "value": 0.46
+          }
+        ]
       },
       "transform": {
         "translate": [

--- a/sdf-js/scenes/rec-status-4.json
+++ b/sdf-js/scenes/rec-status-4.json
@@ -15,7 +15,29 @@
         "barWidth": 0.55,
         "barDepth": 0.55,
         "gap": 0.25,
-        "maxHeight": 2.2
+        "maxHeight": 2.2,
+        "colors": [
+          {
+            "hue": 0.58,
+            "sat": 0.58,
+            "value": 0.76
+          },
+          {
+            "hue": 0.58,
+            "sat": 0.6066666666666666,
+            "value": 0.66
+          },
+          {
+            "hue": 0.58,
+            "sat": 0.6333333333333333,
+            "value": 0.56
+          },
+          {
+            "hue": 0.58,
+            "sat": 0.6599999999999999,
+            "value": 0.46
+          }
+        ]
       },
       "transform": {
         "translate": [

--- a/sdf-js/scenes/rec-strategy-4.json
+++ b/sdf-js/scenes/rec-strategy-4.json
@@ -6,7 +6,29 @@
       "id": "pyramid",
       "type": "pyramid-3d",
       "args": {
-        "levels": 4
+        "levels": 4,
+        "colors": [
+          {
+            "hue": 0.11,
+            "sat": 0.7,
+            "value": 0.88
+          },
+          {
+            "hue": 0.11,
+            "sat": 0.7266666666666666,
+            "value": 0.78
+          },
+          {
+            "hue": 0.11,
+            "sat": 0.7533333333333333,
+            "value": 0.68
+          },
+          {
+            "hue": 0.11,
+            "sat": 0.7799999999999999,
+            "value": 0.5800000000000001
+          }
+        ]
       },
       "transform": {
         "translate": [

--- a/sdf-js/scenes/rec-stratmap-4.json
+++ b/sdf-js/scenes/rec-stratmap-4.json
@@ -15,7 +15,29 @@
         "barWidth": 0.55,
         "barDepth": 0.55,
         "gap": 0.25,
-        "maxHeight": 2.2
+        "maxHeight": 2.2,
+        "colors": [
+          {
+            "hue": 0.58,
+            "sat": 0.58,
+            "value": 0.76
+          },
+          {
+            "hue": 0.58,
+            "sat": 0.6066666666666666,
+            "value": 0.66
+          },
+          {
+            "hue": 0.58,
+            "sat": 0.6333333333333333,
+            "value": 0.56
+          },
+          {
+            "hue": 0.58,
+            "sat": 0.6599999999999999,
+            "value": 0.46
+          }
+        ]
       },
       "transform": {
         "translate": [

--- a/sdf-js/scenes/rec-stratmap-5.json
+++ b/sdf-js/scenes/rec-stratmap-5.json
@@ -6,7 +6,29 @@
       "id": "pyramid",
       "type": "pyramid-3d",
       "args": {
-        "levels": 4
+        "levels": 4,
+        "colors": [
+          {
+            "hue": 0.11,
+            "sat": 0.7,
+            "value": 0.88
+          },
+          {
+            "hue": 0.11,
+            "sat": 0.7266666666666666,
+            "value": 0.78
+          },
+          {
+            "hue": 0.11,
+            "sat": 0.7533333333333333,
+            "value": 0.68
+          },
+          {
+            "hue": 0.11,
+            "sat": 0.7799999999999999,
+            "value": 0.5800000000000001
+          }
+        ]
       },
       "transform": {
         "translate": [

--- a/sdf-js/scripts/lift-rec-round5.mjs
+++ b/sdf-js/scripts/lift-rec-round5.mjs
@@ -41,7 +41,7 @@ const DECKS = [
   {
     id: 'icons', name: 'Line Icons - Business', slides: [
       { title: 'Categories', type: 'radial-spoke', args: { title: 'Business Icons', values: [1, 1, 1, 1, 1, 1], labels: ['Finance', 'People', 'Growth', 'Tech', 'Strategy', 'Ops'] } },
-      { title: 'Icon Grid', type: 'cube-grid', args: { title: 'Icon Set', size: 3 } },
+      { title: 'Icon Grid', type: 'icon-grid', args: { title: 'Icon Set', rows: 2, cols: 4 } },
       { title: 'Concept Tiles', type: 'matrix-grid', args: { title: 'Concept Tiles', rows: 2, cols: 4 } },
       { title: 'Themes', type: 'circle-segmented', args: { title: 'Themes', segments: 6, labels: ['$', '%', '↑', '★', '✓', '◆'] } },
       { title: 'Toolkit', type: 'radial-spoke', args: { title: 'Toolkit', values: [1, 1, 1, 1], labels: ['Charts', 'Flows', 'Maps', 'KPIs'] } },

--- a/sdf-js/scripts/lift-rec-round5.mjs
+++ b/sdf-js/scripts/lift-rec-round5.mjs
@@ -31,7 +31,7 @@ const DECKS = [
   },
   {
     id: 'mountain', name: 'Mountain Path – Graphics', slides: [
-      { title: 'The Summit', type: 'pyramid', args: { title: 'Mountain Path', layers: [{ label: 'Summit' }, { label: 'Ridge' }, { label: 'Ascent' }, { label: 'Base Camp' }] } },
+      { title: 'The Summit', type: 'mountain', args: { title: 'Mountain Path', stages: [{ label: 'Summit' }, { label: 'Ridge' }, { label: 'Ascent' }, { label: 'Base Camp' }] } },
       { title: 'The Climb', type: 'progression', args: { title: 'The Climb', steps: [{ label: 'Base Camp' }, { label: 'Ascent' }, { label: 'Ridge' }, { label: 'Summit' }] } },
       { title: 'Milestones', type: 'timeline', args: { title: 'Journey Milestones', events: [{ label: 'Start' }, { label: 'Camp 1' }, { label: 'Camp 2' }, { label: 'Peak' }] } },
       { title: 'Elevation Tiers', type: 'circle-stack', args: { title: 'Elevation', layers: [{ label: 'Peak' }, { label: 'High' }, { label: 'Mid' }, { label: 'Foot' }] } },

--- a/sdf-js/src/scene/compile.js
+++ b/sdf-js/src/scene/compile.js
@@ -128,6 +128,7 @@ import { cubeSegmented3dSDF } from './components/shapes/cube-segmented-3d.js';
 import { circleFrame3dSDF } from './components/shapes/circle-frame-3d.js';
 import { circleStack3dSDF } from './components/shapes/circle-stack-3d.js';
 import { circleSegmented3dSDF } from './components/shapes/circle-segmented-3d.js';
+import { mountain3dSDF } from './components/shapes/mountain-3d.js';
 import { circleLoop3dSDF } from './components/shapes/circle-loop-3d.js';
 import { relationshipGraph3dSDF } from './components/charts/diagrams/relationship-graph-3d.js';
 import { orgChart3dSDF } from './components/charts/diagrams/org-chart-3d.js';
@@ -542,6 +543,16 @@ const PRIMITIVE_FACTORIES = {
       diskHeight: a.diskHeight ?? a.thickness ?? 0.18,
       gap: a.gap ?? 0.06,
       colors: a.colors ?? null,
+    }),
+  'mountain-3d': (a) =>
+    mountain3dSDF({
+      height: a.height ?? 2.4,
+      baseRadius: a.baseRadius ?? 1.5,
+      sidePeaks: a.sidePeaks ?? 2,
+      spread: a.spread ?? 1.7,
+      sideScale: a.sideScale ?? 0.6,
+      pathMarkers: a.pathMarkers ?? 4,
+      markerRadius: a.markerRadius ?? 0.13,
     }),
   'circle-segmented-3d': (a) =>
     circleSegmented3dSDF({

--- a/sdf-js/src/scene/compile.js
+++ b/sdf-js/src/scene/compile.js
@@ -129,6 +129,7 @@ import { circleFrame3dSDF } from './components/shapes/circle-frame-3d.js';
 import { circleStack3dSDF } from './components/shapes/circle-stack-3d.js';
 import { circleSegmented3dSDF } from './components/shapes/circle-segmented-3d.js';
 import { mountain3dSDF } from './components/shapes/mountain-3d.js';
+import { iconGrid3dSDF } from './components/shapes/icon-grid-3d.js';
 import { circleLoop3dSDF } from './components/shapes/circle-loop-3d.js';
 import { relationshipGraph3dSDF } from './components/charts/diagrams/relationship-graph-3d.js';
 import { orgChart3dSDF } from './components/charts/diagrams/org-chart-3d.js';
@@ -553,6 +554,15 @@ const PRIMITIVE_FACTORIES = {
       sideScale: a.sideScale ?? 0.6,
       pathMarkers: a.pathMarkers ?? 4,
       markerRadius: a.markerRadius ?? 0.13,
+    }),
+  'icon-grid-3d': (a) =>
+    iconGrid3dSDF({
+      rows: a.rows ?? 2,
+      cols: a.cols ?? 4,
+      tileSize: a.tileSize ?? 0.8,
+      gap: a.gap ?? 0.22,
+      tileDepth: a.tileDepth ?? 0.22,
+      glyphs: a.glyphs ?? null,
     }),
   'circle-segmented-3d': (a) =>
     circleSegmented3dSDF({

--- a/sdf-js/src/scene/compile.js
+++ b/sdf-js/src/scene/compile.js
@@ -355,6 +355,7 @@ const PRIMITIVE_FACTORIES = {
       layerHeight: a.layerHeight ?? a.thickness ?? 0.3,
       gap: a.gap ?? 0.05,
       depth: a.depth ?? 0.6,
+      colors: a.colors ?? null,
     }),
   'bar-3d': (a) =>
     bar3dSDF({
@@ -364,6 +365,7 @@ const PRIMITIVE_FACTORIES = {
       barDepth: a.barDepth ?? a.depth ?? 0.4,
       gap: a.gap ?? 0.1,
       maxHeight: a.maxHeight ?? a.scale ?? 2.0,
+      colors: a.colors ?? null,
     }),
   'column-3d': (a) =>
     column3dSDF({

--- a/sdf-js/src/scene/components/charts/data/bar-3d.js
+++ b/sdf-js/src/scene/components/charts/data/bar-3d.js
@@ -25,6 +25,9 @@
 // =============================================================================
 
 import { SDF3 } from '../../../../sdf/core.js';
+import { box } from '../../../../sdf/d3.js';
+import { union } from '../../../../sdf/dn.js';
+import { resolveMaterial } from '../../../spec.js';
 
 export const MAX_BARS = 32;
 
@@ -102,8 +105,29 @@ export function bar3dSDF({
   barDepth = 0.4,
   gap = 0.1,
   maxHeight = 2.0,
+  colors = null,
 } = {}) {
   const { N, vals, paddedValues } = resolveBarParams(values, count);
+
+  // per-leaf colours: build the same bars as a union of coloured box leaves instead of
+  // the fused prim. Only when colors[] is given — the no-colours path is untouched.
+  if (Array.isArray(colors) && colors.length) {
+    const totalX = N * barWidth + (N - 1) * gap;
+    const xStart = -totalX / 2 + barWidth / 2;
+    const parts = [];
+    for (let i = 0; i < N; i++) {
+      const h = vals[i] * maxHeight;
+      if (h <= 0) continue;
+      const xc = xStart + i * (barWidth + gap);
+      const b = box([barWidth, h, barDepth]).translate([xc, h / 2, 0]);
+      if (colors[i] != null) {
+        const m = resolveMaterial(colors[i]);
+        if (m) b._subjectMaterial = m;
+      }
+      parts.push(b);
+    }
+    if (parts.length) return parts.length === 1 ? parts[0] : union(...parts);
+  }
 
   const inst = SDF3((p) => evalBarsSDF(p, N, vals, barWidth, barDepth, gap, maxHeight));
 

--- a/sdf-js/src/scene/components/charts/hierarchy/pyramid-3d.js
+++ b/sdf-js/src/scene/components/charts/hierarchy/pyramid-3d.js
@@ -21,6 +21,9 @@
 // =============================================================================
 
 import { SDF3 } from '../../../../sdf/core.js';
+import { box } from '../../../../sdf/d3.js';
+import { union } from '../../../../sdf/dn.js';
+import { resolveMaterial } from '../../../spec.js';
 
 /**
  * Multi-level parametric pyramid SDF.
@@ -40,10 +43,29 @@ export function pyramid3dSDF({
   layerHeight = 0.3,
   gap = 0.05,
   depth = 0.6,
+  colors = null,
 } = {}) {
   // Clamp levels to [1, 20] (GPU loop is unrolled to 20)
   const N = Math.max(1, Math.min(20, Math.floor(levels)));
   const totalH = N * layerHeight + (N - 1) * gap;
+
+  // per-leaf colours: same tiers as a union of coloured boxes (only when colors[] given;
+  // the fused no-colours path below is untouched so existing behaviour/tests are stable).
+  if (Array.isArray(colors) && colors.length) {
+    const parts = [];
+    for (let i = 0; i < N; i++) {
+      const t = N > 1 ? i / (N - 1) : 0;
+      const w = baseWidth + t * (topWidth - baseWidth);
+      const yc = i * (layerHeight + gap) - totalH / 2 + layerHeight / 2;
+      const tier = box([w, layerHeight, depth]).translate([0, yc, 0]);
+      if (colors[i] != null) {
+        const m = resolveMaterial(colors[i]);
+        if (m) tier._subjectMaterial = m;
+      }
+      parts.push(tier);
+    }
+    return parts.length === 1 ? parts[0] : union(...parts);
+  }
 
   const inst = SDF3((p) => {
     let minDist = Infinity;

--- a/sdf-js/src/scene/components/shapes/icon-grid-3d.js
+++ b/sdf-js/src/scene/components/shapes/icon-grid-3d.js
@@ -1,0 +1,107 @@
+// =============================================================================
+// icon-grid-3d.js — a wall of icon tiles (Atlas shape atom).
+// -----------------------------------------------------------------------------
+// rows×cols rounded tiles facing the camera, each with a simple raised pictogram
+// (disc / ring / plus / bar / frame / dot / lines / square) cycling across cells.
+// Covers PresentationLoad "Line Icons" style icon sets — an abstract visual
+// language. Composite atom (box + cylinder + sphere + union/difference); glyphs
+// carry an accent _subjectMaterial so they pop off the tile face.
+// =============================================================================
+
+import { box, cylinder, sphere } from '../../../sdf/d3.js';
+import { union, difference } from '../../../sdf/dn.js';
+import { resolveMaterial } from '../../spec.js';
+
+const GLYPH_ACCENT = { hue: 0.57, sat: 0.5, value: 0.95 };
+
+// glyph in the XY plane, thin in Z, centred at origin. s = glyph half-size, d = depth.
+function glyph(kind, s, d) {
+  const k = ((kind % 8) + 8) % 8;
+  switch (k) {
+    case 0: // disc
+      return cylinder(s, d).rotateXYZ([Math.PI / 2, 0, 0]);
+    case 1: // ring
+      return difference(cylinder(s, d), cylinder(s * 0.55, d * 1.6)).rotateXYZ([Math.PI / 2, 0, 0]);
+    case 2: // plus
+      return union(box([s * 1.7, s * 0.5, d]), box([s * 0.5, s * 1.7, d]));
+    case 3: // bar
+      return box([s * 1.8, s * 0.55, d]);
+    case 4: // square frame
+      return difference(box([s * 1.7, s * 1.7, d]), box([s * 0.9, s * 0.9, d * 1.6]));
+    case 5: // dot
+      return sphere(s * 0.9);
+    case 6: // stacked lines
+      return union(
+        box([s * 1.6, s * 0.4, d]).translate([0, s * 0.55, 0]),
+        box([s * 1.6, s * 0.4, d]).translate([0, -s * 0.55, 0]),
+      );
+    default: // 7: filled square
+      return box([s * 1.3, s * 1.3, d]);
+  }
+}
+
+/**
+ * @param {object} opts
+ * @param {number} [opts.rows=2]
+ * @param {number} [opts.cols=4]
+ * @param {number} [opts.tileSize=0.8]   tile edge length
+ * @param {number} [opts.gap=0.22]       gap between tiles
+ * @param {number} [opts.tileDepth=0.22] tile Z depth
+ * @param {number[]} [opts.glyphs]       per-cell glyph indices (default: cycle 0..7)
+ * @returns {SDF3}
+ */
+export function iconGrid3dSDF({
+  rows = 2,
+  cols = 4,
+  tileSize = 0.8,
+  gap = 0.22,
+  tileDepth = 0.22,
+  glyphs = null,
+} = {}) {
+  const R = Math.max(1, Math.floor(rows));
+  const C = Math.max(1, Math.floor(cols));
+  const stride = tileSize + gap;
+  const gs = tileSize * 0.24; // glyph half-size
+  const gd = 0.08; // glyph raised depth
+  const accent = resolveMaterial(GLYPH_ACCENT);
+  const parts = [];
+  let idx = 0;
+  for (let r = 0; r < R; r++) {
+    for (let c = 0; c < C; c++) {
+      const x = (c - (C - 1) / 2) * stride;
+      const y = ((R - 1) / 2 - r) * stride;
+      parts.push(box([tileSize, tileSize, tileDepth]).translate([x, y, 0]));
+      const kind = glyphs && glyphs[idx] != null ? glyphs[idx] : idx;
+      const g = glyph(kind, gs, gd).translate([x, y, tileDepth / 2 + gd / 2]);
+      if (accent) g._subjectMaterial = accent;
+      parts.push(g);
+      idx++;
+    }
+  }
+  return parts.length === 1 ? parts[0] : union(...parts);
+}
+
+export const iconGrid3dSpec = {
+  type: 'icon-grid-3d',
+  category: 'shapes',
+  args: {
+    rows: { type: 'number', default: 2, doc: 'Tile rows' },
+    cols: { type: 'number', default: 4, doc: 'Tile columns' },
+    tileSize: { type: 'number', default: 0.8, doc: 'Tile edge length' },
+    gap: { type: 'number', default: 0.22, doc: 'Gap between tiles' },
+    tileDepth: { type: 'number', default: 0.22, doc: 'Tile Z depth' },
+    glyphs: { type: 'array', default: null, doc: 'Per-cell glyph indices (0..7), default cycles' },
+  },
+  examples: [
+    { name: 'Icon wall 2x4', args: { rows: 2, cols: 4 } },
+    { name: 'Toolbar', args: { rows: 1, cols: 6 } },
+    { name: 'Grid 3x3', args: { rows: 3, cols: 3 } },
+  ],
+  description: 'A wall of icon tiles with raised pictograms — an icon set / visual language',
+  source: {
+    author: 'Atlas',
+    builtAt: '2026-06-25',
+    builder: 'Polish round — recommendations coverage (Line Icons)',
+    license: 'PolyForm Noncommercial 1.0.0',
+  },
+};

--- a/sdf-js/src/scene/components/shapes/mountain-3d.js
+++ b/sdf-js/src/scene/components/shapes/mountain-3d.js
@@ -1,0 +1,88 @@
+// =============================================================================
+// mountain-3d.js — summit / journey metaphor graphic (Atlas shape atom).
+// -----------------------------------------------------------------------------
+// A mountain massif (a main peak + flanking side peaks) with a trail of markers
+// ascending the front face to the summit. Covers PresentationLoad "Mountain Path
+// – Graphics" — the climb-to-goal metaphor. Composite atom (cone + sphere + union),
+// trail markers carry an accent _subjectMaterial so the path reads against the rock.
+// =============================================================================
+
+import { cone, sphere } from '../../../sdf/d3.js';
+import { union } from '../../../sdf/dn.js';
+import { resolveMaterial } from '../../spec.js';
+
+const TRAIL_ACCENT = { hue: 0.08, sat: 0.85, value: 0.92 }; // warm summit-trail accent
+
+/**
+ * @param {object} opts
+ * @param {number} [opts.height=2.4]      main-peak height (base sits on y=0)
+ * @param {number} [opts.baseRadius=1.5]  main-peak base radius
+ * @param {number} [opts.sidePeaks=2]     flanking peaks (0..2)
+ * @param {number} [opts.spread=1.7]      x offset of side peaks
+ * @param {number} [opts.sideScale=0.6]   side-peak size vs main
+ * @param {number} [opts.pathMarkers=4]   trail markers up the front face
+ * @param {number} [opts.markerRadius=0.13] trail marker radius
+ * @returns {SDF3}
+ */
+export function mountain3dSDF({
+  height = 2.4,
+  baseRadius = 1.5,
+  sidePeaks = 2,
+  spread = 1.7,
+  sideScale = 0.6,
+  pathMarkers = 4,
+  markerRadius = 0.13,
+} = {}) {
+  const parts = [];
+  // main peak — cone is centred on its own height, lift base to y=0
+  parts.push(cone(height, baseRadius).translate([0, height / 2, 0]));
+
+  // flanking peaks, slightly back and to the sides
+  const S = Math.max(0, Math.min(2, Math.floor(sidePeaks)));
+  const sh = height * sideScale;
+  const sr = baseRadius * sideScale;
+  if (S >= 1) parts.push(cone(sh, sr).translate([-spread, sh / 2, -0.5]));
+  if (S >= 2) parts.push(cone(sh * 0.9, sr * 0.95).translate([spread * 0.95, (sh * 0.9) / 2, -0.6]));
+
+  // trail of markers zig-zagging up the front face (z+) of the main peak
+  const M = Math.max(0, Math.floor(pathMarkers));
+  const accent = resolveMaterial(TRAIL_ACCENT);
+  for (let i = 0; i < M; i++) {
+    const t = (i + 0.5) / M; // 0..1 up the peak
+    const y = t * height * 0.82;
+    const rAtY = baseRadius * (1 - y / height); // cone radius shrinks with height
+    const x = (i % 2 === 0 ? -1 : 1) * Math.min(0.45, rAtY * 0.5); // zig-zag
+    const z = rAtY * 0.86 + markerRadius * 0.4; // sit on the front slope
+    const m = sphere(markerRadius).translate([x, y + markerRadius, z]);
+    if (accent) m._subjectMaterial = accent;
+    parts.push(m);
+  }
+
+  return parts.length === 1 ? parts[0] : union(...parts);
+}
+
+export const mountain3dSpec = {
+  type: 'mountain-3d',
+  category: 'shapes',
+  args: {
+    height: { type: 'number', default: 2.4, doc: 'Main-peak height' },
+    baseRadius: { type: 'number', default: 1.5, doc: 'Main-peak base radius' },
+    sidePeaks: { type: 'number', default: 2, doc: 'Flanking peaks (0..2)' },
+    spread: { type: 'number', default: 1.7, doc: 'x offset of side peaks' },
+    sideScale: { type: 'number', default: 0.6, doc: 'Side-peak scale vs main' },
+    pathMarkers: { type: 'number', default: 4, doc: 'Trail markers up the front' },
+    markerRadius: { type: 'number', default: 0.13, doc: 'Trail marker radius' },
+  },
+  examples: [
+    { name: 'Summit + trail', args: { pathMarkers: 4 } },
+    { name: 'Lone peak', args: { sidePeaks: 0, pathMarkers: 5 } },
+    { name: 'Range', args: { sidePeaks: 2, pathMarkers: 0 } },
+  ],
+  description: 'Mountain massif with an ascending trail — the climb-to-goal metaphor',
+  source: {
+    author: 'Atlas',
+    builtAt: '2026-06-25',
+    builder: 'Polish round — recommendations coverage (Mountain Path)',
+    license: 'PolyForm Noncommercial 1.0.0',
+  },
+};

--- a/sdf-js/src/scene/lift-2d-to-3d.js
+++ b/sdf-js/src/scene/lift-2d-to-3d.js
@@ -50,7 +50,7 @@ const HUE_BY_TYPE = {
   // org / tree — cyan
   'org-chart': 0.54, 'tree-diagram': 0.54, 'sphere-tree': 0.54,
   // grid / blocks — steel blue
-  'matrix-grid': 0.60, cube: 0.60, 'cube-grid': 0.60, 'cube-segmented': 0.60,
+  'matrix-grid': 0.60, cube: 0.60, 'cube-grid': 0.60, 'cube-segmented': 0.60, 'icon-grid': 0.60,
   // misc
   'sphere-segmented': 0.50, 'kpi-card': 0.58, fishbone: 0.40, diamond: 0.58, gear: 0.58, arrow: 0.58, 'traffic-light': 0.58,
 };
@@ -564,6 +564,17 @@ export const TWIN_MAP = {
         args: { height: 2.6, baseRadius: 1.6, sidePeaks: 2, pathMarkers: a.markers ?? Math.max(3, stages.length || 4) },
         transform: { translate: [0, 0, 0] },
         overlay: rightCards(stages.map(itemLabel)),
+      };
+    },
+  },
+
+  // icon set — a wall of pictogram tiles
+  'icon-grid': {
+    to: 'icon-grid-3d',
+    lift(a) {
+      return {
+        args: { rows: a.rows ?? 2, cols: a.cols ?? 4, glyphs: a.glyphs ?? null },
+        transform: { translate: [0, 1.9, 0] },
       };
     },
   },

--- a/sdf-js/src/scene/lift-2d-to-3d.js
+++ b/sdf-js/src/scene/lift-2d-to-3d.js
@@ -55,7 +55,13 @@ const HUE_BY_TYPE = {
   'sphere-segmented': 0.50, 'kpi-card': 0.58, fishbone: 0.40, diamond: 0.58, gear: 0.58, arrow: 0.58, 'traffic-light': 0.58,
 };
 
+// full-material overrides for atoms whose look needs more than a hue swap
+const MATERIAL_OVERRIDE = {
+  mountain: { hue: 0.6, sat: 0.24, value: 0.62, roughness: 0.55, clearcoat: 0.15 }, // rock
+};
+
 function materialFor(type2d) {
+  if (MATERIAL_OVERRIDE[type2d]) return { ...DEFAULT_MAT, ...MATERIAL_OVERRIDE[type2d] };
   const hue = HUE_BY_TYPE[type2d];
   if (hue == null) return { ...DEFAULT_MAT };
   // warm hues (reds/oranges/golds) turn muddy brown at the default value/sat — brighten
@@ -545,6 +551,19 @@ export const TWIN_MAP = {
         args: { levels: [frac], radius: 1.1 },
         transform: { translate: [0, 1.4, 0] },
         overlay: [{ text: fmt(a.value, a.format ?? 'percent'), anchor: [0, 1.4, 1.2], role: 'value', radius: 0.6 }],
+      };
+    },
+  },
+
+  // summit / journey metaphor — a real mountain with an ascending trail
+  mountain: {
+    to: 'mountain-3d',
+    lift(a) {
+      const stages = a.stages || a.steps || a.layers || [];
+      return {
+        args: { height: 2.6, baseRadius: 1.6, sidePeaks: 2, pathMarkers: a.markers ?? Math.max(3, stages.length || 4) },
+        transform: { translate: [0, 0, 0] },
+        overlay: rightCards(stages.map(itemLabel)),
       };
     },
   },

--- a/sdf-js/src/scene/lift-2d-to-3d.js
+++ b/sdf-js/src/scene/lift-2d-to-3d.js
@@ -251,7 +251,7 @@ export const TWIN_MAP = {
         radius: 0.32,
       }));
       return {
-        args: { values: norm, barWidth, barDepth: 0.55, gap, maxHeight },
+        args: { values: norm, barWidth, barDepth: 0.55, gap, maxHeight, colors: shades(HUE_BY_TYPE.bar, norm.length) },
         transform: { translate: [0, ty, 0] },
         overlay,
       };
@@ -370,7 +370,19 @@ export const TWIN_MAP = {
   'agenda-list': itemsTwin('agenda-list-3d', 'items', 'items'),
   'bullet-list': itemsTwin('bullet-list-3d', 'items', 'items'),
   progression: itemsTwin('progression-3d', 'steps', 'steps', { transform: { translate: [-1.0, 0.6, 0] } }),
-  pyramid: itemsTwin('pyramid-3d', 'layers', 'levels', { transform: { translate: [0, 0.6, 0] } }),
+  pyramid: {
+    to: 'pyramid-3d',
+    lift(a) {
+      const arr = asArray(a.layers);
+      const n = arr.length || (typeof a.layers === 'number' ? a.layers : 0) || 3;
+      const labels = arr.map(itemLabel).filter(Boolean);
+      return {
+        args: { levels: n, colors: shades(HUE_BY_TYPE.pyramid, n) },
+        transform: { translate: [0, 0.6, 0] },
+        overlay: rightCards(labels.length ? labels : a.labels || []),
+      };
+    },
+  },
   'traffic-light': itemsTwin('traffic-light-3d', 'lights', 'lights', { transform: { translate: [0, 1.8, 0] } }),
   'circle-stack': {
     to: 'circle-stack-3d',

--- a/sdf-js/src/scene/spec.js
+++ b/sdf-js/src/scene/spec.js
@@ -213,6 +213,7 @@ export const PRIMITIVE_TYPES = new Set([
   'circle-stack-3d',
   'circle-segmented-3d',
   'mountain-3d',
+  'icon-grid-3d',
   'circle-loop-3d',
   // Sprint 4 node-edge charts — sphere/box nodes + capsule edges (+ cone arrows).
   'relationship-graph-3d',

--- a/sdf-js/src/scene/spec.js
+++ b/sdf-js/src/scene/spec.js
@@ -212,6 +212,7 @@ export const PRIMITIVE_TYPES = new Set([
   'circle-frame-3d',
   'circle-stack-3d',
   'circle-segmented-3d',
+  'mountain-3d',
   'circle-loop-3d',
   // Sprint 4 node-edge charts — sphere/box nodes + capsule edges (+ cone arrows).
   'relationship-graph-3d',


### PR DESCRIPTION
打磨轮 backlog 1 + 2:

## 1. per-leaf 分色扩到融合原子(opt-in,不破现有)
**bar-3d / pyramid-3d** 加可选 `colors[]`:传了就用「union of 彩色 box leaf」走通用路径,不传就走原融合 prim → GLSL 快路径 + atom 测试全不动。lift 喂同色系渐变(蓝柱/金字塔金)。
- circle-segmented 跳过(modPolar 环形,分段需环形扇区构造,易失配)—— 已记 backlog。

## 2. 两个新原子(填补 rec 覆盖缺口)
- **mountain-3d** —— 主峰+侧峰山体 + 金色路径标记上行到顶。Mountain Path deck 封面用上真山(替原 pyramid 近似)。山岩材质 override。
- **icon-grid-3d** —— rows×cols 瓦片墙,8 种浮雕字形循环(disc/ring/plus/bar/frame/dot/lines/square),强调色字形。Line Icons deck 用上(替 cube-grid 空瓦)。

两个新原子都走完整两道闸门注册(spec + compile),registry-sync 绿。

验证(Playwright):bar 蓝渐变、pyramid 金渐变、山体+金路径、2×4 图标墙。`npm test` 100/100。

看:`?deck=deck-rec-mountain` · `?deck=deck-rec-icons` · `?scene=rec-okr-2`(bar 渐变)

🤖 Generated with [Claude Code](https://claude.com/claude-code)