### PR TITLE
feat(lift): brand theming — scaffold decks use the source deck theme colours

### DIFF
--- a/sdf-js/scenes/scaffold-vc-00.json
+++ b/sdf-js/scenes/scaffold-vc-00.json
@@ -20,9 +20,9 @@
         "scale": 1.75
       },
       "material": {
-        "hue": 0.57,
-        "sat": 0.55,
-        "value": 0.64,
+        "hue": 0.06201550387596899,
+        "sat": 0.72,
+        "value": 0.72,
         "kind": "normal",
         "roughness": 0.3,
         "clearcoat": 0.45

--- a/sdf-js/scenes/scaffold-vc-01.json
+++ b/sdf-js/scenes/scaffold-vc-01.json
@@ -17,9 +17,9 @@
         "scale": 1.565217391304348
       },
       "material": {
-        "hue": 0.4,
-        "sat": 0.55,
-        "value": 0.64,
+        "hue": 0.06201550387596899,
+        "sat": 0.72,
+        "value": 0.72,
         "kind": "normal",
         "roughness": 0.3,
         "clearcoat": 0.45
@@ -43,9 +43,9 @@
         "scale": 0.9130434782608696
       },
       "material": {
-        "hue": 0.58,
-        "sat": 0.55,
-        "value": 0.64,
+        "hue": 0.625,
+        "sat": 0.72,
+        "value": 0.7058823529411765,
         "kind": "normal",
         "roughness": 0.3,
         "clearcoat": 0.45
@@ -68,9 +68,9 @@
         "scale": 0.55
       },
       "material": {
-        "hue": 0.6,
-        "sat": 0.55,
-        "value": 0.64,
+        "hue": 0.638888888888889,
+        "sat": 0.5,
+        "value": 0.5,
         "kind": "normal",
         "roughness": 0.3,
         "clearcoat": 0.45
@@ -93,9 +93,9 @@
         "scale": 0.55
       },
       "material": {
-        "hue": 0.6,
-        "sat": 0.55,
-        "value": 0.64,
+        "hue": 0.06201550387596899,
+        "sat": 0.72,
+        "value": 0.72,
         "kind": "normal",
         "roughness": 0.3,
         "clearcoat": 0.45

--- a/sdf-js/scenes/scaffold-vc-02.json
+++ b/sdf-js/scenes/scaffold-vc-02.json
@@ -9,17 +9,17 @@
         "levels": 3,
         "colors": [
           {
-            "hue": 0.11,
+            "hue": 0.06201550387596899,
             "sat": 0.7,
             "value": 0.88
           },
           {
-            "hue": 0.11,
+            "hue": 0.06201550387596899,
             "sat": 0.74,
             "value": 0.73
           },
           {
-            "hue": 0.11,
+            "hue": 0.06201550387596899,
             "sat": 0.7799999999999999,
             "value": 0.5800000000000001
           }
@@ -34,9 +34,9 @@
         "scale": 1.6956521739130437
       },
       "material": {
-        "hue": 0.11,
+        "hue": 0.06201550387596899,
         "sat": 0.72,
-        "value": 0.82,
+        "value": 0.72,
         "kind": "normal",
         "roughness": 0.3,
         "clearcoat": 0.45
@@ -58,9 +58,9 @@
         "scale": 0.5869565217391305
       },
       "material": {
-        "hue": 0.58,
-        "sat": 0.55,
-        "value": 0.64,
+        "hue": 0.625,
+        "sat": 0.72,
+        "value": 0.7058823529411765,
         "kind": "normal",
         "roughness": 0.3,
         "clearcoat": 0.45
@@ -82,9 +82,9 @@
         "scale": 0.55
       },
       "material": {
-        "hue": 0.58,
-        "sat": 0.55,
-        "value": 0.64,
+        "hue": 0.638888888888889,
+        "sat": 0.5,
+        "value": 0.5,
         "kind": "normal",
         "roughness": 0.3,
         "clearcoat": 0.45
@@ -106,9 +106,9 @@
         "scale": 0.55
       },
       "material": {
-        "hue": 0.58,
-        "sat": 0.55,
-        "value": 0.64,
+        "hue": 0.06201550387596899,
+        "sat": 0.72,
+        "value": 0.72,
         "kind": "normal",
         "roughness": 0.3,
         "clearcoat": 0.45

--- a/sdf-js/scenes/scaffold-vc-03.json
+++ b/sdf-js/scenes/scaffold-vc-03.json
@@ -17,9 +17,9 @@
         "scale": 1.6956521739130437
       },
       "material": {
-        "hue": 0.4,
-        "sat": 0.55,
-        "value": 0.64,
+        "hue": 0.06201550387596899,
+        "sat": 0.72,
+        "value": 0.72,
         "kind": "normal",
         "roughness": 0.3,
         "clearcoat": 0.45
@@ -42,9 +42,9 @@
         "scale": 0.55
       },
       "material": {
-        "hue": 0.6,
-        "sat": 0.55,
-        "value": 0.64,
+        "hue": 0.625,
+        "sat": 0.72,
+        "value": 0.7058823529411765,
         "kind": "normal",
         "roughness": 0.3,
         "clearcoat": 0.45
@@ -67,9 +67,9 @@
         "scale": 0.55
       },
       "material": {
-        "hue": 0.6,
-        "sat": 0.55,
-        "value": 0.64,
+        "hue": 0.638888888888889,
+        "sat": 0.5,
+        "value": 0.5,
         "kind": "normal",
         "roughness": 0.3,
         "clearcoat": 0.45
@@ -92,9 +92,9 @@
         "scale": 0.55
       },
       "material": {
-        "hue": 0.6,
-        "sat": 0.55,
-        "value": 0.64,
+        "hue": 0.06201550387596899,
+        "sat": 0.72,
+        "value": 0.72,
         "kind": "normal",
         "roughness": 0.3,
         "clearcoat": 0.45
@@ -117,9 +117,9 @@
         "scale": 0.55
       },
       "material": {
-        "hue": 0.6,
-        "sat": 0.55,
-        "value": 0.64,
+        "hue": 0.625,
+        "sat": 0.72,
+        "value": 0.7058823529411765,
         "kind": "normal",
         "roughness": 0.3,
         "clearcoat": 0.45

--- a/sdf-js/scenes/scaffold-vc-04.json
+++ b/sdf-js/scenes/scaffold-vc-04.json
@@ -17,9 +17,9 @@
         "scale": 1.6956521739130437
       },
       "material": {
-        "hue": 0.6,
-        "sat": 0.55,
-        "value": 0.64,
+        "hue": 0.06201550387596899,
+        "sat": 0.72,
+        "value": 0.72,
         "kind": "normal",
         "roughness": 0.3,
         "clearcoat": 0.45
@@ -40,9 +40,9 @@
         "scale": 1.565217391304348
       },
       "material": {
-        "hue": 0.4,
-        "sat": 0.55,
-        "value": 0.64,
+        "hue": 0.625,
+        "sat": 0.72,
+        "value": 0.7058823529411765,
         "kind": "normal",
         "roughness": 0.3,
         "clearcoat": 0.45

--- a/sdf-js/scenes/scaffold-vc-05.json
+++ b/sdf-js/scenes/scaffold-vc-05.json
@@ -26,9 +26,9 @@
         "scale": 1.3695652173913047
       },
       "material": {
-        "hue": 0.55,
-        "sat": 0.55,
-        "value": 0.64,
+        "hue": 0.06201550387596899,
+        "sat": 0.72,
+        "value": 0.72,
         "kind": "normal",
         "roughness": 0.3,
         "clearcoat": 0.45
@@ -51,9 +51,9 @@
         "scale": 0.55
       },
       "material": {
-        "hue": 0.58,
-        "sat": 0.55,
-        "value": 0.64,
+        "hue": 0.625,
+        "sat": 0.72,
+        "value": 0.7058823529411765,
         "kind": "normal",
         "roughness": 0.3,
         "clearcoat": 0.45
@@ -76,9 +76,9 @@
         "scale": 0.55
       },
       "material": {
-        "hue": 0.58,
-        "sat": 0.55,
-        "value": 0.64,
+        "hue": 0.638888888888889,
+        "sat": 0.5,
+        "value": 0.5,
         "kind": "normal",
         "roughness": 0.3,
         "clearcoat": 0.45

--- a/sdf-js/scenes/scaffold-vc-06.json
+++ b/sdf-js/scenes/scaffold-vc-06.json
@@ -27,9 +27,9 @@
         "scale": 1.565217391304348
       },
       "material": {
-        "hue": 0.4,
-        "sat": 0.55,
-        "value": 0.64,
+        "hue": 0.06201550387596899,
+        "sat": 0.72,
+        "value": 0.72,
         "kind": "normal",
         "roughness": 0.3,
         "clearcoat": 0.45
@@ -51,9 +51,9 @@
         "scale": 0.55
       },
       "material": {
-        "hue": 0.58,
-        "sat": 0.55,
-        "value": 0.64,
+        "hue": 0.625,
+        "sat": 0.72,
+        "value": 0.7058823529411765,
         "kind": "normal",
         "roughness": 0.3,
         "clearcoat": 0.45
@@ -74,9 +74,9 @@
         "scale": 0.9782608695652176
       },
       "material": {
-        "hue": 0.4,
-        "sat": 0.55,
-        "value": 0.64,
+        "hue": 0.638888888888889,
+        "sat": 0.5,
+        "value": 0.5,
         "kind": "normal",
         "roughness": 0.3,
         "clearcoat": 0.45

--- a/sdf-js/scenes/scaffold-vc-07.json
+++ b/sdf-js/scenes/scaffold-vc-07.json
@@ -18,9 +18,9 @@
         "scale": 1.6956521739130437
       },
       "material": {
-        "hue": 0.58,
-        "sat": 0.55,
-        "value": 0.64,
+        "hue": 0.06201550387596899,
+        "sat": 0.72,
+        "value": 0.72,
         "kind": "normal",
         "roughness": 0.3,
         "clearcoat": 0.45
@@ -42,9 +42,9 @@
         "scale": 0.55
       },
       "material": {
-        "hue": 0.58,
-        "sat": 0.55,
-        "value": 0.64,
+        "hue": 0.625,
+        "sat": 0.72,
+        "value": 0.7058823529411765,
         "kind": "normal",
         "roughness": 0.3,
         "clearcoat": 0.45
@@ -66,9 +66,9 @@
         "scale": 0.55
       },
       "material": {
-        "hue": 0.58,
-        "sat": 0.55,
-        "value": 0.64,
+        "hue": 0.638888888888889,
+        "sat": 0.5,
+        "value": 0.5,
         "kind": "normal",
         "roughness": 0.3,
         "clearcoat": 0.45
@@ -91,9 +91,9 @@
         "scale": 0.55
       },
       "material": {
-        "hue": 0.6,
-        "sat": 0.55,
-        "value": 0.64,
+        "hue": 0.06201550387596899,
+        "sat": 0.72,
+        "value": 0.72,
         "kind": "normal",
         "roughness": 0.3,
         "clearcoat": 0.45
@@ -116,9 +116,9 @@
         "scale": 0.55
       },
       "material": {
-        "hue": 0.6,
-        "sat": 0.55,
-        "value": 0.64,
+        "hue": 0.625,
+        "sat": 0.72,
+        "value": 0.7058823529411765,
         "kind": "normal",
         "roughness": 0.3,
         "clearcoat": 0.45

--- a/sdf-js/scenes/scaffold-vc-08.json
+++ b/sdf-js/scenes/scaffold-vc-08.json
@@ -18,9 +18,9 @@
         "scale": 0.782608695652174
       },
       "material": {
-        "hue": 0.58,
-        "sat": 0.55,
-        "value": 0.64,
+        "hue": 0.06201550387596899,
+        "sat": 0.72,
+        "value": 0.72,
         "kind": "normal",
         "roughness": 0.3,
         "clearcoat": 0.45
@@ -53,9 +53,9 @@
         ]
       },
       "material": {
-        "hue": 0.5,
-        "sat": 0.55,
-        "value": 0.64,
+        "hue": 0.625,
+        "sat": 0.72,
+        "value": 0.7058823529411765,
         "kind": "normal",
         "roughness": 0.3,
         "clearcoat": 0.45
@@ -76,9 +76,9 @@
         "scale": 0.9130434782608696
       },
       "material": {
-        "hue": 0.4,
-        "sat": 0.55,
-        "value": 0.64,
+        "hue": 0.638888888888889,
+        "sat": 0.5,
+        "value": 0.5,
         "kind": "normal",
         "roughness": 0.3,
         "clearcoat": 0.45

--- a/sdf-js/scripts/lift-scaffold-deck.mjs
+++ b/sdf-js/scripts/lift-scaffold-deck.mjs
@@ -21,7 +21,7 @@ for (const f of slotFiles) {
   const slot = JSON.parse(readFileSync(join(slotDir, f), 'utf8'));
   const sd = slot.sceneData;
   if (!sd || !Array.isArray(sd.subjects)) continue;
-  const { scene, skipped } = liftScaffoldSlot(sd, { title: slot.slotTitle });
+  const { scene, skipped } = liftScaffoldSlot(sd, { title: slot.slotTitle, theme: deck.theme });
   const outName = `scaffold-vc-${String(slot.slotIdx).padStart(2, '0')}.json`;
   writeFileSync(resolve(SCENES, outName), `${JSON.stringify(scene, null, 2)}\n`);
   segments.push({ file: outName, title: slot.slotTitle, kind: 'slide', durationSec: 7 });

--- a/sdf-js/src/scene/lift-2d-to-3d.js
+++ b/sdf-js/src/scene/lift-2d-to-3d.js
@@ -74,7 +74,7 @@ function materialFor(type2d) {
 
 // per-leaf shade ramp of one hue (light→dark) — for atoms that accept colors[]
 // (funnel / layer-stack / circle-stack). Gives intra-chart depth without going garish.
-function shades(hue, n) {
+export function shades(hue, n) {
   const warm = hue < 0.16 || hue > 0.95;
   const out = [];
   for (let i = 0; i < n; i++) {

--- a/sdf-js/src/scene/lift-scaffold.js
+++ b/sdf-js/src/scene/lift-scaffold.js
@@ -11,10 +11,35 @@
 // them to each subject's 3D box is the next step. Types without a 3D twin are skipped
 // (logged), not faked.
 
-import { liftSubject, twinTypeOf, pushInCamera } from './lift-2d-to-3d.js';
+import { liftSubject, twinTypeOf, pushInCamera, shades } from './lift-2d-to-3d.js';
 import { PRIMITIVE_FACTORY_TYPES } from './compile.js';
 
 const FACTORY = new Set(PRIMITIVE_FACTORY_TYPES);
+
+// ── brand theming: map the source deck's theme.colors → 3D materials ──
+// RGB (0-255) → HSV (h,s,v ∈ 0..1) so it drops straight into a material.
+function rgbToHsv([r, g, b]) {
+  r /= 255; g /= 255; b /= 255;
+  const mx = Math.max(r, g, b), mn = Math.min(r, g, b), d = mx - mn;
+  let h = 0;
+  if (d) {
+    if (mx === r) h = ((g - b) / d) % 6;
+    else if (mx === g) h = (b - r) / d + 2;
+    else h = (r - g) / d + 4;
+    h /= 6;
+    if (h < 0) h += 1;
+  }
+  return { hue: h, sat: mx ? d / mx : 0, value: mx };
+}
+
+// vivid brand colours only (drop near-white / near-grey), tamed to read in 3D PBR.
+function themePalette(theme) {
+  const cols = (theme && Array.isArray(theme.colors) ? theme.colors : [])
+    .map(rgbToHsv)
+    .filter((c) => c.sat > 0.28 && c.value > 0.22)
+    .map((c) => ({ hue: c.hue, sat: Math.min(0.72, Math.max(0.5, c.sat)), value: Math.min(0.72, Math.max(0.5, c.value)) }));
+  return cols.length ? cols : null;
+}
 
 const CANVAS_W = 1280;
 const CANVAS_H = 720;
@@ -47,7 +72,7 @@ function placeBox(x, y, w, h) {
 /**
  * Lift one scaffold slot (sceneData) → a 3D studio scene.
  * @param {object} sceneData  { name, layout, subjects:[{type,x,y,w,h,args}] }
- * @param {object} [opts]     { title }
+ * @param {object} [opts]     { title, theme }  theme = deck.json theme (brand colours)
  * @returns {{scene: object, skipped: string[]}}
  */
 export function liftScaffoldSlot(sceneData, opts = {}) {
@@ -55,6 +80,7 @@ export function liftScaffoldSlot(sceneData, opts = {}) {
   const overlay = [];
   const skipped = [];
   const title = opts.title || sceneData.title || sceneData.name || null;
+  const pal = themePalette(opts.theme); // brand palette, or null → keep family palette
 
   (sceneData.subjects || []).forEach((s, i) => {
     if (!hasTwin(s.type)) {
@@ -69,6 +95,14 @@ export function liftScaffoldSlot(sceneData, opts = {}) {
     const base = (subject3d.transform && subject3d.transform.translate) || [0, 1.5, 0];
     const baseRotate = subject3d.transform && subject3d.transform.rotate;
     subject3d.transform = { translate: [worldX, worldY, 0], scale, ...(baseRotate ? { rotate: baseRotate } : {}) };
+
+    // brand theming: recolour the subject (and its per-leaf ramp) from the deck's
+    // theme palette, cycling by index so hero/secondary alternate on-brand.
+    if (pal) {
+      const tc = pal[i % pal.length];
+      subject3d.material = { ...subject3d.material, hue: tc.hue, sat: tc.sat, value: tc.value };
+      if (Array.isArray(subject3d.args.colors)) subject3d.args.colors = shades(tc.hue, subject3d.args.colors.length);
+    }
     subjects.push(subject3d);
 
     // re-anchor the subject's overlays to its 3D box: newAnchor = T + scale·(a − base).


### PR DESCRIPTION
方向 2:**品牌主题接入**。scaffold 3D deck 之前不管品牌一律通用蓝;现在 lift 读 `deck.json` 的 `theme.colors`,用品牌色板给 3D subject 上色 —— 是**你的 deck 的 3D**(vc-pitch → 钴蓝-橙),不是通用的。

- `lift-scaffold.js`:`rgbToHsv` + `themePalette`(theme.colors → HSV 材质,丢近白/灰,PBR 下调顺)。每 subject 按品牌色板循环上色(hero/secondary 交替);per-leaf 渐变(funnel/bar/pyramid)重生成为该品牌 hue 的 shades。opt-in via `opts.theme`(无 theme→保留家族色板,独立 rec deck 不受影响)。
- `shades()` 从 lift-2d-to-3d export 供 per-leaf 重上色。

验证(Playwright):market(橙金字塔 + 钴蓝 KPI $4.8B/$68B)、ask(橙 $15M + 钴蓝 pie/bullet)。全 deck on-brand。`npm test` 105/105。

后续(未做):DOM overlay 卡片色(现固定蓝)也接品牌 accent,做到完全 on-brand。

🤖 Generated with [Claude Code](https://claude.com/claude-code)