### PR TITLE
polish(lift): suppress decorative-accent labels in scaffold slots (declutter)

### DIFF
--- a/sdf-js/scenes/scaffold-vc-01.json
+++ b/sdf-js/scenes/scaffold-vc-01.json
@@ -144,26 +144,6 @@
       "radius": 0.4565217391304348
     },
     {
-      "text": "Outdated",
-      "anchor": [
-        -1.4625000000000001,
-        -0.44250000000000034,
-        0
-      ],
-      "role": "card",
-      "align": "center"
-    },
-    {
-      "text": "Time Drain",
-      "anchor": [
-        -2.7625,
-        -0.44250000000000034,
-        0
-      ],
-      "role": "card",
-      "align": "center"
-    },
-    {
       "text": "PROBLEM",
       "anchor": [
         0,

--- a/sdf-js/scenes/scaffold-vc-03.json
+++ b/sdf-js/scenes/scaffold-vc-03.json
@@ -168,46 +168,6 @@
       "align": "left"
     },
     {
-      "text": "Intent",
-      "anchor": [
-        3.7375000000000003,
-        2.1075,
-        0
-      ],
-      "role": "card",
-      "align": "center"
-    },
-    {
-      "text": "Runtime",
-      "anchor": [
-        1.4625000000000001,
-        2.1075,
-        0
-      ],
-      "role": "card",
-      "align": "center"
-    },
-    {
-      "text": "Renderers",
-      "anchor": [
-        -0.8125,
-        2.1075,
-        0
-      ],
-      "role": "card",
-      "align": "center"
-    },
-    {
-      "text": "Editable",
-      "anchor": [
-        -3.0875,
-        2.1075,
-        0
-      ],
-      "role": "card",
-      "align": "center"
-    },
-    {
       "text": "OUR SOLUTION",
       "anchor": [
         0,

--- a/sdf-js/scenes/scaffold-vc-07.json
+++ b/sdf-js/scenes/scaffold-vc-07.json
@@ -177,26 +177,6 @@
       "radius": 0.36
     },
     {
-      "text": "NYC HQ",
-      "anchor": [
-        -0.9750000000000001,
-        -0.7425000000000006,
-        0
-      ],
-      "role": "card",
-      "align": "center"
-    },
-    {
-      "text": "Remote",
-      "anchor": [
-        -2.275,
-        -0.7425000000000006,
-        0
-      ],
-      "role": "card",
-      "align": "center"
-    },
-    {
       "text": "TEAM",
       "anchor": [
         0,

--- a/sdf-js/src/scene/lift-scaffold.js
+++ b/sdf-js/src/scene/lift-scaffold.js
@@ -23,6 +23,9 @@ const SPAN_X = 10.4; // world width  → X ∈ [-5.2, 5.2]
 const SPAN_Y = 5.4; // world height
 const CENTER_Y = 2.5; // vertical centre of the content band
 const NATURAL = 2.3; // an atom's rough built diameter, for box-fit scaling
+// decorative accent types — kept as small geometry, but their labels are suppressed
+// (usually duplicate a neighbour's text and clutter dense slides).
+const ACCENT_TYPES = new Set(['icon-badge']);
 
 export function hasTwin(type2d) {
   return FACTORY.has(twinTypeOf(type2d));
@@ -72,6 +75,10 @@ export function liftScaffoldSlot(sceneData, opts = {}) {
     // drop the per-subject title (the slot carries one); shrink value fonts with scale.
     // legend cards sit 3u to the side in single-subject layout — in a packed slide that
     // flings them to the screen edge, so compress the horizontal offset to hug the box.
+    // decorative accents (icon badges) stay label-free — their text is usually a
+    // duplicate of a neighbouring element's and just clutters a dense slide. (KPI cards
+    // are ALSO small but carry real numbers, so gate on type, not scale.)
+    if (ACCENT_TYPES.has(s.type)) return;
     const T = [worldX, worldY, 0];
     for (const o of ov) {
       if (o.role === 'title') continue;


### PR DESCRIPTION
密集页(vc-pitch「Our Solution」:宽 flow-chart + 4 icon-badge)挤了 8+ 张重叠文字卡 —— 每个 icon-badge 重复标了 flow 已有的步骤词。现在装饰 accent 类型(icon-badge)**保留小几何、去掉标签**,按**类型**而非 scale 判断,所以真内容(KPI 卡 `$2.4M`/`110%`)的数字保住。

slot-03 overlay 9→5;slot-05 KPI 值完好。`npm test` 105/105。

🤖 Generated with [Claude Code](https://claude.com/claude-code)