### PR TITLE
polish(present): per-slide-type camera moves

### DIFF
--- a/sdf-js/scenes/lifted-charts-circle-segments.json
+++ b/sdf-js/scenes/lifted-charts-circle-segments.json
@@ -109,28 +109,27 @@
     "loop": false,
     "shots": [
       {
-        "duration": 0.01,
         "pos": [
-          1,
-          2.1,
-          9.799999999999999
+          6.5520000000000005,
+          2.3,
+          5.208
         ],
         "target": [
           0,
           1.6,
           0
         ],
-        "fov": 50,
+        "fov": 48,
+        "focalDistance": 8.4,
+        "duration": 0.01,
         "aperture": 0,
-        "focalDistance": 8.2,
         "ease": "smooth"
       },
       {
-        "duration": 13,
         "pos": [
           0,
           1.8,
-          8.2
+          8.4
         ],
         "target": [
           0,
@@ -138,9 +137,10 @@
           0
         ],
         "fov": 46,
+        "focalDistance": 8.4,
+        "duration": 14,
         "transition": "blend",
         "aperture": 0,
-        "focalDistance": 8.2,
         "ease": "smooth"
       }
     ]

--- a/sdf-js/scenes/lifted-charts-graphs.json
+++ b/sdf-js/scenes/lifted-charts-graphs.json
@@ -127,11 +127,10 @@
     "loop": false,
     "shots": [
       {
-        "duration": 0.01,
         "pos": [
-          1,
-          2.1,
-          9.799999999999999
+          -4.2,
+          2.1500000000000004,
+          7.9799999999999995
         ],
         "target": [
           0,
@@ -139,26 +138,27 @@
           0
         ],
         "fov": 50,
+        "focalDistance": 8.4,
+        "duration": 0.01,
         "aperture": 0,
-        "focalDistance": 8.2,
         "ease": "smooth"
       },
       {
-        "duration": 13,
         "pos": [
-          0,
+          1.512,
           1.8,
-          8.2
+          7.392
         ],
         "target": [
           0,
           1.6,
           0
         ],
-        "fov": 46,
+        "fov": 47,
+        "focalDistance": 8.4,
+        "duration": 14,
         "transition": "blend",
         "aperture": 0,
-        "focalDistance": 8.2,
         "ease": "smooth"
       }
     ]

--- a/sdf-js/scenes/lifted-charts-graphs.json
+++ b/sdf-js/scenes/lifted-charts-graphs.json
@@ -16,7 +16,34 @@
         "barWidth": 0.55,
         "barDepth": 0.55,
         "gap": 0.25,
-        "maxHeight": 2.2
+        "maxHeight": 2.2,
+        "colors": [
+          {
+            "hue": 0.58,
+            "sat": 0.58,
+            "value": 0.76
+          },
+          {
+            "hue": 0.58,
+            "sat": 0.6,
+            "value": 0.685
+          },
+          {
+            "hue": 0.58,
+            "sat": 0.62,
+            "value": 0.61
+          },
+          {
+            "hue": 0.58,
+            "sat": 0.6399999999999999,
+            "value": 0.535
+          },
+          {
+            "hue": 0.58,
+            "sat": 0.6599999999999999,
+            "value": 0.46
+          }
+        ]
       },
       "transform": {
         "translate": [

--- a/sdf-js/scenes/lifted-charts-layer-objects.json
+++ b/sdf-js/scenes/lifted-charts-layer-objects.json
@@ -112,38 +112,38 @@
     "loop": false,
     "shots": [
       {
-        "duration": 0.01,
         "pos": [
-          1,
-          2.1,
-          9.799999999999999
+          0.6,
+          0.7000000000000001,
+          9.8
         ],
         "target": [
           0,
-          1.6,
+          1.9000000000000001,
           0
         ],
-        "fov": 50,
+        "fov": 52,
+        "focalDistance": 8.4,
+        "duration": 0.01,
         "aperture": 0,
-        "focalDistance": 8.2,
         "ease": "smooth"
       },
       {
-        "duration": 13,
         "pos": [
           0,
-          1.8,
-          8.2
+          2.2,
+          8.4
         ],
         "target": [
           0,
-          1.6,
+          1.9000000000000001,
           0
         ],
         "fov": 46,
+        "focalDistance": 8.4,
+        "duration": 14,
         "transition": "blend",
         "aperture": 0,
-        "focalDistance": 8.2,
         "ease": "smooth"
       }
     ]

--- a/sdf-js/scenes/lifted-charts-round-plates.json
+++ b/sdf-js/scenes/lifted-charts-round-plates.json
@@ -102,38 +102,38 @@
     "loop": false,
     "shots": [
       {
-        "duration": 0.01,
         "pos": [
-          1,
-          2.1,
-          9.799999999999999
+          0.6,
+          0.7000000000000001,
+          9.8
         ],
         "target": [
           0,
-          1.6,
+          1.9000000000000001,
           0
         ],
-        "fov": 50,
+        "fov": 52,
+        "focalDistance": 8.4,
+        "duration": 0.01,
         "aperture": 0,
-        "focalDistance": 8.2,
         "ease": "smooth"
       },
       {
-        "duration": 13,
         "pos": [
           0,
-          1.8,
-          8.2
+          2.2,
+          8.4
         ],
         "target": [
           0,
-          1.6,
+          1.9000000000000001,
           0
         ],
         "fov": 46,
+        "focalDistance": 8.4,
+        "duration": 14,
         "transition": "blend",
         "aperture": 0,
-        "focalDistance": 8.2,
         "ease": "smooth"
       }
     ]

--- a/sdf-js/scenes/lifted-charts-step-diagram.json
+++ b/sdf-js/scenes/lifted-charts-step-diagram.json
@@ -90,11 +90,10 @@
     "loop": false,
     "shots": [
       {
-        "duration": 0.01,
         "pos": [
-          1,
-          2.1,
-          9.799999999999999
+          -4.2,
+          2.1500000000000004,
+          7.9799999999999995
         ],
         "target": [
           0,
@@ -102,26 +101,27 @@
           0
         ],
         "fov": 50,
+        "focalDistance": 8.4,
+        "duration": 0.01,
         "aperture": 0,
-        "focalDistance": 8.2,
         "ease": "smooth"
       },
       {
-        "duration": 13,
         "pos": [
-          0,
+          1.512,
           1.8,
-          8.2
+          7.392
         ],
         "target": [
           0,
           1.6,
           0
         ],
-        "fov": 46,
+        "fov": 47,
+        "focalDistance": 8.4,
+        "duration": 14,
         "transition": "blend",
         "aperture": 0,
-        "focalDistance": 8.2,
         "ease": "smooth"
       }
     ]

--- a/sdf-js/scenes/lifted-charts-timeline-spheres.json
+++ b/sdf-js/scenes/lifted-charts-timeline-spheres.json
@@ -104,11 +104,10 @@
     "loop": false,
     "shots": [
       {
-        "duration": 0.01,
         "pos": [
-          1,
-          2.1,
-          9.799999999999999
+          -4.2,
+          2.1500000000000004,
+          7.9799999999999995
         ],
         "target": [
           0,
@@ -116,26 +115,27 @@
           0
         ],
         "fov": 50,
+        "focalDistance": 8.4,
+        "duration": 0.01,
         "aperture": 0,
-        "focalDistance": 8.2,
         "ease": "smooth"
       },
       {
-        "duration": 13,
         "pos": [
-          0,
+          1.512,
           1.8,
-          8.2
+          7.392
         ],
         "target": [
           0,
           1.6,
           0
         ],
-        "fov": 46,
+        "fov": 47,
+        "focalDistance": 8.4,
+        "duration": 14,
         "transition": "blend",
         "aperture": 0,
-        "focalDistance": 8.2,
         "ease": "smooth"
       }
     ]

--- a/sdf-js/scenes/lifted-cloud-share.json
+++ b/sdf-js/scenes/lifted-cloud-share.json
@@ -93,28 +93,27 @@
     "loop": false,
     "shots": [
       {
-        "duration": 0.01,
         "pos": [
-          1,
-          2.1,
-          9.799999999999999
+          6.5520000000000005,
+          2.3,
+          5.208
         ],
         "target": [
           0,
           1.6,
           0
         ],
-        "fov": 50,
+        "fov": 48,
+        "focalDistance": 8.4,
+        "duration": 0.01,
         "aperture": 0,
-        "focalDistance": 8.2,
         "ease": "smooth"
       },
       {
-        "duration": 13,
         "pos": [
           0,
           1.8,
-          8.2
+          8.4
         ],
         "target": [
           0,
@@ -122,9 +121,10 @@
           0
         ],
         "fov": 46,
+        "focalDistance": 8.4,
+        "duration": 14,
         "transition": "blend",
         "aperture": 0,
-        "focalDistance": 8.2,
         "ease": "smooth"
       }
     ]

--- a/sdf-js/scenes/lifted-maturity.json
+++ b/sdf-js/scenes/lifted-maturity.json
@@ -6,7 +6,29 @@
       "id": "pyramid",
       "type": "pyramid-3d",
       "args": {
-        "levels": 4
+        "levels": 4,
+        "colors": [
+          {
+            "hue": 0.11,
+            "sat": 0.7,
+            "value": 0.88
+          },
+          {
+            "hue": 0.11,
+            "sat": 0.7266666666666666,
+            "value": 0.78
+          },
+          {
+            "hue": 0.11,
+            "sat": 0.7533333333333333,
+            "value": 0.68
+          },
+          {
+            "hue": 0.11,
+            "sat": 0.7799999999999999,
+            "value": 0.5800000000000001
+          }
+        ]
       },
       "transform": {
         "translate": [

--- a/sdf-js/scenes/lifted-maturity.json
+++ b/sdf-js/scenes/lifted-maturity.json
@@ -102,38 +102,38 @@
     "loop": false,
     "shots": [
       {
-        "duration": 0.01,
         "pos": [
-          1,
-          2.1,
-          9.799999999999999
+          0.6,
+          0.7000000000000001,
+          9.8
         ],
         "target": [
           0,
-          1.6,
+          1.9000000000000001,
           0
         ],
-        "fov": 50,
+        "fov": 52,
+        "focalDistance": 8.4,
+        "duration": 0.01,
         "aperture": 0,
-        "focalDistance": 8.2,
         "ease": "smooth"
       },
       {
-        "duration": 13,
         "pos": [
           0,
-          1.8,
-          8.2
+          2.2,
+          8.4
         ],
         "target": [
           0,
-          1.6,
+          1.9000000000000001,
           0
         ],
         "fov": 46,
+        "focalDistance": 8.4,
+        "duration": 14,
         "transition": "blend",
         "aperture": 0,
-        "focalDistance": 8.2,
         "ease": "smooth"
       }
     ]

--- a/sdf-js/scenes/lifted-quarterly.json
+++ b/sdf-js/scenes/lifted-quarterly.json
@@ -127,11 +127,10 @@
     "loop": false,
     "shots": [
       {
-        "duration": 0.01,
         "pos": [
-          1,
-          2.1,
-          9.799999999999999
+          -4.2,
+          2.1500000000000004,
+          7.9799999999999995
         ],
         "target": [
           0,
@@ -139,26 +138,27 @@
           0
         ],
         "fov": 50,
+        "focalDistance": 8.4,
+        "duration": 0.01,
         "aperture": 0,
-        "focalDistance": 8.2,
         "ease": "smooth"
       },
       {
-        "duration": 13,
         "pos": [
-          0,
+          1.512,
           1.8,
-          8.2
+          7.392
         ],
         "target": [
           0,
           1.6,
           0
         ],
-        "fov": 46,
+        "fov": 47,
+        "focalDistance": 8.4,
+        "duration": 14,
         "transition": "blend",
         "aperture": 0,
-        "focalDistance": 8.2,
         "ease": "smooth"
       }
     ]

--- a/sdf-js/scenes/lifted-quarterly.json
+++ b/sdf-js/scenes/lifted-quarterly.json
@@ -16,7 +16,34 @@
         "barWidth": 0.55,
         "barDepth": 0.55,
         "gap": 0.25,
-        "maxHeight": 2.2
+        "maxHeight": 2.2,
+        "colors": [
+          {
+            "hue": 0.58,
+            "sat": 0.58,
+            "value": 0.76
+          },
+          {
+            "hue": 0.58,
+            "sat": 0.6,
+            "value": 0.685
+          },
+          {
+            "hue": 0.58,
+            "sat": 0.62,
+            "value": 0.61
+          },
+          {
+            "hue": 0.58,
+            "sat": 0.6399999999999999,
+            "value": 0.535
+          },
+          {
+            "hue": 0.58,
+            "sat": 0.6599999999999999,
+            "value": 0.46
+          }
+        ]
       },
       "transform": {
         "translate": [

--- a/sdf-js/scenes/lifted-roadmap.json
+++ b/sdf-js/scenes/lifted-roadmap.json
@@ -94,11 +94,10 @@
     "loop": false,
     "shots": [
       {
-        "duration": 0.01,
         "pos": [
-          1,
-          2.1,
-          9.799999999999999
+          -4.2,
+          2.1500000000000004,
+          7.9799999999999995
         ],
         "target": [
           0,
@@ -106,26 +105,27 @@
           0
         ],
         "fov": 50,
+        "focalDistance": 8.4,
+        "duration": 0.01,
         "aperture": 0,
-        "focalDistance": 8.2,
         "ease": "smooth"
       },
       {
-        "duration": 13,
         "pos": [
-          0,
+          1.512,
           1.8,
-          8.2
+          7.392
         ],
         "target": [
           0,
           1.6,
           0
         ],
-        "fov": 46,
+        "fov": 47,
+        "focalDistance": 8.4,
+        "duration": 14,
         "transition": "blend",
         "aperture": 0,
-        "focalDistance": 8.2,
         "ease": "smooth"
       }
     ]

--- a/sdf-js/scenes/lifted-sales-funnel.json
+++ b/sdf-js/scenes/lifted-sales-funnel.json
@@ -111,38 +111,38 @@
     "loop": false,
     "shots": [
       {
-        "duration": 0.01,
         "pos": [
-          1,
-          2.1,
-          9.799999999999999
+          0.6,
+          0.7000000000000001,
+          9.8
         ],
         "target": [
           0,
-          1.6,
+          1.9000000000000001,
           0
         ],
-        "fov": 50,
+        "fov": 52,
+        "focalDistance": 8.4,
+        "duration": 0.01,
         "aperture": 0,
-        "focalDistance": 8.2,
         "ease": "smooth"
       },
       {
-        "duration": 13,
         "pos": [
           0,
-          1.8,
-          8.2
+          2.2,
+          8.4
         ],
         "target": [
           0,
-          1.6,
+          1.9000000000000001,
           0
         ],
         "fov": 46,
+        "focalDistance": 8.4,
+        "duration": 14,
         "transition": "blend",
         "aperture": 0,
-        "focalDistance": 8.2,
         "ease": "smooth"
       }
     ]

--- a/sdf-js/scenes/rec-ai-2.json
+++ b/sdf-js/scenes/rec-ai-2.json
@@ -90,11 +90,10 @@
     "loop": false,
     "shots": [
       {
-        "duration": 0.01,
         "pos": [
-          1,
-          2.1,
-          9.799999999999999
+          -4.2,
+          2.1500000000000004,
+          7.9799999999999995
         ],
         "target": [
           0,
@@ -102,26 +101,27 @@
           0
         ],
         "fov": 50,
+        "focalDistance": 8.4,
+        "duration": 0.01,
         "aperture": 0,
-        "focalDistance": 8.2,
         "ease": "smooth"
       },
       {
-        "duration": 13,
         "pos": [
-          0,
+          1.512,
           1.8,
-          8.2
+          7.392
         ],
         "target": [
           0,
           1.6,
           0
         ],
-        "fov": 46,
+        "fov": 47,
+        "focalDistance": 8.4,
+        "duration": 14,
         "transition": "blend",
         "aperture": 0,
-        "focalDistance": 8.2,
         "ease": "smooth"
       }
     ]

--- a/sdf-js/scenes/rec-ai-3.json
+++ b/sdf-js/scenes/rec-ai-3.json
@@ -82,28 +82,27 @@
     "loop": false,
     "shots": [
       {
-        "duration": 0.01,
         "pos": [
-          1,
-          2.1,
-          9.799999999999999
+          6.5520000000000005,
+          2.3,
+          5.208
         ],
         "target": [
           0,
           1.6,
           0
         ],
-        "fov": 50,
+        "fov": 48,
+        "focalDistance": 8.4,
+        "duration": 0.01,
         "aperture": 0,
-        "focalDistance": 8.2,
         "ease": "smooth"
       },
       {
-        "duration": 13,
         "pos": [
           0,
           1.8,
-          8.2
+          8.4
         ],
         "target": [
           0,
@@ -111,9 +110,10 @@
           0
         ],
         "fov": 46,
+        "focalDistance": 8.4,
+        "duration": 14,
         "transition": "blend",
         "aperture": 0,
-        "focalDistance": 8.2,
         "ease": "smooth"
       }
     ]

--- a/sdf-js/scenes/rec-ai-4.json
+++ b/sdf-js/scenes/rec-ai-4.json
@@ -84,11 +84,10 @@
     "loop": false,
     "shots": [
       {
-        "duration": 0.01,
         "pos": [
-          1,
-          2.1,
-          9.799999999999999
+          -4.2,
+          2.1500000000000004,
+          7.9799999999999995
         ],
         "target": [
           0,
@@ -96,26 +95,27 @@
           0
         ],
         "fov": 50,
+        "focalDistance": 8.4,
+        "duration": 0.01,
         "aperture": 0,
-        "focalDistance": 8.2,
         "ease": "smooth"
       },
       {
-        "duration": 13,
         "pos": [
-          0,
+          1.512,
           1.8,
-          8.2
+          7.392
         ],
         "target": [
           0,
           1.6,
           0
         ],
-        "fov": 46,
+        "fov": 47,
+        "focalDistance": 8.4,
+        "duration": 14,
         "transition": "blend",
         "aperture": 0,
-        "focalDistance": 8.2,
         "ease": "smooth"
       }
     ]

--- a/sdf-js/scenes/rec-ai-5.json
+++ b/sdf-js/scenes/rec-ai-5.json
@@ -126,38 +126,38 @@
     "loop": false,
     "shots": [
       {
-        "duration": 0.01,
         "pos": [
-          1,
-          2.1,
-          9.799999999999999
+          0.6,
+          0.7000000000000001,
+          9.8
         ],
         "target": [
           0,
-          1.6,
+          1.9000000000000001,
           0
         ],
-        "fov": 50,
+        "fov": 52,
+        "focalDistance": 8.4,
+        "duration": 0.01,
         "aperture": 0,
-        "focalDistance": 8.2,
         "ease": "smooth"
       },
       {
-        "duration": 13,
         "pos": [
           0,
-          1.8,
-          8.2
+          2.2,
+          8.4
         ],
         "target": [
           0,
-          1.6,
+          1.9000000000000001,
           0
         ],
         "fov": 46,
+        "focalDistance": 8.4,
+        "duration": 14,
         "transition": "blend",
         "aperture": 0,
-        "focalDistance": 8.2,
         "ease": "smooth"
       }
     ]

--- a/sdf-js/scenes/rec-bizcase-1.json
+++ b/sdf-js/scenes/rec-bizcase-1.json
@@ -6,7 +6,24 @@
       "id": "pyramid",
       "type": "pyramid-3d",
       "args": {
-        "levels": 3
+        "levels": 3,
+        "colors": [
+          {
+            "hue": 0.11,
+            "sat": 0.7,
+            "value": 0.88
+          },
+          {
+            "hue": 0.11,
+            "sat": 0.74,
+            "value": 0.73
+          },
+          {
+            "hue": 0.11,
+            "sat": 0.7799999999999999,
+            "value": 0.5800000000000001
+          }
+        ]
       },
       "transform": {
         "translate": [

--- a/sdf-js/scenes/rec-bizcase-3.json
+++ b/sdf-js/scenes/rec-bizcase-3.json
@@ -111,11 +111,10 @@
     "loop": false,
     "shots": [
       {
-        "duration": 0.01,
         "pos": [
-          1,
-          2.1,
-          9.799999999999999
+          -4.2,
+          2.1500000000000004,
+          7.9799999999999995
         ],
         "target": [
           0,
@@ -123,26 +122,27 @@
           0
         ],
         "fov": 50,
+        "focalDistance": 8.4,
+        "duration": 0.01,
         "aperture": 0,
-        "focalDistance": 8.2,
         "ease": "smooth"
       },
       {
-        "duration": 13,
         "pos": [
-          0,
+          1.512,
           1.8,
-          8.2
+          7.392
         ],
         "target": [
           0,
           1.6,
           0
         ],
-        "fov": 46,
+        "fov": 47,
+        "focalDistance": 8.4,
+        "duration": 14,
         "transition": "blend",
         "aperture": 0,
-        "focalDistance": 8.2,
         "ease": "smooth"
       }
     ]

--- a/sdf-js/scenes/rec-bizcase-3.json
+++ b/sdf-js/scenes/rec-bizcase-3.json
@@ -15,7 +15,29 @@
         "barWidth": 0.55,
         "barDepth": 0.55,
         "gap": 0.25,
-        "maxHeight": 2.2
+        "maxHeight": 2.2,
+        "colors": [
+          {
+            "hue": 0.58,
+            "sat": 0.58,
+            "value": 0.76
+          },
+          {
+            "hue": 0.58,
+            "sat": 0.6066666666666666,
+            "value": 0.66
+          },
+          {
+            "hue": 0.58,
+            "sat": 0.6333333333333333,
+            "value": 0.56
+          },
+          {
+            "hue": 0.58,
+            "sat": 0.6599999999999999,
+            "value": 0.46
+          }
+        ]
       },
       "transform": {
         "translate": [

--- a/sdf-js/scenes/rec-bizcase-4.json
+++ b/sdf-js/scenes/rec-bizcase-4.json
@@ -84,11 +84,10 @@
     "loop": false,
     "shots": [
       {
-        "duration": 0.01,
         "pos": [
-          1,
-          2.1,
-          9.799999999999999
+          -4.2,
+          2.1500000000000004,
+          7.9799999999999995
         ],
         "target": [
           0,
@@ -96,26 +95,27 @@
           0
         ],
         "fov": 50,
+        "focalDistance": 8.4,
+        "duration": 0.01,
         "aperture": 0,
-        "focalDistance": 8.2,
         "ease": "smooth"
       },
       {
-        "duration": 13,
         "pos": [
-          0,
+          1.512,
           1.8,
-          8.2
+          7.392
         ],
         "target": [
           0,
           1.6,
           0
         ],
-        "fov": 46,
+        "fov": 47,
+        "focalDistance": 8.4,
+        "duration": 14,
         "transition": "blend",
         "aperture": 0,
-        "focalDistance": 8.2,
         "ease": "smooth"
       }
     ]

--- a/sdf-js/scenes/rec-bizcase-5.json
+++ b/sdf-js/scenes/rec-bizcase-5.json
@@ -111,38 +111,38 @@
     "loop": false,
     "shots": [
       {
-        "duration": 0.01,
         "pos": [
-          1,
-          2.1,
-          9.799999999999999
+          0.6,
+          0.7000000000000001,
+          9.8
         ],
         "target": [
           0,
-          1.6,
+          1.9000000000000001,
           0
         ],
-        "fov": 50,
+        "fov": 52,
+        "focalDistance": 8.4,
+        "duration": 0.01,
         "aperture": 0,
-        "focalDistance": 8.2,
         "ease": "smooth"
       },
       {
-        "duration": 13,
         "pos": [
           0,
-          1.8,
-          8.2
+          2.2,
+          8.4
         ],
         "target": [
           0,
-          1.6,
+          1.9000000000000001,
           0
         ],
         "fov": 46,
+        "focalDistance": 8.4,
+        "duration": 14,
         "transition": "blend",
         "aperture": 0,
-        "focalDistance": 8.2,
         "ease": "smooth"
       }
     ]

--- a/sdf-js/scenes/rec-bizplan-1.json
+++ b/sdf-js/scenes/rec-bizplan-1.json
@@ -6,7 +6,29 @@
       "id": "pyramid",
       "type": "pyramid-3d",
       "args": {
-        "levels": 4
+        "levels": 4,
+        "colors": [
+          {
+            "hue": 0.11,
+            "sat": 0.7,
+            "value": 0.88
+          },
+          {
+            "hue": 0.11,
+            "sat": 0.7266666666666666,
+            "value": 0.78
+          },
+          {
+            "hue": 0.11,
+            "sat": 0.7533333333333333,
+            "value": 0.68
+          },
+          {
+            "hue": 0.11,
+            "sat": 0.7799999999999999,
+            "value": 0.5800000000000001
+          }
+        ]
       },
       "transform": {
         "translate": [

--- a/sdf-js/scenes/rec-bizplan-2.json
+++ b/sdf-js/scenes/rec-bizplan-2.json
@@ -94,11 +94,10 @@
     "loop": false,
     "shots": [
       {
-        "duration": 0.01,
         "pos": [
-          1,
-          2.1,
-          9.799999999999999
+          -4.2,
+          2.1500000000000004,
+          7.9799999999999995
         ],
         "target": [
           0,
@@ -106,26 +105,27 @@
           0
         ],
         "fov": 50,
+        "focalDistance": 8.4,
+        "duration": 0.01,
         "aperture": 0,
-        "focalDistance": 8.2,
         "ease": "smooth"
       },
       {
-        "duration": 13,
         "pos": [
-          0,
+          1.512,
           1.8,
-          8.2
+          7.392
         ],
         "target": [
           0,
           1.6,
           0
         ],
-        "fov": 46,
+        "fov": 47,
+        "focalDistance": 8.4,
+        "duration": 14,
         "transition": "blend",
         "aperture": 0,
-        "focalDistance": 8.2,
         "ease": "smooth"
       }
     ]

--- a/sdf-js/scenes/rec-bizplan-3.json
+++ b/sdf-js/scenes/rec-bizplan-3.json
@@ -127,11 +127,10 @@
     "loop": false,
     "shots": [
       {
-        "duration": 0.01,
         "pos": [
-          1,
-          2.1,
-          9.799999999999999
+          -4.2,
+          2.1500000000000004,
+          7.9799999999999995
         ],
         "target": [
           0,
@@ -139,26 +138,27 @@
           0
         ],
         "fov": 50,
+        "focalDistance": 8.4,
+        "duration": 0.01,
         "aperture": 0,
-        "focalDistance": 8.2,
         "ease": "smooth"
       },
       {
-        "duration": 13,
         "pos": [
-          0,
+          1.512,
           1.8,
-          8.2
+          7.392
         ],
         "target": [
           0,
           1.6,
           0
         ],
-        "fov": 46,
+        "fov": 47,
+        "focalDistance": 8.4,
+        "duration": 14,
         "transition": "blend",
         "aperture": 0,
-        "focalDistance": 8.2,
         "ease": "smooth"
       }
     ]

--- a/sdf-js/scenes/rec-bizplan-3.json
+++ b/sdf-js/scenes/rec-bizplan-3.json
@@ -16,7 +16,34 @@
         "barWidth": 0.55,
         "barDepth": 0.55,
         "gap": 0.25,
-        "maxHeight": 2.2
+        "maxHeight": 2.2,
+        "colors": [
+          {
+            "hue": 0.58,
+            "sat": 0.58,
+            "value": 0.76
+          },
+          {
+            "hue": 0.58,
+            "sat": 0.6,
+            "value": 0.685
+          },
+          {
+            "hue": 0.58,
+            "sat": 0.62,
+            "value": 0.61
+          },
+          {
+            "hue": 0.58,
+            "sat": 0.6399999999999999,
+            "value": 0.535
+          },
+          {
+            "hue": 0.58,
+            "sat": 0.6599999999999999,
+            "value": 0.46
+          }
+        ]
       },
       "transform": {
         "translate": [

--- a/sdf-js/scenes/rec-bizplan-4.json
+++ b/sdf-js/scenes/rec-bizplan-4.json
@@ -82,28 +82,27 @@
     "loop": false,
     "shots": [
       {
-        "duration": 0.01,
         "pos": [
-          1,
-          2.1,
-          9.799999999999999
+          6.5520000000000005,
+          2.3,
+          5.208
         ],
         "target": [
           0,
           1.6,
           0
         ],
-        "fov": 50,
+        "fov": 48,
+        "focalDistance": 8.4,
+        "duration": 0.01,
         "aperture": 0,
-        "focalDistance": 8.2,
         "ease": "smooth"
       },
       {
-        "duration": 13,
         "pos": [
           0,
           1.8,
-          8.2
+          8.4
         ],
         "target": [
           0,
@@ -111,9 +110,10 @@
           0
         ],
         "fov": 46,
+        "focalDistance": 8.4,
+        "duration": 14,
         "transition": "blend",
         "aperture": 0,
-        "focalDistance": 8.2,
         "ease": "smooth"
       }
     ]

--- a/sdf-js/scenes/rec-bizplan-5.json
+++ b/sdf-js/scenes/rec-bizplan-5.json
@@ -111,38 +111,38 @@
     "loop": false,
     "shots": [
       {
-        "duration": 0.01,
         "pos": [
-          1,
-          2.1,
-          9.799999999999999
+          0.6,
+          0.7000000000000001,
+          9.8
         ],
         "target": [
           0,
-          1.6,
+          1.9000000000000001,
           0
         ],
-        "fov": 50,
+        "fov": 52,
+        "focalDistance": 8.4,
+        "duration": 0.01,
         "aperture": 0,
-        "focalDistance": 8.2,
         "ease": "smooth"
       },
       {
-        "duration": 13,
         "pos": [
           0,
-          1.8,
-          8.2
+          2.2,
+          8.4
         ],
         "target": [
           0,
-          1.6,
+          1.9000000000000001,
           0
         ],
         "fov": 46,
+        "focalDistance": 8.4,
+        "duration": 14,
         "transition": "blend",
         "aperture": 0,
-        "focalDistance": 8.2,
         "ease": "smooth"
       }
     ]

--- a/sdf-js/scenes/rec-comms-2.json
+++ b/sdf-js/scenes/rec-comms-2.json
@@ -90,11 +90,10 @@
     "loop": false,
     "shots": [
       {
-        "duration": 0.01,
         "pos": [
-          1,
-          2.1,
-          9.799999999999999
+          -4.2,
+          2.1500000000000004,
+          7.9799999999999995
         ],
         "target": [
           0,
@@ -102,26 +101,27 @@
           0
         ],
         "fov": 50,
+        "focalDistance": 8.4,
+        "duration": 0.01,
         "aperture": 0,
-        "focalDistance": 8.2,
         "ease": "smooth"
       },
       {
-        "duration": 13,
         "pos": [
-          0,
+          1.512,
           1.8,
-          8.2
+          7.392
         ],
         "target": [
           0,
           1.6,
           0
         ],
-        "fov": 46,
+        "fov": 47,
+        "focalDistance": 8.4,
+        "duration": 14,
         "transition": "blend",
         "aperture": 0,
-        "focalDistance": 8.2,
         "ease": "smooth"
       }
     ]

--- a/sdf-js/scenes/rec-comms-4.json
+++ b/sdf-js/scenes/rec-comms-4.json
@@ -84,11 +84,10 @@
     "loop": false,
     "shots": [
       {
-        "duration": 0.01,
         "pos": [
-          1,
-          2.1,
-          9.799999999999999
+          -4.2,
+          2.1500000000000004,
+          7.9799999999999995
         ],
         "target": [
           0,
@@ -96,26 +95,27 @@
           0
         ],
         "fov": 50,
+        "focalDistance": 8.4,
+        "duration": 0.01,
         "aperture": 0,
-        "focalDistance": 8.2,
         "ease": "smooth"
       },
       {
-        "duration": 13,
         "pos": [
-          0,
+          1.512,
           1.8,
-          8.2
+          7.392
         ],
         "target": [
           0,
           1.6,
           0
         ],
-        "fov": 46,
+        "fov": 47,
+        "focalDistance": 8.4,
+        "duration": 14,
         "transition": "blend",
         "aperture": 0,
-        "focalDistance": 8.2,
         "ease": "smooth"
       }
     ]

--- a/sdf-js/scenes/rec-comms-5.json
+++ b/sdf-js/scenes/rec-comms-5.json
@@ -93,28 +93,27 @@
     "loop": false,
     "shots": [
       {
-        "duration": 0.01,
         "pos": [
-          1,
-          2.1,
-          9.799999999999999
+          6.5520000000000005,
+          2.3,
+          5.208
         ],
         "target": [
           0,
           1.6,
           0
         ],
-        "fov": 50,
+        "fov": 48,
+        "focalDistance": 8.4,
+        "duration": 0.01,
         "aperture": 0,
-        "focalDistance": 8.2,
         "ease": "smooth"
       },
       {
-        "duration": 13,
         "pos": [
           0,
           1.8,
-          8.2
+          8.4
         ],
         "target": [
           0,
@@ -122,9 +121,10 @@
           0
         ],
         "fov": 46,
+        "focalDistance": 8.4,
+        "duration": 14,
         "transition": "blend",
         "aperture": 0,
-        "focalDistance": 8.2,
         "ease": "smooth"
       }
     ]

--- a/sdf-js/scenes/rec-consulting-3.json
+++ b/sdf-js/scenes/rec-consulting-3.json
@@ -90,11 +90,10 @@
     "loop": false,
     "shots": [
       {
-        "duration": 0.01,
         "pos": [
-          1,
-          2.1,
-          9.799999999999999
+          -4.2,
+          2.1500000000000004,
+          7.9799999999999995
         ],
         "target": [
           0,
@@ -102,26 +101,27 @@
           0
         ],
         "fov": 50,
+        "focalDistance": 8.4,
+        "duration": 0.01,
         "aperture": 0,
-        "focalDistance": 8.2,
         "ease": "smooth"
       },
       {
-        "duration": 13,
         "pos": [
-          0,
+          1.512,
           1.8,
-          8.2
+          7.392
         ],
         "target": [
           0,
           1.6,
           0
         ],
-        "fov": 46,
+        "fov": 47,
+        "focalDistance": 8.4,
+        "duration": 14,
         "transition": "blend",
         "aperture": 0,
-        "focalDistance": 8.2,
         "ease": "smooth"
       }
     ]

--- a/sdf-js/scenes/rec-consulting-4.json
+++ b/sdf-js/scenes/rec-consulting-4.json
@@ -6,7 +6,24 @@
       "id": "pyramid",
       "type": "pyramid-3d",
       "args": {
-        "levels": 3
+        "levels": 3,
+        "colors": [
+          {
+            "hue": 0.11,
+            "sat": 0.7,
+            "value": 0.88
+          },
+          {
+            "hue": 0.11,
+            "sat": 0.74,
+            "value": 0.73
+          },
+          {
+            "hue": 0.11,
+            "sat": 0.7799999999999999,
+            "value": 0.5800000000000001
+          }
+        ]
       },
       "transform": {
         "translate": [

--- a/sdf-js/scenes/rec-consulting-4.json
+++ b/sdf-js/scenes/rec-consulting-4.json
@@ -87,38 +87,38 @@
     "loop": false,
     "shots": [
       {
-        "duration": 0.01,
         "pos": [
-          1,
-          2.1,
-          9.799999999999999
+          0.6,
+          0.7000000000000001,
+          9.8
         ],
         "target": [
           0,
-          1.6,
+          1.9000000000000001,
           0
         ],
-        "fov": 50,
+        "fov": 52,
+        "focalDistance": 8.4,
+        "duration": 0.01,
         "aperture": 0,
-        "focalDistance": 8.2,
         "ease": "smooth"
       },
       {
-        "duration": 13,
         "pos": [
           0,
-          1.8,
-          8.2
+          2.2,
+          8.4
         ],
         "target": [
           0,
-          1.6,
+          1.9000000000000001,
           0
         ],
         "fov": 46,
+        "focalDistance": 8.4,
+        "duration": 14,
         "transition": "blend",
         "aperture": 0,
-        "focalDistance": 8.2,
         "ease": "smooth"
       }
     ]

--- a/sdf-js/scenes/rec-consulting-5.json
+++ b/sdf-js/scenes/rec-consulting-5.json
@@ -84,11 +84,10 @@
     "loop": false,
     "shots": [
       {
-        "duration": 0.01,
         "pos": [
-          1,
-          2.1,
-          9.799999999999999
+          -4.2,
+          2.1500000000000004,
+          7.9799999999999995
         ],
         "target": [
           0,
@@ -96,26 +95,27 @@
           0
         ],
         "fov": 50,
+        "focalDistance": 8.4,
+        "duration": 0.01,
         "aperture": 0,
-        "focalDistance": 8.2,
         "ease": "smooth"
       },
       {
-        "duration": 13,
         "pos": [
-          0,
+          1.512,
           1.8,
-          8.2
+          7.392
         ],
         "target": [
           0,
           1.6,
           0
         ],
-        "fov": 46,
+        "fov": 47,
+        "focalDistance": 8.4,
+        "duration": 14,
         "transition": "blend",
         "aperture": 0,
-        "focalDistance": 8.2,
         "ease": "smooth"
       }
     ]

--- a/sdf-js/scenes/rec-cyber-2.json
+++ b/sdf-js/scenes/rec-cyber-2.json
@@ -127,38 +127,38 @@
     "loop": false,
     "shots": [
       {
-        "duration": 0.01,
         "pos": [
-          1,
-          2.1,
-          9.799999999999999
+          0.6,
+          0.7000000000000001,
+          9.8
         ],
         "target": [
           0,
-          1.6,
+          1.9000000000000001,
           0
         ],
-        "fov": 50,
+        "fov": 52,
+        "focalDistance": 8.4,
+        "duration": 0.01,
         "aperture": 0,
-        "focalDistance": 8.2,
         "ease": "smooth"
       },
       {
-        "duration": 13,
         "pos": [
           0,
-          1.8,
-          8.2
+          2.2,
+          8.4
         ],
         "target": [
           0,
-          1.6,
+          1.9000000000000001,
           0
         ],
         "fov": 46,
+        "focalDistance": 8.4,
+        "duration": 14,
         "transition": "blend",
         "aperture": 0,
-        "focalDistance": 8.2,
         "ease": "smooth"
       }
     ]

--- a/sdf-js/scenes/rec-cyber-3.json
+++ b/sdf-js/scenes/rec-cyber-3.json
@@ -111,38 +111,38 @@
     "loop": false,
     "shots": [
       {
-        "duration": 0.01,
         "pos": [
-          1,
-          2.1,
-          9.799999999999999
+          0.6,
+          0.7000000000000001,
+          9.8
         ],
         "target": [
           0,
-          1.6,
+          1.9000000000000001,
           0
         ],
-        "fov": 50,
+        "fov": 52,
+        "focalDistance": 8.4,
+        "duration": 0.01,
         "aperture": 0,
-        "focalDistance": 8.2,
         "ease": "smooth"
       },
       {
-        "duration": 13,
         "pos": [
           0,
-          1.8,
-          8.2
+          2.2,
+          8.4
         ],
         "target": [
           0,
-          1.6,
+          1.9000000000000001,
           0
         ],
         "fov": 46,
+        "focalDistance": 8.4,
+        "duration": 14,
         "transition": "blend",
         "aperture": 0,
-        "focalDistance": 8.2,
         "ease": "smooth"
       }
     ]

--- a/sdf-js/scenes/rec-cyber-4.json
+++ b/sdf-js/scenes/rec-cyber-4.json
@@ -6,7 +6,29 @@
       "id": "pyramid",
       "type": "pyramid-3d",
       "args": {
-        "levels": 4
+        "levels": 4,
+        "colors": [
+          {
+            "hue": 0.11,
+            "sat": 0.7,
+            "value": 0.88
+          },
+          {
+            "hue": 0.11,
+            "sat": 0.7266666666666666,
+            "value": 0.78
+          },
+          {
+            "hue": 0.11,
+            "sat": 0.7533333333333333,
+            "value": 0.68
+          },
+          {
+            "hue": 0.11,
+            "sat": 0.7799999999999999,
+            "value": 0.5800000000000001
+          }
+        ]
       },
       "transform": {
         "translate": [

--- a/sdf-js/scenes/rec-cyber-4.json
+++ b/sdf-js/scenes/rec-cyber-4.json
@@ -102,38 +102,38 @@
     "loop": false,
     "shots": [
       {
-        "duration": 0.01,
         "pos": [
-          1,
-          2.1,
-          9.799999999999999
+          0.6,
+          0.7000000000000001,
+          9.8
         ],
         "target": [
           0,
-          1.6,
+          1.9000000000000001,
           0
         ],
-        "fov": 50,
+        "fov": 52,
+        "focalDistance": 8.4,
+        "duration": 0.01,
         "aperture": 0,
-        "focalDistance": 8.2,
         "ease": "smooth"
       },
       {
-        "duration": 13,
         "pos": [
           0,
-          1.8,
-          8.2
+          2.2,
+          8.4
         ],
         "target": [
           0,
-          1.6,
+          1.9000000000000001,
           0
         ],
         "fov": 46,
+        "focalDistance": 8.4,
+        "duration": 14,
         "transition": "blend",
         "aperture": 0,
-        "focalDistance": 8.2,
         "ease": "smooth"
       }
     ]

--- a/sdf-js/scenes/rec-cyber-5.json
+++ b/sdf-js/scenes/rec-cyber-5.json
@@ -80,11 +80,10 @@
     "loop": false,
     "shots": [
       {
-        "duration": 0.01,
         "pos": [
-          1,
-          2.1,
-          9.799999999999999
+          -4.2,
+          2.1500000000000004,
+          7.9799999999999995
         ],
         "target": [
           0,
@@ -92,26 +91,27 @@
           0
         ],
         "fov": 50,
+        "focalDistance": 8.4,
+        "duration": 0.01,
         "aperture": 0,
-        "focalDistance": 8.2,
         "ease": "smooth"
       },
       {
-        "duration": 13,
         "pos": [
-          0,
+          1.512,
           1.8,
-          8.2
+          7.392
         ],
         "target": [
           0,
           1.6,
           0
         ],
-        "fov": 46,
+        "fov": 47,
+        "focalDistance": 8.4,
+        "duration": 14,
         "transition": "blend",
         "aperture": 0,
-        "focalDistance": 8.2,
         "ease": "smooth"
       }
     ]

--- a/sdf-js/scenes/rec-digital-2.json
+++ b/sdf-js/scenes/rec-digital-2.json
@@ -94,11 +94,10 @@
     "loop": false,
     "shots": [
       {
-        "duration": 0.01,
         "pos": [
-          1,
-          2.1,
-          9.799999999999999
+          -4.2,
+          2.1500000000000004,
+          7.9799999999999995
         ],
         "target": [
           0,
@@ -106,26 +105,27 @@
           0
         ],
         "fov": 50,
+        "focalDistance": 8.4,
+        "duration": 0.01,
         "aperture": 0,
-        "focalDistance": 8.2,
         "ease": "smooth"
       },
       {
-        "duration": 13,
         "pos": [
-          0,
+          1.512,
           1.8,
-          8.2
+          7.392
         ],
         "target": [
           0,
           1.6,
           0
         ],
-        "fov": 46,
+        "fov": 47,
+        "focalDistance": 8.4,
+        "duration": 14,
         "transition": "blend",
         "aperture": 0,
-        "focalDistance": 8.2,
         "ease": "smooth"
       }
     ]

--- a/sdf-js/scenes/rec-digital-3.json
+++ b/sdf-js/scenes/rec-digital-3.json
@@ -6,7 +6,29 @@
       "id": "pyramid",
       "type": "pyramid-3d",
       "args": {
-        "levels": 4
+        "levels": 4,
+        "colors": [
+          {
+            "hue": 0.11,
+            "sat": 0.7,
+            "value": 0.88
+          },
+          {
+            "hue": 0.11,
+            "sat": 0.7266666666666666,
+            "value": 0.78
+          },
+          {
+            "hue": 0.11,
+            "sat": 0.7533333333333333,
+            "value": 0.68
+          },
+          {
+            "hue": 0.11,
+            "sat": 0.7799999999999999,
+            "value": 0.5800000000000001
+          }
+        ]
       },
       "transform": {
         "translate": [

--- a/sdf-js/scenes/rec-digital-3.json
+++ b/sdf-js/scenes/rec-digital-3.json
@@ -102,38 +102,38 @@
     "loop": false,
     "shots": [
       {
-        "duration": 0.01,
         "pos": [
-          1,
-          2.1,
-          9.799999999999999
+          0.6,
+          0.7000000000000001,
+          9.8
         ],
         "target": [
           0,
-          1.6,
+          1.9000000000000001,
           0
         ],
-        "fov": 50,
+        "fov": 52,
+        "focalDistance": 8.4,
+        "duration": 0.01,
         "aperture": 0,
-        "focalDistance": 8.2,
         "ease": "smooth"
       },
       {
-        "duration": 13,
         "pos": [
           0,
-          1.8,
-          8.2
+          2.2,
+          8.4
         ],
         "target": [
           0,
-          1.6,
+          1.9000000000000001,
           0
         ],
         "fov": 46,
+        "focalDistance": 8.4,
+        "duration": 14,
         "transition": "blend",
         "aperture": 0,
-        "focalDistance": 8.2,
         "ease": "smooth"
       }
     ]

--- a/sdf-js/scenes/rec-digital-4.json
+++ b/sdf-js/scenes/rec-digital-4.json
@@ -95,28 +95,27 @@
     "loop": false,
     "shots": [
       {
-        "duration": 0.01,
         "pos": [
-          1,
-          2.1,
-          9.799999999999999
+          6.5520000000000005,
+          2.3,
+          5.208
         ],
         "target": [
           0,
           1.6,
           0
         ],
-        "fov": 50,
+        "fov": 48,
+        "focalDistance": 8.4,
+        "duration": 0.01,
         "aperture": 0,
-        "focalDistance": 8.2,
         "ease": "smooth"
       },
       {
-        "duration": 13,
         "pos": [
           0,
           1.8,
-          8.2
+          8.4
         ],
         "target": [
           0,
@@ -124,9 +123,10 @@
           0
         ],
         "fov": 46,
+        "focalDistance": 8.4,
+        "duration": 14,
         "transition": "blend",
         "aperture": 0,
-        "focalDistance": 8.2,
         "ease": "smooth"
       }
     ]

--- a/sdf-js/scenes/rec-digital-5.json
+++ b/sdf-js/scenes/rec-digital-5.json
@@ -111,38 +111,38 @@
     "loop": false,
     "shots": [
       {
-        "duration": 0.01,
         "pos": [
-          1,
-          2.1,
-          9.799999999999999
+          0.6,
+          0.7000000000000001,
+          9.8
         ],
         "target": [
           0,
-          1.6,
+          1.9000000000000001,
           0
         ],
-        "fov": 50,
+        "fov": 52,
+        "focalDistance": 8.4,
+        "duration": 0.01,
         "aperture": 0,
-        "focalDistance": 8.2,
         "ease": "smooth"
       },
       {
-        "duration": 13,
         "pos": [
           0,
-          1.8,
-          8.2
+          2.2,
+          8.4
         ],
         "target": [
           0,
-          1.6,
+          1.9000000000000001,
           0
         ],
         "fov": 46,
+        "focalDistance": 8.4,
+        "duration": 14,
         "transition": "blend",
         "aperture": 0,
-        "focalDistance": 8.2,
         "ease": "smooth"
       }
     ]

--- a/sdf-js/scenes/rec-flowchart-2.json
+++ b/sdf-js/scenes/rec-flowchart-2.json
@@ -90,11 +90,10 @@
     "loop": false,
     "shots": [
       {
-        "duration": 0.01,
         "pos": [
-          1,
-          2.1,
-          9.799999999999999
+          -4.2,
+          2.1500000000000004,
+          7.9799999999999995
         ],
         "target": [
           0,
@@ -102,26 +101,27 @@
           0
         ],
         "fov": 50,
+        "focalDistance": 8.4,
+        "duration": 0.01,
         "aperture": 0,
-        "focalDistance": 8.2,
         "ease": "smooth"
       },
       {
-        "duration": 13,
         "pos": [
-          0,
+          1.512,
           1.8,
-          8.2
+          7.392
         ],
         "target": [
           0,
           1.6,
           0
         ],
-        "fov": 46,
+        "fov": 47,
+        "focalDistance": 8.4,
+        "duration": 14,
         "transition": "blend",
         "aperture": 0,
-        "focalDistance": 8.2,
         "ease": "smooth"
       }
     ]

--- a/sdf-js/scenes/rec-flowchart-4.json
+++ b/sdf-js/scenes/rec-flowchart-4.json
@@ -80,11 +80,10 @@
     "loop": false,
     "shots": [
       {
-        "duration": 0.01,
         "pos": [
-          1,
-          2.1,
-          9.799999999999999
+          -4.2,
+          2.1500000000000004,
+          7.9799999999999995
         ],
         "target": [
           0,
@@ -92,26 +91,27 @@
           0
         ],
         "fov": 50,
+        "focalDistance": 8.4,
+        "duration": 0.01,
         "aperture": 0,
-        "focalDistance": 8.2,
         "ease": "smooth"
       },
       {
-        "duration": 13,
         "pos": [
-          0,
+          1.512,
           1.8,
-          8.2
+          7.392
         ],
         "target": [
           0,
           1.6,
           0
         ],
-        "fov": 46,
+        "fov": 47,
+        "focalDistance": 8.4,
+        "duration": 14,
         "transition": "blend",
         "aperture": 0,
-        "focalDistance": 8.2,
         "ease": "smooth"
       }
     ]

--- a/sdf-js/scenes/rec-flowchart-5.json
+++ b/sdf-js/scenes/rec-flowchart-5.json
@@ -85,28 +85,27 @@
     "loop": false,
     "shots": [
       {
-        "duration": 0.01,
         "pos": [
-          1,
-          2.1,
-          9.799999999999999
+          6.5520000000000005,
+          2.3,
+          5.208
         ],
         "target": [
           0,
           1.6,
           0
         ],
-        "fov": 50,
+        "fov": 48,
+        "focalDistance": 8.4,
+        "duration": 0.01,
         "aperture": 0,
-        "focalDistance": 8.2,
         "ease": "smooth"
       },
       {
-        "duration": 13,
         "pos": [
           0,
           1.8,
-          8.2
+          8.4
         ],
         "target": [
           0,
@@ -114,9 +113,10 @@
           0
         ],
         "fov": 46,
+        "focalDistance": 8.4,
+        "duration": 14,
         "transition": "blend",
         "aperture": 0,
-        "focalDistance": 8.2,
         "ease": "smooth"
       }
     ]

--- a/sdf-js/scenes/rec-grow-2.json
+++ b/sdf-js/scenes/rec-grow-2.json
@@ -80,11 +80,10 @@
     "loop": false,
     "shots": [
       {
-        "duration": 0.01,
         "pos": [
-          1,
-          2.1,
-          9.799999999999999
+          -4.2,
+          2.1500000000000004,
+          7.9799999999999995
         ],
         "target": [
           0,
@@ -92,26 +91,27 @@
           0
         ],
         "fov": 50,
+        "focalDistance": 8.4,
+        "duration": 0.01,
         "aperture": 0,
-        "focalDistance": 8.2,
         "ease": "smooth"
       },
       {
-        "duration": 13,
         "pos": [
-          0,
+          1.512,
           1.8,
-          8.2
+          7.392
         ],
         "target": [
           0,
           1.6,
           0
         ],
-        "fov": 46,
+        "fov": 47,
+        "focalDistance": 8.4,
+        "duration": 14,
         "transition": "blend",
         "aperture": 0,
-        "focalDistance": 8.2,
         "ease": "smooth"
       }
     ]

--- a/sdf-js/scenes/rec-grow-3.json
+++ b/sdf-js/scenes/rec-grow-3.json
@@ -85,28 +85,27 @@
     "loop": false,
     "shots": [
       {
-        "duration": 0.01,
         "pos": [
-          1,
-          2.1,
-          9.799999999999999
+          6.5520000000000005,
+          2.3,
+          5.208
         ],
         "target": [
           0,
           1.6,
           0
         ],
-        "fov": 50,
+        "fov": 48,
+        "focalDistance": 8.4,
+        "duration": 0.01,
         "aperture": 0,
-        "focalDistance": 8.2,
         "ease": "smooth"
       },
       {
-        "duration": 13,
         "pos": [
           0,
           1.8,
-          8.2
+          8.4
         ],
         "target": [
           0,
@@ -114,9 +113,10 @@
           0
         ],
         "fov": 46,
+        "focalDistance": 8.4,
+        "duration": 14,
         "transition": "blend",
         "aperture": 0,
-        "focalDistance": 8.2,
         "ease": "smooth"
       }
     ]

--- a/sdf-js/scenes/rec-grow-4.json
+++ b/sdf-js/scenes/rec-grow-4.json
@@ -85,28 +85,27 @@
     "loop": false,
     "shots": [
       {
-        "duration": 0.01,
         "pos": [
-          1,
-          2.1,
-          9.799999999999999
+          6.5520000000000005,
+          2.3,
+          5.208
         ],
         "target": [
           0,
           1.6,
           0
         ],
-        "fov": 50,
+        "fov": 48,
+        "focalDistance": 8.4,
+        "duration": 0.01,
         "aperture": 0,
-        "focalDistance": 8.2,
         "ease": "smooth"
       },
       {
-        "duration": 13,
         "pos": [
           0,
           1.8,
-          8.2
+          8.4
         ],
         "target": [
           0,
@@ -114,9 +113,10 @@
           0
         ],
         "fov": 46,
+        "focalDistance": 8.4,
+        "duration": 14,
         "transition": "blend",
         "aperture": 0,
-        "focalDistance": 8.2,
         "ease": "smooth"
       }
     ]

--- a/sdf-js/scenes/rec-grow-5.json
+++ b/sdf-js/scenes/rec-grow-5.json
@@ -84,11 +84,10 @@
     "loop": false,
     "shots": [
       {
-        "duration": 0.01,
         "pos": [
-          1,
-          2.1,
-          9.799999999999999
+          -4.2,
+          2.1500000000000004,
+          7.9799999999999995
         ],
         "target": [
           0,
@@ -96,26 +95,27 @@
           0
         ],
         "fov": 50,
+        "focalDistance": 8.4,
+        "duration": 0.01,
         "aperture": 0,
-        "focalDistance": 8.2,
         "ease": "smooth"
       },
       {
-        "duration": 13,
         "pos": [
-          0,
+          1.512,
           1.8,
-          8.2
+          7.392
         ],
         "target": [
           0,
           1.6,
           0
         ],
-        "fov": 46,
+        "fov": 47,
+        "focalDistance": 8.4,
+        "duration": 14,
         "transition": "blend",
         "aperture": 0,
-        "focalDistance": 8.2,
         "ease": "smooth"
       }
     ]

--- a/sdf-js/scenes/rec-icons-2.json
+++ b/sdf-js/scenes/rec-icons-2.json
@@ -3,28 +3,17 @@
   "name": "(lifted) icons-Icon Grid",
   "subjects": [
     {
-      "id": "cube-grid",
-      "type": "cube-3d",
+      "id": "icon-grid",
+      "type": "icon-grid-3d",
       "args": {
-        "arrangement": "grid",
-        "count": 9,
-        "cubeSize": 0.5,
-        "spacing": 0.22,
-        "material": "solid",
-        "colors": null,
-        "arrangementParams": {
-          "cols": 3
-        }
+        "rows": 2,
+        "cols": 4,
+        "glyphs": null
       },
       "transform": {
         "translate": [
           0,
           1.9,
-          0
-        ],
-        "rotate": [
-          1.5708,
-          0,
           0
         ]
       },

--- a/sdf-js/scenes/rec-icons-4.json
+++ b/sdf-js/scenes/rec-icons-4.json
@@ -109,28 +109,27 @@
     "loop": false,
     "shots": [
       {
-        "duration": 0.01,
         "pos": [
-          1,
-          2.1,
-          9.799999999999999
+          6.5520000000000005,
+          2.3,
+          5.208
         ],
         "target": [
           0,
           1.6,
           0
         ],
-        "fov": 50,
+        "fov": 48,
+        "focalDistance": 8.4,
+        "duration": 0.01,
         "aperture": 0,
-        "focalDistance": 8.2,
         "ease": "smooth"
       },
       {
-        "duration": 13,
         "pos": [
           0,
           1.8,
-          8.2
+          8.4
         ],
         "target": [
           0,
@@ -138,9 +137,10 @@
           0
         ],
         "fov": 46,
+        "focalDistance": 8.4,
+        "duration": 14,
         "transition": "blend",
         "aperture": 0,
-        "focalDistance": 8.2,
         "ease": "smooth"
       }
     ]

--- a/sdf-js/scenes/rec-icons-5.json
+++ b/sdf-js/scenes/rec-icons-5.json
@@ -85,28 +85,27 @@
     "loop": false,
     "shots": [
       {
-        "duration": 0.01,
         "pos": [
-          1,
-          2.1,
-          9.799999999999999
+          6.5520000000000005,
+          2.3,
+          5.208
         ],
         "target": [
           0,
           1.6,
           0
         ],
-        "fov": 50,
+        "fov": 48,
+        "focalDistance": 8.4,
+        "duration": 0.01,
         "aperture": 0,
-        "focalDistance": 8.2,
         "ease": "smooth"
       },
       {
-        "duration": 13,
         "pos": [
           0,
           1.8,
-          8.2
+          8.4
         ],
         "target": [
           0,
@@ -114,9 +113,10 @@
           0
         ],
         "fov": 46,
+        "focalDistance": 8.4,
+        "duration": 14,
         "transition": "blend",
         "aperture": 0,
-        "focalDistance": 8.2,
         "ease": "smooth"
       }
     ]

--- a/sdf-js/scenes/rec-innovation-2.json
+++ b/sdf-js/scenes/rec-innovation-2.json
@@ -111,38 +111,38 @@
     "loop": false,
     "shots": [
       {
-        "duration": 0.01,
         "pos": [
-          1,
-          2.1,
-          9.799999999999999
+          0.6,
+          0.7000000000000001,
+          9.8
         ],
         "target": [
           0,
-          1.6,
+          1.9000000000000001,
           0
         ],
-        "fov": 50,
+        "fov": 52,
+        "focalDistance": 8.4,
+        "duration": 0.01,
         "aperture": 0,
-        "focalDistance": 8.2,
         "ease": "smooth"
       },
       {
-        "duration": 13,
         "pos": [
           0,
-          1.8,
-          8.2
+          2.2,
+          8.4
         ],
         "target": [
           0,
-          1.6,
+          1.9000000000000001,
           0
         ],
         "fov": 46,
+        "focalDistance": 8.4,
+        "duration": 14,
         "transition": "blend",
         "aperture": 0,
-        "focalDistance": 8.2,
         "ease": "smooth"
       }
     ]

--- a/sdf-js/scenes/rec-innovation-3.json
+++ b/sdf-js/scenes/rec-innovation-3.json
@@ -90,11 +90,10 @@
     "loop": false,
     "shots": [
       {
-        "duration": 0.01,
         "pos": [
-          1,
-          2.1,
-          9.799999999999999
+          -4.2,
+          2.1500000000000004,
+          7.9799999999999995
         ],
         "target": [
           0,
@@ -102,26 +101,27 @@
           0
         ],
         "fov": 50,
+        "focalDistance": 8.4,
+        "duration": 0.01,
         "aperture": 0,
-        "focalDistance": 8.2,
         "ease": "smooth"
       },
       {
-        "duration": 13,
         "pos": [
-          0,
+          1.512,
           1.8,
-          8.2
+          7.392
         ],
         "target": [
           0,
           1.6,
           0
         ],
-        "fov": 46,
+        "fov": 47,
+        "focalDistance": 8.4,
+        "duration": 14,
         "transition": "blend",
         "aperture": 0,
-        "focalDistance": 8.2,
         "ease": "smooth"
       }
     ]

--- a/sdf-js/scenes/rec-innovation-5.json
+++ b/sdf-js/scenes/rec-innovation-5.json
@@ -74,11 +74,10 @@
     "loop": false,
     "shots": [
       {
-        "duration": 0.01,
         "pos": [
-          1,
-          2.1,
-          9.799999999999999
+          -4.2,
+          2.1500000000000004,
+          7.9799999999999995
         ],
         "target": [
           0,
@@ -86,26 +85,27 @@
           0
         ],
         "fov": 50,
+        "focalDistance": 8.4,
+        "duration": 0.01,
         "aperture": 0,
-        "focalDistance": 8.2,
         "ease": "smooth"
       },
       {
-        "duration": 13,
         "pos": [
-          0,
+          1.512,
           1.8,
-          8.2
+          7.392
         ],
         "target": [
           0,
           1.6,
           0
         ],
-        "fov": 46,
+        "fov": 47,
+        "focalDistance": 8.4,
+        "duration": 14,
         "transition": "blend",
         "aperture": 0,
-        "focalDistance": 8.2,
         "ease": "smooth"
       }
     ]

--- a/sdf-js/scenes/rec-itstrategy-2.json
+++ b/sdf-js/scenes/rec-itstrategy-2.json
@@ -84,11 +84,10 @@
     "loop": false,
     "shots": [
       {
-        "duration": 0.01,
         "pos": [
-          1,
-          2.1,
-          9.799999999999999
+          -4.2,
+          2.1500000000000004,
+          7.9799999999999995
         ],
         "target": [
           0,
@@ -96,26 +95,27 @@
           0
         ],
         "fov": 50,
+        "focalDistance": 8.4,
+        "duration": 0.01,
         "aperture": 0,
-        "focalDistance": 8.2,
         "ease": "smooth"
       },
       {
-        "duration": 13,
         "pos": [
-          0,
+          1.512,
           1.8,
-          8.2
+          7.392
         ],
         "target": [
           0,
           1.6,
           0
         ],
-        "fov": 46,
+        "fov": 47,
+        "focalDistance": 8.4,
+        "duration": 14,
         "transition": "blend",
         "aperture": 0,
-        "focalDistance": 8.2,
         "ease": "smooth"
       }
     ]

--- a/sdf-js/scenes/rec-itstrategy-3.json
+++ b/sdf-js/scenes/rec-itstrategy-3.json
@@ -95,28 +95,27 @@
     "loop": false,
     "shots": [
       {
-        "duration": 0.01,
         "pos": [
-          1,
-          2.1,
-          9.799999999999999
+          6.5520000000000005,
+          2.3,
+          5.208
         ],
         "target": [
           0,
           1.6,
           0
         ],
-        "fov": 50,
+        "fov": 48,
+        "focalDistance": 8.4,
+        "duration": 0.01,
         "aperture": 0,
-        "focalDistance": 8.2,
         "ease": "smooth"
       },
       {
-        "duration": 13,
         "pos": [
           0,
           1.8,
-          8.2
+          8.4
         ],
         "target": [
           0,
@@ -124,9 +123,10 @@
           0
         ],
         "fov": 46,
+        "focalDistance": 8.4,
+        "duration": 14,
         "transition": "blend",
         "aperture": 0,
-        "focalDistance": 8.2,
         "ease": "smooth"
       }
     ]

--- a/sdf-js/scenes/rec-itstrategy-4.json
+++ b/sdf-js/scenes/rec-itstrategy-4.json
@@ -6,7 +6,29 @@
       "id": "pyramid",
       "type": "pyramid-3d",
       "args": {
-        "levels": 4
+        "levels": 4,
+        "colors": [
+          {
+            "hue": 0.11,
+            "sat": 0.7,
+            "value": 0.88
+          },
+          {
+            "hue": 0.11,
+            "sat": 0.7266666666666666,
+            "value": 0.78
+          },
+          {
+            "hue": 0.11,
+            "sat": 0.7533333333333333,
+            "value": 0.68
+          },
+          {
+            "hue": 0.11,
+            "sat": 0.7799999999999999,
+            "value": 0.5800000000000001
+          }
+        ]
       },
       "transform": {
         "translate": [

--- a/sdf-js/scenes/rec-itstrategy-4.json
+++ b/sdf-js/scenes/rec-itstrategy-4.json
@@ -102,38 +102,38 @@
     "loop": false,
     "shots": [
       {
-        "duration": 0.01,
         "pos": [
-          1,
-          2.1,
-          9.799999999999999
+          0.6,
+          0.7000000000000001,
+          9.8
         ],
         "target": [
           0,
-          1.6,
+          1.9000000000000001,
           0
         ],
-        "fov": 50,
+        "fov": 52,
+        "focalDistance": 8.4,
+        "duration": 0.01,
         "aperture": 0,
-        "focalDistance": 8.2,
         "ease": "smooth"
       },
       {
-        "duration": 13,
         "pos": [
           0,
-          1.8,
-          8.2
+          2.2,
+          8.4
         ],
         "target": [
           0,
-          1.6,
+          1.9000000000000001,
           0
         ],
         "fov": 46,
+        "focalDistance": 8.4,
+        "duration": 14,
         "transition": "blend",
         "aperture": 0,
-        "focalDistance": 8.2,
         "ease": "smooth"
       }
     ]

--- a/sdf-js/scenes/rec-journey-2.json
+++ b/sdf-js/scenes/rec-journey-2.json
@@ -90,11 +90,10 @@
     "loop": false,
     "shots": [
       {
-        "duration": 0.01,
         "pos": [
-          1,
-          2.1,
-          9.799999999999999
+          -4.2,
+          2.1500000000000004,
+          7.9799999999999995
         ],
         "target": [
           0,
@@ -102,26 +101,27 @@
           0
         ],
         "fov": 50,
+        "focalDistance": 8.4,
+        "duration": 0.01,
         "aperture": 0,
-        "focalDistance": 8.2,
         "ease": "smooth"
       },
       {
-        "duration": 13,
         "pos": [
-          0,
+          1.512,
           1.8,
-          8.2
+          7.392
         ],
         "target": [
           0,
           1.6,
           0
         ],
-        "fov": 46,
+        "fov": 47,
+        "focalDistance": 8.4,
+        "duration": 14,
         "transition": "blend",
         "aperture": 0,
-        "focalDistance": 8.2,
         "ease": "smooth"
       }
     ]

--- a/sdf-js/scenes/rec-journey-3.json
+++ b/sdf-js/scenes/rec-journey-3.json
@@ -95,28 +95,27 @@
     "loop": false,
     "shots": [
       {
-        "duration": 0.01,
         "pos": [
-          1,
-          2.1,
-          9.799999999999999
+          6.5520000000000005,
+          2.3,
+          5.208
         ],
         "target": [
           0,
           1.6,
           0
         ],
-        "fov": 50,
+        "fov": 48,
+        "focalDistance": 8.4,
+        "duration": 0.01,
         "aperture": 0,
-        "focalDistance": 8.2,
         "ease": "smooth"
       },
       {
-        "duration": 13,
         "pos": [
           0,
           1.8,
-          8.2
+          8.4
         ],
         "target": [
           0,
@@ -124,9 +123,10 @@
           0
         ],
         "fov": 46,
+        "focalDistance": 8.4,
+        "duration": 14,
         "transition": "blend",
         "aperture": 0,
-        "focalDistance": 8.2,
         "ease": "smooth"
       }
     ]

--- a/sdf-js/scenes/rec-journey-4.json
+++ b/sdf-js/scenes/rec-journey-4.json
@@ -127,11 +127,10 @@
     "loop": false,
     "shots": [
       {
-        "duration": 0.01,
         "pos": [
-          1,
-          2.1,
-          9.799999999999999
+          -4.2,
+          2.1500000000000004,
+          7.9799999999999995
         ],
         "target": [
           0,
@@ -139,26 +138,27 @@
           0
         ],
         "fov": 50,
+        "focalDistance": 8.4,
+        "duration": 0.01,
         "aperture": 0,
-        "focalDistance": 8.2,
         "ease": "smooth"
       },
       {
-        "duration": 13,
         "pos": [
-          0,
+          1.512,
           1.8,
-          8.2
+          7.392
         ],
         "target": [
           0,
           1.6,
           0
         ],
-        "fov": 46,
+        "fov": 47,
+        "focalDistance": 8.4,
+        "duration": 14,
         "transition": "blend",
         "aperture": 0,
-        "focalDistance": 8.2,
         "ease": "smooth"
       }
     ]

--- a/sdf-js/scenes/rec-journey-4.json
+++ b/sdf-js/scenes/rec-journey-4.json
@@ -16,7 +16,34 @@
         "barWidth": 0.55,
         "barDepth": 0.55,
         "gap": 0.25,
-        "maxHeight": 2.2
+        "maxHeight": 2.2,
+        "colors": [
+          {
+            "hue": 0.58,
+            "sat": 0.58,
+            "value": 0.76
+          },
+          {
+            "hue": 0.58,
+            "sat": 0.6,
+            "value": 0.685
+          },
+          {
+            "hue": 0.58,
+            "sat": 0.62,
+            "value": 0.61
+          },
+          {
+            "hue": 0.58,
+            "sat": 0.6399999999999999,
+            "value": 0.535
+          },
+          {
+            "hue": 0.58,
+            "sat": 0.6599999999999999,
+            "value": 0.46
+          }
+        ]
       },
       "transform": {
         "translate": [

--- a/sdf-js/scenes/rec-journey-5.json
+++ b/sdf-js/scenes/rec-journey-5.json
@@ -111,38 +111,38 @@
     "loop": false,
     "shots": [
       {
-        "duration": 0.01,
         "pos": [
-          1,
-          2.1,
-          9.799999999999999
+          0.6,
+          0.7000000000000001,
+          9.8
         ],
         "target": [
           0,
-          1.6,
+          1.9000000000000001,
           0
         ],
-        "fov": 50,
+        "fov": 52,
+        "focalDistance": 8.4,
+        "duration": 0.01,
         "aperture": 0,
-        "focalDistance": 8.2,
         "ease": "smooth"
       },
       {
-        "duration": 13,
         "pos": [
           0,
-          1.8,
-          8.2
+          2.2,
+          8.4
         ],
         "target": [
           0,
-          1.6,
+          1.9000000000000001,
           0
         ],
         "fov": 46,
+        "focalDistance": 8.4,
+        "duration": 14,
         "transition": "blend",
         "aperture": 0,
-        "focalDistance": 8.2,
         "ease": "smooth"
       }
     ]

--- a/sdf-js/scenes/rec-leadership-3.json
+++ b/sdf-js/scenes/rec-leadership-3.json
@@ -80,11 +80,10 @@
     "loop": false,
     "shots": [
       {
-        "duration": 0.01,
         "pos": [
-          1,
-          2.1,
-          9.799999999999999
+          -4.2,
+          2.1500000000000004,
+          7.9799999999999995
         ],
         "target": [
           0,
@@ -92,26 +91,27 @@
           0
         ],
         "fov": 50,
+        "focalDistance": 8.4,
+        "duration": 0.01,
         "aperture": 0,
-        "focalDistance": 8.2,
         "ease": "smooth"
       },
       {
-        "duration": 13,
         "pos": [
-          0,
+          1.512,
           1.8,
-          8.2
+          7.392
         ],
         "target": [
           0,
           1.6,
           0
         ],
-        "fov": 46,
+        "fov": 47,
+        "focalDistance": 8.4,
+        "duration": 14,
         "transition": "blend",
         "aperture": 0,
-        "focalDistance": 8.2,
         "ease": "smooth"
       }
     ]

--- a/sdf-js/scenes/rec-leadership-4.json
+++ b/sdf-js/scenes/rec-leadership-4.json
@@ -6,7 +6,29 @@
       "id": "pyramid",
       "type": "pyramid-3d",
       "args": {
-        "levels": 4
+        "levels": 4,
+        "colors": [
+          {
+            "hue": 0.11,
+            "sat": 0.7,
+            "value": 0.88
+          },
+          {
+            "hue": 0.11,
+            "sat": 0.7266666666666666,
+            "value": 0.78
+          },
+          {
+            "hue": 0.11,
+            "sat": 0.7533333333333333,
+            "value": 0.68
+          },
+          {
+            "hue": 0.11,
+            "sat": 0.7799999999999999,
+            "value": 0.5800000000000001
+          }
+        ]
       },
       "transform": {
         "translate": [

--- a/sdf-js/scenes/rec-leadership-4.json
+++ b/sdf-js/scenes/rec-leadership-4.json
@@ -102,38 +102,38 @@
     "loop": false,
     "shots": [
       {
-        "duration": 0.01,
         "pos": [
-          1,
-          2.1,
-          9.799999999999999
+          0.6,
+          0.7000000000000001,
+          9.8
         ],
         "target": [
           0,
-          1.6,
+          1.9000000000000001,
           0
         ],
-        "fov": 50,
+        "fov": 52,
+        "focalDistance": 8.4,
+        "duration": 0.01,
         "aperture": 0,
-        "focalDistance": 8.2,
         "ease": "smooth"
       },
       {
-        "duration": 13,
         "pos": [
           0,
-          1.8,
-          8.2
+          2.2,
+          8.4
         ],
         "target": [
           0,
-          1.6,
+          1.9000000000000001,
           0
         ],
         "fov": 46,
+        "focalDistance": 8.4,
+        "duration": 14,
         "transition": "blend",
         "aperture": 0,
-        "focalDistance": 8.2,
         "ease": "smooth"
       }
     ]

--- a/sdf-js/scenes/rec-leadership-5.json
+++ b/sdf-js/scenes/rec-leadership-5.json
@@ -81,28 +81,27 @@
     "loop": false,
     "shots": [
       {
-        "duration": 0.01,
         "pos": [
-          1,
-          2.1,
-          9.799999999999999
+          6.5520000000000005,
+          2.3,
+          5.208
         ],
         "target": [
           0,
           1.6,
           0
         ],
-        "fov": 50,
+        "fov": 48,
+        "focalDistance": 8.4,
+        "duration": 0.01,
         "aperture": 0,
-        "focalDistance": 8.2,
         "ease": "smooth"
       },
       {
-        "duration": 13,
         "pos": [
           0,
           1.8,
-          8.2
+          8.4
         ],
         "target": [
           0,
@@ -110,9 +109,10 @@
           0
         ],
         "fov": 46,
+        "focalDistance": 8.4,
+        "duration": 14,
         "transition": "blend",
         "aperture": 0,
-        "focalDistance": 8.2,
         "ease": "smooth"
       }
     ]

--- a/sdf-js/scenes/rec-marketing-2.json
+++ b/sdf-js/scenes/rec-marketing-2.json
@@ -111,38 +111,38 @@
     "loop": false,
     "shots": [
       {
-        "duration": 0.01,
         "pos": [
-          1,
-          2.1,
-          9.799999999999999
+          0.6,
+          0.7000000000000001,
+          9.8
         ],
         "target": [
           0,
-          1.6,
+          1.9000000000000001,
           0
         ],
-        "fov": 50,
+        "fov": 52,
+        "focalDistance": 8.4,
+        "duration": 0.01,
         "aperture": 0,
-        "focalDistance": 8.2,
         "ease": "smooth"
       },
       {
-        "duration": 13,
         "pos": [
           0,
-          1.8,
-          8.2
+          2.2,
+          8.4
         ],
         "target": [
           0,
-          1.6,
+          1.9000000000000001,
           0
         ],
         "fov": 46,
+        "focalDistance": 8.4,
+        "duration": 14,
         "transition": "blend",
         "aperture": 0,
-        "focalDistance": 8.2,
         "ease": "smooth"
       }
     ]

--- a/sdf-js/scenes/rec-marketing-3.json
+++ b/sdf-js/scenes/rec-marketing-3.json
@@ -104,28 +104,27 @@
     "loop": false,
     "shots": [
       {
-        "duration": 0.01,
         "pos": [
-          1,
-          2.1,
-          9.799999999999999
+          6.5520000000000005,
+          2.3,
+          5.208
         ],
         "target": [
           0,
           1.6,
           0
         ],
-        "fov": 50,
+        "fov": 48,
+        "focalDistance": 8.4,
+        "duration": 0.01,
         "aperture": 0,
-        "focalDistance": 8.2,
         "ease": "smooth"
       },
       {
-        "duration": 13,
         "pos": [
           0,
           1.8,
-          8.2
+          8.4
         ],
         "target": [
           0,
@@ -133,9 +132,10 @@
           0
         ],
         "fov": 46,
+        "focalDistance": 8.4,
+        "duration": 14,
         "transition": "blend",
         "aperture": 0,
-        "focalDistance": 8.2,
         "ease": "smooth"
       }
     ]

--- a/sdf-js/scenes/rec-marketing-4.json
+++ b/sdf-js/scenes/rec-marketing-4.json
@@ -84,11 +84,10 @@
     "loop": false,
     "shots": [
       {
-        "duration": 0.01,
         "pos": [
-          1,
-          2.1,
-          9.799999999999999
+          -4.2,
+          2.1500000000000004,
+          7.9799999999999995
         ],
         "target": [
           0,
@@ -96,26 +95,27 @@
           0
         ],
         "fov": 50,
+        "focalDistance": 8.4,
+        "duration": 0.01,
         "aperture": 0,
-        "focalDistance": 8.2,
         "ease": "smooth"
       },
       {
-        "duration": 13,
         "pos": [
-          0,
+          1.512,
           1.8,
-          8.2
+          7.392
         ],
         "target": [
           0,
           1.6,
           0
         ],
-        "fov": 46,
+        "fov": 47,
+        "focalDistance": 8.4,
+        "duration": 14,
         "transition": "blend",
         "aperture": 0,
-        "focalDistance": 8.2,
         "ease": "smooth"
       }
     ]

--- a/sdf-js/scenes/rec-mountain-1.json
+++ b/sdf-js/scenes/rec-mountain-1.json
@@ -6,7 +6,29 @@
       "id": "pyramid",
       "type": "pyramid-3d",
       "args": {
-        "levels": 4
+        "levels": 4,
+        "colors": [
+          {
+            "hue": 0.11,
+            "sat": 0.7,
+            "value": 0.88
+          },
+          {
+            "hue": 0.11,
+            "sat": 0.7266666666666666,
+            "value": 0.78
+          },
+          {
+            "hue": 0.11,
+            "sat": 0.7533333333333333,
+            "value": 0.68
+          },
+          {
+            "hue": 0.11,
+            "sat": 0.7799999999999999,
+            "value": 0.5800000000000001
+          }
+        ]
       },
       "transform": {
         "translate": [

--- a/sdf-js/scenes/rec-mountain-1.json
+++ b/sdf-js/scenes/rec-mountain-1.json
@@ -3,47 +3,28 @@
   "name": "(lifted) mountain-The Summit",
   "subjects": [
     {
-      "id": "pyramid",
-      "type": "pyramid-3d",
+      "id": "mountain",
+      "type": "mountain-3d",
       "args": {
-        "levels": 4,
-        "colors": [
-          {
-            "hue": 0.11,
-            "sat": 0.7,
-            "value": 0.88
-          },
-          {
-            "hue": 0.11,
-            "sat": 0.7266666666666666,
-            "value": 0.78
-          },
-          {
-            "hue": 0.11,
-            "sat": 0.7533333333333333,
-            "value": 0.68
-          },
-          {
-            "hue": 0.11,
-            "sat": 0.7799999999999999,
-            "value": 0.5800000000000001
-          }
-        ]
+        "height": 2.6,
+        "baseRadius": 1.6,
+        "sidePeaks": 2,
+        "pathMarkers": 4
       },
       "transform": {
         "translate": [
           0,
-          0.6,
+          0,
           0
         ]
       },
       "material": {
-        "hue": 0.11,
-        "sat": 0.72,
-        "value": 0.82,
+        "hue": 0.6,
+        "sat": 0.24,
+        "value": 0.62,
         "kind": "normal",
-        "roughness": 0.3,
-        "clearcoat": 0.45
+        "roughness": 0.55,
+        "clearcoat": 0.15
       }
     }
   ],

--- a/sdf-js/scenes/rec-mountain-2.json
+++ b/sdf-js/scenes/rec-mountain-2.json
@@ -80,11 +80,10 @@
     "loop": false,
     "shots": [
       {
-        "duration": 0.01,
         "pos": [
-          1,
-          2.1,
-          9.799999999999999
+          -4.2,
+          2.1500000000000004,
+          7.9799999999999995
         ],
         "target": [
           0,
@@ -92,26 +91,27 @@
           0
         ],
         "fov": 50,
+        "focalDistance": 8.4,
+        "duration": 0.01,
         "aperture": 0,
-        "focalDistance": 8.2,
         "ease": "smooth"
       },
       {
-        "duration": 13,
         "pos": [
-          0,
+          1.512,
           1.8,
-          8.2
+          7.392
         ],
         "target": [
           0,
           1.6,
           0
         ],
-        "fov": 46,
+        "fov": 47,
+        "focalDistance": 8.4,
+        "duration": 14,
         "transition": "blend",
         "aperture": 0,
-        "focalDistance": 8.2,
         "ease": "smooth"
       }
     ]

--- a/sdf-js/scenes/rec-mountain-3.json
+++ b/sdf-js/scenes/rec-mountain-3.json
@@ -84,11 +84,10 @@
     "loop": false,
     "shots": [
       {
-        "duration": 0.01,
         "pos": [
-          1,
-          2.1,
-          9.799999999999999
+          -4.2,
+          2.1500000000000004,
+          7.9799999999999995
         ],
         "target": [
           0,
@@ -96,26 +95,27 @@
           0
         ],
         "fov": 50,
+        "focalDistance": 8.4,
+        "duration": 0.01,
         "aperture": 0,
-        "focalDistance": 8.2,
         "ease": "smooth"
       },
       {
-        "duration": 13,
         "pos": [
-          0,
+          1.512,
           1.8,
-          8.2
+          7.392
         ],
         "target": [
           0,
           1.6,
           0
         ],
-        "fov": 46,
+        "fov": 47,
+        "focalDistance": 8.4,
+        "duration": 14,
         "transition": "blend",
         "aperture": 0,
-        "focalDistance": 8.2,
         "ease": "smooth"
       }
     ]

--- a/sdf-js/scenes/rec-mountain-4.json
+++ b/sdf-js/scenes/rec-mountain-4.json
@@ -102,38 +102,38 @@
     "loop": false,
     "shots": [
       {
-        "duration": 0.01,
         "pos": [
-          1,
-          2.1,
-          9.799999999999999
+          0.6,
+          0.7000000000000001,
+          9.8
         ],
         "target": [
           0,
-          1.6,
+          1.9000000000000001,
           0
         ],
-        "fov": 50,
+        "fov": 52,
+        "focalDistance": 8.4,
+        "duration": 0.01,
         "aperture": 0,
-        "focalDistance": 8.2,
         "ease": "smooth"
       },
       {
-        "duration": 13,
         "pos": [
           0,
-          1.8,
-          8.2
+          2.2,
+          8.4
         ],
         "target": [
           0,
-          1.6,
+          1.9000000000000001,
           0
         ],
         "fov": 46,
+        "focalDistance": 8.4,
+        "duration": 14,
         "transition": "blend",
         "aperture": 0,
-        "focalDistance": 8.2,
         "ease": "smooth"
       }
     ]

--- a/sdf-js/scenes/rec-mountain-5.json
+++ b/sdf-js/scenes/rec-mountain-5.json
@@ -111,38 +111,38 @@
     "loop": false,
     "shots": [
       {
-        "duration": 0.01,
         "pos": [
-          1,
-          2.1,
-          9.799999999999999
+          0.6,
+          0.7000000000000001,
+          9.8
         ],
         "target": [
           0,
-          1.6,
+          1.9000000000000001,
           0
         ],
-        "fov": 50,
+        "fov": 52,
+        "focalDistance": 8.4,
+        "duration": 0.01,
         "aperture": 0,
-        "focalDistance": 8.2,
         "ease": "smooth"
       },
       {
-        "duration": 13,
         "pos": [
           0,
-          1.8,
-          8.2
+          2.2,
+          8.4
         ],
         "target": [
           0,
-          1.6,
+          1.9000000000000001,
           0
         ],
         "fov": 46,
+        "focalDistance": 8.4,
+        "duration": 14,
         "transition": "blend",
         "aperture": 0,
-        "focalDistance": 8.2,
         "ease": "smooth"
       }
     ]

--- a/sdf-js/scenes/rec-okr-2.json
+++ b/sdf-js/scenes/rec-okr-2.json
@@ -111,11 +111,10 @@
     "loop": false,
     "shots": [
       {
-        "duration": 0.01,
         "pos": [
-          1,
-          2.1,
-          9.799999999999999
+          -4.2,
+          2.1500000000000004,
+          7.9799999999999995
         ],
         "target": [
           0,
@@ -123,26 +122,27 @@
           0
         ],
         "fov": 50,
+        "focalDistance": 8.4,
+        "duration": 0.01,
         "aperture": 0,
-        "focalDistance": 8.2,
         "ease": "smooth"
       },
       {
-        "duration": 13,
         "pos": [
-          0,
+          1.512,
           1.8,
-          8.2
+          7.392
         ],
         "target": [
           0,
           1.6,
           0
         ],
-        "fov": 46,
+        "fov": 47,
+        "focalDistance": 8.4,
+        "duration": 14,
         "transition": "blend",
         "aperture": 0,
-        "focalDistance": 8.2,
         "ease": "smooth"
       }
     ]

--- a/sdf-js/scenes/rec-okr-2.json
+++ b/sdf-js/scenes/rec-okr-2.json
@@ -15,7 +15,29 @@
         "barWidth": 0.55,
         "barDepth": 0.55,
         "gap": 0.25,
-        "maxHeight": 2.2
+        "maxHeight": 2.2,
+        "colors": [
+          {
+            "hue": 0.58,
+            "sat": 0.58,
+            "value": 0.76
+          },
+          {
+            "hue": 0.58,
+            "sat": 0.6066666666666666,
+            "value": 0.66
+          },
+          {
+            "hue": 0.58,
+            "sat": 0.6333333333333333,
+            "value": 0.56
+          },
+          {
+            "hue": 0.58,
+            "sat": 0.6599999999999999,
+            "value": 0.46
+          }
+        ]
       },
       "transform": {
         "translate": [

--- a/sdf-js/scenes/rec-okr-4.json
+++ b/sdf-js/scenes/rec-okr-4.json
@@ -84,11 +84,10 @@
     "loop": false,
     "shots": [
       {
-        "duration": 0.01,
         "pos": [
-          1,
-          2.1,
-          9.799999999999999
+          -4.2,
+          2.1500000000000004,
+          7.9799999999999995
         ],
         "target": [
           0,
@@ -96,26 +95,27 @@
           0
         ],
         "fov": 50,
+        "focalDistance": 8.4,
+        "duration": 0.01,
         "aperture": 0,
-        "focalDistance": 8.2,
         "ease": "smooth"
       },
       {
-        "duration": 13,
         "pos": [
-          0,
+          1.512,
           1.8,
-          8.2
+          7.392
         ],
         "target": [
           0,
           1.6,
           0
         ],
-        "fov": 46,
+        "fov": 47,
+        "focalDistance": 8.4,
+        "duration": 14,
         "transition": "blend",
         "aperture": 0,
-        "focalDistance": 8.2,
         "ease": "smooth"
       }
     ]

--- a/sdf-js/scenes/rec-okr-5.json
+++ b/sdf-js/scenes/rec-okr-5.json
@@ -6,7 +6,29 @@
       "id": "pyramid",
       "type": "pyramid-3d",
       "args": {
-        "levels": 4
+        "levels": 4,
+        "colors": [
+          {
+            "hue": 0.11,
+            "sat": 0.7,
+            "value": 0.88
+          },
+          {
+            "hue": 0.11,
+            "sat": 0.7266666666666666,
+            "value": 0.78
+          },
+          {
+            "hue": 0.11,
+            "sat": 0.7533333333333333,
+            "value": 0.68
+          },
+          {
+            "hue": 0.11,
+            "sat": 0.7799999999999999,
+            "value": 0.5800000000000001
+          }
+        ]
       },
       "transform": {
         "translate": [

--- a/sdf-js/scenes/rec-okr-5.json
+++ b/sdf-js/scenes/rec-okr-5.json
@@ -102,38 +102,38 @@
     "loop": false,
     "shots": [
       {
-        "duration": 0.01,
         "pos": [
-          1,
-          2.1,
-          9.799999999999999
+          0.6,
+          0.7000000000000001,
+          9.8
         ],
         "target": [
           0,
-          1.6,
+          1.9000000000000001,
           0
         ],
-        "fov": 50,
+        "fov": 52,
+        "focalDistance": 8.4,
+        "duration": 0.01,
         "aperture": 0,
-        "focalDistance": 8.2,
         "ease": "smooth"
       },
       {
-        "duration": 13,
         "pos": [
           0,
-          1.8,
-          8.2
+          2.2,
+          8.4
         ],
         "target": [
           0,
-          1.6,
+          1.9000000000000001,
           0
         ],
         "fov": 46,
+        "focalDistance": 8.4,
+        "duration": 14,
         "transition": "blend",
         "aperture": 0,
-        "focalDistance": 8.2,
         "ease": "smooth"
       }
     ]

--- a/sdf-js/scenes/rec-pitch-2.json
+++ b/sdf-js/scenes/rec-pitch-2.json
@@ -111,38 +111,38 @@
     "loop": false,
     "shots": [
       {
-        "duration": 0.01,
         "pos": [
-          1,
-          2.1,
-          9.799999999999999
+          0.6,
+          0.7000000000000001,
+          9.8
         ],
         "target": [
           0,
-          1.6,
+          1.9000000000000001,
           0
         ],
-        "fov": 50,
+        "fov": 52,
+        "focalDistance": 8.4,
+        "duration": 0.01,
         "aperture": 0,
-        "focalDistance": 8.2,
         "ease": "smooth"
       },
       {
-        "duration": 13,
         "pos": [
           0,
-          1.8,
-          8.2
+          2.2,
+          8.4
         ],
         "target": [
           0,
-          1.6,
+          1.9000000000000001,
           0
         ],
         "fov": 46,
+        "focalDistance": 8.4,
+        "duration": 14,
         "transition": "blend",
         "aperture": 0,
-        "focalDistance": 8.2,
         "ease": "smooth"
       }
     ]

--- a/sdf-js/scenes/rec-pitch-3.json
+++ b/sdf-js/scenes/rec-pitch-3.json
@@ -87,38 +87,38 @@
     "loop": false,
     "shots": [
       {
-        "duration": 0.01,
         "pos": [
-          1,
-          2.1,
-          9.799999999999999
+          0.6,
+          0.7000000000000001,
+          9.8
         ],
         "target": [
           0,
-          1.6,
+          1.9000000000000001,
           0
         ],
-        "fov": 50,
+        "fov": 52,
+        "focalDistance": 8.4,
+        "duration": 0.01,
         "aperture": 0,
-        "focalDistance": 8.2,
         "ease": "smooth"
       },
       {
-        "duration": 13,
         "pos": [
           0,
-          1.8,
-          8.2
+          2.2,
+          8.4
         ],
         "target": [
           0,
-          1.6,
+          1.9000000000000001,
           0
         ],
         "fov": 46,
+        "focalDistance": 8.4,
+        "duration": 14,
         "transition": "blend",
         "aperture": 0,
-        "focalDistance": 8.2,
         "ease": "smooth"
       }
     ]

--- a/sdf-js/scenes/rec-pitch-4.json
+++ b/sdf-js/scenes/rec-pitch-4.json
@@ -111,11 +111,10 @@
     "loop": false,
     "shots": [
       {
-        "duration": 0.01,
         "pos": [
-          1,
-          2.1,
-          9.799999999999999
+          -4.2,
+          2.1500000000000004,
+          7.9799999999999995
         ],
         "target": [
           0,
@@ -123,26 +122,27 @@
           0
         ],
         "fov": 50,
+        "focalDistance": 8.4,
+        "duration": 0.01,
         "aperture": 0,
-        "focalDistance": 8.2,
         "ease": "smooth"
       },
       {
-        "duration": 13,
         "pos": [
-          0,
+          1.512,
           1.8,
-          8.2
+          7.392
         ],
         "target": [
           0,
           1.6,
           0
         ],
-        "fov": 46,
+        "fov": 47,
+        "focalDistance": 8.4,
+        "duration": 14,
         "transition": "blend",
         "aperture": 0,
-        "focalDistance": 8.2,
         "ease": "smooth"
       }
     ]

--- a/sdf-js/scenes/rec-pitch-4.json
+++ b/sdf-js/scenes/rec-pitch-4.json
@@ -15,7 +15,29 @@
         "barWidth": 0.55,
         "barDepth": 0.55,
         "gap": 0.25,
-        "maxHeight": 2.2
+        "maxHeight": 2.2,
+        "colors": [
+          {
+            "hue": 0.58,
+            "sat": 0.58,
+            "value": 0.76
+          },
+          {
+            "hue": 0.58,
+            "sat": 0.6066666666666666,
+            "value": 0.66
+          },
+          {
+            "hue": 0.58,
+            "sat": 0.6333333333333333,
+            "value": 0.56
+          },
+          {
+            "hue": 0.58,
+            "sat": 0.6599999999999999,
+            "value": 0.46
+          }
+        ]
       },
       "transform": {
         "translate": [

--- a/sdf-js/scenes/rec-pitch-5.json
+++ b/sdf-js/scenes/rec-pitch-5.json
@@ -84,11 +84,10 @@
     "loop": false,
     "shots": [
       {
-        "duration": 0.01,
         "pos": [
-          1,
-          2.1,
-          9.799999999999999
+          -4.2,
+          2.1500000000000004,
+          7.9799999999999995
         ],
         "target": [
           0,
@@ -96,26 +95,27 @@
           0
         ],
         "fov": 50,
+        "focalDistance": 8.4,
+        "duration": 0.01,
         "aperture": 0,
-        "focalDistance": 8.2,
         "ease": "smooth"
       },
       {
-        "duration": 13,
         "pos": [
-          0,
+          1.512,
           1.8,
-          8.2
+          7.392
         ],
         "target": [
           0,
           1.6,
           0
         ],
-        "fov": 46,
+        "fov": 47,
+        "focalDistance": 8.4,
+        "duration": 14,
         "transition": "blend",
         "aperture": 0,
-        "focalDistance": 8.2,
         "ease": "smooth"
       }
     ]

--- a/sdf-js/scenes/rec-pmtoolbox-2.json
+++ b/sdf-js/scenes/rec-pmtoolbox-2.json
@@ -90,11 +90,10 @@
     "loop": false,
     "shots": [
       {
-        "duration": 0.01,
         "pos": [
-          1,
-          2.1,
-          9.799999999999999
+          -4.2,
+          2.1500000000000004,
+          7.9799999999999995
         ],
         "target": [
           0,
@@ -102,26 +101,27 @@
           0
         ],
         "fov": 50,
+        "focalDistance": 8.4,
+        "duration": 0.01,
         "aperture": 0,
-        "focalDistance": 8.2,
         "ease": "smooth"
       },
       {
-        "duration": 13,
         "pos": [
-          0,
+          1.512,
           1.8,
-          8.2
+          7.392
         ],
         "target": [
           0,
           1.6,
           0
         ],
-        "fov": 46,
+        "fov": 47,
+        "focalDistance": 8.4,
+        "duration": 14,
         "transition": "blend",
         "aperture": 0,
-        "focalDistance": 8.2,
         "ease": "smooth"
       }
     ]

--- a/sdf-js/scenes/rec-pmtoolbox-3.json
+++ b/sdf-js/scenes/rec-pmtoolbox-3.json
@@ -80,11 +80,10 @@
     "loop": false,
     "shots": [
       {
-        "duration": 0.01,
         "pos": [
-          1,
-          2.1,
-          9.799999999999999
+          -4.2,
+          2.1500000000000004,
+          7.9799999999999995
         ],
         "target": [
           0,
@@ -92,26 +91,27 @@
           0
         ],
         "fov": 50,
+        "focalDistance": 8.4,
+        "duration": 0.01,
         "aperture": 0,
-        "focalDistance": 8.2,
         "ease": "smooth"
       },
       {
-        "duration": 13,
         "pos": [
-          0,
+          1.512,
           1.8,
-          8.2
+          7.392
         ],
         "target": [
           0,
           1.6,
           0
         ],
-        "fov": 46,
+        "fov": 47,
+        "focalDistance": 8.4,
+        "duration": 14,
         "transition": "blend",
         "aperture": 0,
-        "focalDistance": 8.2,
         "ease": "smooth"
       }
     ]

--- a/sdf-js/scenes/rec-pmtoolbox-4.json
+++ b/sdf-js/scenes/rec-pmtoolbox-4.json
@@ -84,11 +84,10 @@
     "loop": false,
     "shots": [
       {
-        "duration": 0.01,
         "pos": [
-          1,
-          2.1,
-          9.799999999999999
+          -4.2,
+          2.1500000000000004,
+          7.9799999999999995
         ],
         "target": [
           0,
@@ -96,26 +95,27 @@
           0
         ],
         "fov": 50,
+        "focalDistance": 8.4,
+        "duration": 0.01,
         "aperture": 0,
-        "focalDistance": 8.2,
         "ease": "smooth"
       },
       {
-        "duration": 13,
         "pos": [
-          0,
+          1.512,
           1.8,
-          8.2
+          7.392
         ],
         "target": [
           0,
           1.6,
           0
         ],
-        "fov": 46,
+        "fov": 47,
+        "focalDistance": 8.4,
+        "duration": 14,
         "transition": "blend",
         "aperture": 0,
-        "focalDistance": 8.2,
         "ease": "smooth"
       }
     ]

--- a/sdf-js/scenes/rec-status-2.json
+++ b/sdf-js/scenes/rec-status-2.json
@@ -94,11 +94,10 @@
     "loop": false,
     "shots": [
       {
-        "duration": 0.01,
         "pos": [
-          1,
-          2.1,
-          9.799999999999999
+          -4.2,
+          2.1500000000000004,
+          7.9799999999999995
         ],
         "target": [
           0,
@@ -106,26 +105,27 @@
           0
         ],
         "fov": 50,
+        "focalDistance": 8.4,
+        "duration": 0.01,
         "aperture": 0,
-        "focalDistance": 8.2,
         "ease": "smooth"
       },
       {
-        "duration": 13,
         "pos": [
-          0,
+          1.512,
           1.8,
-          8.2
+          7.392
         ],
         "target": [
           0,
           1.6,
           0
         ],
-        "fov": 46,
+        "fov": 47,
+        "focalDistance": 8.4,
+        "duration": 14,
         "transition": "blend",
         "aperture": 0,
-        "focalDistance": 8.2,
         "ease": "smooth"
       }
     ]

--- a/sdf-js/scenes/rec-status-3.json
+++ b/sdf-js/scenes/rec-status-3.json
@@ -80,11 +80,10 @@
     "loop": false,
     "shots": [
       {
-        "duration": 0.01,
         "pos": [
-          1,
-          2.1,
-          9.799999999999999
+          -4.2,
+          2.1500000000000004,
+          7.9799999999999995
         ],
         "target": [
           0,
@@ -92,26 +91,27 @@
           0
         ],
         "fov": 50,
+        "focalDistance": 8.4,
+        "duration": 0.01,
         "aperture": 0,
-        "focalDistance": 8.2,
         "ease": "smooth"
       },
       {
-        "duration": 13,
         "pos": [
-          0,
+          1.512,
           1.8,
-          8.2
+          7.392
         ],
         "target": [
           0,
           1.6,
           0
         ],
-        "fov": 46,
+        "fov": 47,
+        "focalDistance": 8.4,
+        "duration": 14,
         "transition": "blend",
         "aperture": 0,
-        "focalDistance": 8.2,
         "ease": "smooth"
       }
     ]

--- a/sdf-js/scenes/rec-status-4.json
+++ b/sdf-js/scenes/rec-status-4.json
@@ -111,11 +111,10 @@
     "loop": false,
     "shots": [
       {
-        "duration": 0.01,
         "pos": [
-          1,
-          2.1,
-          9.799999999999999
+          -4.2,
+          2.1500000000000004,
+          7.9799999999999995
         ],
         "target": [
           0,
@@ -123,26 +122,27 @@
           0
         ],
         "fov": 50,
+        "focalDistance": 8.4,
+        "duration": 0.01,
         "aperture": 0,
-        "focalDistance": 8.2,
         "ease": "smooth"
       },
       {
-        "duration": 13,
         "pos": [
-          0,
+          1.512,
           1.8,
-          8.2
+          7.392
         ],
         "target": [
           0,
           1.6,
           0
         ],
-        "fov": 46,
+        "fov": 47,
+        "focalDistance": 8.4,
+        "duration": 14,
         "transition": "blend",
         "aperture": 0,
-        "focalDistance": 8.2,
         "ease": "smooth"
       }
     ]

--- a/sdf-js/scenes/rec-status-4.json
+++ b/sdf-js/scenes/rec-status-4.json
@@ -15,7 +15,29 @@
         "barWidth": 0.55,
         "barDepth": 0.55,
         "gap": 0.25,
-        "maxHeight": 2.2
+        "maxHeight": 2.2,
+        "colors": [
+          {
+            "hue": 0.58,
+            "sat": 0.58,
+            "value": 0.76
+          },
+          {
+            "hue": 0.58,
+            "sat": 0.6066666666666666,
+            "value": 0.66
+          },
+          {
+            "hue": 0.58,
+            "sat": 0.6333333333333333,
+            "value": 0.56
+          },
+          {
+            "hue": 0.58,
+            "sat": 0.6599999999999999,
+            "value": 0.46
+          }
+        ]
       },
       "transform": {
         "translate": [

--- a/sdf-js/scenes/rec-status-5.json
+++ b/sdf-js/scenes/rec-status-5.json
@@ -80,11 +80,10 @@
     "loop": false,
     "shots": [
       {
-        "duration": 0.01,
         "pos": [
-          1,
-          2.1,
-          9.799999999999999
+          -4.2,
+          2.1500000000000004,
+          7.9799999999999995
         ],
         "target": [
           0,
@@ -92,26 +91,27 @@
           0
         ],
         "fov": 50,
+        "focalDistance": 8.4,
+        "duration": 0.01,
         "aperture": 0,
-        "focalDistance": 8.2,
         "ease": "smooth"
       },
       {
-        "duration": 13,
         "pos": [
-          0,
+          1.512,
           1.8,
-          8.2
+          7.392
         ],
         "target": [
           0,
           1.6,
           0
         ],
-        "fov": 46,
+        "fov": 47,
+        "focalDistance": 8.4,
+        "duration": 14,
         "transition": "blend",
         "aperture": 0,
-        "focalDistance": 8.2,
         "ease": "smooth"
       }
     ]

--- a/sdf-js/scenes/rec-strategy-3.json
+++ b/sdf-js/scenes/rec-strategy-3.json
@@ -89,28 +89,27 @@
     "loop": false,
     "shots": [
       {
-        "duration": 0.01,
         "pos": [
-          1,
-          2.1,
-          9.799999999999999
+          6.5520000000000005,
+          2.3,
+          5.208
         ],
         "target": [
           0,
           1.6,
           0
         ],
-        "fov": 50,
+        "fov": 48,
+        "focalDistance": 8.4,
+        "duration": 0.01,
         "aperture": 0,
-        "focalDistance": 8.2,
         "ease": "smooth"
       },
       {
-        "duration": 13,
         "pos": [
           0,
           1.8,
-          8.2
+          8.4
         ],
         "target": [
           0,
@@ -118,9 +117,10 @@
           0
         ],
         "fov": 46,
+        "focalDistance": 8.4,
+        "duration": 14,
         "transition": "blend",
         "aperture": 0,
-        "focalDistance": 8.2,
         "ease": "smooth"
       }
     ]

--- a/sdf-js/scenes/rec-strategy-4.json
+++ b/sdf-js/scenes/rec-strategy-4.json
@@ -6,7 +6,29 @@
       "id": "pyramid",
       "type": "pyramid-3d",
       "args": {
-        "levels": 4
+        "levels": 4,
+        "colors": [
+          {
+            "hue": 0.11,
+            "sat": 0.7,
+            "value": 0.88
+          },
+          {
+            "hue": 0.11,
+            "sat": 0.7266666666666666,
+            "value": 0.78
+          },
+          {
+            "hue": 0.11,
+            "sat": 0.7533333333333333,
+            "value": 0.68
+          },
+          {
+            "hue": 0.11,
+            "sat": 0.7799999999999999,
+            "value": 0.5800000000000001
+          }
+        ]
       },
       "transform": {
         "translate": [

--- a/sdf-js/scenes/rec-strategy-4.json
+++ b/sdf-js/scenes/rec-strategy-4.json
@@ -102,38 +102,38 @@
     "loop": false,
     "shots": [
       {
-        "duration": 0.01,
         "pos": [
-          1,
-          2.1,
-          9.799999999999999
+          0.6,
+          0.7000000000000001,
+          9.8
         ],
         "target": [
           0,
-          1.6,
+          1.9000000000000001,
           0
         ],
-        "fov": 50,
+        "fov": 52,
+        "focalDistance": 8.4,
+        "duration": 0.01,
         "aperture": 0,
-        "focalDistance": 8.2,
         "ease": "smooth"
       },
       {
-        "duration": 13,
         "pos": [
           0,
-          1.8,
-          8.2
+          2.2,
+          8.4
         ],
         "target": [
           0,
-          1.6,
+          1.9000000000000001,
           0
         ],
         "fov": 46,
+        "focalDistance": 8.4,
+        "duration": 14,
         "transition": "blend",
         "aperture": 0,
-        "focalDistance": 8.2,
         "ease": "smooth"
       }
     ]

--- a/sdf-js/scenes/rec-strategy-5.json
+++ b/sdf-js/scenes/rec-strategy-5.json
@@ -84,11 +84,10 @@
     "loop": false,
     "shots": [
       {
-        "duration": 0.01,
         "pos": [
-          1,
-          2.1,
-          9.799999999999999
+          -4.2,
+          2.1500000000000004,
+          7.9799999999999995
         ],
         "target": [
           0,
@@ -96,26 +95,27 @@
           0
         ],
         "fov": 50,
+        "focalDistance": 8.4,
+        "duration": 0.01,
         "aperture": 0,
-        "focalDistance": 8.2,
         "ease": "smooth"
       },
       {
-        "duration": 13,
         "pos": [
-          0,
+          1.512,
           1.8,
-          8.2
+          7.392
         ],
         "target": [
           0,
           1.6,
           0
         ],
-        "fov": 46,
+        "fov": 47,
+        "focalDistance": 8.4,
+        "duration": 14,
         "transition": "blend",
         "aperture": 0,
-        "focalDistance": 8.2,
         "ease": "smooth"
       }
     ]

--- a/sdf-js/scenes/rec-stratmap-2.json
+++ b/sdf-js/scenes/rec-stratmap-2.json
@@ -80,11 +80,10 @@
     "loop": false,
     "shots": [
       {
-        "duration": 0.01,
         "pos": [
-          1,
-          2.1,
-          9.799999999999999
+          -4.2,
+          2.1500000000000004,
+          7.9799999999999995
         ],
         "target": [
           0,
@@ -92,26 +91,27 @@
           0
         ],
         "fov": 50,
+        "focalDistance": 8.4,
+        "duration": 0.01,
         "aperture": 0,
-        "focalDistance": 8.2,
         "ease": "smooth"
       },
       {
-        "duration": 13,
         "pos": [
-          0,
+          1.512,
           1.8,
-          8.2
+          7.392
         ],
         "target": [
           0,
           1.6,
           0
         ],
-        "fov": 46,
+        "fov": 47,
+        "focalDistance": 8.4,
+        "duration": 14,
         "transition": "blend",
         "aperture": 0,
-        "focalDistance": 8.2,
         "ease": "smooth"
       }
     ]

--- a/sdf-js/scenes/rec-stratmap-3.json
+++ b/sdf-js/scenes/rec-stratmap-3.json
@@ -41,28 +41,27 @@
     "loop": false,
     "shots": [
       {
-        "duration": 0.01,
         "pos": [
-          1,
-          2.1,
-          9.799999999999999
+          6.5520000000000005,
+          2.3,
+          5.208
         ],
         "target": [
           0,
           1.6,
           0
         ],
-        "fov": 50,
+        "fov": 48,
+        "focalDistance": 8.4,
+        "duration": 0.01,
         "aperture": 0,
-        "focalDistance": 8.2,
         "ease": "smooth"
       },
       {
-        "duration": 13,
         "pos": [
           0,
           1.8,
-          8.2
+          8.4
         ],
         "target": [
           0,
@@ -70,9 +69,10 @@
           0
         ],
         "fov": 46,
+        "focalDistance": 8.4,
+        "duration": 14,
         "transition": "blend",
         "aperture": 0,
-        "focalDistance": 8.2,
         "ease": "smooth"
       }
     ]

--- a/sdf-js/scenes/rec-stratmap-4.json
+++ b/sdf-js/scenes/rec-stratmap-4.json
@@ -111,11 +111,10 @@
     "loop": false,
     "shots": [
       {
-        "duration": 0.01,
         "pos": [
-          1,
-          2.1,
-          9.799999999999999
+          -4.2,
+          2.1500000000000004,
+          7.9799999999999995
         ],
         "target": [
           0,
@@ -123,26 +122,27 @@
           0
         ],
         "fov": 50,
+        "focalDistance": 8.4,
+        "duration": 0.01,
         "aperture": 0,
-        "focalDistance": 8.2,
         "ease": "smooth"
       },
       {
-        "duration": 13,
         "pos": [
-          0,
+          1.512,
           1.8,
-          8.2
+          7.392
         ],
         "target": [
           0,
           1.6,
           0
         ],
-        "fov": 46,
+        "fov": 47,
+        "focalDistance": 8.4,
+        "duration": 14,
         "transition": "blend",
         "aperture": 0,
-        "focalDistance": 8.2,
         "ease": "smooth"
       }
     ]

--- a/sdf-js/scenes/rec-stratmap-4.json
+++ b/sdf-js/scenes/rec-stratmap-4.json
@@ -15,7 +15,29 @@
         "barWidth": 0.55,
         "barDepth": 0.55,
         "gap": 0.25,
-        "maxHeight": 2.2
+        "maxHeight": 2.2,
+        "colors": [
+          {
+            "hue": 0.58,
+            "sat": 0.58,
+            "value": 0.76
+          },
+          {
+            "hue": 0.58,
+            "sat": 0.6066666666666666,
+            "value": 0.66
+          },
+          {
+            "hue": 0.58,
+            "sat": 0.6333333333333333,
+            "value": 0.56
+          },
+          {
+            "hue": 0.58,
+            "sat": 0.6599999999999999,
+            "value": 0.46
+          }
+        ]
       },
       "transform": {
         "translate": [

--- a/sdf-js/scenes/rec-stratmap-5.json
+++ b/sdf-js/scenes/rec-stratmap-5.json
@@ -6,7 +6,29 @@
       "id": "pyramid",
       "type": "pyramid-3d",
       "args": {
-        "levels": 4
+        "levels": 4,
+        "colors": [
+          {
+            "hue": 0.11,
+            "sat": 0.7,
+            "value": 0.88
+          },
+          {
+            "hue": 0.11,
+            "sat": 0.7266666666666666,
+            "value": 0.78
+          },
+          {
+            "hue": 0.11,
+            "sat": 0.7533333333333333,
+            "value": 0.68
+          },
+          {
+            "hue": 0.11,
+            "sat": 0.7799999999999999,
+            "value": 0.5800000000000001
+          }
+        ]
       },
       "transform": {
         "translate": [

--- a/sdf-js/scenes/rec-stratmap-5.json
+++ b/sdf-js/scenes/rec-stratmap-5.json
@@ -102,38 +102,38 @@
     "loop": false,
     "shots": [
       {
-        "duration": 0.01,
         "pos": [
-          1,
-          2.1,
-          9.799999999999999
+          0.6,
+          0.7000000000000001,
+          9.8
         ],
         "target": [
           0,
-          1.6,
+          1.9000000000000001,
           0
         ],
-        "fov": 50,
+        "fov": 52,
+        "focalDistance": 8.4,
+        "duration": 0.01,
         "aperture": 0,
-        "focalDistance": 8.2,
         "ease": "smooth"
       },
       {
-        "duration": 13,
         "pos": [
           0,
-          1.8,
-          8.2
+          2.2,
+          8.4
         ],
         "target": [
           0,
-          1.6,
+          1.9000000000000001,
           0
         ],
         "fov": 46,
+        "focalDistance": 8.4,
+        "duration": 14,
         "transition": "blend",
         "aperture": 0,
-        "focalDistance": 8.2,
         "ease": "smooth"
       }
     ]

--- a/sdf-js/scenes/rec-timelines-2.json
+++ b/sdf-js/scenes/rec-timelines-2.json
@@ -94,11 +94,10 @@
     "loop": false,
     "shots": [
       {
-        "duration": 0.01,
         "pos": [
-          1,
-          2.1,
-          9.799999999999999
+          -4.2,
+          2.1500000000000004,
+          7.9799999999999995
         ],
         "target": [
           0,
@@ -106,26 +105,27 @@
           0
         ],
         "fov": 50,
+        "focalDistance": 8.4,
+        "duration": 0.01,
         "aperture": 0,
-        "focalDistance": 8.2,
         "ease": "smooth"
       },
       {
-        "duration": 13,
         "pos": [
-          0,
+          1.512,
           1.8,
-          8.2
+          7.392
         ],
         "target": [
           0,
           1.6,
           0
         ],
-        "fov": 46,
+        "fov": 47,
+        "focalDistance": 8.4,
+        "duration": 14,
         "transition": "blend",
         "aperture": 0,
-        "focalDistance": 8.2,
         "ease": "smooth"
       }
     ]

--- a/sdf-js/scenes/rec-timelines-3.json
+++ b/sdf-js/scenes/rec-timelines-3.json
@@ -80,11 +80,10 @@
     "loop": false,
     "shots": [
       {
-        "duration": 0.01,
         "pos": [
-          1,
-          2.1,
-          9.799999999999999
+          -4.2,
+          2.1500000000000004,
+          7.9799999999999995
         ],
         "target": [
           0,
@@ -92,26 +91,27 @@
           0
         ],
         "fov": 50,
+        "focalDistance": 8.4,
+        "duration": 0.01,
         "aperture": 0,
-        "focalDistance": 8.2,
         "ease": "smooth"
       },
       {
-        "duration": 13,
         "pos": [
-          0,
+          1.512,
           1.8,
-          8.2
+          7.392
         ],
         "target": [
           0,
           1.6,
           0
         ],
-        "fov": 46,
+        "fov": 47,
+        "focalDistance": 8.4,
+        "duration": 14,
         "transition": "blend",
         "aperture": 0,
-        "focalDistance": 8.2,
         "ease": "smooth"
       }
     ]

--- a/sdf-js/scenes/rec-timelines-4.json
+++ b/sdf-js/scenes/rec-timelines-4.json
@@ -80,11 +80,10 @@
     "loop": false,
     "shots": [
       {
-        "duration": 0.01,
         "pos": [
-          1,
-          2.1,
-          9.799999999999999
+          -4.2,
+          2.1500000000000004,
+          7.9799999999999995
         ],
         "target": [
           0,
@@ -92,26 +91,27 @@
           0
         ],
         "fov": 50,
+        "focalDistance": 8.4,
+        "duration": 0.01,
         "aperture": 0,
-        "focalDistance": 8.2,
         "ease": "smooth"
       },
       {
-        "duration": 13,
         "pos": [
-          0,
+          1.512,
           1.8,
-          8.2
+          7.392
         ],
         "target": [
           0,
           1.6,
           0
         ],
-        "fov": 46,
+        "fov": 47,
+        "focalDistance": 8.4,
+        "duration": 14,
         "transition": "blend",
         "aperture": 0,
-        "focalDistance": 8.2,
         "ease": "smooth"
       }
     ]

--- a/sdf-js/scenes/rec-timelines-5.json
+++ b/sdf-js/scenes/rec-timelines-5.json
@@ -112,38 +112,38 @@
     "loop": false,
     "shots": [
       {
-        "duration": 0.01,
         "pos": [
-          1,
-          2.1,
-          9.799999999999999
+          0.6,
+          0.7000000000000001,
+          9.8
         ],
         "target": [
           0,
-          1.6,
+          1.9000000000000001,
           0
         ],
-        "fov": 50,
+        "fov": 52,
+        "focalDistance": 8.4,
+        "duration": 0.01,
         "aperture": 0,
-        "focalDistance": 8.2,
         "ease": "smooth"
       },
       {
-        "duration": 13,
         "pos": [
           0,
-          1.8,
-          8.2
+          2.2,
+          8.4
         ],
         "target": [
           0,
-          1.6,
+          1.9000000000000001,
           0
         ],
         "fov": 46,
+        "focalDistance": 8.4,
+        "duration": 14,
         "transition": "blend",
         "aperture": 0,
-        "focalDistance": 8.2,
         "ease": "smooth"
       }
     ]

--- a/sdf-js/scripts/lift-rec-round5.mjs
+++ b/sdf-js/scripts/lift-rec-round5.mjs
@@ -41,7 +41,7 @@ const DECKS = [
   {
     id: 'icons', name: 'Line Icons - Business', slides: [
       { title: 'Categories', type: 'radial-spoke', args: { title: 'Business Icons', values: [1, 1, 1, 1, 1, 1], labels: ['Finance', 'People', 'Growth', 'Tech', 'Strategy', 'Ops'] } },
-      { title: 'Icon Grid', type: 'cube-grid', args: { title: 'Icon Set', size: 3 } },
+      { title: 'Icon Grid', type: 'icon-grid', args: { title: 'Icon Set', rows: 2, cols: 4 } },
       { title: 'Concept Tiles', type: 'matrix-grid', args: { title: 'Concept Tiles', rows: 2, cols: 4 } },
       { title: 'Themes', type: 'circle-segmented', args: { title: 'Themes', segments: 6, labels: ['$', '%', '↑', '★', '✓', '◆'] } },
       { title: 'Toolkit', type: 'radial-spoke', args: { title: 'Toolkit', values: [1, 1, 1, 1], labels: ['Charts', 'Flows', 'Maps', 'KPIs'] } },

--- a/sdf-js/scripts/lift-rec-round5.mjs
+++ b/sdf-js/scripts/lift-rec-round5.mjs
@@ -31,7 +31,7 @@ const DECKS = [
   },
   {
     id: 'mountain', name: 'Mountain Path – Graphics', slides: [
-      { title: 'The Summit', type: 'pyramid', args: { title: 'Mountain Path', layers: [{ label: 'Summit' }, { label: 'Ridge' }, { label: 'Ascent' }, { label: 'Base Camp' }] } },
+      { title: 'The Summit', type: 'mountain', args: { title: 'Mountain Path', stages: [{ label: 'Summit' }, { label: 'Ridge' }, { label: 'Ascent' }, { label: 'Base Camp' }] } },
       { title: 'The Climb', type: 'progression', args: { title: 'The Climb', steps: [{ label: 'Base Camp' }, { label: 'Ascent' }, { label: 'Ridge' }, { label: 'Summit' }] } },
       { title: 'Milestones', type: 'timeline', args: { title: 'Journey Milestones', events: [{ label: 'Start' }, { label: 'Camp 1' }, { label: 'Camp 2' }, { label: 'Peak' }] } },
       { title: 'Elevation Tiers', type: 'circle-stack', args: { title: 'Elevation', layers: [{ label: 'Peak' }, { label: 'High' }, { label: 'Mid' }, { label: 'Foot' }] } },

--- a/sdf-js/src/scene/compile.js
+++ b/sdf-js/src/scene/compile.js
@@ -128,6 +128,7 @@ import { cubeSegmented3dSDF } from './components/shapes/cube-segmented-3d.js';
 import { circleFrame3dSDF } from './components/shapes/circle-frame-3d.js';
 import { circleStack3dSDF } from './components/shapes/circle-stack-3d.js';
 import { circleSegmented3dSDF } from './components/shapes/circle-segmented-3d.js';
+import { mountain3dSDF } from './components/shapes/mountain-3d.js';
 import { circleLoop3dSDF } from './components/shapes/circle-loop-3d.js';
 import { relationshipGraph3dSDF } from './components/charts/diagrams/relationship-graph-3d.js';
 import { orgChart3dSDF } from './components/charts/diagrams/org-chart-3d.js';
@@ -542,6 +543,16 @@ const PRIMITIVE_FACTORIES = {
       diskHeight: a.diskHeight ?? a.thickness ?? 0.18,
       gap: a.gap ?? 0.06,
       colors: a.colors ?? null,
+    }),
+  'mountain-3d': (a) =>
+    mountain3dSDF({
+      height: a.height ?? 2.4,
+      baseRadius: a.baseRadius ?? 1.5,
+      sidePeaks: a.sidePeaks ?? 2,
+      spread: a.spread ?? 1.7,
+      sideScale: a.sideScale ?? 0.6,
+      pathMarkers: a.pathMarkers ?? 4,
+      markerRadius: a.markerRadius ?? 0.13,
     }),
   'circle-segmented-3d': (a) =>
     circleSegmented3dSDF({

--- a/sdf-js/src/scene/compile.js
+++ b/sdf-js/src/scene/compile.js
@@ -129,6 +129,7 @@ import { circleFrame3dSDF } from './components/shapes/circle-frame-3d.js';
 import { circleStack3dSDF } from './components/shapes/circle-stack-3d.js';
 import { circleSegmented3dSDF } from './components/shapes/circle-segmented-3d.js';
 import { mountain3dSDF } from './components/shapes/mountain-3d.js';
+import { iconGrid3dSDF } from './components/shapes/icon-grid-3d.js';
 import { circleLoop3dSDF } from './components/shapes/circle-loop-3d.js';
 import { relationshipGraph3dSDF } from './components/charts/diagrams/relationship-graph-3d.js';
 import { orgChart3dSDF } from './components/charts/diagrams/org-chart-3d.js';
@@ -553,6 +554,15 @@ const PRIMITIVE_FACTORIES = {
       sideScale: a.sideScale ?? 0.6,
       pathMarkers: a.pathMarkers ?? 4,
       markerRadius: a.markerRadius ?? 0.13,
+    }),
+  'icon-grid-3d': (a) =>
+    iconGrid3dSDF({
+      rows: a.rows ?? 2,
+      cols: a.cols ?? 4,
+      tileSize: a.tileSize ?? 0.8,
+      gap: a.gap ?? 0.22,
+      tileDepth: a.tileDepth ?? 0.22,
+      glyphs: a.glyphs ?? null,
     }),
   'circle-segmented-3d': (a) =>
     circleSegmented3dSDF({

--- a/sdf-js/src/scene/compile.js
+++ b/sdf-js/src/scene/compile.js
@@ -355,6 +355,7 @@ const PRIMITIVE_FACTORIES = {
       layerHeight: a.layerHeight ?? a.thickness ?? 0.3,
       gap: a.gap ?? 0.05,
       depth: a.depth ?? 0.6,
+      colors: a.colors ?? null,
     }),
   'bar-3d': (a) =>
     bar3dSDF({
@@ -364,6 +365,7 @@ const PRIMITIVE_FACTORIES = {
       barDepth: a.barDepth ?? a.depth ?? 0.4,
       gap: a.gap ?? 0.1,
       maxHeight: a.maxHeight ?? a.scale ?? 2.0,
+      colors: a.colors ?? null,
     }),
   'column-3d': (a) =>
     column3dSDF({

--- a/sdf-js/src/scene/components/charts/data/bar-3d.js
+++ b/sdf-js/src/scene/components/charts/data/bar-3d.js
@@ -25,6 +25,9 @@
 // =============================================================================
 
 import { SDF3 } from '../../../../sdf/core.js';
+import { box } from '../../../../sdf/d3.js';
+import { union } from '../../../../sdf/dn.js';
+import { resolveMaterial } from '../../../spec.js';
 
 export const MAX_BARS = 32;
 
@@ -102,8 +105,29 @@ export function bar3dSDF({
   barDepth = 0.4,
   gap = 0.1,
   maxHeight = 2.0,
+  colors = null,
 } = {}) {
   const { N, vals, paddedValues } = resolveBarParams(values, count);
+
+  // per-leaf colours: build the same bars as a union of coloured box leaves instead of
+  // the fused prim. Only when colors[] is given — the no-colours path is untouched.
+  if (Array.isArray(colors) && colors.length) {
+    const totalX = N * barWidth + (N - 1) * gap;
+    const xStart = -totalX / 2 + barWidth / 2;
+    const parts = [];
+    for (let i = 0; i < N; i++) {
+      const h = vals[i] * maxHeight;
+      if (h <= 0) continue;
+      const xc = xStart + i * (barWidth + gap);
+      const b = box([barWidth, h, barDepth]).translate([xc, h / 2, 0]);
+      if (colors[i] != null) {
+        const m = resolveMaterial(colors[i]);
+        if (m) b._subjectMaterial = m;
+      }
+      parts.push(b);
+    }
+    if (parts.length) return parts.length === 1 ? parts[0] : union(...parts);
+  }
 
   const inst = SDF3((p) => evalBarsSDF(p, N, vals, barWidth, barDepth, gap, maxHeight));
 

--- a/sdf-js/src/scene/components/charts/hierarchy/pyramid-3d.js
+++ b/sdf-js/src/scene/components/charts/hierarchy/pyramid-3d.js
@@ -21,6 +21,9 @@
 // =============================================================================
 
 import { SDF3 } from '../../../../sdf/core.js';
+import { box } from '../../../../sdf/d3.js';
+import { union } from '../../../../sdf/dn.js';
+import { resolveMaterial } from '../../../spec.js';
 
 /**
  * Multi-level parametric pyramid SDF.
@@ -40,10 +43,29 @@ export function pyramid3dSDF({
   layerHeight = 0.3,
   gap = 0.05,
   depth = 0.6,
+  colors = null,
 } = {}) {
   // Clamp levels to [1, 20] (GPU loop is unrolled to 20)
   const N = Math.max(1, Math.min(20, Math.floor(levels)));
   const totalH = N * layerHeight + (N - 1) * gap;
+
+  // per-leaf colours: same tiers as a union of coloured boxes (only when colors[] given;
+  // the fused no-colours path below is untouched so existing behaviour/tests are stable).
+  if (Array.isArray(colors) && colors.length) {
+    const parts = [];
+    for (let i = 0; i < N; i++) {
+      const t = N > 1 ? i / (N - 1) : 0;
+      const w = baseWidth + t * (topWidth - baseWidth);
+      const yc = i * (layerHeight + gap) - totalH / 2 + layerHeight / 2;
+      const tier = box([w, layerHeight, depth]).translate([0, yc, 0]);
+      if (colors[i] != null) {
+        const m = resolveMaterial(colors[i]);
+        if (m) tier._subjectMaterial = m;
+      }
+      parts.push(tier);
+    }
+    return parts.length === 1 ? parts[0] : union(...parts);
+  }
 
   const inst = SDF3((p) => {
     let minDist = Infinity;

--- a/sdf-js/src/scene/components/shapes/icon-grid-3d.js
+++ b/sdf-js/src/scene/components/shapes/icon-grid-3d.js
@@ -1,0 +1,107 @@
+// =============================================================================
+// icon-grid-3d.js — a wall of icon tiles (Atlas shape atom).
+// -----------------------------------------------------------------------------
+// rows×cols rounded tiles facing the camera, each with a simple raised pictogram
+// (disc / ring / plus / bar / frame / dot / lines / square) cycling across cells.
+// Covers PresentationLoad "Line Icons" style icon sets — an abstract visual
+// language. Composite atom (box + cylinder + sphere + union/difference); glyphs
+// carry an accent _subjectMaterial so they pop off the tile face.
+// =============================================================================
+
+import { box, cylinder, sphere } from '../../../sdf/d3.js';
+import { union, difference } from '../../../sdf/dn.js';
+import { resolveMaterial } from '../../spec.js';
+
+const GLYPH_ACCENT = { hue: 0.57, sat: 0.5, value: 0.95 };
+
+// glyph in the XY plane, thin in Z, centred at origin. s = glyph half-size, d = depth.
+function glyph(kind, s, d) {
+  const k = ((kind % 8) + 8) % 8;
+  switch (k) {
+    case 0: // disc
+      return cylinder(s, d).rotateXYZ([Math.PI / 2, 0, 0]);
+    case 1: // ring
+      return difference(cylinder(s, d), cylinder(s * 0.55, d * 1.6)).rotateXYZ([Math.PI / 2, 0, 0]);
+    case 2: // plus
+      return union(box([s * 1.7, s * 0.5, d]), box([s * 0.5, s * 1.7, d]));
+    case 3: // bar
+      return box([s * 1.8, s * 0.55, d]);
+    case 4: // square frame
+      return difference(box([s * 1.7, s * 1.7, d]), box([s * 0.9, s * 0.9, d * 1.6]));
+    case 5: // dot
+      return sphere(s * 0.9);
+    case 6: // stacked lines
+      return union(
+        box([s * 1.6, s * 0.4, d]).translate([0, s * 0.55, 0]),
+        box([s * 1.6, s * 0.4, d]).translate([0, -s * 0.55, 0]),
+      );
+    default: // 7: filled square
+      return box([s * 1.3, s * 1.3, d]);
+  }
+}
+
+/**
+ * @param {object} opts
+ * @param {number} [opts.rows=2]
+ * @param {number} [opts.cols=4]
+ * @param {number} [opts.tileSize=0.8]   tile edge length
+ * @param {number} [opts.gap=0.22]       gap between tiles
+ * @param {number} [opts.tileDepth=0.22] tile Z depth
+ * @param {number[]} [opts.glyphs]       per-cell glyph indices (default: cycle 0..7)
+ * @returns {SDF3}
+ */
+export function iconGrid3dSDF({
+  rows = 2,
+  cols = 4,
+  tileSize = 0.8,
+  gap = 0.22,
+  tileDepth = 0.22,
+  glyphs = null,
+} = {}) {
+  const R = Math.max(1, Math.floor(rows));
+  const C = Math.max(1, Math.floor(cols));
+  const stride = tileSize + gap;
+  const gs = tileSize * 0.24; // glyph half-size
+  const gd = 0.08; // glyph raised depth
+  const accent = resolveMaterial(GLYPH_ACCENT);
+  const parts = [];
+  let idx = 0;
+  for (let r = 0; r < R; r++) {
+    for (let c = 0; c < C; c++) {
+      const x = (c - (C - 1) / 2) * stride;
+      const y = ((R - 1) / 2 - r) * stride;
+      parts.push(box([tileSize, tileSize, tileDepth]).translate([x, y, 0]));
+      const kind = glyphs && glyphs[idx] != null ? glyphs[idx] : idx;
+      const g = glyph(kind, gs, gd).translate([x, y, tileDepth / 2 + gd / 2]);
+      if (accent) g._subjectMaterial = accent;
+      parts.push(g);
+      idx++;
+    }
+  }
+  return parts.length === 1 ? parts[0] : union(...parts);
+}
+
+export const iconGrid3dSpec = {
+  type: 'icon-grid-3d',
+  category: 'shapes',
+  args: {
+    rows: { type: 'number', default: 2, doc: 'Tile rows' },
+    cols: { type: 'number', default: 4, doc: 'Tile columns' },
+    tileSize: { type: 'number', default: 0.8, doc: 'Tile edge length' },
+    gap: { type: 'number', default: 0.22, doc: 'Gap between tiles' },
+    tileDepth: { type: 'number', default: 0.22, doc: 'Tile Z depth' },
+    glyphs: { type: 'array', default: null, doc: 'Per-cell glyph indices (0..7), default cycles' },
+  },
+  examples: [
+    { name: 'Icon wall 2x4', args: { rows: 2, cols: 4 } },
+    { name: 'Toolbar', args: { rows: 1, cols: 6 } },
+    { name: 'Grid 3x3', args: { rows: 3, cols: 3 } },
+  ],
+  description: 'A wall of icon tiles with raised pictograms — an icon set / visual language',
+  source: {
+    author: 'Atlas',
+    builtAt: '2026-06-25',
+    builder: 'Polish round — recommendations coverage (Line Icons)',
+    license: 'PolyForm Noncommercial 1.0.0',
+  },
+};

--- a/sdf-js/src/scene/components/shapes/mountain-3d.js
+++ b/sdf-js/src/scene/components/shapes/mountain-3d.js
@@ -1,0 +1,88 @@
+// =============================================================================
+// mountain-3d.js — summit / journey metaphor graphic (Atlas shape atom).
+// -----------------------------------------------------------------------------
+// A mountain massif (a main peak + flanking side peaks) with a trail of markers
+// ascending the front face to the summit. Covers PresentationLoad "Mountain Path
+// – Graphics" — the climb-to-goal metaphor. Composite atom (cone + sphere + union),
+// trail markers carry an accent _subjectMaterial so the path reads against the rock.
+// =============================================================================
+
+import { cone, sphere } from '../../../sdf/d3.js';
+import { union } from '../../../sdf/dn.js';
+import { resolveMaterial } from '../../spec.js';
+
+const TRAIL_ACCENT = { hue: 0.08, sat: 0.85, value: 0.92 }; // warm summit-trail accent
+
+/**
+ * @param {object} opts
+ * @param {number} [opts.height=2.4]      main-peak height (base sits on y=0)
+ * @param {number} [opts.baseRadius=1.5]  main-peak base radius
+ * @param {number} [opts.sidePeaks=2]     flanking peaks (0..2)
+ * @param {number} [opts.spread=1.7]      x offset of side peaks
+ * @param {number} [opts.sideScale=0.6]   side-peak size vs main
+ * @param {number} [opts.pathMarkers=4]   trail markers up the front face
+ * @param {number} [opts.markerRadius=0.13] trail marker radius
+ * @returns {SDF3}
+ */
+export function mountain3dSDF({
+  height = 2.4,
+  baseRadius = 1.5,
+  sidePeaks = 2,
+  spread = 1.7,
+  sideScale = 0.6,
+  pathMarkers = 4,
+  markerRadius = 0.13,
+} = {}) {
+  const parts = [];
+  // main peak — cone is centred on its own height, lift base to y=0
+  parts.push(cone(height, baseRadius).translate([0, height / 2, 0]));
+
+  // flanking peaks, slightly back and to the sides
+  const S = Math.max(0, Math.min(2, Math.floor(sidePeaks)));
+  const sh = height * sideScale;
+  const sr = baseRadius * sideScale;
+  if (S >= 1) parts.push(cone(sh, sr).translate([-spread, sh / 2, -0.5]));
+  if (S >= 2) parts.push(cone(sh * 0.9, sr * 0.95).translate([spread * 0.95, (sh * 0.9) / 2, -0.6]));
+
+  // trail of markers zig-zagging up the front face (z+) of the main peak
+  const M = Math.max(0, Math.floor(pathMarkers));
+  const accent = resolveMaterial(TRAIL_ACCENT);
+  for (let i = 0; i < M; i++) {
+    const t = (i + 0.5) / M; // 0..1 up the peak
+    const y = t * height * 0.82;
+    const rAtY = baseRadius * (1 - y / height); // cone radius shrinks with height
+    const x = (i % 2 === 0 ? -1 : 1) * Math.min(0.45, rAtY * 0.5); // zig-zag
+    const z = rAtY * 0.86 + markerRadius * 0.4; // sit on the front slope
+    const m = sphere(markerRadius).translate([x, y + markerRadius, z]);
+    if (accent) m._subjectMaterial = accent;
+    parts.push(m);
+  }
+
+  return parts.length === 1 ? parts[0] : union(...parts);
+}
+
+export const mountain3dSpec = {
+  type: 'mountain-3d',
+  category: 'shapes',
+  args: {
+    height: { type: 'number', default: 2.4, doc: 'Main-peak height' },
+    baseRadius: { type: 'number', default: 1.5, doc: 'Main-peak base radius' },
+    sidePeaks: { type: 'number', default: 2, doc: 'Flanking peaks (0..2)' },
+    spread: { type: 'number', default: 1.7, doc: 'x offset of side peaks' },
+    sideScale: { type: 'number', default: 0.6, doc: 'Side-peak scale vs main' },
+    pathMarkers: { type: 'number', default: 4, doc: 'Trail markers up the front' },
+    markerRadius: { type: 'number', default: 0.13, doc: 'Trail marker radius' },
+  },
+  examples: [
+    { name: 'Summit + trail', args: { pathMarkers: 4 } },
+    { name: 'Lone peak', args: { sidePeaks: 0, pathMarkers: 5 } },
+    { name: 'Range', args: { sidePeaks: 2, pathMarkers: 0 } },
+  ],
+  description: 'Mountain massif with an ascending trail — the climb-to-goal metaphor',
+  source: {
+    author: 'Atlas',
+    builtAt: '2026-06-25',
+    builder: 'Polish round — recommendations coverage (Mountain Path)',
+    license: 'PolyForm Noncommercial 1.0.0',
+  },
+};

--- a/sdf-js/src/scene/lift-2d-to-3d.js
+++ b/sdf-js/src/scene/lift-2d-to-3d.js
@@ -50,7 +50,7 @@ const HUE_BY_TYPE = {
   // org / tree — cyan
   'org-chart': 0.54, 'tree-diagram': 0.54, 'sphere-tree': 0.54,
   // grid / blocks — steel blue
-  'matrix-grid': 0.60, cube: 0.60, 'cube-grid': 0.60, 'cube-segmented': 0.60,
+  'matrix-grid': 0.60, cube: 0.60, 'cube-grid': 0.60, 'cube-segmented': 0.60, 'icon-grid': 0.60,
   // misc
   'sphere-segmented': 0.50, 'kpi-card': 0.58, fishbone: 0.40, diamond: 0.58, gear: 0.58, arrow: 0.58, 'traffic-light': 0.58,
 };
@@ -564,6 +564,17 @@ export const TWIN_MAP = {
         args: { height: 2.6, baseRadius: 1.6, sidePeaks: 2, pathMarkers: a.markers ?? Math.max(3, stages.length || 4) },
         transform: { translate: [0, 0, 0] },
         overlay: rightCards(stages.map(itemLabel)),
+      };
+    },
+  },
+
+  // icon set — a wall of pictogram tiles
+  'icon-grid': {
+    to: 'icon-grid-3d',
+    lift(a) {
+      return {
+        args: { rows: a.rows ?? 2, cols: a.cols ?? 4, glyphs: a.glyphs ?? null },
+        transform: { translate: [0, 1.9, 0] },
       };
     },
   },

--- a/sdf-js/src/scene/lift-2d-to-3d.js
+++ b/sdf-js/src/scene/lift-2d-to-3d.js
@@ -122,6 +122,37 @@ export function coverCamera(target = [0, 1.6, 0]) {
   };
 }
 
+// ── per-slide-type camera moves: a subtle motion that suits the shape, instead of one
+//    push-in for everything. All 2-shot blends that settle to a clean front framing. ──
+const two = (a, b) => ({ loop: false, shots: [{ ...a, duration: 0.01, aperture: 0, ease: 'smooth' }, { ...b, duration: 14, transition: 'blend', aperture: 0, ease: 'smooth' }] });
+
+// radial / network — swing around to the front (orbit-in)
+function orbitIn(t, d = 8.4) {
+  return two({ pos: [d * 0.78, t[1] + 0.7, d * 0.62], target: t, fov: 48, focalDistance: d }, { pos: [0, t[1] + 0.2, d], target: t, fov: 46, focalDistance: d });
+}
+// horizontal sequences (timeline/gantt/bars) — glide laterally while pushing in
+function lateralPan(t, d = 8.4) {
+  return two({ pos: [-d * 0.5, t[1] + 0.55, d * 0.95], target: t, fov: 50, focalDistance: d }, { pos: [d * 0.18, t[1] + 0.2, d * 0.88], target: t, fov: 47, focalDistance: d });
+}
+// tall shapes (funnel/pyramid/mountain/stacks) — crane up from a low hero angle
+function craneUp(t, d = 8.4) {
+  const tgt = [t[0], t[1] + 0.3, t[2]];
+  return two({ pos: [0.6, t[1] - 0.9, d + 1.4], target: tgt, fov: 52, focalDistance: d }, { pos: [0, t[1] + 0.6, d], target: tgt, fov: 46, focalDistance: d });
+}
+
+const CAMERA_BY_TYPE = {
+  'sphere-network': orbitIn, mindmap: orbitIn, 'radial-spoke': orbitIn, 'relationship-graph': orbitIn,
+  pie: orbitIn, venn: orbitIn, 'circle-segmented': orbitIn, 'circle-loop': orbitIn, 'sphere-segmented': orbitIn,
+  timeline: lateralPan, gantt: lateralPan, progression: lateralPan, 'flow-chart': lateralPan,
+  bar: lateralPan, column: lateralPan, line: lateralPan,
+  funnel: craneUp, pyramid: craneUp, mountain: craneUp, 'layer-stack': craneUp, 'circle-stack': craneUp,
+};
+
+function cameraFor(type2d, target) {
+  const fn = CAMERA_BY_TYPE[type2d];
+  return fn ? fn(target) : pushInCamera(target);
+}
+
 // ── value formatting (2D atoms carry format: 'number'|'percent'|'currency') ──
 export function fmt(v, format) {
   if (v == null || Number.isNaN(Number(v))) return String(v ?? '');
@@ -629,12 +660,13 @@ export function liftSceneData2dTo3d(scene2d) {
   }
 
   const target = [0, 1.6, 0];
+  const primaryType = scene2d.subjects?.[0]?.type;
   return {
     v: 1,
     name: `(lifted) ${scene2d.name || scene2d.subjects?.[0]?.type || 'scene'}`,
     subjects,
     overlay,
-    cameraSequence: scene2d.cover ? coverCamera(target) : pushInCamera(target),
+    cameraSequence: scene2d.cover ? coverCamera(target) : cameraFor(primaryType, target),
     defaults: { stage: { size: [18, 9, 11] } },
   };
 }

--- a/sdf-js/src/scene/lift-2d-to-3d.js
+++ b/sdf-js/src/scene/lift-2d-to-3d.js
@@ -55,7 +55,13 @@ const HUE_BY_TYPE = {
   'sphere-segmented': 0.50, 'kpi-card': 0.58, fishbone: 0.40, diamond: 0.58, gear: 0.58, arrow: 0.58, 'traffic-light': 0.58,
 };
 
+// full-material overrides for atoms whose look needs more than a hue swap
+const MATERIAL_OVERRIDE = {
+  mountain: { hue: 0.6, sat: 0.24, value: 0.62, roughness: 0.55, clearcoat: 0.15 }, // rock
+};
+
 function materialFor(type2d) {
+  if (MATERIAL_OVERRIDE[type2d]) return { ...DEFAULT_MAT, ...MATERIAL_OVERRIDE[type2d] };
   const hue = HUE_BY_TYPE[type2d];
   if (hue == null) return { ...DEFAULT_MAT };
   // warm hues (reds/oranges/golds) turn muddy brown at the default value/sat — brighten
@@ -545,6 +551,19 @@ export const TWIN_MAP = {
         args: { levels: [frac], radius: 1.1 },
         transform: { translate: [0, 1.4, 0] },
         overlay: [{ text: fmt(a.value, a.format ?? 'percent'), anchor: [0, 1.4, 1.2], role: 'value', radius: 0.6 }],
+      };
+    },
+  },
+
+  // summit / journey metaphor — a real mountain with an ascending trail
+  mountain: {
+    to: 'mountain-3d',
+    lift(a) {
+      const stages = a.stages || a.steps || a.layers || [];
+      return {
+        args: { height: 2.6, baseRadius: 1.6, sidePeaks: 2, pathMarkers: a.markers ?? Math.max(3, stages.length || 4) },
+        transform: { translate: [0, 0, 0] },
+        overlay: rightCards(stages.map(itemLabel)),
       };
     },
   },

--- a/sdf-js/src/scene/lift-2d-to-3d.js
+++ b/sdf-js/src/scene/lift-2d-to-3d.js
@@ -251,7 +251,7 @@ export const TWIN_MAP = {
         radius: 0.32,
       }));
       return {
-        args: { values: norm, barWidth, barDepth: 0.55, gap, maxHeight },
+        args: { values: norm, barWidth, barDepth: 0.55, gap, maxHeight, colors: shades(HUE_BY_TYPE.bar, norm.length) },
         transform: { translate: [0, ty, 0] },
         overlay,
       };
@@ -370,7 +370,19 @@ export const TWIN_MAP = {
   'agenda-list': itemsTwin('agenda-list-3d', 'items', 'items'),
   'bullet-list': itemsTwin('bullet-list-3d', 'items', 'items'),
   progression: itemsTwin('progression-3d', 'steps', 'steps', { transform: { translate: [-1.0, 0.6, 0] } }),
-  pyramid: itemsTwin('pyramid-3d', 'layers', 'levels', { transform: { translate: [0, 0.6, 0] } }),
+  pyramid: {
+    to: 'pyramid-3d',
+    lift(a) {
+      const arr = asArray(a.layers);
+      const n = arr.length || (typeof a.layers === 'number' ? a.layers : 0) || 3;
+      const labels = arr.map(itemLabel).filter(Boolean);
+      return {
+        args: { levels: n, colors: shades(HUE_BY_TYPE.pyramid, n) },
+        transform: { translate: [0, 0.6, 0] },
+        overlay: rightCards(labels.length ? labels : a.labels || []),
+      };
+    },
+  },
   'traffic-light': itemsTwin('traffic-light-3d', 'lights', 'lights', { transform: { translate: [0, 1.8, 0] } }),
   'circle-stack': {
     to: 'circle-stack-3d',

--- a/sdf-js/src/scene/spec.js
+++ b/sdf-js/src/scene/spec.js
@@ -213,6 +213,7 @@ export const PRIMITIVE_TYPES = new Set([
   'circle-stack-3d',
   'circle-segmented-3d',
   'mountain-3d',
+  'icon-grid-3d',
   'circle-loop-3d',
   // Sprint 4 node-edge charts — sphere/box nodes + capsule edges (+ cone arrows).
   'relationship-graph-3d',

--- a/sdf-js/src/scene/spec.js
+++ b/sdf-js/src/scene/spec.js
@@ -212,6 +212,7 @@ export const PRIMITIVE_TYPES = new Set([
   'circle-frame-3d',
   'circle-stack-3d',
   'circle-segmented-3d',
+  'mountain-3d',
   'circle-loop-3d',
   // Sprint 4 node-edge charts — sphere/box nodes + capsule edges (+ cone arrows).
   'relationship-graph-3d',


### PR DESCRIPTION
打磨 backlog #2:普通页都统一推入 → 按页型配运镜(`CAMERA_BY_TYPE`):

- **orbitIn** —— 放射/网络(sphere-network/mindmap/radial-spoke/pie/venn/circle-segmented·loop):绕到正面
- **lateralPan** —— 横向序列(timeline/gantt/progression/flow-chart/bar/column/line):侧向滑入
- **craneUp** —— 高瘦形(funnel/pyramid/mountain/layer-stack/circle-stack):低角度起摇上升
- **pushIn** —— 其余(matrix/icon 网格、org/tree、cube)不变;封面仍用 coverCamera

都是 2-shot blend 收到干净正面构图。Playwright 验证 craneUp(funnel)/orbitIn(network)终帧构图正常。`npm test` 100/100。

> 注:本 PR stack 在 #182 之上(都改 lift-2d-to-3d.js)。建议 merge 顺序 #181 → #182 → #183;如冲突我来 rebase。

🤖 Generated with [Claude Code](https://claude.com/claude-code)