### PR TITLE
feat(render-sequence): fighting-game camera — hero / spiral / super punch-in / payoff

### DIFF
--- a/sdf-js/scripts/test-render-sequence.mjs
+++ b/sdf-js/scripts/test-render-sequence.mjs
@@ -52,9 +52,22 @@ ok(
 const starts = stages.map((s) => Number(s.animation[0].expr.match(/smoothstep\(([\d.]+)/)[1]));
 ok(starts[0] < starts[3], 'reveal windows staggered by order (top reveals first)');
 
-ok(scene.cameraSequence && scene.cameraSequence.shots.length >= 2, 'has a multi-shot fly-through');
-const ys = scene.cameraSequence.shots.map((s) => s.pos[1]);
-ok(ys[0] > ys[ys.length - 1], 'camera descends (fly-through)');
+ok(scene.cameraSequence && scene.cameraSequence.shots.length >= 4, 'has a multi-shot fly-through');
+// fighting-game grammar: low hero opening → crane peak → spiral descent →
+// hard-cut punch-in on the emphasis stage (shake + exposure pop) → wide payoff.
+const shots = scene.cameraSequence.shots;
+const ys = shots.map((s) => s.pos[1]);
+const peakIdx = ys.indexOf(Math.max(...ys));
+ok(ys[0] < ys[peakIdx], 'opens low (hero angle), rises to the crane peak');
+ok(Math.min(...ys.slice(peakIdx)) < ys[peakIdx] - 2, 'descends from the peak (fly-through)');
+const superShot = shots.find((s) => s.transition === 'cut' && (s.shake || 0) >= 0.2);
+ok(!!superShot, 'has a hard-cut punch-in with heavy shake (the super)');
+ok(Array.isArray(superShot?.exposure), 'super shot pops exposure (ramp)');
+ok(
+  shots.some((s) => Math.abs(s.pos[0]) > 0.8 && s.transition === 'blend'),
+  'descent orbits off-axis (spiral)',
+);
+ok((shots[shots.length - 1].focalDistance || 0) > 4, 'ends on a wide payoff frame');
 
 // labels → overlay, each with a revealAt; title present; NO baked SDF text
 const labels = scene.overlay.filter((o) => o.role === 'card' || o.role === 'value');

--- a/sdf-js/src/scene/render-sequence.js
+++ b/sdf-js/src/scene/render-sequence.js
@@ -57,12 +57,18 @@ export function renderSequence(ir) {
   // ONE subject per stage (a single-band frustum) so each builds in independently.
   // build-in: translate.y from (yc + drop) → yc over [revealStart, revealEnd], then holds.
   // The translate.y channel REPLACES the static y (applyTransform resolveVec3Field), so the
-  // expr must produce the FULL y. Reveal windows stagger by the node's position in `order`.
+  // expr must produce the FULL y.
+  //
+  // Timing (fighting-game staging): the FORM assembles during the intro — a rapid
+  // top-to-bottom cascade (0.35s per stage ≈ stages fall almost together, which
+  // also keeps a falling stage from interpenetrating the settled one above) while
+  // the hero/crane shots play. The DATA then reveals during the spiral tour
+  // (labels per stage, below). Geometry spectacle first, narration second.
   const subjects = [];
   order.forEach((i, k) => {
     const yc = stageY(i);
-    const revealStart = 0.2 + k * holdEach;
-    const revealEnd = revealStart + 0.7;
+    const revealStart = 0.25 + k * 0.35;
+    const revealEnd = revealStart + 0.6;
     const yFull = (yc + drop).toFixed(3);
     subjects.push({
       id: `stage-${i}`,
@@ -79,37 +85,76 @@ export function renderSequence(ir) {
     });
   });
 
-  // fly-through: start above the mouth, descend through the axis to the emphasis stage.
+  // Fly-through — fighting-game camera language (GGST / SF6 supers): hold a calm
+  // reading plane most of the time, then BREAK it at the big moment. Beats:
+  //   1. hero low-angle opening (monumental — looking UP at the mouth)
+  //   2. crane up-and-over the rim
+  //   3. spiral descent — azimuth orbits as the camera drops stage to stage,
+  //      a touch of handheld shake for energy (the 3D-selling move)
+  //   4. the SUPER: hard CUT to a tight low-angle punch-in on the gold outcome
+  //      stage — heavy shake + an exposure pop that settles (SF6 punish-counter)
+  //   5. payoff pull-back — the whole story in one wide frame
+  const midY = topY - totalH / 2;
+  const emphasisIdx = ir.emphasis && ir.emphasis.length ? ir.emphasis[0] : N - 1;
+  const goldY = stageY(emphasisIdx);
   const shots = [
+    // 1 — hero low angle, worm's-eye at the mouth
     {
-      duration: 0.01,
-      pos: [0.6, topY + 2.4, 6.2],
-      target: [0, topY, 0],
-      fov: 52,
+      duration: 0.9,
+      pos: [2.3, 0.55, 5.2],
+      target: [0, topY - 0.2, 0],
+      fov: 54,
       aperture: 0,
-      focalDistance: 6,
-      ease: 'smooth',
+      focalDistance: 5.5,
+      ease: 'out',
+    },
+    // 2 — crane up and over the rim
+    {
+      duration: 1.3,
+      pos: [0.9, topY + 2.5, 4.4],
+      target: [0, topY - 0.3, 0],
+      fov: 50,
+      transition: 'blend',
+      aperture: 0,
+      focalDistance: 5,
+      ease: 'inout',
     },
   ];
+  // 3 — spiral descent: orbit ~0.9 rad per stage while dropping
   for (let i = 0; i < N; i++) {
     const y = stageY(i);
+    const theta = 0.9 * (i + 1);
+    const dist = Math.max(2.6, radii[i] * 3.2 + 2.2);
     shots.push({
       duration: holdEach,
-      pos: [0, y + 0.9, Math.max(2.6, radii[i] * 3.2 + 2.2)],
+      pos: [Math.sin(theta) * dist, y + 0.85, Math.cos(theta) * dist],
       target: [0, y, 0],
       fov: 46,
       transition: 'blend',
       aperture: 0,
-      focalDistance: 4,
+      focalDistance: dist,
+      shake: 0.08,
       ease: 'smooth',
     });
   }
-  // Payoff ending: after arriving at the outcome, pull back and slightly up to
-  // frame the WHOLE funnel — the audience leaves seeing the full story at once
-  // (every stage revealed, the gold emphasis stage in context).
-  const midY = topY - totalH / 2;
+  // 4 — the super: hard cut, tight low-angle punch-in on the gold stage.
+  // Camera stays above the floor (the emphasis stage can sit near y=0) while
+  // still looking slightly UP at the stage for the hero read.
   shots.push({
-    duration: 2.2,
+    duration: 1.0,
+    pos: [0.55, Math.max(goldY - 0.15, 0.14), 1.9],
+    target: [0, goldY + 0.12, 0],
+    fov: 40,
+    transition: 'cut',
+    aperture: 0,
+    focalDistance: 2,
+    shake: 0.3,
+    exposure: [1.45, 1.0],
+    ease: 'out',
+  });
+  // 5 — payoff pull-back: the whole funnel, every stage revealed, gold in context
+  shots.push({
+    duration: 2.4,
     pos: [1.4, midY + 1.1, totalH * 1.7 + radii[0] * 2.6],
     target: [0, midY + 0.2, 0],
     fov: 44,
@@ -119,13 +164,15 @@ export function renderSequence(ir) {
     ease: 'out',
   });
 
-  // labels → overlay, reveal-tagged just after each stage settles.
+  // labels → overlay, reveal-tagged as the spiral tour reaches each stage
+  // (introLead = hero 0.9s + crane 1.3s before the descent begins).
+  const introLead = 2.2;
   const overlay = [
     { text: String(ir.title || nodes[0]).toUpperCase(), anchor: [0, topY + 1.4, 0], role: 'title' },
   ];
   order.forEach((i, k) => {
     const y = stageY(i);
-    const revealAt = 0.2 + k * holdEach + 0.5; // just after this stage's build-in
+    const revealAt = introLead + k * holdEach + 0.45; // as the tour reaches this stage
     overlay.push({
       text: nodes[i],
       anchor: [radii[i] + 0.5, y, 0],


### PR DESCRIPTION
## What — bolder camera, fighting-game grammar

Post-GO upgrade per user direction: study how GGST / SF6 / Fatal Fury CotW stage "2D fights on 3D sets" — hold a calm reading plane, then **break it at the big moment**. New shot grammar for the funnel fly-through:

1. **Hero low-angle opening** — worm's-eye looking up at the mouth (monumental).
2. **Crane** up and over the rim.
3. **Spiral descent** — azimuth orbits ~0.9 rad per stage while dropping, light handheld shake (0.08). The 3D-selling move.
4. **The super** — hard **CUT** to a tight low-angle punch-in on the gold outcome stage: shake **0.3** + exposure pop **[1.45→1.0]** (SF6 punish-counter vibe).
5. **Payoff pull-back** — the whole story in one wide frame.

**Staging split (fighting-game arena logic):** the FORM assembles during the intro — a rapid top-to-bottom cascade (0.35s/stage; also prevents a falling stage interpenetrating the settled one above) while the hero/crane shots play — and the DATA (labels) reveals during the spiral tour. Geometry spectacle first, narration second.

All from the existing shot schema (`transition:'cut'` / `shake` / `exposure` ramps) — zero engine changes.

## Verified

- Pinned-time captures: hero low-angle ✓, spiral off-axis with labels tracking ✓, super punch-in framing ✓ (first attempt put the camera **underground** — `goldY−0.4` below the floor → fog-only frame; fixed with a floor clamp).
- Test rewritten to the new grammar (opens low → crane peak → descends; has a hard-cut super with shake + exposure ramp; orbits off-axis; ends wide): 22/22. Full suite 112/112.

🤖 Generated with [Claude Code](https://claude.com/claude-code)