### PR TITLE
perf(studio): async shader compile (KHR_parallel_shader_compile) — kills the cold-load black screen

### DIFF
--- a/sdf-js/apps/present/figure.html
+++ b/sdf-js/apps/present/figure.html
@@ -40,10 +40,51 @@
         background: rgba(40, 116, 196, 0.92);
         font-weight: 700;
       }
+      /* Boot loader — visible until the first frame is drawn. Pure CSS-transform
+         animation so it keeps moving even if the main thread hiccups. */
+      #loading {
+        position: fixed;
+        inset: 0;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        gap: 14px;
+        background: #0e0f12;
+        transition: opacity 0.4s;
+        z-index: 10;
+      }
+      #loading.done {
+        opacity: 0;
+        pointer-events: none;
+      }
+      #loading .ring {
+        width: 34px;
+        height: 34px;
+        border-radius: 50%;
+        border: 3px solid rgba(255, 255, 255, 0.14);
+        border-top-color: rgba(255, 255, 255, 0.85);
+        animation: spin 0.9s linear infinite;
+      }
+      #loading .msg {
+        font:
+          500 12px -apple-system,
+          Inter,
+          sans-serif;
+        color: rgba(255, 255, 255, 0.55);
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+      }
+      @keyframes spin {
+        to {
+          transform: rotate(360deg);
+        }
+      }
     </style>
   </head>
   <body>
     <div id="wrap"><canvas id="c"></canvas></div>
+    <div id="loading"><div class="ring"></div><div class="msg">compiling scene</div></div>
     <script type="module" src="./figure.js"></script>
   </body>
 </html>

--- a/sdf-js/apps/present/figure.js
+++ b/sdf-js/apps/present/figure.js
@@ -59,7 +59,13 @@ const els = items.map((o) => {
   document.body.appendChild(d);
   return d;
 });
+// Dismiss the boot loader on the first drawn frame (the async shader compile
+// keeps the main thread free, so the spinner animates while we wait).
+const loading = document.getElementById('loading');
 function tick() {
+  if (loading && !loading.classList.contains('done') && studio.hasDrawn && studio.hasDrawn()) {
+    loading.classList.add('done');
+  }
   const t = studio.getSequenceTime ? studio.getSequenceTime() : 1e9;
   for (let i = 0; i < items.length; i++) {
     const o = items[i],

--- a/sdf-js/src/render/studio.js
+++ b/sdf-js/src/render/studio.js
@@ -1842,6 +1842,15 @@ export function createStudioRenderer({
   // 200-500ms on complex scenes — the BIG source of perceived page lag).
   const programCache = new Map();
   const PROGRAM_CACHE_MAX = 6;
+  // KHR_parallel_shader_compile: lets the driver compile+link on background
+  // threads. We link WITHOUT querying LINK_STATUS (that query forces a
+  // synchronous compile of the whole ~150KB+ shader — the multi-second
+  // main-thread block behind every cold-load black screen) and instead poll
+  // COMPLETION_STATUS_KHR on rAF, swapping the program in when it's ready.
+  const parallelExt = gl.getExtension('KHR_parallel_shader_compile');
+  // The one in-flight async compile. A newer upload abandons the older pending
+  // program (deleted, never swapped in).
+  let pendingProgram = null;
   // Per-leaf material + pattern LUTs — built at uploadSDF time from
   // compileSDF3ToGLSL() output. Float32Arrays of MAX_MATERIAL * 4. Sentinels:
   //   materialLUT[i*4+1] = -1   → no material, shader uses hash palette
@@ -2049,48 +2058,103 @@ export function createStudioRenderer({
   // before the 200-500ms compile blocks the main thread).
   // `result` carries leafMaterials + leafPatterns + glsl for LUT upload.
   function uploadCompiledFrag(fragSource, result) {
-    // Program cache: hit avoids the 200-500ms GLSL compile+link that
-    // dominates "switch from BOB GPU to FLY 3D" perceived latency.
+    // Program cache: hit avoids the GLSL compile+link that dominates scene-swap
+    // perceived latency.
     // 2026-05-24: cache entry now carries the FS too. WebGL deleteProgram does
     // NOT release attached shaders — without explicit detach + deleteShader on
     // eviction, every FS leaks (~1MB of GLSL bytecode each). Over many scene
     // swaps that's real GPU memory pressure.
-    let entry = programCache.get(fragSource);
-    let cacheHit = false;
-    if (entry) {
-      cacheHit = true;
-    } else {
-      let fs;
-      try {
-        fs = compileShader(fragSource, gl.FRAGMENT_SHADER);
-      } catch (e) {
-        console.error('Fragment shader source was:\n', fragSource);
-        throw new Error(`GLSL shader compile failed: ${e.message}`);
-      }
-      const prog = gl.createProgram();
-      gl.attachShader(prog, vs);
-      gl.attachShader(prog, fs);
-      gl.linkProgram(prog);
-      if (!gl.getProgramParameter(prog, gl.LINK_STATUS)) {
-        throw new Error(`Program link failed: ${gl.getProgramInfoLog(prog)}`);
-      }
-      // LRU eviction — drop oldest cached program if at capacity. Crucial:
-      // detach + delete the FS attached to the old program; otherwise the FS
-      // outlives the program and leaks. The VS is shared across all programs
-      // so we do NOT delete it.
-      if (programCache.size >= PROGRAM_CACHE_MAX) {
-        const firstKey = programCache.keys().next().value;
-        const old = programCache.get(firstKey);
-        gl.detachShader(old.prog, vs);
-        gl.detachShader(old.prog, old.fs);
-        gl.deleteShader(old.fs);
-        gl.deleteProgram(old.prog);
-        programCache.delete(firstKey);
-      }
-      entry = { prog, fs };
-      programCache.set(fragSource, entry);
+    const cached = programCache.get(fragSource);
+    if (cached) {
+      pendingProgram = null; // a cache hit supersedes any in-flight compile
+      finishProgramSetup(cached, result);
+      console.log('[studio] program cache hit — skipped GLSL compile');
+      return result.glsl.length;
     }
 
+    // Compile + link WITHOUT querying status — status queries force the driver
+    // to finish compiling synchronously (the cold-load black-screen block).
+    const fs = gl.createShader(gl.FRAGMENT_SHADER);
+    gl.shaderSource(fs, fragSource);
+    gl.compileShader(fs);
+    const prog = gl.createProgram();
+    gl.attachShader(prog, vs);
+    gl.attachShader(prog, fs);
+    gl.linkProgram(prog);
+    const entry = { prog, fs };
+
+    if (parallelExt) {
+      // Async path: poll completion on rAF; swap the program in when ready.
+      // Until then the previous program (or nothing, on first load) keeps
+      // rendering and the main thread stays free (loading UIs can animate).
+      const mine = { entry, fragSource, result };
+      pendingProgram = mine;
+      const poll = () => {
+        if (pendingProgram !== mine) {
+          // superseded by a newer upload — abandon this program entirely
+          gl.detachShader(prog, vs);
+          gl.detachShader(prog, fs);
+          gl.deleteShader(fs);
+          gl.deleteProgram(prog);
+          return;
+        }
+        if (!gl.getProgramParameter(prog, parallelExt.COMPLETION_STATUS_KHR)) {
+          requestAnimationFrame(poll);
+          return;
+        }
+        pendingProgram = null;
+        try {
+          validateAndCache(entry, fragSource); // throws on real compile errors
+        } catch (e) {
+          console.error('[studio] async program compile failed:', e);
+          return;
+        }
+        finishProgramSetup(entry, result);
+        _debugFirstDraw = true; // first frame of THIS program resets the clocks
+        wake();
+      };
+      requestAnimationFrame(poll);
+      return result.glsl.length;
+    }
+
+    // Sync fallback (extension unavailable): old behavior, blocks on link check.
+    validateAndCache(entry, fragSource);
+    finishProgramSetup(entry, result);
+    return result.glsl.length;
+  }
+
+  // Check compile/link results (forces compile completion — cheap once
+  // COMPLETION_STATUS_KHR reported done, blocking on the sync path) and insert
+  // into the LRU cache.
+  function validateAndCache(entry, fragSource) {
+    const { prog, fs } = entry;
+    if (!gl.getProgramParameter(prog, gl.LINK_STATUS)) {
+      const fsLog = gl.getShaderInfoLog(fs);
+      console.error('Fragment shader source was:\n', fragSource);
+      gl.detachShader(prog, vs);
+      gl.detachShader(prog, fs);
+      gl.deleteShader(fs);
+      gl.deleteProgram(prog);
+      throw new Error(`GLSL compile/link failed: ${fsLog || gl.getProgramInfoLog(prog)}`);
+    }
+    // LRU eviction — drop oldest cached program if at capacity. Crucial:
+    // detach + delete the FS attached to the old program; otherwise the FS
+    // outlives the program and leaks. The VS is shared across all programs
+    // so we do NOT delete it.
+    if (programCache.size >= PROGRAM_CACHE_MAX) {
+      const firstKey = programCache.keys().next().value;
+      const old = programCache.get(firstKey);
+      gl.detachShader(old.prog, vs);
+      gl.detachShader(old.prog, old.fs);
+      gl.deleteShader(old.fs);
+      gl.deleteProgram(old.prog);
+      programCache.delete(firstKey);
+    }
+    programCache.set(fragSource, entry);
+  }
+
+  // Activate a ready program: attribs, uniform locations, per-leaf LUT upload.
+  function finishProgramSetup(entry, result) {
     program = entry.prog;
 
     gl.useProgram(program);
@@ -2201,9 +2265,6 @@ export function createStudioRenderer({
     if (uniformsCache['u_leafPattern[0]'] != null) {
       gl.uniform4fv(uniformsCache['u_leafPattern[0]'], patternLUT);
     }
-
-    if (cacheHit) console.log('[studio] program cache hit — skipped GLSL compile');
-    return result.glsl.length;
   }
 
   let _debugFirstDraw = true;
@@ -3060,6 +3121,12 @@ export function createStudioRenderer({
     },
     getSequenceDuration() {
       return activeSequence ? seqTotalDuration(activeSequence) : 0;
+    },
+    // Has at least one frame of the current scene actually been drawn? False
+    // while the (async) shader compile is still pending — loading UIs poll this
+    // to know when to dismiss.
+    hasDrawn() {
+      return !!lastCam;
     },
     isSequenceActive() {
       return !!activeSequence && !userTookCam;


### PR DESCRIPTION
## What

Fixes the cold-load **black screen** on the figure page (user report: "开始先黑屏一段时间" before the funnel appears) — and every other studio page benefits.

## Root cause

`uploadCompiledFrag` queried `LINK_STATUS` immediately after `linkProgram`. That query forces the driver to finish compiling the whole ~150KB+ fragment shader **synchronously on the main thread** — seconds of frozen, black page on any cold shader source.

## Fix

**Async compile via `KHR_parallel_shader_compile`.** Link with NO status query, poll `COMPLETION_STATUS_KHR` on rAF, and only when the driver reports ready: validate (errors surface with the same source-dump convention), insert into the LRU cache, set up uniforms/LUTs, swap the program in, re-arm the first-frame clock reset, `wake()`. Until then the previous program (or nothing, on first load) keeps rendering and the main thread stays free. A newer upload abandons the in-flight one. Sync fallback preserves old behavior where the extension is missing.

`uploadCompiledFrag` is split into `validateAndCache` + `finishProgramSetup` shared by the cached/async/sync paths. New tiny API: **`studio.hasDrawn()`** for loading UIs.

**Figure page boot loader**: CSS-transform spinner + "compiling scene", dismissed at the first drawn frame. The blind page inherits it via the iframe.

## Measured (cold source, this machine)

- Longest main-thread stall: **multi-second → ~0.9s** (the driver's first-draw finalization; the loader spins through it).
- Sequence still starts at the first visible frame (composes with the slice-1 clock fix): `seq=2.47` at wall ~2.5s.
- Loader shows → fades; `hasDrawn()` flips true.

## Regression

apps/present renders normally on the async path (sphere-fill-gauge checked visually). Full suite **112/112**; changed files lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)