### PR TITLE
feat(expr): GLSL-style builtins (smoothstep/clamp/step/…) in animation exprs

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -55,6 +55,7 @@ const TESTS = [
   { category: 'math', file: 'sdf-js/scripts/test-extra.mjs' },
   // IQ-shader program W13 — gap-fill (2D bbox, multires/box AO, GI, implicit dist)
   { category: 'math', file: 'sdf-js/scripts/test-gaps.mjs' },
+  { category: 'math', file: 'sdf-js/scripts/test-expr-anim-builtins.mjs' },
 
   // M7 world runtime — determinism CI (the foundation Fable 5 asked for)
   { category: 'world', file: 'sdf-js/scripts/world/test-determinism.mjs' },

--- a/sdf-js/scripts/test-expr-anim-builtins.mjs
+++ b/sdf-js/scripts/test-expr-anim-builtins.mjs
@@ -1,0 +1,66 @@
+// test-expr-anim-builtins.mjs — GLSL-style builtins in the animation expr grammar
+// (smoothstep / clamp / step / min / max / mix / abs / floor / fract / sqrt / sign / pow / mod).
+import { parseExpr } from '../src/scene/expr.js';
+import { evalT, isTimeExpr, callT, linearT } from '../src/sdf/time.js';
+import { sphere } from '../src/sdf/d3.js';
+import { compileSDF3ToGLSL } from '../src/sdf/sdf3.compile.js';
+
+let pass = 0, fail = 0;
+const ok = (c, n) => (c ? (pass++, console.log(`  ✓ ${n}`)) : (fail++, console.log(`  ✗ ${n}`)));
+const near = (a, b, e = 1e-6) => Math.abs(a - b) < e;
+console.log('=== expr animation builtins ===\n');
+
+// ── parse structure ──
+{
+  const e = parseExpr('smoothstep(0, 2, t)');
+  ok(isTimeExpr(e) && e.form === 'call' && e.fn === 'smoothstep', 'smoothstep parses to a call form');
+  ok(e.args.length === 3 && e.args[0] === 0 && e.args[1] === 2, 'edges are literal numbers');
+  ok(isTimeExpr(e.args[2]) && e.args[2].form === 'linear', 'third arg is the time expr t');
+}
+
+// ── CPU eval: smoothstep(0,2,t) reveal curve ──
+{
+  const e = parseExpr('smoothstep(0, 2, t)');
+  ok(near(evalT(e, 0), 0), 'smoothstep(0,2,0) = 0 (hidden at start)');
+  ok(near(evalT(e, 1), 0.5), 'smoothstep(0,2,1) = 0.5 (mid reveal)');
+  ok(near(evalT(e, 2), 1), 'smoothstep(0,2,2) = 1 (fully revealed)');
+  ok(near(evalT(e, 5), 1), 'smoothstep past edge stays 1 (one-shot, not oscillation)');
+}
+
+// ── clamp / step / mix / others ──
+ok(near(evalT(parseExpr('clamp(t, 0, 1)'), 5), 1), 'clamp(t,0,1) at t=5 → 1');
+ok(near(evalT(parseExpr('clamp(t, 0, 1)'), -3), 0), 'clamp(t,0,1) at t=-3 → 0');
+ok(near(evalT(parseExpr('step(2, t)'), 1), 0) && near(evalT(parseExpr('step(2, t)'), 3), 1), 'step(2,t): 0 before, 1 after');
+ok(near(evalT(parseExpr('mix(0, 10, smoothstep(0, 1, t))'), 1), 10), 'mix + nested smoothstep composes');
+ok(near(evalT(parseExpr('0.2 + 0.8 * smoothstep(0, 1, t)'), 0), 0.2), 'scale from 0.2→1 via + and *');
+ok(near(evalT(parseExpr('0.2 + 0.8 * smoothstep(0, 1, t)'), 1), 1.0), 'scale reaches 1 at t=1');
+ok(near(evalT(parseExpr('abs(t)'), -2), 2), 'abs');
+ok(near(evalT(parseExpr('floor(t)'), 2.7), 2), 'floor');
+ok(near(evalT(parseExpr('sqrt(t)'), 9), 3), 'sqrt');
+
+// ── unknown function still rejected ──
+{
+  let threw = false;
+  try { parseExpr('wat(t)'); } catch { threw = true; }
+  ok(threw, 'unknown function rejected');
+}
+
+// ── sin/cos unchanged (back-compat) ──
+{
+  const e = parseExpr('0.3 + 0.05 * sin(t)');
+  ok(isTimeExpr(e), 'sin still parses (back-compat)');
+}
+
+// ── GLSL emit: a smoothstep-animated transform emits GLSL smoothstep(…, u_time) ──
+{
+  const anim = callT('smoothstep', 0, 2, linearT(1)); // = smoothstep(0, 2, t)
+  const sdf = sphere(0.4).translate([anim, 0, 0]);
+  const r = compileSDF3ToGLSL(sdf);
+  ok(!r.error, `smoothstep animation compiles to GLSL${r.error ? ' — ' + r.error : ''}`);
+  const withTime = [...(r.glsl || '').matchAll(/smoothstep\([^;]*?u_time[^;]*?\)/g)];
+  ok(withTime.length === 1, 'emits exactly one time-driven smoothstep(..., u_time)');
+  ok((r.glsl || '').includes('smoothstep(0.0, 2.0, (1.0 * u_time)'), 'emit matches smoothstep(0.0, 2.0, (1.0 * u_time))');
+}
+
+console.log(`\n${pass} passed, ${fail} failed`);
+process.exit(fail ? 1 : 0);

--- a/sdf-js/src/scene/expr.js
+++ b/sdf-js/src/scene/expr.js
@@ -25,7 +25,7 @@
 // composite expressions return `{form:'sum', terms:[...]}`.
 // =============================================================================
 
-import { linearT, sinT, cosT, sumT, mulT, isTimeExpr } from '../sdf/time.js';
+import { linearT, sinT, cosT, sumT, mulT, isTimeExpr, callT, CALL_FN_NAMES } from '../sdf/time.js';
 
 // =============================================================================
 // Tokenizer
@@ -39,6 +39,7 @@ const TOKEN_TYPES = {
   STAR: 'STAR',
   LPAREN: 'LPAREN',
   RPAREN: 'RPAREN',
+  COMMA: 'COMMA',
   EOF: 'EOF',
 };
 
@@ -73,6 +74,11 @@ function tokenize(src) {
     }
     if (c === ')') {
       tokens.push({ type: TOKEN_TYPES.RPAREN, pos: i });
+      i++;
+      continue;
+    }
+    if (c === ',') {
+      tokens.push({ type: TOKEN_TYPES.COMMA, pos: i });
       i++;
       continue;
     }
@@ -185,16 +191,24 @@ class Parser {
       this.consume();
       // function call?
       if (this.peek().type === TOKEN_TYPES.LPAREN) {
-        if (t.value !== 'sin' && t.value !== 'cos') {
-          throw new Error(
-            `Unsupported function "${t.value}" at position ${t.pos} (v1 supports: sin, cos)`,
-          );
-        }
         this.consume(); // (
-        const arg = this.parseExpr();
+        const args = [this.parseExpr()];
+        while (this.peek().type === TOKEN_TYPES.COMMA) {
+          this.consume(); // ,
+          args.push(this.parseExpr());
+        }
         this.expect(TOKEN_TYPES.RPAREN);
-        // sin(arg) where arg is TimeExpr (typically `t*freq + phase`)
-        return makeSinOrCos(t.value, arg);
+        // sin/cos keep their structured single-arg form (amp·sin(freq·t+phase))
+        if ((t.value === 'sin' || t.value === 'cos') && args.length === 1) {
+          return makeSinOrCos(t.value, args[0]);
+        }
+        // GLSL-style builtins (smoothstep/clamp/step/…) → generic call form
+        if (CALL_FN_NAMES.includes(t.value)) {
+          return callT(t.value, ...args);
+        }
+        throw new Error(
+          `Unsupported function "${t.value}" at position ${t.pos} (supports: sin, cos, ${CALL_FN_NAMES.join(', ')})`,
+        );
       }
       // bare identifier — only `t` allowed
       if (t.value === 't') {

--- a/sdf-js/src/sdf/sdf3.compile.js
+++ b/sdf-js/src/sdf/sdf3.compile.js
@@ -47,6 +47,12 @@ function emitTimeExpr(e) {
   if (e.form === 'cos')
     return `(${fltLit(e.amp)} * cos(${fltLit(e.freq)} * u_time + ${fltLit(e.phase)}))`;
   if (e.form === 'sum') return `(${e.terms.map(fltOrTime).join(' + ')})`;
+  // GLSL-style builtin call: fn is a GLSL built-in (smoothstep/clamp/step/…), so
+  // emit verbatim; args may be numbers or nested time-exprs. scale defaults to 1.
+  if (e.form === 'call') {
+    const inner = `${e.fn}(${e.args.map(fltOrTime).join(', ')})`;
+    return (e.scale ?? 1) === 1 ? `(${inner})` : `(${fltLit(e.scale)} * ${inner})`;
+  }
   // Sprint 4: uniform reference — emit raw GLSL string (caller must declare
   // the uniform externally). Used for subject motion offsets driven from JS
   // per frame (u_subjectOffset[slot].y for rocket lift-off etc).

--- a/sdf-js/src/sdf/time.js
+++ b/sdf-js/src/sdf/time.js
@@ -65,6 +65,44 @@ export function sumT(...terms) {
   return { kind: TIME_KIND, form: 'sum', terms };
 }
 
+// ----------------------------------------------------------------------------
+// GLSL-style builtin calls: smoothstep / clamp / step / min / max / mix / abs /
+// floor / fract / sqrt / sign / pow / mod. These are the one-shot / shaping
+// functions that oscillation (sin/cos) can't express — e.g. a build-in reveal
+// `smoothstep(0, 2, t)` (0→1 over [0,2]s, then STAYS 1). All are GLSL built-ins,
+// so emit is `fn(args...)` verbatim; CPU eval mirrors GLSL semantics here.
+// ----------------------------------------------------------------------------
+
+export const CALL_FNS = {
+  smoothstep: (e0, e1, x) => {
+    const t = Math.min(Math.max((x - e0) / (e1 - e0 || 1e-9), 0), 1);
+    return t * t * (3 - 2 * t);
+  },
+  clamp: (x, lo, hi) => Math.min(Math.max(x, lo), hi),
+  step: (edge, x) => (x < edge ? 0 : 1),
+  min: (a, b) => Math.min(a, b),
+  max: (a, b) => Math.max(a, b),
+  mix: (a, b, t) => a + (b - a) * t,
+  abs: (x) => Math.abs(x),
+  floor: (x) => Math.floor(x),
+  fract: (x) => x - Math.floor(x),
+  sqrt: (x) => Math.sqrt(Math.max(0, x)),
+  sign: (x) => Math.sign(x),
+  pow: (x, y) => Math.pow(x, y),
+  mod: (x, y) => (y === 0 ? 0 : x - y * Math.floor(x / y)),
+};
+
+export const CALL_FN_NAMES = Object.keys(CALL_FNS);
+
+/**
+ * Builtin call: `scale * fn(...args)`. args may be numbers or time-exprs.
+ * @example callT('smoothstep', 0, 2, linearT(1))   // 0→1 reveal over 2 seconds
+ */
+export function callT(fn, ...args) {
+  if (!CALL_FNS[fn]) throw new Error(`callT: unknown function '${fn}'`);
+  return { kind: TIME_KIND, form: 'call', fn, args, scale: 1 };
+}
+
 /**
  * Sprint 4: uniform reference — emits raw GLSL ref. Used to plumb per-frame
  * JS-computed values (subject motion offset from CarInt) into the SDF without
@@ -86,6 +124,7 @@ export function mulT(expr, k) {
   if (expr.form === 'linear') return { ...expr, coef: expr.coef * k };
   if (expr.form === 'sin' || expr.form === 'cos') return { ...expr, amp: expr.amp * k };
   if (expr.form === 'sum') return { ...expr, terms: expr.terms.map((t) => mulT(t, k)) };
+  if (expr.form === 'call') return { ...expr, scale: (expr.scale ?? 1) * k };
   if (expr.form === 'uniform') {
     // Scale by k by wrapping in a sum with a scaled-ref string. We're in a
     // closed world (only transform.translate uses uniform form in v1), so
@@ -107,6 +146,8 @@ export function evalT(expr, t = 0) {
   if (expr.form === 'sin') return expr.amp * Math.sin(expr.freq * t + expr.phase);
   if (expr.form === 'cos') return expr.amp * Math.cos(expr.freq * t + expr.phase);
   if (expr.form === 'sum') return expr.terms.reduce((acc, term) => acc + evalT(term, t), 0);
+  if (expr.form === 'call')
+    return (expr.scale ?? 1) * CALL_FNS[expr.fn](...expr.args.map((a) => evalT(a, t)));
   if (expr.form === 'uniform') return 0; // GPU-only; CPU sees zero offset
   throw new Error(`evalT: unknown form '${expr.form}'`);
 }


### PR DESCRIPTION
动画表达式文法之前只有 `sin/cos(t)` 连续振荡,**表达不了一次性 build-in**(0→1 揭示后停住)。加一批 shaping 内置函数,让 build-in 成为可能。

- **`smoothstep / clamp / step / min / max / mix / abs / floor / fract / sqrt / sign / pow / mod`**
- 实现为通用 `call` time-expr form(GLSL 都是内置函数,原样发射;CPU eval 镜像 GLSL 语义)
- 改三处:`time.js`(callT + CALL_FNS + evalT/mulT)、`expr.js`(COMMA token + 多参解析)、`sdf3.compile.js`(emitTimeExpr call case)

`expr: "smoothstep(0, 2, t)"` 现在发射 `smoothstep(0.0, 2.0, (1.0 * u_time))` —— 0→2 秒揭示后停住,正是 build-in 需要的。sin/cos 单参结构化路径不变(back-compat)。

`test-expr-anim-builtins`:21 断言(解析/CPU 曲线/嵌套/GLSL emit/back-compat)。`npm test` **106/106**。

**注(预存独立 bug)**:`.scale(<time-expr>)` 对任意 time-expr(sin 也是)抛 `flt got undefined` → build-in 暂用 `transform.translate` 动画;scale 动画路径是另一个修复(backlog)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)