### PR TITLE
Sprint 24 iter2: contract A — unfillable slots omitted from deck.json

### DIFF
--- a/sdf-js/examples/scaffold-pipeline/eval-edu-course-intro/deck.json
+++ b/sdf-js/examples/scaffold-pipeline/eval-edu-course-intro/deck.json
@@ -7,9 +7,9 @@
     "description": "Workshop / onboarding / how-to-do-X",
     "pickScore": 9,
     "pickSignals": [
-      "This is a course syllabus with clear instructional structure: objectives, topics, grading, readings, and support — all hallmarks of a training/workshop format",
-      "The 8-slot training scaffold maps perfectly: cover → objectives (learning objectives) → context (prerequisites/format) → concept (weekly topics) → steps (grading breakdown) → example (reading list) → exercise (labs/project) → summary (office hours/support)",
-      "The deck is teaching students 'how to do X' (build distributed systems), with structured learning outcomes, weekly progression, and hands-on labs — exactly what the training scaffold is designed for"
+      "This is a course syllabus deck — a structured instructional document that teaches students how to succeed in a distributed systems course",
+      "Perfect semantic match: cover → objectives (learning objectives) → context (prerequisites, format) → concept (weekly topics) → steps (grading breakdown, reading list) → example (weekly topics detail) → exercise (labs, project) → summary (office hours, support)",
+      "The training scaffold's 8-slot structure maps cleanly to syllabus sections: intro, learning goals, context, content breakdown, assessment steps, resources, and support — all core elements present in the source"
     ],
     "fallback": false,
     "pickerMethod": "llm"
@@ -113,22 +113,6 @@
       ]
     },
     {
-      "slotIdx": 3,
-      "slotName": "concept",
-      "slotTitle": "Core Concept",
-      "slotPurpose": "The main idea visualized",
-      "sourceSlideIdx": -1,
-      "sourceSlideTitle": null,
-      "mappingScore": 0,
-      "mappingFallback": false,
-      "mappingEmpty": true,
-      "liftFile": null,
-      "cached": false,
-      "dryRun": false,
-      "error": null,
-      "subjectTypes": []
-    },
-    {
       "slotIdx": 4,
       "slotName": "steps",
       "slotTitle": "Step by Step",
@@ -146,64 +130,42 @@
         "cover",
         "timeline"
       ]
+    }
+  ],
+  "droppedSlots": [
+    {
+      "slotIdx": 3,
+      "slotName": "concept",
+      "slotTitle": "Core Concept",
+      "reason": "no-source-content"
     },
     {
       "slotIdx": 5,
       "slotName": "example",
       "slotTitle": "Worked Example",
-      "slotPurpose": "Concrete walk-through",
-      "sourceSlideIdx": -1,
-      "sourceSlideTitle": null,
-      "mappingScore": 0,
-      "mappingFallback": false,
-      "mappingEmpty": true,
-      "liftFile": null,
-      "cached": false,
-      "dryRun": false,
-      "error": null,
-      "subjectTypes": []
+      "reason": "no-source-content"
     },
     {
       "slotIdx": 6,
       "slotName": "exercise",
       "slotTitle": "Try It Yourself",
-      "slotPurpose": "Hands-on activity",
-      "sourceSlideIdx": -1,
-      "sourceSlideTitle": null,
-      "mappingScore": 0,
-      "mappingFallback": false,
-      "mappingEmpty": true,
-      "liftFile": null,
-      "cached": false,
-      "dryRun": false,
-      "error": null,
-      "subjectTypes": []
+      "reason": "no-source-content"
     },
     {
       "slotIdx": 7,
       "slotName": "summary",
       "slotTitle": "Summary",
-      "slotPurpose": "Key takeaways",
-      "sourceSlideIdx": -1,
-      "sourceSlideTitle": null,
-      "mappingScore": 0,
-      "mappingFallback": false,
-      "mappingEmpty": true,
-      "liftFile": null,
-      "cached": false,
-      "dryRun": false,
-      "error": null,
-      "subjectTypes": []
+      "reason": "no-source-content"
     }
   ],
   "totals": {
     "slotsBaked": 4,
     "slotsEmpty": 4,
     "slotsErrored": 0,
-    "totalCostUSD": 0.0851706
+    "totalCostUSD": 0.1302582
   },
   "meta": {
-    "generatedAt": "2026-07-05T05:34:06.210Z",
+    "generatedAt": "2026-07-05T05:46:51.434Z",
     "model": "claude-sonnet-4-5-20250929",
     "pipelineVersion": "sprint-16-v1"
   }

--- a/sdf-js/examples/scaffold-pipeline/eval-edu-course-intro/eval.json
+++ b/sdf-js/examples/scaffold-pipeline/eval-edu-course-intro/eval.json
@@ -29,8 +29,8 @@
     "lifted_subject_rate": 1
   },
   "textBudget": {
-    "chars_per_slot": 254.5,
-    "max_slot_chars": 326
+    "chars_per_slot": 254.25,
+    "max_slot_chars": 324
   },
   "score": {
     "total": 80,
@@ -43,5 +43,5 @@
       "text": 10
     }
   },
-  "generatedAt": "2026-07-05T05:36:18.174Z"
+  "generatedAt": "2026-07-05T05:47:05.053Z"
 }

--- a/sdf-js/examples/scaffold-pipeline/eval-edu-course-intro/slots/slot-00-cover.json
+++ b/sdf-js/examples/scaffold-pipeline/eval-edu-course-intro/slots/slot-00-cover.json
@@ -34,19 +34,19 @@
     "forbiddenAtoms": [],
     "tokenUsage": {
       "input_tokens": 3931,
-      "cache_creation_input_tokens": 0,
-      "cache_read_input_tokens": 13008,
+      "cache_creation_input_tokens": 13008,
+      "cache_read_input_tokens": 0,
       "cache_creation": {
-        "ephemeral_5m_input_tokens": 0,
+        "ephemeral_5m_input_tokens": 13008,
         "ephemeral_1h_input_tokens": 0
       },
       "output_tokens": 170,
       "service_tier": "standard",
       "inference_geo": "not_available"
     },
-    "costUSD": 0.0182454,
-    "elapsedSec": 4.3,
-    "generatedAt": "2026-07-05T05:33:42.822Z",
+    "costUSD": 0.063123,
+    "elapsedSec": 4.2,
+    "generatedAt": "2026-07-05T05:46:29.482Z",
     "model": "claude-sonnet-4-5-20250929"
   }
 }

--- a/sdf-js/examples/scaffold-pipeline/eval-edu-course-intro/slots/slot-01-objectives.json
+++ b/sdf-js/examples/scaffold-pipeline/eval-edu-course-intro/slots/slot-01-objectives.json
@@ -16,15 +16,16 @@
         "w": 1280,
         "h": 120,
         "args": {
-          "title": "Learning Objectives"
+          "title": "Learning Objectives",
+          "style": "gradient"
         }
       },
       {
         "type": "radial-wheel-segmented",
-        "x": 80,
+        "x": 140,
         "y": 160,
-        "w": 1120,
-        "h": 520,
+        "w": 1000,
+        "h": 500,
         "args": {
           "hub": "Distributed Systems Mastery",
           "segments": [
@@ -34,19 +35,19 @@
             },
             {
               "label": "Raft Consensus",
-              "sublabel": "Implement module from scratch"
+              "sublabel": "Implement from scratch"
             },
             {
-              "label": "Failure Diagnosis",
-              "sublabel": "Split-brain & network partitions"
+              "label": "Failure Modes",
+              "sublabel": "Diagnose split-brain & partitions"
             },
             {
               "label": "Sharded KV Store",
-              "sublabel": "Design under failure scenarios"
+              "sublabel": "Design under failure"
             },
             {
-              "label": "Paper Analysis",
-              "sublabel": "Read & critique 3 seminal papers"
+              "label": "Research Papers",
+              "sublabel": "Read & critique 3 seminal works"
             }
           ],
           "segmentColors": [
@@ -97,13 +98,13 @@
         "ephemeral_5m_input_tokens": 0,
         "ephemeral_1h_input_tokens": 0
       },
-      "output_tokens": 414,
+      "output_tokens": 422,
       "service_tier": "standard",
       "inference_geo": "not_available"
     },
-    "costUSD": 0.0220764,
-    "elapsedSec": 7.6,
-    "generatedAt": "2026-07-05T05:33:50.399Z",
+    "costUSD": 0.022196399999999998,
+    "elapsedSec": 6.9,
+    "generatedAt": "2026-07-05T05:46:36.432Z",
     "model": "claude-sonnet-4-5-20250929"
   }
 }

--- a/sdf-js/examples/scaffold-pipeline/eval-edu-course-intro/slots/slot-02-context.json
+++ b/sdf-js/examples/scaffold-pipeline/eval-edu-course-intro/slots/slot-02-context.json
@@ -17,7 +17,7 @@
         "h": 120,
         "args": {
           "title": "Why This Matters",
-          "style": "gradient"
+          "style": "section"
         }
       },
       {
@@ -30,23 +30,23 @@
           "items": [
             {
               "icon": "network",
-              "label": "Build systems across many machines",
-              "sublabel": "Theory and practice of distributed computing"
+              "label": "Master distributed systems theory and practice",
+              "sublabel": "Build systems that scale across many machines"
             },
             {
-              "icon": "gear-six",
-              "label": "Master core distributed topics",
-              "sublabel": "Consensus, replication, partitioning, fault tolerance"
+              "icon": "shield-check",
+              "label": "Learn consensus and fault tolerance",
+              "sublabel": "Replication, partitioning, consistency models"
             },
             {
               "icon": "code",
-              "label": "Hands-on weekly labs",
-              "sublabel": "Apply concepts in Go or Rust"
+              "label": "Hands-on experience with Go or Rust",
+              "sublabel": "Weekly labs plus one group project"
             },
             {
-              "icon": "users-three",
-              "label": "Collaborative group project",
-              "sublabel": "Design and implement a real distributed system"
+              "icon": "graduation-cap",
+              "label": "Build on OS foundations",
+              "sublabel": "Prerequisite: CS 240 (Operating Systems)"
             }
           ],
           "title": null
@@ -71,13 +71,13 @@
         "ephemeral_5m_input_tokens": 0,
         "ephemeral_1h_input_tokens": 0
       },
-      "output_tokens": 357,
+      "output_tokens": 365,
       "service_tier": "standard",
       "inference_geo": "not_available"
     },
-    "costUSD": 0.021194400000000002,
-    "elapsedSec": 7.7,
-    "generatedAt": "2026-07-05T05:33:58.105Z",
+    "costUSD": 0.0213144,
+    "elapsedSec": 7,
+    "generatedAt": "2026-07-05T05:46:43.437Z",
     "model": "claude-sonnet-4-5-20250929"
   }
 }

--- a/sdf-js/examples/scaffold-pipeline/eval-edu-course-intro/slots/slot-04-steps.json
+++ b/sdf-js/examples/scaffold-pipeline/eval-edu-course-intro/slots/slot-04-steps.json
@@ -22,10 +22,10 @@
       },
       {
         "type": "timeline",
-        "x": 80,
-        "y": 180,
-        "w": 1120,
-        "h": 480,
+        "x": 60,
+        "y": 160,
+        "w": 1160,
+        "h": 520,
         "args": {
           "events": [
             {
@@ -56,16 +56,16 @@
             {
               "date": "Week 11-12",
               "label": "Transactions",
-              "sublabel": "Distributed ACID"
+              "sublabel": "Distributed"
             },
             {
               "date": "Week 13-14",
               "label": "Case Studies",
-              "sublabel": "Spanner, Dynamo, Kafka"
+              "sublabel": "Spanner, DynamoDB, Kafka"
             },
             {
               "date": "Week 15",
-              "label": "Final Project",
+              "label": "Final Projects",
               "sublabel": "Presentations"
             }
           ],
@@ -91,13 +91,13 @@
         "ephemeral_5m_input_tokens": 0,
         "ephemeral_1h_input_tokens": 0
       },
-      "output_tokens": 511,
+      "output_tokens": 509,
       "service_tier": "standard",
       "inference_geo": "not_available"
     },
-    "costUSD": 0.0236544,
-    "elapsedSec": 8.1,
-    "generatedAt": "2026-07-05T05:34:06.208Z",
+    "costUSD": 0.0236244,
+    "elapsedSec": 8,
+    "generatedAt": "2026-07-05T05:46:51.430Z",
     "model": "claude-sonnet-4-5-20250929"
   }
 }

--- a/sdf-js/scripts/bake-scaffold-pipeline.mjs
+++ b/sdf-js/scripts/bake-scaffold-pipeline.mjs
@@ -582,25 +582,40 @@ const deckManifest = {
     colors: theme.colors,
     font: theme.font,
   },
-  slots: slotAssignments.map((a) => {
-    const lift = slotLifts.find((l) => l.slotIdx === a.slotIdx) || {};
-    return {
+  // Sprint 24 iter2 (contract A, user-approved 2026-07-05): slots[] contains
+  // ONLY filled slots — the played deck has no holes. Unfillable slots are
+  // recorded in droppedSlots[] for transparency (eval fill_rate = delivered /
+  // (delivered + dropped), same meaning as before). slotIdx keeps the original
+  // scaffold position (sparse is fine; consumers iterate the array).
+  slots: slotAssignments
+    .filter((a) => !a.empty)
+    .map((a) => {
+      const lift = slotLifts.find((l) => l.slotIdx === a.slotIdx) || {};
+      return {
+        slotIdx: a.slotIdx,
+        slotName: a.slot.name,
+        slotTitle: a.slot.title,
+        slotPurpose: a.slot.purpose,
+        sourceSlideIdx: a.slideIdx,
+        sourceSlideTitle: a.slideIdx >= 0 ? slides[a.slideIdx].title || '' : null,
+        mappingScore: a.score,
+        mappingFallback: !!a.fallback,
+        mappingEmpty: false,
+        liftFile: lift.outFile ? lift.outFile.replace(`${OUT_DIR}/`, '') : null,
+        cached: !!lift.cached,
+        dryRun: !!lift.dryRun,
+        error: lift.error || null,
+        subjectTypes: lift.subjectTypes || [],
+      };
+    }),
+  droppedSlots: slotAssignments
+    .filter((a) => a.empty)
+    .map((a) => ({
       slotIdx: a.slotIdx,
       slotName: a.slot.name,
       slotTitle: a.slot.title,
-      slotPurpose: a.slot.purpose,
-      sourceSlideIdx: a.slideIdx,
-      sourceSlideTitle: a.slideIdx >= 0 ? slides[a.slideIdx].title || '' : null,
-      mappingScore: a.score,
-      mappingFallback: !!a.fallback,
-      mappingEmpty: !!a.empty,
-      liftFile: lift.outFile ? lift.outFile.replace(`${OUT_DIR}/`, '') : null,
-      cached: !!lift.cached,
-      dryRun: !!lift.dryRun,
-      error: lift.error || null,
-      subjectTypes: lift.subjectTypes || [],
-    };
-  }),
+      reason: 'no-source-content',
+    })),
   totals: {
     slotsBaked: slotLifts.filter((l) => l.sceneData || l.cached || l.dryRun).length,
     slotsEmpty: slotLifts.filter((l) => l.empty).length,

--- a/sdf-js/scripts/eval-deck-quality.mjs
+++ b/sdf-js/scripts/eval-deck-quality.mjs
@@ -113,8 +113,14 @@ export async function scoreDeckQuality(deckDir) {
   }
   const manifest = JSON.parse(readFileSync(deckJsonPath, 'utf8'));
 
-  const slotsTotal = manifest.slots.length;
-  const slotsEmpty = manifest.slots.filter((s) => s.mappingEmpty).length;
+  // Sprint 24 iter2 (contract A): empty slots are OMITTED from slots[] and
+  // recorded in droppedSlots[] instead — the played deck has no holes. The
+  // fill_rate metric keeps its original meaning (delivered / planned) so
+  // scores stay comparable across iterations: planned = slots + dropped.
+  const droppedSlots = Array.isArray(manifest.droppedSlots) ? manifest.droppedSlots : [];
+  const legacyEmpty = manifest.slots.filter((s) => s.mappingEmpty).length; // pre-iter2 decks
+  const slotsTotal = manifest.slots.length + droppedSlots.length;
+  const slotsEmpty = droppedSlots.length + legacyEmpty;
   const slotsErrored = manifest.slots.filter((s) => s.error).length;
   const bakedSlotEntries = manifest.slots.filter((s) => s.liftFile && !s.error && !s.mappingEmpty);
   const slotsBaked = bakedSlotEntries.length;

--- a/sdf-js/scripts/eval-results/summary.json
+++ b/sdf-js/scripts/eval-results/summary.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-07-05T05:36:18.176Z",
+  "generatedAt": "2026-07-05T05:47:05.055Z",
   "corpusSize": 10,
   "scored": 10,
   "skipped": [],
@@ -288,8 +288,8 @@
       "liftSuccess": 4,
       "liftAttempted": 4,
       "liftedSubjectRate": 1,
-      "charsPerSlot": 254.5,
-      "maxSlotChars": 326
+      "charsPerSlot": 254.25,
+      "maxSlotChars": 324
     }
   ]
 }

--- a/sdf-js/scripts/test-eval-harness.mjs
+++ b/sdf-js/scripts/test-eval-harness.mjs
@@ -171,6 +171,23 @@ ok(
   'collectTextChars skips enum keys, counts prose keys',
 );
 
+// ── Sprint 24 iter2 (contract A): droppedSlots[] count toward planned total ──
+// A deck that delivered 2 slots and dropped 2 has fill_rate 0.5 — same metric
+// meaning as the pre-iter2 mappingEmpty representation.
+deckManifest.droppedSlots = [
+  { slotIdx: 2, slotName: 'exercise', reason: 'no-source-content' },
+  { slotIdx: 3, slotName: 'summary', reason: 'no-source-content' },
+];
+writeFileSync(join(dir, 'deck.json'), JSON.stringify(deckManifest, null, 2));
+const result2 = await scoreDeckQuality(dir);
+ok(result2.structure.slots_total === 4, 'iter2: slots_total counts dropped (2+2=4)');
+ok(result2.structure.slots_baked === 2, 'iter2: slots_baked === 2');
+ok(
+  approxEqual(result2.structure.fill_rate, 0.5),
+  'iter2: fill_rate === 0.5 (2 delivered / 4 planned)',
+);
+ok(result2.structure.slots_empty === 2, 'iter2: slots_empty === droppedSlots.length');
+
 rmSync(dir, { recursive: true, force: true });
 
 console.log(`\n${pass} passed, ${fail} failed`);


### PR DESCRIPTION
## Summary

User 拍板选 A: mapper 分配不到内容的 slot 从 deck.json **直接省略** — 影院播紧凑的 N 张 deck, 不播带洞的。

## Contract change

**Before**: `slots[]` 含全部 scaffold slot, 空的带 `mappingEmpty: true, liftFile: null` — 播放器要自己跳洞
**After**: `slots[]` 只含已填 slot (全部有 liftFile); 省略的进 `droppedSlots[]`:

```json
"droppedSlots": [
  { "slotIdx": 4, "slotName": "exercise", "reason": "no-source-content" }
]
```

`slotIdx` 保留 scaffold 原位 (sparse OK — 所有消费者都是遍历数组)。

## 指标诚实性 (关键设计)

**fill_rate 语义不变**: delivered / (delivered + dropped)。edu deck 还是读 4/8 = 80 分 — 契约变更改善**产品** (播放无洞), 不改善**数字**。跨迭代分数保持可比。Legacy deck (pre-iter2 带 mappingEmpty 的) scorer 兼容照旧。

## e2e 验证

重 bake `eval-edu-course-intro` (上轮 4/8-fill 最差 deck):
- `slots[]` = 4 个, **全部有 liftFile** ✅
- `droppedSlots[]` = concept/example/exercise/summary ×4 带 reason ✅
- 浏览器 viewer + 3D lift-scaffold-deck 都遍历 slots[] → 免费获得无洞 deck ✅
- score 仍 80 (fill 4/8) — 指标没被 game ✅

## Tests

- test-eval-harness +4 assertions (dropped-slots 路径)
- npm test **112/112**

Per CLAUDE.md: DO NOT merge. Awaiting user review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)