### PR TITLE
Sprint 22 B4: 4 PL-rec atoms (funnel-with-conversion / pillar-3up / testimonial-wall / balance-scale)

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -180,6 +180,8 @@ const TESTS = [
   { category: 'present', file: 'sdf-js/scripts/test-sprint22-batch2-atoms.mjs' },
   // Sprint 22 Batch 3 — new atoms (risk-heatmap / org-vs-org-matrix / kanban-board / donut-with-center)
   { category: 'present', file: 'sdf-js/scripts/test-sprint22-batch3-atoms.mjs' },
+  // Sprint 22 Batch 4 — new atoms (funnel-with-conversion / pillar-3up / testimonial-wall / balance-scale)
+  { category: 'present', file: 'sdf-js/scripts/test-sprint22-batch4-atoms.mjs' },
 ];
 
 // -----------------------------------------------------------------------------

--- a/sdf-js/examples/scaffold-pipeline/sprint22-b4-atomdemo/deck.json
+++ b/sdf-js/examples/scaffold-pipeline/sprint22-b4-atomdemo/deck.json
@@ -1,0 +1,67 @@
+{
+  "deckName": "sprint22-b4-atomdemo",
+  "scaffold": {
+    "id": "demo",
+    "label": "Sprint 22 B4 Atom Demo",
+    "description": "Direct render of 4 PL-rec atoms (funnel-with-conversion / pillar-3up / testimonial-wall / balance-scale)",
+    "pickScore": 0,
+    "pickSignals": ["manual demo"],
+    "fallback": false,
+    "pickerMethod": "manual"
+  },
+  "theme": {
+    "id": "finance-navy-gold",
+    "label": "Finance Navy Gold",
+    "macroCluster": "editorial",
+    "bg": [20, 28, 50],
+    "accent": [200, 160, 50],
+    "colors": [
+      [80, 130, 220],
+      [200, 160, 50],
+      [60, 180, 140],
+      [180, 80, 160],
+      [220, 100, 60]
+    ],
+    "silhouetteColor": [240, 240, 240]
+  },
+  "meta": { "model": "manual-demo", "timestamp": "2026-06-28" },
+  "totals": { "slotsBaked": 4, "slotsEmpty": 0, "totalCostUSD": 0 },
+  "slots": [
+    {
+      "slotIdx": 0,
+      "slotName": "funnel",
+      "slotTitle": "funnel-with-conversion",
+      "slotPurpose": "SaaS conversion funnel with % chips between stages",
+      "sourceSlideIdx": 0,
+      "subjectTypes": ["funnel-with-conversion"],
+      "liftFile": "slots/slot-00-funnel-with-conversion.json"
+    },
+    {
+      "slotIdx": 1,
+      "slotName": "pillars",
+      "slotTitle": "pillar-3up",
+      "slotPurpose": "Three pillars hero card layout",
+      "sourceSlideIdx": 1,
+      "subjectTypes": ["pillar-3up"],
+      "liftFile": "slots/slot-01-pillar-3up.json"
+    },
+    {
+      "slotIdx": 2,
+      "slotName": "testimonials",
+      "slotTitle": "testimonial-wall",
+      "slotPurpose": "Social proof 3-card testimonial grid",
+      "sourceSlideIdx": 2,
+      "subjectTypes": ["testimonial-wall"],
+      "liftFile": "slots/slot-02-testimonial-wall.json"
+    },
+    {
+      "slotIdx": 3,
+      "slotName": "balance",
+      "slotTitle": "balance-scale",
+      "slotPurpose": "Build vs Buy decision balance scale",
+      "sourceSlideIdx": 3,
+      "subjectTypes": ["balance-scale"],
+      "liftFile": "slots/slot-03-balance-scale.json"
+    }
+  ]
+}

--- a/sdf-js/examples/scaffold-pipeline/sprint22-b4-atomdemo/slots/slot-00-funnel-with-conversion.json
+++ b/sdf-js/examples/scaffold-pipeline/sprint22-b4-atomdemo/slots/slot-00-funnel-with-conversion.json
@@ -1,0 +1,27 @@
+{
+  "slotIdx": 0,
+  "slotName": "funnel",
+  "slotTitle": "funnel-with-conversion",
+  "sceneData": {
+    "subjects": [
+      {
+        "type": "funnel-with-conversion",
+        "x": 0,
+        "y": 0,
+        "w": 1280,
+        "h": 720,
+        "args": {
+          "title": "SaaS Conversion Funnel",
+          "stages": [
+            { "label": "Website Visitors", "value": 100000 },
+            { "label": "Free Signups", "value": 12000 },
+            { "label": "Trial Active", "value": 4200 },
+            { "label": "Paid Customers", "value": 760 }
+          ],
+          "showAbsolute": true,
+          "showConversion": true
+        }
+      }
+    ]
+  }
+}

--- a/sdf-js/examples/scaffold-pipeline/sprint22-b4-atomdemo/slots/slot-01-pillar-3up.json
+++ b/sdf-js/examples/scaffold-pipeline/sprint22-b4-atomdemo/slots/slot-01-pillar-3up.json
@@ -1,0 +1,37 @@
+{
+  "slotIdx": 1,
+  "slotName": "pillars",
+  "slotTitle": "pillar-3up",
+  "sceneData": {
+    "subjects": [
+      {
+        "type": "pillar-3up",
+        "x": 0,
+        "y": 0,
+        "w": 1280,
+        "h": 720,
+        "args": {
+          "title": "Our Three Pillars",
+          "pillars": [
+            {
+              "icon": "lightning",
+              "heading": "Speed",
+              "body": "Sub-100ms response across all queries, globally distributed edge infrastructure."
+            },
+            {
+              "icon": "shield-check",
+              "heading": "Security",
+              "body": "SOC 2 Type II certified. Zero-trust architecture with encryption at rest and in transit."
+            },
+            {
+              "icon": "globe",
+              "heading": "Scale",
+              "body": "100+ regions, auto-scaling infrastructure, zero operational burden for your team."
+            }
+          ],
+          "accentLine": true
+        }
+      }
+    ]
+  }
+}

--- a/sdf-js/examples/scaffold-pipeline/sprint22-b4-atomdemo/slots/slot-02-testimonial-wall.json
+++ b/sdf-js/examples/scaffold-pipeline/sprint22-b4-atomdemo/slots/slot-02-testimonial-wall.json
@@ -1,0 +1,36 @@
+{
+  "slotIdx": 2,
+  "slotName": "testimonials",
+  "slotTitle": "testimonial-wall",
+  "sceneData": {
+    "subjects": [
+      {
+        "type": "testimonial-wall",
+        "x": 0,
+        "y": 0,
+        "w": 1280,
+        "h": 720,
+        "args": {
+          "title": "What Our Customers Say",
+          "testimonials": [
+            {
+              "quote": "Cut our deployment time from 2 weeks to 2 hours. The team is now shipping daily.",
+              "name": "Sarah Chen",
+              "role": "VP Engineering, Acme Corp"
+            },
+            {
+              "quote": "The analytics dashboard is the first thing my team opens every single morning.",
+              "name": "Marcus Johnson",
+              "role": "CFO, BrightWave"
+            },
+            {
+              "quote": "Onboarding was the easiest we've ever experienced. Three days to first value.",
+              "name": "Priya Sharma",
+              "role": "COO, Meridian"
+            }
+          ]
+        }
+      }
+    ]
+  }
+}

--- a/sdf-js/examples/scaffold-pipeline/sprint22-b4-atomdemo/slots/slot-03-balance-scale.json
+++ b/sdf-js/examples/scaffold-pipeline/sprint22-b4-atomdemo/slots/slot-03-balance-scale.json
@@ -1,0 +1,34 @@
+{
+  "slotIdx": 3,
+  "slotName": "balance",
+  "slotTitle": "balance-scale",
+  "sceneData": {
+    "subjects": [
+      {
+        "type": "balance-scale",
+        "x": 0,
+        "y": 0,
+        "w": 1280,
+        "h": 720,
+        "args": {
+          "title": "Build vs Buy Analysis",
+          "leftLabel": "BUILD",
+          "rightLabel": "BUY",
+          "leftItems": [
+            "Full control over roadmap",
+            "IP retention",
+            "Custom fit to workflow",
+            "No vendor lock-in"
+          ],
+          "rightItems": [
+            "Faster time to market",
+            "Lower upfront cost",
+            "Vendor SLA & support",
+            "Proven at scale"
+          ],
+          "verdict": "Recommendation: Buy for v1, Build for v2"
+        }
+      }
+    ]
+  }
+}

--- a/sdf-js/scripts/bake-scaffold-pipeline.mjs
+++ b/sdf-js/scripts/bake-scaffold-pipeline.mjs
@@ -489,7 +489,11 @@ for (const a of slotAssignments) {
     `    - 5×5 risk grid (Cybersecurity / Risk Assessment) with likelihood × impact cells → \`risk-heatmap\` (NOT generic \`matrix-grid\`)\n` +
     `    - Competitive positioning 2×2 (Magic Quadrant style) with org/company bubbles → \`org-vs-org-matrix\` (NOT generic \`matrix-grid\`)\n` +
     `    - Project status board with column workflow (Backlog / In Progress / Done) → \`kanban-board\` (NOT generic \`flow-chart\`)\n` +
-    `    - Donut chart with prominent center metric / hero KPI value in the ring hole → \`donut-with-center\` (NOT generic \`pie\`)\n`;
+    `    - Donut chart with prominent center metric / hero KPI value in the ring hole → \`donut-with-center\` (NOT generic \`pie\`)\n` +
+    `    - Funnel with explicit conversion % chips between stages (SaaS 12% → 35% → 18%) → \`funnel-with-conversion\` (NOT generic \`funnel\`)\n` +
+    `    - 2-4 tall hero pillar cards side-by-side (Three Pillars / Three Principles / Our Values) → \`pillar-3up\` (NOT \`feature-card-grid\`)\n` +
+    `    - Row of 2-4 customer quote/testimonial cards (social proof, "What our customers say") → \`testimonial-wall\` (NOT \`bullet-list\`)\n` +
+    `    - Build vs Buy / Pros vs Cons / Left vs Right two-side comparison with visual scale → \`balance-scale\` (NOT \`swot\` or \`cost-benefit-matrix\`)\n`;
 
   if (DRY_RUN) {
     slotLifts.push({

--- a/sdf-js/scripts/lift-sprint22-b4-demo.mjs
+++ b/sdf-js/scripts/lift-sprint22-b4-demo.mjs
@@ -1,0 +1,118 @@
+// lift-sprint22-b4-demo.mjs — Sprint 22 B4: lift 4 new PL-rec atoms.
+//
+// Run: node sdf-js/scripts/lift-sprint22-b4-demo.mjs  (from repo root)
+
+import { writeFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+import { liftSceneData2dTo3d } from '../src/scene/lift-2d-to-3d.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const SCENES = resolve(__dirname, '../scenes');
+
+const SAMPLES = [
+  {
+    name: 'lifted-funnel-with-conversion',
+    subjects: [
+      {
+        type: 'funnel-with-conversion',
+        args: {
+          title: 'SaaS Conversion Funnel',
+          stages: [
+            { label: 'Website Visitors', value: 100000 },
+            { label: 'Free Signups', value: 12000 },
+            { label: 'Trial Active', value: 4200 },
+            { label: 'Paid Customers', value: 760 },
+          ],
+          showAbsolute: true,
+          showConversion: true,
+        },
+      },
+    ],
+  },
+  {
+    name: 'lifted-pillar-3up',
+    subjects: [
+      {
+        type: 'pillar-3up',
+        args: {
+          title: 'Our Three Pillars',
+          pillars: [
+            {
+              icon: 'lightning',
+              heading: 'Speed',
+              body: 'Sub-100ms response across all queries, globally distributed edge.',
+            },
+            {
+              icon: 'shield-check',
+              heading: 'Security',
+              body: 'SOC 2 Type II + zero-trust + encryption at rest and in transit.',
+            },
+            {
+              icon: 'globe',
+              heading: 'Scale',
+              body: '100+ regions, auto-scaling infrastructure, no operational burden.',
+            },
+          ],
+          accentLine: true,
+        },
+      },
+    ],
+  },
+  {
+    name: 'lifted-testimonial-wall',
+    subjects: [
+      {
+        type: 'testimonial-wall',
+        args: {
+          title: 'What Our Customers Say',
+          testimonials: [
+            {
+              quote: 'Cut our deployment time from 2 weeks to 2 hours.',
+              name: 'Sarah Chen',
+              role: 'VP Engineering, Acme Corp',
+            },
+            {
+              quote: 'The dashboard is the first thing my team opens every morning.',
+              name: 'Marcus Johnson',
+              role: 'CFO, BrightWave',
+            },
+            {
+              quote: "Onboarding was the easiest we've ever done. 3 days to value.",
+              name: 'Priya Sharma',
+              role: 'COO, Meridian',
+            },
+          ],
+        },
+      },
+    ],
+  },
+  {
+    name: 'lifted-balance-scale',
+    subjects: [
+      {
+        type: 'balance-scale',
+        args: {
+          title: 'Build vs Buy Analysis',
+          leftLabel: 'BUILD',
+          rightLabel: 'BUY',
+          leftItems: ['Full control', 'IP retention', 'Custom fit', 'No vendor lock-in'],
+          rightItems: ['Faster to market', 'Lower upfront cost', 'Vendor SLA', 'Proven at scale'],
+          verdict: 'Recommendation: Buy for v1, Build for v2',
+        },
+      },
+    ],
+  },
+];
+
+let allOk = true;
+for (const s of SAMPLES) {
+  const lifted = liftSceneData2dTo3d(s);
+  const path = resolve(SCENES, `${s.name}.json`);
+  writeFileSync(path, `${JSON.stringify(lifted, null, 2)}\n`);
+  const subject3dType = lifted.subjects[0].type;
+  const verdict = `✓ ${subject3dType}`;
+  console.log(`  ${verdict}  →  scenes/${s.name}.json  (${s.subjects[0].type} → ${subject3dType})`);
+}
+console.log(`\n${SAMPLES.length} scenes lifted. ${allOk ? 'All OK.' : 'ERRORS detected.'}`);
+if (!allOk) process.exit(1);

--- a/sdf-js/scripts/test-lift-2d-to-3d.mjs
+++ b/sdf-js/scripts/test-lift-2d-to-3d.mjs
@@ -452,5 +452,102 @@ ok(fmt(7, 'number') === '7', 'fmt number');
   ok(cards.some((c) => c.text === 'Enterprise'), 'donut-with-center: segment labels in overlay');
 }
 
+// ── Sprint 22 B4: funnel-with-conversion → funnel-3d ──
+{
+  const out = liftSceneData2dTo3d({
+    subjects: [
+      {
+        type: 'funnel-with-conversion',
+        args: {
+          title: 'SaaS Funnel',
+          stages: [
+            { label: 'Visitors', value: 100000 },
+            { label: 'Signups', value: 12000 },
+            { label: 'Trials', value: 4200 },
+            { label: 'Paid', value: 760 },
+          ],
+        },
+      },
+    ],
+  });
+  ok(out.subjects[0].type === 'funnel-3d', 'funnel-with-conversion → funnel-3d');
+  ok(out.subjects[0].args.stages === 4, 'funnel-with-conversion: stages = stages.length (4)');
+  const cards = out.overlay.filter((o) => o.role === 'card');
+  ok(cards.some((c) => c.text.includes('Visitors')), 'funnel-with-conversion: stage labels in overlay');
+  ok(cards.some((c) => c.text.includes('Paid')), 'funnel-with-conversion: last stage label in overlay');
+}
+
+// ── Sprint 22 B4: pillar-3up → column-3d ──
+{
+  const out = liftSceneData2dTo3d({
+    subjects: [
+      {
+        type: 'pillar-3up',
+        args: {
+          title: 'Our Three Pillars',
+          pillars: [
+            { icon: 'lightning', heading: 'Speed', body: 'Fast.' },
+            { icon: 'shield-check', heading: 'Security', body: 'Safe.' },
+            { icon: 'globe', heading: 'Scale', body: 'Big.' },
+          ],
+        },
+      },
+    ],
+  });
+  ok(out.subjects[0].type === 'column-3d', 'pillar-3up → column-3d');
+  ok(out.subjects[0].args.columns === 3, 'pillar-3up: columns = pillars.length (3)');
+  const cards = out.overlay.filter((o) => o.role === 'card');
+  ok(cards.some((c) => c.text === 'Speed'), 'pillar-3up: pillar heading in overlay');
+}
+
+// ── Sprint 22 B4: testimonial-wall → matrix-grid-3d ──
+{
+  const out = liftSceneData2dTo3d({
+    subjects: [
+      {
+        type: 'testimonial-wall',
+        args: {
+          title: 'What Customers Say',
+          testimonials: [
+            { quote: 'Great product.', name: 'Alice', role: 'CEO, Corp A' },
+            { quote: 'Loved it.', name: 'Bob', role: 'CTO, Corp B' },
+            { quote: 'Best tool.', name: 'Carol', role: 'VP, Corp C' },
+          ],
+        },
+      },
+    ],
+  });
+  ok(out.subjects[0].type === 'matrix-grid-3d', 'testimonial-wall → matrix-grid-3d');
+  ok(out.subjects[0].args.rows === 1 && out.subjects[0].args.cols === 3, 'testimonial-wall: rows=1 cols=3');
+  const cards = out.overlay.filter((o) => o.role === 'card');
+  ok(cards.some((c) => c.text.includes('Alice')), 'testimonial-wall: name in overlay');
+}
+
+// ── Sprint 22 B4: balance-scale → venn-3d ──
+{
+  const out = liftSceneData2dTo3d({
+    subjects: [
+      {
+        type: 'balance-scale',
+        args: {
+          title: 'Build vs Buy',
+          leftLabel: 'BUILD',
+          rightLabel: 'BUY',
+          leftItems: ['Full control', 'IP retention'],
+          rightItems: ['Faster to market', 'Lower cost'],
+          verdict: 'Buy for v1',
+        },
+      },
+    ],
+  });
+  ok(out.subjects[0].type === 'venn-3d', 'balance-scale → venn-3d');
+  ok(out.subjects[0].args.sets === 2, 'balance-scale: sets = 2');
+  const cards = out.overlay.filter((o) => o.role === 'card');
+  ok(cards.some((c) => c.text === 'BUILD'), 'balance-scale: leftLabel in overlay');
+  ok(cards.some((c) => c.text === 'BUY'), 'balance-scale: rightLabel in overlay');
+  const vals = out.overlay.filter((o) => o.role === 'value');
+  ok(vals.some((v) => v.text === 'Buy for v1'), 'balance-scale: verdict → value overlay');
+}
+
 console.log(`\n${pass} passed, ${fail} failed`);
 process.exit(fail ? 1 : 0);

--- a/sdf-js/scripts/test-sprint22-batch4-atoms.mjs
+++ b/sdf-js/scripts/test-sprint22-batch4-atoms.mjs
@@ -1,0 +1,335 @@
+#!/usr/bin/env node
+// Smoke test for Sprint 22 Batch 4 atoms:
+// funnel-with-conversion, pillar-3up, testimonial-wall, balance-scale
+
+import { isAtom2DType, getAtomSpec, renderAtom } from '../src/present/atoms-2d/registry.js';
+import { buildAtomCatalogString, _resetCatalogCache } from '../src/present/atoms-2d/catalog.js';
+
+let pass = 0;
+let fail = 0;
+
+function ok(label, cond) {
+  if (cond) {
+    pass++;
+    console.log('  ✓ ' + label);
+  } else {
+    fail++;
+    console.log('  ✗ ' + label);
+  }
+}
+
+// Minimal Canvas2D context mock
+const stubCtx = {
+  save() {},
+  restore() {},
+  beginPath() {},
+  moveTo() {},
+  lineTo() {},
+  quadraticCurveTo() {},
+  bezierCurveTo() {},
+  closePath() {},
+  clip() {},
+  fillRect() {},
+  strokeRect() {},
+  fillText() {},
+  measureText() {
+    return { width: 50 };
+  },
+  drawImage() {},
+  createLinearGradient() {
+    return { addColorStop() {} };
+  },
+  createRadialGradient() {
+    return { addColorStop() {} };
+  },
+  arc() {},
+  ellipse() {},
+  arcTo() {},
+  fill() {},
+  stroke() {},
+  rotate() {},
+  translate() {},
+  scale() {},
+  setLineDash() {},
+  rect() {},
+  roundRect() {},
+  set fillStyle(_v) {},
+  set strokeStyle(_v) {},
+  set lineWidth(_v) {},
+  set lineCap(_v) {},
+  set lineJoin(_v) {},
+  set font(_v) {},
+  set textAlign(_v) {},
+  set textBaseline(_v) {},
+  set shadowColor(_v) {},
+  set shadowBlur(_v) {},
+  set shadowOffsetY(_v) {},
+};
+
+console.log('=== Sprint 22 Batch 4 atom smoke ===');
+
+// ──────────────────────────────────────────────────────────────────────────────
+// 1. Registration checks
+// ──────────────────────────────────────────────────────────────────────────────
+console.log('\n-- Registration --');
+ok('funnel-with-conversion registered', isAtom2DType('funnel-with-conversion'));
+ok('pillar-3up registered', isAtom2DType('pillar-3up'));
+ok('testimonial-wall registered', isAtom2DType('testimonial-wall'));
+ok('balance-scale registered', isAtom2DType('balance-scale'));
+
+// ──────────────────────────────────────────────────────────────────────────────
+// 2. Spec checks
+// ──────────────────────────────────────────────────────────────────────────────
+console.log('\n-- Specs --');
+
+const fwcSpec = await getAtomSpec('funnel-with-conversion');
+ok('funnel-with-conversion spec exists', Boolean(fwcSpec));
+ok('funnel-with-conversion spec.type correct', fwcSpec?.type === 'funnel-with-conversion');
+ok('funnel-with-conversion spec has stages (required)', fwcSpec?.args?.stages?.required === true);
+ok('funnel-with-conversion spec has optional title', 'title' in (fwcSpec?.args ?? {}));
+ok('funnel-with-conversion spec has showConversion', 'showConversion' in (fwcSpec?.args ?? {}));
+
+const p3Spec = await getAtomSpec('pillar-3up');
+ok('pillar-3up spec exists', Boolean(p3Spec));
+ok('pillar-3up spec.type correct', p3Spec?.type === 'pillar-3up');
+ok('pillar-3up spec has pillars (required)', p3Spec?.args?.pillars?.required === true);
+ok('pillar-3up spec has optional title', 'title' in (p3Spec?.args ?? {}));
+
+const twSpec = await getAtomSpec('testimonial-wall');
+ok('testimonial-wall spec exists', Boolean(twSpec));
+ok('testimonial-wall spec.type correct', twSpec?.type === 'testimonial-wall');
+ok(
+  'testimonial-wall spec has testimonials (required)',
+  twSpec?.args?.testimonials?.required === true,
+);
+ok('testimonial-wall spec has optional title', 'title' in (twSpec?.args ?? {}));
+
+const bsSpec = await getAtomSpec('balance-scale');
+ok('balance-scale spec exists', Boolean(bsSpec));
+ok('balance-scale spec.type correct', bsSpec?.type === 'balance-scale');
+ok('balance-scale spec has leftLabel (required)', bsSpec?.args?.leftLabel?.required === true);
+ok('balance-scale spec has rightLabel (required)', bsSpec?.args?.rightLabel?.required === true);
+ok('balance-scale spec has leftItems (required)', bsSpec?.args?.leftItems?.required === true);
+ok('balance-scale spec has rightItems (required)', bsSpec?.args?.rightItems?.required === true);
+
+// ──────────────────────────────────────────────────────────────────────────────
+// 3. Render checks — no throw
+// ──────────────────────────────────────────────────────────────────────────────
+console.log('\n-- Render (no-throw) --');
+
+const palette = {
+  bg: [248, 246, 240],
+  silhouetteColor: [30, 27, 30],
+  accent: [42, 130, 200],
+  colors: [
+    [42, 130, 200],
+    [60, 180, 140],
+    [200, 120, 60],
+    [180, 80, 160],
+    [220, 160, 40],
+  ],
+};
+const renderOpts = { x: 0, y: 0, w: 720, h: 480, palette };
+
+// funnel-with-conversion — 4 stages with values
+const r1 = renderAtom(
+  stubCtx,
+  'funnel-with-conversion',
+  {
+    title: 'SaaS Conversion Funnel',
+    stages: [
+      { label: 'Visitors', value: 100000 },
+      { label: 'Signups', value: 12000 },
+      { label: 'Trials', value: 4200 },
+      { label: 'Paid', value: 760 },
+    ],
+    showAbsolute: true,
+    showConversion: true,
+  },
+  'pseudo3d',
+  renderOpts,
+);
+ok('funnel-with-conversion render returns Promise', r1 instanceof Promise);
+await r1;
+ok('funnel-with-conversion 4-stage render resolves without throw', true);
+
+// funnel-with-conversion — no title, showConversion false
+const r1b = renderAtom(
+  stubCtx,
+  'funnel-with-conversion',
+  {
+    stages: [
+      { label: 'Top', value: 1000 },
+      { label: 'Mid', value: 200 },
+      { label: 'Bottom', value: 40 },
+    ],
+    showConversion: false,
+  },
+  'pseudo3d',
+  renderOpts,
+);
+ok('funnel-with-conversion no-title no-conversion resolves without throw', r1b instanceof Promise);
+await r1b;
+
+// funnel-with-conversion — empty stages edge case
+const r1c = renderAtom(stubCtx, 'funnel-with-conversion', { stages: [] }, 'pseudo3d', renderOpts);
+ok('funnel-with-conversion empty stages resolves without throw', r1c instanceof Promise);
+await r1c;
+
+// pillar-3up — 3 pillars with icons
+const r2 = renderAtom(
+  stubCtx,
+  'pillar-3up',
+  {
+    title: 'Our Three Pillars',
+    pillars: [
+      { icon: 'lightning', heading: 'Speed', body: 'Sub-100ms response across all queries.' },
+      {
+        icon: 'shield-check',
+        heading: 'Security',
+        body: 'SOC 2 Type II + zero-trust architecture.',
+      },
+      { icon: 'globe', heading: 'Scale', body: '100+ regions, auto-scaling infrastructure.' },
+    ],
+    accentLine: true,
+  },
+  'pseudo3d',
+  renderOpts,
+);
+ok('pillar-3up render returns Promise', r2 instanceof Promise);
+await r2;
+ok('pillar-3up 3-pillar render resolves without throw', true);
+
+// pillar-3up — 2 pillars, no title, no icons
+const r2b = renderAtom(
+  stubCtx,
+  'pillar-3up',
+  {
+    pillars: [
+      { heading: 'Mission', body: 'We build great software.' },
+      { heading: 'Vision', body: 'A world where shipping is effortless.' },
+    ],
+    accentLine: false,
+  },
+  'pseudo3d',
+  renderOpts,
+);
+ok('pillar-3up 2-pillar no-title resolves without throw', r2b instanceof Promise);
+await r2b;
+
+// pillar-3up — empty pillars edge case
+const r2c = renderAtom(stubCtx, 'pillar-3up', { pillars: [] }, 'pseudo3d', renderOpts);
+ok('pillar-3up empty pillars resolves without throw', r2c instanceof Promise);
+await r2c;
+
+// testimonial-wall — 3 testimonials with title
+const r3 = renderAtom(
+  stubCtx,
+  'testimonial-wall',
+  {
+    title: 'What Our Customers Say',
+    testimonials: [
+      {
+        quote: 'Cut our deployment time from 2 weeks to 2 hours.',
+        name: 'Sarah Chen',
+        role: 'VP Engineering, Acme',
+      },
+      {
+        quote: 'The dashboard is the first thing my team opens every morning.',
+        name: 'Marcus Johnson',
+        role: 'CFO, BrightWave',
+      },
+      {
+        quote: "Onboarding was the easiest we've ever done. 3 days to value.",
+        name: 'Priya Sharma',
+        role: 'COO, Meridian',
+      },
+    ],
+  },
+  'pseudo3d',
+  renderOpts,
+);
+ok('testimonial-wall render returns Promise', r3 instanceof Promise);
+await r3;
+ok('testimonial-wall 3-card render resolves without throw', true);
+
+// testimonial-wall — 2 testimonials, no title, no role
+const r3b = renderAtom(
+  stubCtx,
+  'testimonial-wall',
+  {
+    testimonials: [
+      { quote: 'Amazing product.', name: 'Alice' },
+      { quote: 'Changed how we work.', name: 'Bob' },
+    ],
+  },
+  'pseudo3d',
+  renderOpts,
+);
+ok('testimonial-wall 2-card no-title resolves without throw', r3b instanceof Promise);
+await r3b;
+
+// testimonial-wall — empty testimonials edge case
+const r3c = renderAtom(stubCtx, 'testimonial-wall', { testimonials: [] }, 'pseudo3d', renderOpts);
+ok('testimonial-wall empty testimonials resolves without throw', r3c instanceof Promise);
+await r3c;
+
+// balance-scale — full build vs buy with verdict
+const r4 = renderAtom(
+  stubCtx,
+  'balance-scale',
+  {
+    title: 'Build vs Buy Analysis',
+    leftLabel: 'BUILD',
+    rightLabel: 'BUY',
+    leftItems: ['Full control', 'IP retention', 'Custom fit', 'No vendor lock-in'],
+    rightItems: ['Faster to market', 'Lower upfront cost', 'Vendor SLA', 'Proven reliability'],
+    verdict: 'Recommend: Buy for v1',
+  },
+  'pseudo3d',
+  renderOpts,
+);
+ok('balance-scale render returns Promise', r4 instanceof Promise);
+await r4;
+ok('balance-scale full render resolves without throw', true);
+
+// balance-scale — no title, no verdict
+const r4b = renderAtom(
+  stubCtx,
+  'balance-scale',
+  {
+    leftLabel: 'PROS',
+    rightLabel: 'CONS',
+    leftItems: ['Pro A', 'Pro B'],
+    rightItems: ['Con A'],
+  },
+  'pseudo3d',
+  renderOpts,
+);
+ok('balance-scale no-title no-verdict resolves without throw', r4b instanceof Promise);
+await r4b;
+
+// balance-scale — empty items edge case
+const r4c = renderAtom(
+  stubCtx,
+  'balance-scale',
+  { leftLabel: 'L', rightLabel: 'R', leftItems: [], rightItems: [] },
+  'pseudo3d',
+  renderOpts,
+);
+ok('balance-scale empty items resolves without throw', r4c instanceof Promise);
+await r4c;
+
+// ──────────────────────────────────────────────────────────────────────────────
+// 4. Catalog auto-pickup
+// ──────────────────────────────────────────────────────────────────────────────
+console.log('\n-- Catalog --');
+_resetCatalogCache();
+const catalog = await buildAtomCatalogString();
+ok('catalog includes funnel-with-conversion', catalog.includes('`funnel-with-conversion`'));
+ok('catalog includes pillar-3up', catalog.includes('`pillar-3up`'));
+ok('catalog includes testimonial-wall', catalog.includes('`testimonial-wall`'));
+ok('catalog includes balance-scale', catalog.includes('`balance-scale`'));
+
+console.log(`\n=== Result: ${pass} passed, ${fail} failed ===`);
+if (fail > 0) process.exit(1);

--- a/sdf-js/src/present/atoms-2d/charts/data/funnel-with-conversion.js
+++ b/sdf-js/src/present/atoms-2d/charts/data/funnel-with-conversion.js
@@ -1,0 +1,221 @@
+// =============================================================================
+// atoms-2d/charts/data/funnel-with-conversion.js — Funnel + conversion rate chips
+// -----------------------------------------------------------------------------
+// Like funnel.js but with explicit conversion % chips between consecutive stages.
+// E.g. SaaS funnel: Visitors → (12%) → Signups → (35%) → Trials → (18%) → Paid
+//
+// Args:
+//   title          — optional chart title
+//   stages         — array of { label, value, sublabel? } (3-7) REQUIRED
+//   showAbsolute   — show absolute values inside stages (default true)
+//   showConversion — show conversion % chips between stages (default true)
+// =============================================================================
+
+import { rgbCss, rgbaCss } from '../../renderer.js';
+
+export const spec = {
+  type: 'funnel-with-conversion',
+  category: 'charts/data',
+  description:
+    'Funnel chart with explicit conversion rate % shown between consecutive stages (e.g. SaaS funnel: Visitors → Signups 12% → Trials 35% → Paid 18%).',
+  args: {
+    title: { type: 'string?', example: 'SaaS Conversion Funnel' },
+    stages: {
+      type: 'array of { label, value, sublabel? } (3-7)',
+      required: true,
+      example: [
+        { label: 'Visitors', value: 100000 },
+        { label: 'Signups', value: 12000 },
+        { label: 'Trials', value: 4200 },
+        { label: 'Paid', value: 760 },
+      ],
+    },
+    showAbsolute: { type: 'boolean?', default: true },
+    showConversion: { type: 'boolean?', default: true },
+  },
+};
+
+const PAD = 14;
+const STAGE_GAP = 18; // larger gap to fit conversion chip
+
+export function drawPseudo3D(ctx, args, opts = {}) {
+  const x = opts.x ?? 0;
+  const y = opts.y ?? 0;
+  const w = opts.w ?? 480;
+  const h = opts.h ?? 380;
+  const palette = opts.palette || {};
+  const fg = palette.silhouetteColor || [30, 27, 30];
+  const accent = palette.accent || palette.colors?.[0] || [60, 130, 200];
+  const baseColor = palette.colors?.[0] || [60, 130, 200];
+
+  const stages = Array.isArray(args.stages) ? args.stages : [];
+  const showAbsolute = args.showAbsolute !== false;
+  const showConversion = args.showConversion !== false;
+  const n = stages.length;
+  if (n === 0) return;
+
+  // Background
+  const bgColor = palette.bg ? rgbCss(palette.bg) : '#fafaf8';
+  ctx.fillStyle = bgColor;
+  ctx.fillRect(x, y, w, h);
+
+  // Title
+  let plotTop = y + PAD;
+  if (args.title) {
+    const ts = Math.round(h * 0.065);
+    ctx.fillStyle = rgbCss(fg);
+    ctx.font = `700 ${ts}px Inter, system-ui, sans-serif`;
+    ctx.textAlign = 'left';
+    ctx.textBaseline = 'top';
+    ctx.fillText(args.title, x + PAD, y + PAD);
+    plotTop = y + h * 0.13;
+  }
+
+  // Reserve right column for value annotations
+  const rightColW = 110;
+  const plotH = y + h - plotTop - PAD;
+  const plotW = w - PAD * 2 - rightColW;
+  const cx = x + PAD + plotW / 2;
+  const topY = plotTop;
+  const chipH = STAGE_GAP - 2;
+  const stageH = (plotH - STAGE_GAP * (n - 1)) / n;
+
+  // Width tapering proportional to sqrt(value)
+  const values = stages.map((s) => (s.value != null ? Number(s.value) : null));
+  const firstValue = values[0] || 1;
+  const maxW = plotW * 0.92;
+  const minW = plotW * 0.22;
+
+  const widthAt = (i) => {
+    if (values[i] != null && values[0] != null) {
+      const ratio = Math.sqrt(values[i] / firstValue);
+      const wEdge = minW + (maxW - minW) * ratio;
+      const ratioNext =
+        i + 1 < n && values[i + 1] != null
+          ? Math.sqrt(values[i + 1] / firstValue)
+          : ratio * (minW / maxW);
+      return [wEdge, minW + (maxW - minW) * ratioNext];
+    }
+    const t0 = i / n;
+    const t1 = (i + 1) / n;
+    return [maxW + (minW - maxW) * t0, maxW + (minW - maxW) * t1];
+  };
+
+  const makeStageColor = (i) => {
+    const darken = i * 0.08;
+    return [
+      Math.max(0, Math.round(baseColor[0] * (1 - darken))),
+      Math.max(0, Math.round(baseColor[1] * (1 - darken))),
+      Math.max(0, Math.round(baseColor[2] * (1 - darken))),
+    ];
+  };
+
+  for (let i = 0; i < n; i++) {
+    const [wTop, wBot] = widthAt(i);
+    const topEdgeY = topY + i * (stageH + STAGE_GAP);
+    const botEdgeY = topEdgeY + stageH;
+    const color = makeStageColor(i);
+
+    // Trapezoid stage
+    ctx.save();
+    ctx.shadowColor = 'rgba(0,0,0,0.1)';
+    ctx.shadowBlur = 10;
+    ctx.shadowOffsetY = 2;
+    const grad = ctx.createLinearGradient(0, topEdgeY, 0, botEdgeY);
+    grad.addColorStop(0, rgbCss(lighten(color, 0.08)));
+    grad.addColorStop(1, rgbCss(color));
+    ctx.fillStyle = grad;
+    ctx.beginPath();
+    ctx.moveTo(cx - wTop / 2, topEdgeY);
+    ctx.lineTo(cx + wTop / 2, topEdgeY);
+    ctx.lineTo(cx + wBot / 2, botEdgeY);
+    ctx.lineTo(cx - wBot / 2, botEdgeY);
+    ctx.closePath();
+    ctx.fill();
+    ctx.restore();
+
+    // Border
+    ctx.save();
+    ctx.strokeStyle = rgbaCss(color, 0.25);
+    ctx.lineWidth = 1.5;
+    ctx.beginPath();
+    ctx.moveTo(cx - wTop / 2, topEdgeY);
+    ctx.lineTo(cx + wTop / 2, topEdgeY);
+    ctx.lineTo(cx + wBot / 2, botEdgeY);
+    ctx.lineTo(cx - wBot / 2, botEdgeY);
+    ctx.closePath();
+    ctx.stroke();
+    ctx.restore();
+
+    // Labels inside stage
+    const stageCy = (topEdgeY + botEdgeY) / 2;
+    const labelFs = Math.min(14, stageH * 0.28);
+    const subFs = Math.min(11, stageH * 0.2);
+
+    ctx.save();
+    ctx.shadowColor = 'rgba(0,0,0,0.35)';
+    ctx.shadowBlur = 2;
+    ctx.fillStyle = 'rgba(255,255,255,0.97)';
+    ctx.font = `700 ${labelFs}px Inter, system-ui, sans-serif`;
+    ctx.textAlign = 'center';
+    ctx.textBaseline = 'middle';
+    const hasSubLine = showAbsolute && stages[i].value != null;
+    ctx.fillText(stages[i].label || '', cx, stageCy - (hasSubLine ? stageH * 0.1 : 0));
+    ctx.restore();
+
+    if (hasSubLine) {
+      ctx.save();
+      ctx.shadowColor = 'rgba(0,0,0,0.25)';
+      ctx.shadowBlur = 1;
+      ctx.fillStyle = 'rgba(255,255,255,0.75)';
+      ctx.font = `400 ${subFs}px Inter, system-ui, sans-serif`;
+      ctx.textAlign = 'center';
+      ctx.textBaseline = 'middle';
+      ctx.fillText(Number(stages[i].value).toLocaleString(), cx, stageCy + stageH * 0.18);
+      ctx.restore();
+    }
+
+    // Right column value
+    if (stages[i].value != null) {
+      ctx.fillStyle = rgbCss(fg);
+      ctx.font = `600 ${Math.min(12, stageH * 0.25)}px Inter, system-ui, sans-serif`;
+      ctx.textAlign = 'left';
+      ctx.textBaseline = 'middle';
+      ctx.fillText(Number(stages[i].value).toLocaleString(), cx + plotW / 2 + 12, stageCy);
+    }
+
+    // Conversion chip between this stage and next
+    if (showConversion && i < n - 1 && values[i] != null && values[i + 1] != null) {
+      const convRate = ((Number(values[i + 1]) / Number(values[i])) * 100).toFixed(1);
+      const gapCY = botEdgeY + STAGE_GAP / 2;
+      const chipW = Math.min(80, plotW * 0.35);
+
+      // Chip pill background
+      ctx.save();
+      ctx.fillStyle = rgbCss(accent);
+      ctx.beginPath();
+      const chipX = cx - chipW / 2;
+      const chipY = gapCY - chipH / 2;
+      ctx.roundRect(chipX, chipY, chipW, chipH, chipH / 2);
+      ctx.fill();
+      ctx.restore();
+
+      // Chip text
+      ctx.save();
+      ctx.fillStyle = 'rgba(255,255,255,0.97)';
+      ctx.font = `700 ${Math.min(11, chipH * 0.55)}px Inter, system-ui, sans-serif`;
+      ctx.textAlign = 'center';
+      ctx.textBaseline = 'middle';
+      ctx.fillText(`↓ ${convRate}%`, cx, gapCY);
+      ctx.restore();
+    }
+  }
+}
+
+function lighten(rgb, amt) {
+  return [
+    Math.min(255, rgb[0] + (255 - rgb[0]) * amt),
+    Math.min(255, rgb[1] + (255 - rgb[1]) * amt),
+    Math.min(255, rgb[2] + (255 - rgb[2]) * amt),
+  ];
+}

--- a/sdf-js/src/present/atoms-2d/charts/diagrams/balance-scale.js
+++ b/sdf-js/src/present/atoms-2d/charts/diagrams/balance-scale.js
@@ -1,0 +1,276 @@
+// =============================================================================
+// atoms-2d/charts/diagrams/balance-scale.js — Trade-off balance scale
+// -----------------------------------------------------------------------------
+// Pros vs cons / build vs buy / left vs right stylized balance scale. A central
+// beam with two pans, items listed under each pan. PL "left vs right" decision
+// pattern. Different from swot (4 quadrants) and matrix-grid (2x2 cells).
+//
+// Args:
+//   title       — optional title
+//   leftLabel   — label for left pan (e.g. "BUILD")
+//   rightLabel  — label for right pan (e.g. "BUY")
+//   leftItems   — string[] (2-6)
+//   rightItems  — string[] (2-6)
+//   leftAccent  — optional rgb css override
+//   rightAccent — optional rgb css override
+//   verdict     — optional conclusion string
+// =============================================================================
+
+import { rgbCss, rgbaCss } from '../../renderer.js';
+
+export const spec = {
+  type: 'balance-scale',
+  category: 'charts/diagrams',
+  description:
+    'Balance scale comparing items on left vs right. PL pros/cons, build vs buy, before/after pattern.',
+  args: {
+    title: { type: 'string?', example: 'Build vs Buy Analysis' },
+    leftLabel: { type: 'string', required: true, example: 'BUILD' },
+    rightLabel: { type: 'string', required: true, example: 'BUY' },
+    leftItems: {
+      type: 'string[] (2-6)',
+      required: true,
+      example: ['Full control', 'IP retention', 'Custom fit'],
+    },
+    rightItems: {
+      type: 'string[] (2-6)',
+      required: true,
+      example: ['Faster to market', 'Lower upfront cost', 'Vendor SLA'],
+    },
+    leftAccent: { type: 'string?', example: null },
+    rightAccent: { type: 'string?', example: null },
+    verdict: { type: 'string?', example: 'Recommend: Buy for v1' },
+  },
+};
+
+export function drawPseudo3D(ctx, args, opts = {}) {
+  const x = opts.x ?? 0;
+  const y = opts.y ?? 0;
+  const w = opts.w ?? 720;
+  const h = opts.h ?? 480;
+  const palette = opts.palette || {};
+  const fg = palette.silhouetteColor ?? [20, 28, 50];
+  const bgColor = palette.bg ?? [248, 246, 240];
+  const accent = palette.accent ?? [30, 80, 180];
+  const colors = palette.colors ?? [
+    [30, 80, 180],
+    [200, 80, 60],
+    [60, 180, 140],
+  ];
+
+  const leftColor = args.leftAccent ? parseCss(args.leftAccent) : colors[0] || [30, 80, 180];
+  const rightColor = args.rightAccent ? parseCss(args.rightAccent) : colors[1] || [200, 80, 60];
+
+  const leftItems = Array.isArray(args.leftItems) ? args.leftItems : [];
+  const rightItems = Array.isArray(args.rightItems) ? args.rightItems : [];
+
+  ctx.fillStyle = rgbCss(bgColor);
+  ctx.fillRect(x, y, w, h);
+
+  const PAD = 20;
+  let plotTop = y + PAD;
+
+  if (args.title) {
+    const titleFs = Math.round(h * 0.065);
+    ctx.font = `700 ${titleFs}px Inter, system-ui, sans-serif`;
+    ctx.fillStyle = rgbCss(fg);
+    ctx.textAlign = 'center';
+    ctx.textBaseline = 'top';
+    ctx.fillText(args.title, x + w / 2, plotTop);
+    plotTop += titleFs + PAD;
+  }
+
+  const verdictH = args.verdict ? h * 0.1 : 0;
+  const scaleAreaH = h - (plotTop - y) - PAD - verdictH;
+  const scaleAreaT = plotTop;
+
+  // Beam geometry
+  const beamY = scaleAreaT + scaleAreaH * 0.18;
+  const beamH = Math.max(5, scaleAreaH * 0.012);
+  const pivotX = x + w / 2;
+  const armHalf = w * 0.36;
+
+  // Pivot triangle
+  const triH = beamH * 4;
+  ctx.save();
+  ctx.fillStyle = rgbaCss(fg, 0.3);
+  ctx.beginPath();
+  ctx.moveTo(pivotX - triH * 0.6, beamY + triH);
+  ctx.lineTo(pivotX + triH * 0.6, beamY + triH);
+  ctx.lineTo(pivotX, beamY);
+  ctx.closePath();
+  ctx.fill();
+  ctx.restore();
+
+  // Beam
+  ctx.save();
+  ctx.fillStyle = rgbaCss(fg, 0.3);
+  ctx.beginPath();
+  ctx.roundRect(pivotX - armHalf, beamY - beamH / 2, armHalf * 2, beamH, beamH / 2);
+  ctx.fill();
+  ctx.restore();
+
+  // Pan vertical lines (chains)
+  const panW = armHalf * 0.55;
+  const panH = beamH * 1.2;
+  const chainH = scaleAreaH * 0.08;
+  const leftPanX = pivotX - armHalf;
+  const rightPanX = pivotX + armHalf;
+  const panY = beamY + chainH;
+
+  ctx.save();
+  ctx.strokeStyle = rgbaCss(fg, 0.22);
+  ctx.lineWidth = 1.5;
+  // Left chain
+  ctx.beginPath();
+  ctx.moveTo(leftPanX, beamY);
+  ctx.lineTo(leftPanX, panY);
+  ctx.stroke();
+  // Right chain
+  ctx.beginPath();
+  ctx.moveTo(rightPanX, beamY);
+  ctx.lineTo(rightPanX, panY);
+  ctx.stroke();
+  ctx.restore();
+
+  // Left pan ellipse
+  ctx.save();
+  ctx.fillStyle = rgbaCss(leftColor, 0.15);
+  ctx.strokeStyle = rgbCss(leftColor);
+  ctx.lineWidth = 2;
+  ctx.beginPath();
+  ctx.ellipse(leftPanX, panY + panH / 2, panW / 2, panH / 2, 0, 0, Math.PI * 2);
+  ctx.fill();
+  ctx.stroke();
+  ctx.restore();
+
+  // Right pan ellipse
+  ctx.save();
+  ctx.fillStyle = rgbaCss(rightColor, 0.15);
+  ctx.strokeStyle = rgbCss(rightColor);
+  ctx.lineWidth = 2;
+  ctx.beginPath();
+  ctx.ellipse(rightPanX, panY + panH / 2, panW / 2, panH / 2, 0, 0, Math.PI * 2);
+  ctx.fill();
+  ctx.stroke();
+  ctx.restore();
+
+  // Items area
+  const itemsTop = panY + panH + scaleAreaH * 0.03;
+  const itemAreaH = scaleAreaT + scaleAreaH - itemsTop;
+  const colW = w * 0.38;
+  const itemFs = Math.min(Math.round(h * 0.04), 13);
+  const bulletR = 4;
+
+  // Left label
+  const labelFs = Math.min(Math.round(h * 0.075), 22);
+  ctx.font = `700 ${labelFs}px Inter, system-ui, sans-serif`;
+  ctx.fillStyle = rgbCss(leftColor);
+  ctx.textAlign = 'center';
+  ctx.textBaseline = 'middle';
+  ctx.fillText(args.leftLabel || '', leftPanX, beamY - labelFs * 0.8);
+
+  // Right label
+  ctx.fillStyle = rgbCss(rightColor);
+  ctx.fillText(args.rightLabel || '', rightPanX, beamY - labelFs * 0.8);
+
+  // Left items
+  const leftColX = x + PAD;
+  const rightColX = x + w / 2 + PAD;
+  drawItems(
+    ctx,
+    leftItems,
+    leftColX,
+    itemsTop,
+    colW - PAD,
+    itemAreaH,
+    leftColor,
+    fg,
+    itemFs,
+    bulletR,
+  );
+  drawItems(
+    ctx,
+    rightItems,
+    rightColX,
+    itemsTop,
+    colW - PAD,
+    itemAreaH,
+    rightColor,
+    fg,
+    itemFs,
+    bulletR,
+  );
+
+  // Verdict
+  if (args.verdict) {
+    const vFs = Math.min(Math.round(h * 0.048), 14);
+    const vText = String(args.verdict);
+    const vY = scaleAreaT + scaleAreaH + verdictH / 2;
+    const vPadH = verdictH * 0.55;
+    const vPadW = w * 0.04;
+
+    ctx.save();
+    ctx.font = `700 ${vFs}px Inter, system-ui, sans-serif`;
+    const vW = ctx.measureText(vText).width + vPadW * 2;
+    ctx.fillStyle = rgbaCss(accent, 0.12);
+    ctx.beginPath();
+    ctx.roundRect(x + w / 2 - vW / 2, vY - vPadH / 2, vW, vPadH, vPadH / 2);
+    ctx.fill();
+    ctx.fillStyle = rgbCss(accent);
+    ctx.textAlign = 'center';
+    ctx.textBaseline = 'middle';
+    ctx.fillText(vText, x + w / 2, vY);
+    ctx.restore();
+  }
+}
+
+function drawItems(ctx, items, colX, itemsTop, colW, availH, color, fg, itemFs, bulletR) {
+  const safeItems = items.slice(0, 6);
+  if (!safeItems.length) return;
+  const rowH = availH / safeItems.length;
+  ctx.font = `500 ${itemFs}px Inter, system-ui, sans-serif`;
+
+  for (let i = 0; i < safeItems.length; i++) {
+    const rowCY = itemsTop + rowH * (i + 0.5);
+    const bulletX = colX + bulletR + 2;
+    const textX = bulletX + bulletR + 6;
+
+    ctx.save();
+    ctx.fillStyle = rgbaCss(color, 0.8);
+    ctx.beginPath();
+    ctx.arc(bulletX, rowCY, bulletR, 0, Math.PI * 2);
+    ctx.fill();
+    ctx.restore();
+
+    ctx.save();
+    ctx.fillStyle = rgbaCss(fg, 0.85);
+    ctx.font = `500 ${itemFs}px Inter, system-ui, sans-serif`;
+    ctx.textAlign = 'left';
+    ctx.textBaseline = 'middle';
+    const maxTW = colX + colW - textX;
+    const text = String(safeItems[i] || '');
+    let lineY = rowCY;
+    const words = text.split(' ');
+    let line = '';
+    for (const word of words) {
+      const test = line ? line + ' ' + word : word;
+      if (ctx.measureText(test).width > maxTW && line) {
+        ctx.fillText(line, textX, lineY);
+        line = word;
+        lineY += itemFs * 1.1;
+      } else {
+        line = test;
+      }
+    }
+    if (line) ctx.fillText(line, textX, lineY);
+    ctx.restore();
+  }
+}
+
+function parseCss(str) {
+  // simple rgb(...) parser
+  const m = String(str).match(/rgb\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)\s*\)/);
+  if (m) return [Number(m[1]), Number(m[2]), Number(m[3])];
+  return [30, 80, 180]; // fallback
+}

--- a/sdf-js/src/present/atoms-2d/charts/lists/pillar-3up.js
+++ b/sdf-js/src/present/atoms-2d/charts/lists/pillar-3up.js
@@ -1,0 +1,206 @@
+// =============================================================================
+// atoms-2d/charts/lists/pillar-3up.js — Three Pillars / Three Principles hero
+// -----------------------------------------------------------------------------
+// 2-4 vertical pillar cards side by side. Each pillar: top accent rule +
+// icon badge + bold heading + body paragraph. PL "three pillars" hero pattern.
+// Different from feature-card-grid: taller hero cards, less items, bold accent.
+//
+// Args:
+//   title      — optional heading
+//   pillars    — array of { icon, heading, body, accent? } (2-4) REQUIRED
+//   accentLine — show top color rule (default true)
+// =============================================================================
+
+import { rgbCss, rgbaCss } from '../../renderer.js';
+import { resolveIcon } from '../../../../icons/index.js';
+
+export const spec = {
+  type: 'pillar-3up',
+  category: 'charts/lists',
+  description:
+    'Three vertical pillar cards side-by-side. Hero "three pillars" / "three principles" / "three steps" pattern.',
+  args: {
+    title: { type: 'string?', example: 'Our Three Pillars' },
+    pillars: {
+      type: 'array of { icon, heading, body, accent? } (2-4)',
+      required: true,
+      example: [
+        {
+          icon: 'lightning',
+          heading: 'Speed',
+          body: 'Sub-100ms response across all queries, globally distributed edge.',
+        },
+        {
+          icon: 'shield-check',
+          heading: 'Security',
+          body: 'SOC 2 Type II + zero-trust + encryption at rest and in transit.',
+        },
+        {
+          icon: 'globe',
+          heading: 'Scale',
+          body: '100+ regions, auto-scaling infrastructure, no operational burden.',
+        },
+      ],
+    },
+    accentLine: { type: 'boolean?', default: true },
+  },
+};
+
+function lighten([r, g, b], amount = 0.88) {
+  return [
+    Math.round(r + (255 - r) * amount),
+    Math.round(g + (255 - g) * amount),
+    Math.round(b + (255 - b) * amount),
+  ];
+}
+
+function wrapText(ctx, text, maxW, maxLines = 4) {
+  const words = String(text).split(' ');
+  const lines = [];
+  let line = '';
+  for (const word of words) {
+    const test = line ? line + ' ' + word : word;
+    if (ctx.measureText(test).width > maxW && line) {
+      lines.push(line);
+      line = word;
+      if (lines.length >= maxLines) break;
+    } else {
+      line = test;
+    }
+  }
+  if (line && lines.length < maxLines) lines.push(line);
+  return lines;
+}
+
+function drawIconCentered(ctx, iconName, cx, cy, size, color) {
+  const resolved = resolveIcon(iconName);
+  if (!resolved || !resolved.path) return;
+  const viewBox = resolved.source === 'brand' ? 24 : 256;
+  const scale = size / viewBox;
+  try {
+    ctx.save();
+    ctx.fillStyle = rgbCss(color);
+    ctx.translate(cx - size / 2, cy - size / 2);
+    ctx.scale(scale, scale);
+    ctx.fill(resolved.path);
+    ctx.restore();
+  } catch (_) {
+    ctx.restore();
+  }
+}
+
+export function drawPseudo3D(ctx, args, opts = {}) {
+  const x = opts.x ?? 0;
+  const y = opts.y ?? 0;
+  const w = opts.w ?? 720;
+  const h = opts.h ?? 480;
+  const palette = opts.palette || {};
+  const fg = palette.silhouetteColor ?? [20, 28, 50];
+  const bgColor = palette.bg ?? [248, 246, 240];
+  const accent = palette.accent ?? [30, 80, 180];
+  const colors = palette.colors ?? [
+    [30, 80, 180],
+    [60, 180, 140],
+    [200, 120, 60],
+    [160, 80, 200],
+  ];
+  const pillars = Array.isArray(args.pillars) ? args.pillars : [];
+  const accentLine = args.accentLine !== false;
+
+  ctx.fillStyle = rgbCss(bgColor);
+  ctx.fillRect(x, y, w, h);
+
+  const PAD = 20;
+  let plotTop = y + PAD;
+
+  if (args.title) {
+    const titleFs = Math.round(h * 0.07);
+    ctx.font = `700 ${titleFs}px Inter, system-ui, sans-serif`;
+    ctx.fillStyle = rgbCss(fg);
+    ctx.textAlign = 'center';
+    ctx.textBaseline = 'top';
+    ctx.fillText(args.title, x + w / 2, plotTop);
+    plotTop += titleFs + PAD;
+  }
+
+  if (!pillars.length) return;
+
+  const n = Math.min(4, Math.max(2, pillars.length));
+  const GAP = 16;
+  const colW = (w - PAD * 2 - GAP * (n - 1)) / n;
+  const availH = h - (plotTop - y) - PAD;
+  const CARD_PAD = 18;
+
+  for (let i = 0; i < n; i++) {
+    const p = pillars[i] || {};
+    const colX = x + PAD + i * (colW + GAP);
+    const colY = plotTop;
+    const pillarColor = colors[i % colors.length] || accent;
+
+    // Card background
+    ctx.save();
+    ctx.shadowColor = 'rgba(0,0,0,0.10)';
+    ctx.shadowBlur = 12;
+    ctx.shadowOffsetY = 3;
+    ctx.fillStyle = '#ffffff';
+    ctx.beginPath();
+    ctx.roundRect(colX, colY, colW, availH, 10);
+    ctx.fill();
+    ctx.restore();
+
+    let curY = colY;
+
+    // Top accent rule
+    if (accentLine) {
+      ctx.save();
+      ctx.fillStyle = rgbCss(pillarColor);
+      ctx.beginPath();
+      ctx.roundRect(colX, colY, colW, 5, [5, 5, 0, 0]);
+      ctx.fill();
+      ctx.restore();
+      curY += 5;
+    }
+
+    curY += CARD_PAD;
+
+    // Icon
+    const iconSize = Math.min(availH * 0.14, colW * 0.3, 42);
+    const iconCX = colX + colW / 2;
+    const iconCY = curY + iconSize / 2;
+
+    if (p.icon) {
+      const badgeBg = lighten(pillarColor, 0.88);
+      ctx.fillStyle = rgbCss(badgeBg);
+      ctx.beginPath();
+      ctx.arc(iconCX, iconCY, iconSize / 2 + 6, 0, Math.PI * 2);
+      ctx.fill();
+      drawIconCentered(ctx, p.icon, iconCX, iconCY, iconSize, pillarColor);
+    }
+    curY += iconSize + CARD_PAD;
+
+    // Heading
+    const headingFs = Math.min(Math.round(availH * 0.085), 22);
+    ctx.font = `700 ${headingFs}px Inter, system-ui, sans-serif`;
+    ctx.fillStyle = rgbCss(fg);
+    ctx.textAlign = 'center';
+    ctx.textBaseline = 'top';
+    if (p.heading) {
+      ctx.fillText(p.heading, iconCX, curY);
+      curY += headingFs + 8;
+    }
+
+    // Body
+    const bodyFs = Math.min(Math.round(availH * 0.048), 14);
+    ctx.font = `500 ${bodyFs}px Inter, system-ui`;
+    ctx.fillStyle = rgbaCss(fg, 0.55);
+    ctx.textAlign = 'center';
+    ctx.textBaseline = 'top';
+    if (p.body) {
+      const lines = wrapText(ctx, p.body, colW - CARD_PAD * 2, 4);
+      for (const line of lines) {
+        ctx.fillText(line, iconCX, curY);
+        curY += bodyFs + 3;
+      }
+    }
+  }
+}

--- a/sdf-js/src/present/atoms-2d/charts/lists/testimonial-wall.js
+++ b/sdf-js/src/present/atoms-2d/charts/lists/testimonial-wall.js
@@ -1,0 +1,176 @@
+// =============================================================================
+// atoms-2d/charts/lists/testimonial-wall.js — 3 customer testimonial cards
+// -----------------------------------------------------------------------------
+// Social proof page: 3 cards in a row, each with pull-quote + name + role.
+// PL "What our customers say" pattern. Different from quote-pull (single hero
+// quote) — this is N cards in a grid for comparative social proof.
+//
+// Args:
+//   title        — optional heading
+//   testimonials — array of { quote, name, role? } (2-4) REQUIRED
+// =============================================================================
+
+import { rgbCss, rgbaCss } from '../../renderer.js';
+
+export const spec = {
+  type: 'testimonial-wall',
+  category: 'charts/lists',
+  description:
+    '3 customer testimonial cards in a row. Each: quote + name + role. PL social proof / "what customers say" pattern.',
+  args: {
+    title: { type: 'string?', example: 'What Our Customers Say' },
+    testimonials: {
+      type: 'array of { quote, name, role? } (2-4)',
+      required: true,
+      example: [
+        {
+          quote: 'Cut our deployment time from 2 weeks to 2 hours.',
+          name: 'Sarah Chen',
+          role: 'VP Engineering, Acme Corp',
+        },
+        {
+          quote: 'The dashboard is the first thing my team opens every morning.',
+          name: 'Marcus Johnson',
+          role: 'CFO, BrightWave',
+        },
+        {
+          quote: "Onboarding was the easiest we've ever done. 3 days to value.",
+          name: 'Priya Sharma',
+          role: 'COO, Meridian',
+        },
+      ],
+    },
+  },
+};
+
+function wrapText(ctx, text, maxW, maxLines = 5) {
+  const words = String(text).split(/\s+/);
+  const lines = [];
+  let cur = '';
+  for (const word of words) {
+    const test = cur ? cur + ' ' + word : word;
+    if (ctx.measureText(test).width > maxW && cur) {
+      lines.push(cur);
+      if (lines.length >= maxLines) break;
+      cur = word;
+    } else {
+      cur = test;
+    }
+  }
+  if (cur && lines.length < maxLines) lines.push(cur);
+  return lines;
+}
+
+export function drawPseudo3D(ctx, args, opts = {}) {
+  const x = opts.x ?? 0;
+  const y = opts.y ?? 0;
+  const w = opts.w ?? 720;
+  const h = opts.h ?? 480;
+  const palette = opts.palette || {};
+  const fg = palette.silhouetteColor ?? [20, 28, 50];
+  const bgColor = palette.bg ?? [248, 246, 240];
+  const accent = palette.accent ?? [30, 80, 180];
+  const colors = palette.colors ?? [
+    [30, 80, 180],
+    [60, 180, 140],
+    [200, 120, 60],
+  ];
+  const testimonials = Array.isArray(args.testimonials) ? args.testimonials : [];
+
+  ctx.fillStyle = rgbCss(bgColor);
+  ctx.fillRect(x, y, w, h);
+
+  const PAD = 20;
+  let plotTop = y + PAD;
+
+  if (args.title) {
+    const titleFs = Math.round(h * 0.07);
+    ctx.font = `700 ${titleFs}px Inter, system-ui, sans-serif`;
+    ctx.fillStyle = rgbCss(fg);
+    ctx.textAlign = 'center';
+    ctx.textBaseline = 'top';
+    ctx.fillText(args.title, x + w / 2, plotTop);
+    plotTop += titleFs + PAD;
+  }
+
+  if (!testimonials.length) return;
+
+  const n = Math.min(4, Math.max(2, testimonials.length));
+  const GAP = 14;
+  const colW = (w - PAD * 2 - GAP * (n - 1)) / n;
+  const availH = h - (plotTop - y) - PAD;
+  const CARD_PAD = 16;
+
+  for (let i = 0; i < n; i++) {
+    const t = testimonials[i] || {};
+    const colX = x + PAD + i * (colW + GAP);
+    const colY = plotTop;
+    const cardColor = colors[i % colors.length] || accent;
+
+    // Card background
+    ctx.save();
+    ctx.shadowColor = 'rgba(0,0,0,0.10)';
+    ctx.shadowBlur = 10;
+    ctx.shadowOffsetY = 3;
+    ctx.fillStyle = '#ffffff';
+    ctx.beginPath();
+    ctx.roundRect(colX, colY, colW, availH, 8);
+    ctx.fill();
+    ctx.restore();
+
+    // Left accent border (3px)
+    ctx.save();
+    ctx.fillStyle = rgbCss(cardColor);
+    ctx.beginPath();
+    ctx.roundRect(colX, colY, 4, availH, [4, 0, 0, 4]);
+    ctx.fill();
+    ctx.restore();
+
+    let curY = colY + CARD_PAD;
+
+    // Decorative quote mark
+    const markSize = Math.round(availH * 0.18);
+    ctx.save();
+    ctx.fillStyle = rgbaCss(accent, 0.25);
+    ctx.font = `900 ${markSize}px Georgia, serif`;
+    ctx.textAlign = 'left';
+    ctx.textBaseline = 'top';
+    ctx.fillText('"', colX + CARD_PAD + 6, curY - 4);
+    ctx.restore();
+    curY += Math.round(markSize * 0.55);
+
+    // Quote text
+    const quoteFs = Math.min(Math.round(availH * 0.058), 14);
+    ctx.font = `500 ${quoteFs}px Inter, system-ui, sans-serif`;
+    ctx.fillStyle = rgbCss(fg);
+    ctx.textAlign = 'center';
+    ctx.textBaseline = 'top';
+    if (t.quote) {
+      const lines = wrapText(ctx, t.quote, colW - CARD_PAD * 2, 5);
+      for (const line of lines) {
+        ctx.fillText(line, colX + colW / 2, curY);
+        curY += quoteFs * 1.4;
+      }
+    }
+
+    // Name
+    const nameFs = Math.min(Math.round(availH * 0.05), 14);
+    ctx.font = `700 ${nameFs}px Inter, system-ui, sans-serif`;
+    ctx.fillStyle = rgbCss(cardColor);
+    ctx.textAlign = 'center';
+    ctx.textBaseline = 'bottom';
+    if (t.name) {
+      ctx.fillText(t.name, colX + colW / 2, colY + availH - CARD_PAD - (t.role ? nameFs * 1.4 : 0));
+    }
+
+    // Role/company
+    if (t.role) {
+      const roleFs = Math.min(Math.round(availH * 0.036), 11);
+      ctx.font = `500 ${roleFs}px Inter, system-ui, sans-serif`;
+      ctx.fillStyle = rgbaCss(fg, 0.5);
+      ctx.textAlign = 'center';
+      ctx.textBaseline = 'bottom';
+      ctx.fillText(t.role, colX + colW / 2, colY + availH - CARD_PAD);
+    }
+  }
+}

--- a/sdf-js/src/present/atoms-2d/charts/lists/testimonial-wall.js
+++ b/sdf-js/src/present/atoms-2d/charts/lists/testimonial-wall.js
@@ -139,10 +139,11 @@ export function drawPseudo3D(ctx, args, opts = {}) {
     ctx.restore();
     curY += Math.round(markSize * 0.55);
 
-    // Quote text
+    // Quote text — card bg is hardcoded white, use fixed dark text
+    // (do NOT use palette.silhouetteColor which is white in dark themes → invisible)
     const quoteFs = Math.min(Math.round(availH * 0.058), 14);
     ctx.font = `500 ${quoteFs}px Inter, system-ui, sans-serif`;
-    ctx.fillStyle = rgbCss(fg);
+    ctx.fillStyle = 'rgba(20,24,34,0.88)';
     ctx.textAlign = 'center';
     ctx.textBaseline = 'top';
     if (t.quote) {
@@ -167,7 +168,7 @@ export function drawPseudo3D(ctx, args, opts = {}) {
     if (t.role) {
       const roleFs = Math.min(Math.round(availH * 0.036), 11);
       ctx.font = `500 ${roleFs}px Inter, system-ui, sans-serif`;
-      ctx.fillStyle = rgbaCss(fg, 0.5);
+      ctx.fillStyle = 'rgba(40,46,60,0.55)';
       ctx.textAlign = 'center';
       ctx.textBaseline = 'bottom';
       ctx.fillText(t.role, colX + colW / 2, colY + availH - CARD_PAD);

--- a/sdf-js/src/present/atoms-2d/registry.js
+++ b/sdf-js/src/present/atoms-2d/registry.js
@@ -180,6 +180,12 @@ const ATOM_LOADERS = {
   'kanban-board': () => import('./charts/diagrams/kanban-board.js'),
   'donut-with-center': () => import('./charts/data/donut-with-center.js'),
 
+  // Sprint 22 Batch 4 (2026-06-28) — PL-recommendations atoms (funnel-with-conversion / pillar-3up / testimonial-wall / balance-scale)
+  'funnel-with-conversion': () => import('./charts/data/funnel-with-conversion.js'),
+  'pillar-3up': () => import('./charts/lists/pillar-3up.js'),
+  'testimonial-wall': () => import('./charts/lists/testimonial-wall.js'),
+  'balance-scale': () => import('./charts/diagrams/balance-scale.js'),
+
   // Charts / diagrams (Phase 2)
   // Charts / hierarchy (Phase 2)
   // Shapes (Phase 3)

--- a/sdf-js/src/present/scaffold-view.js
+++ b/sdf-js/src/present/scaffold-view.js
@@ -438,7 +438,11 @@ export async function mountScaffoldView(target, deckId) {
       `    - 5×5 risk grid (Cybersecurity / Risk Assessment) with likelihood × impact cells → \`risk-heatmap\` (NOT generic \`matrix-grid\`)\n` +
       `    - Competitive positioning 2×2 (Magic Quadrant style) with org/company bubbles → \`org-vs-org-matrix\` (NOT generic \`matrix-grid\`)\n` +
       `    - Project status board with column workflow (Backlog / In Progress / Done) → \`kanban-board\` (NOT generic \`flow-chart\`)\n` +
-      `    - Donut chart with prominent center metric / hero KPI value in the ring hole → \`donut-with-center\` (NOT generic \`pie\`)\n`;
+      `    - Donut chart with prominent center metric / hero KPI value in the ring hole → \`donut-with-center\` (NOT generic \`pie\`)\n` +
+      `    - Funnel with explicit conversion % chips between stages (SaaS 12% → 35% → 18%) → \`funnel-with-conversion\` (NOT generic \`funnel\`)\n` +
+      `    - 2-4 tall hero pillar cards side-by-side (Three Pillars / Three Principles / Our Values) → \`pillar-3up\` (NOT \`feature-card-grid\`)\n` +
+      `    - Row of 2-4 customer quote/testimonial cards (social proof, "What our customers say") → \`testimonial-wall\` (NOT \`bullet-list\`)\n` +
+      `    - Build vs Buy / Pros vs Cons / Left vs Right two-side comparison with visual scale → \`balance-scale\` (NOT \`swot\` or \`cost-benefit-matrix\`)\n`;
 
     const systemPrompt =
       `You are the Atlas Present scaffold-mode lift LLM. Emit a single JSON ` +

--- a/sdf-js/src/scene/lift-2d-to-3d.js
+++ b/sdf-js/src/scene/lift-2d-to-3d.js
@@ -841,6 +841,97 @@ export const TWIN_MAP = {
       };
     },
   },
+
+  // ── Sprint 22 B4 twins ──
+
+  'funnel-with-conversion': {
+    to: 'funnel-3d',
+    lift(a) {
+      const stages = a.stages || [];
+      const n = stages.length || 4;
+      const titleOverlay = a.title ? [{ text: String(a.title).toUpperCase(), anchor: [0, 3.9, 0], role: 'title' }] : [];
+      return {
+        args: {
+          stages: n,
+          topRadius: 1.15,
+          bottomRadius: 0.28,
+          stageHeight: 0.55,
+          gap: 0.1,
+          colors: shades(HUE_BY_TYPE.funnel, n),
+        },
+        transform: { translate: [0, 1.5, 0] },
+        overlay: [
+          ...titleOverlay,
+          ...rightCards(
+            stages.map((s, i) => {
+              const label = s.label || '';
+              const conv = i > 0 && stages[i - 1]?.value != null && s.value != null
+                ? ` (${((Number(s.value) / Number(stages[i - 1].value)) * 100).toFixed(1)}%)`
+                : '';
+              return label + conv;
+            }),
+          ),
+        ],
+      };
+    },
+  },
+
+  'pillar-3up': {
+    to: 'column-3d',
+    lift(a) {
+      const pillars = a.pillars || [];
+      const n = pillars.length || 3;
+      const titleOverlay = a.title ? [{ text: String(a.title).toUpperCase(), anchor: [0, 3.9, 0], role: 'title' }] : [];
+      return {
+        args: { columns: n, height: 1.8 },
+        transform: { translate: [0, 1.5, 0] },
+        overlay: [
+          ...titleOverlay,
+          ...rightCards(pillars.map((p) => p.heading || '')),
+        ],
+      };
+    },
+  },
+
+  'testimonial-wall': {
+    to: 'matrix-grid-3d',
+    lift(a) {
+      const testimonials = a.testimonials || [];
+      const n = Math.max(2, testimonials.length);
+      const titleOverlay = a.title ? [{ text: String(a.title).toUpperCase(), anchor: [0, 3.9, 0], role: 'title' }] : [];
+      return {
+        args: { rows: 1, cols: n },
+        transform: { translate: [0, 1.5, 0] },
+        overlay: [
+          ...titleOverlay,
+          ...rightCards(
+            testimonials.map((t) => (t.name || '') + (t.role ? ` · ${t.role}` : '')),
+          ),
+        ],
+      };
+    },
+  },
+
+  'balance-scale': {
+    to: 'venn-3d',
+    lift(a) {
+      const leftItems = a.leftItems || [];
+      const rightItems = a.rightItems || [];
+      const titleOverlay = a.title ? [{ text: String(a.title).toUpperCase(), anchor: [0, 3.9, 0], role: 'title' }] : [];
+      return {
+        args: { sets: 2, overlap: 0.12 },
+        transform: { translate: [0, 1.6, 0] },
+        overlay: [
+          ...titleOverlay,
+          ...(a.leftLabel ? [{ text: String(a.leftLabel), anchor: [-2.2, 2.6, 0], role: 'card', align: 'center' }] : []),
+          ...(a.rightLabel ? [{ text: String(a.rightLabel), anchor: [2.2, 2.6, 0], role: 'card', align: 'center' }] : []),
+          ...leftItems.slice(0, 4).map((item) => ({ text: String(item), role: 'card', align: 'left' })),
+          ...rightItems.slice(0, 4).map((item) => ({ text: String(item), role: 'card', align: 'right' })),
+          ...(a.verdict ? [{ text: String(a.verdict), anchor: [0, 0.4, 0], role: 'value', align: 'center' }] : []),
+        ],
+      };
+    },
+  },
 };
 
 // resolve the 3D twin type for a 2D atom type (override or `${type}-3d` rule)


### PR DESCRIPTION
## Summary

- **funnel-with-conversion** (`charts/data`) — funnel chart with explicit conversion % pill chips between consecutive stages (e.g. SaaS: Visitors → 12% → Signups → 35% → Trials → 18% → Paid). Lifts to `funnel-3d` with stage + rate overlay.
- **pillar-3up** (`charts/lists`) — 2-4 tall hero pillar cards side-by-side with top accent rule, icon badge, heading, body text. PL "Three Pillars / Our Values" pattern. Lifts to `column-3d`.
- **testimonial-wall** (`charts/lists`) — 2-4 customer quote cards in a row with left accent border, large decorative quote mark, name + role. PL social proof / "What Our Customers Say" pattern. Lifts to `matrix-grid-3d` (1×N).
- **balance-scale** (`charts/diagrams`) — visual balance scale with beam + pans + bulleted left/right item lists + optional verdict pill. PL Build vs Buy / Pros vs Cons / decision pattern. Lifts to `venn-3d` (2 sets).

## Infrastructure

- `registry.js` — 4 new dynamic imports in Sprint 22 B4 section
- `lift-2d-to-3d.js` — 4 new TWIN_MAP entries
- `test-sprint22-batch4-atoms.mjs` — 43 assertions (registration, spec, render, catalog)
- `test-lift-2d-to-3d.mjs` — 4 new twin assertion blocks
- `run-tests.mjs` — batch 4 test added (104 total test files)
- `bake-scaffold-pipeline.mjs` + `scaffold-view.js` — Rule 17 extended
- `sprint22-b4-atomdemo/` — deck.json + 4 slot files
- `lift-sprint22-b4-demo.mjs` — lift demo script

## Test plan

- [x] `node sdf-js/scripts/test-sprint22-batch4-atoms.mjs` — 43 assertions pass
- [x] `npm test` — 104/104 test files pass (6.14s)
- [x] All 4 atoms render without error on mock canvas
- [x] Lift twin entries resolve to valid 3D atom types

🤖 Generated with [Claude Code](https://claude.com/claude-code)