### PR TITLE
Sprint 24 iter3: course-syllabus scaffold + mapper 1→2 slots — edu 80→100, mean 97.3

### DIFF
--- a/sdf-js/examples/scaffold-pipeline/eval-edu-course-intro/deck.json
+++ b/sdf-js/examples/scaffold-pipeline/eval-edu-course-intro/deck.json
@@ -2,65 +2,65 @@
   "deckName": "eval-edu-course-intro",
   "sourceFile": "sdf-js/scripts/scaffold-pipeline-fixtures/edu-course-intro.json",
   "scaffold": {
-    "id": "training",
-    "label": "Training",
-    "description": "Workshop / onboarding / how-to-do-X",
-    "pickScore": 9,
+    "id": "course-syllabus",
+    "label": "Course Syllabus",
+    "description": "Course introduction / syllabus deck — overview, objectives, schedule, grading, materials, logistics. First-day-of-class, NOT a lesson.",
+    "pickScore": 10,
     "pickSignals": [
-      "This is a course syllabus deck — a structured instructional document that teaches students how to succeed in a distributed systems course",
-      "Perfect semantic match: cover → objectives (learning objectives) → context (prerequisites, format) → concept (weekly topics) → steps (grading breakdown, reading list) → example (weekly topics detail) → exercise (labs, project) → summary (office hours, support)",
-      "The training scaffold's 8-slot structure maps cleanly to syllabus sections: intro, learning goals, context, content breakdown, assessment steps, resources, and support — all core elements present in the source"
+      "Perfect structural match: cover, overview, objectives, topics (schedule), grading, reading (materials), office hours (logistics) — all 7 syllabus slots present",
+      "Clear first-day-of-class intent: introducing the course to students, not teaching a specific lesson",
+      "All canonical syllabus elements present: instructor info, meeting time/place, prerequisites, week-by-week schedule, assessment breakdown, required readings, support resources"
     ],
     "fallback": false,
     "pickerMethod": "llm"
   },
   "theme": {
-    "id": "organic-teal",
-    "label": "Organic · Teal",
-    "macroCluster": "organic",
+    "id": "editorial-navy",
+    "label": "Editorial · Navy",
+    "macroCluster": "editorial",
     "bg": [
-      232,
-      244,
+      248,
+      246,
       240
     ],
     "accent": [
-      60,
-      145,
-      145
+      38,
+      70,
+      130
     ],
     "colors": [
       [
-        60,
-        145,
-        145
+        38,
+        70,
+        130
       ],
       [
         110,
-        175,
-        165
-      ],
-      [
-        220,
-        200,
-        145
+        95,
+        75
       ],
       [
         165,
-        145,
-        115
+        130,
+        90
+      ],
+      [
+        200,
+        195,
+        180
       ]
     ],
     "font": {
-      "heading": "\"Quicksand\", \"Nunito\", Inter, system-ui, sans-serif",
-      "body": "\"Nunito Sans\", Inter, system-ui, sans-serif"
+      "heading": "Georgia, \"Source Serif Pro\", serif",
+      "body": "Inter, system-ui, sans-serif"
     }
   },
   "slots": [
     {
       "slotIdx": 0,
       "slotName": "cover",
-      "slotTitle": "Title",
-      "slotPurpose": "Topic + facilitator + duration",
+      "slotTitle": "Course Title",
+      "slotPurpose": "Course code + name + term + instructor",
       "sourceSlideIdx": 0,
       "sourceSlideTitle": "CS 340: Distributed Systems",
       "mappingScore": 10,
@@ -76,34 +76,92 @@
     },
     {
       "slotIdx": 1,
-      "slotName": "objectives",
-      "slotTitle": "Learning Objectives",
-      "slotPurpose": "What you will know after this",
-      "sourceSlideIdx": 2,
-      "sourceSlideTitle": "Learning Objectives",
+      "slotName": "overview",
+      "slotTitle": "Course Overview",
+      "slotPurpose": "What the course is about — topics, scope, prerequisites",
+      "sourceSlideIdx": 1,
+      "sourceSlideTitle": "Course Overview",
       "mappingScore": 10,
       "mappingFallback": false,
       "mappingEmpty": false,
-      "liftFile": "slots/slot-01-objectives.json",
+      "liftFile": "slots/slot-01-overview.json",
       "cached": false,
       "dryRun": false,
       "error": null,
       "subjectTypes": [
         "cover",
-        "radial-wheel-segmented"
+        "icon-grid",
+        "bullet-list"
       ]
     },
     {
       "slotIdx": 2,
-      "slotName": "context",
-      "slotTitle": "Why This Matters",
-      "slotPurpose": "Stakes + motivation",
-      "sourceSlideIdx": 1,
-      "sourceSlideTitle": "Course Overview",
-      "mappingScore": 7,
+      "slotName": "objectives",
+      "slotTitle": "Learning Objectives",
+      "slotPurpose": "What students will be able to do by the end",
+      "sourceSlideIdx": 2,
+      "sourceSlideTitle": "Learning Objectives",
+      "mappingScore": 10,
       "mappingFallback": false,
       "mappingEmpty": false,
-      "liftFile": "slots/slot-02-context.json",
+      "liftFile": "slots/slot-02-objectives.json",
+      "cached": false,
+      "dryRun": false,
+      "error": null,
+      "subjectTypes": [
+        "cover",
+        "number-list"
+      ]
+    },
+    {
+      "slotIdx": 3,
+      "slotName": "schedule",
+      "slotTitle": "Schedule",
+      "slotPurpose": "Weekly topics / course timeline",
+      "sourceSlideIdx": 3,
+      "sourceSlideTitle": "Weekly Topics",
+      "mappingScore": 10,
+      "mappingFallback": false,
+      "mappingEmpty": false,
+      "liftFile": "slots/slot-03-schedule.json",
+      "cached": false,
+      "dryRun": false,
+      "error": null,
+      "subjectTypes": [
+        "cover",
+        "vertical-timeline"
+      ]
+    },
+    {
+      "slotIdx": 4,
+      "slotName": "grading",
+      "slotTitle": "Grading",
+      "slotPurpose": "Assessment breakdown — components and percentages",
+      "sourceSlideIdx": 4,
+      "sourceSlideTitle": "Grading Breakdown",
+      "mappingScore": 10,
+      "mappingFallback": false,
+      "mappingEmpty": false,
+      "liftFile": "slots/slot-04-grading.json",
+      "cached": false,
+      "dryRun": false,
+      "error": null,
+      "subjectTypes": [
+        "cover",
+        "donut-with-center"
+      ]
+    },
+    {
+      "slotIdx": 5,
+      "slotName": "materials",
+      "slotTitle": "Materials",
+      "slotPurpose": "Required reading, textbooks, tools, resources",
+      "sourceSlideIdx": 5,
+      "sourceSlideTitle": "Required Reading List",
+      "mappingScore": 10,
+      "mappingFallback": false,
+      "mappingEmpty": false,
+      "liftFile": "slots/slot-05-materials.json",
       "cached": false,
       "dryRun": false,
       "error": null,
@@ -113,59 +171,38 @@
       ]
     },
     {
-      "slotIdx": 4,
-      "slotName": "steps",
-      "slotTitle": "Step by Step",
-      "slotPurpose": "Sequential process",
-      "sourceSlideIdx": 3,
-      "sourceSlideTitle": "Weekly Topics",
-      "mappingScore": 6,
+      "slotIdx": 6,
+      "slotName": "logistics",
+      "slotTitle": "Logistics & Support",
+      "slotPurpose": "Office hours, contact channels, policies, where to get help",
+      "sourceSlideIdx": 6,
+      "sourceSlideTitle": "Office Hours & Support",
+      "mappingScore": 10,
       "mappingFallback": false,
       "mappingEmpty": false,
-      "liftFile": "slots/slot-04-steps.json",
+      "liftFile": "slots/slot-06-logistics.json",
       "cached": false,
       "dryRun": false,
       "error": null,
       "subjectTypes": [
         "cover",
-        "timeline"
+        "icon-grid",
+        "icon-row",
+        "quote-pull",
+        "kpi-card",
+        "kpi-card"
       ]
     }
   ],
-  "droppedSlots": [
-    {
-      "slotIdx": 3,
-      "slotName": "concept",
-      "slotTitle": "Core Concept",
-      "reason": "no-source-content"
-    },
-    {
-      "slotIdx": 5,
-      "slotName": "example",
-      "slotTitle": "Worked Example",
-      "reason": "no-source-content"
-    },
-    {
-      "slotIdx": 6,
-      "slotName": "exercise",
-      "slotTitle": "Try It Yourself",
-      "reason": "no-source-content"
-    },
-    {
-      "slotIdx": 7,
-      "slotName": "summary",
-      "slotTitle": "Summary",
-      "reason": "no-source-content"
-    }
-  ],
+  "droppedSlots": [],
   "totals": {
-    "slotsBaked": 4,
-    "slotsEmpty": 4,
+    "slotsBaked": 7,
+    "slotsEmpty": 0,
     "slotsErrored": 0,
-    "totalCostUSD": 0.1302582
+    "totalCostUSD": 0.20413739999999997
   },
   "meta": {
-    "generatedAt": "2026-07-05T05:46:51.434Z",
+    "generatedAt": "2026-07-05T06:02:57.985Z",
     "model": "claude-sonnet-4-5-20250929",
     "pipelineVersion": "sprint-16-v1"
   }

--- a/sdf-js/examples/scaffold-pipeline/eval-edu-course-intro/eval.json
+++ b/sdf-js/examples/scaffold-pipeline/eval-edu-course-intro/eval.json
@@ -2,19 +2,19 @@
   "deckDir": "/Users/hexiaoyang/Documents/sdf-main/sdf-js/examples/scaffold-pipeline/eval-edu-course-intro",
   "deckName": "eval-edu-course-intro",
   "structure": {
-    "slots_total": 8,
-    "slots_baked": 4,
-    "slots_empty": 4,
+    "slots_total": 7,
+    "slots_baked": 7,
+    "slots_empty": 0,
     "slots_errored": 0,
-    "fill_rate": 0.5,
+    "fill_rate": 1,
     "pick_method": "llm",
-    "scaffold_id": "training",
-    "theme_id": "organic-teal"
+    "scaffold_id": "course-syllabus",
+    "theme_id": "editorial-navy"
   },
   "atomQuality": {
-    "atom_instances": 3,
-    "atom_types_distinct": 3,
-    "variety_ratio": 1,
+    "atom_instances": 11,
+    "atom_types_distinct": 8,
+    "variety_ratio": 0.7272727272727273,
     "unknown_atom_count": 0,
     "unknown_atom_types": [],
     "arg_violations": 0,
@@ -23,25 +23,25 @@
   "threeDReadiness": {
     "twin_coverage": 1,
     "untwinned_types": [],
-    "lift_success": 4,
-    "lift_attempted": 4,
+    "lift_success": 7,
+    "lift_attempted": 7,
     "lift_errors": [],
     "lifted_subject_rate": 1
   },
   "textBudget": {
-    "chars_per_slot": 254.25,
-    "max_slot_chars": 324
+    "chars_per_slot": 258.42857142857144,
+    "max_slot_chars": 364
   },
   "score": {
-    "total": 80,
+    "total": 100,
     "breakdown": {
-      "structure": 12.5,
-      "variety": 7.5,
+      "structure": 25,
+      "variety": 15,
       "hallucination": 15,
       "twin": 20,
       "lift": 15,
       "text": 10
     }
   },
-  "generatedAt": "2026-07-05T05:47:05.053Z"
+  "generatedAt": "2026-07-05T06:03:45.571Z"
 }

--- a/sdf-js/examples/scaffold-pipeline/eval-edu-course-intro/slots/slot-00-cover.json
+++ b/sdf-js/examples/scaffold-pipeline/eval-edu-course-intro/slots/slot-00-cover.json
@@ -1,12 +1,12 @@
 {
   "slotIdx": 0,
   "slotName": "cover",
-  "slotTitle": "Title",
-  "slotPurpose": "Topic + facilitator + duration",
+  "slotTitle": "Course Title",
+  "slotPurpose": "Course code + name + term + instructor",
   "sourceSlideIdx": 0,
   "sourceSlideTitle": "CS 340: Distributed Systems",
   "sceneData": {
-    "name": "training/cover",
+    "name": "course-syllabus/cover",
     "layout": "cover",
     "subjects": [
       {
@@ -18,35 +18,35 @@
         "args": {
           "title": "CS 340: Distributed Systems",
           "subtitle": "Fall 2026 · Department of Computer Science",
-          "author": "Prof. Elena Vasquez",
-          "date": "Tue/Thu 2:00-3:30pm, Room 220",
+          "author": "Instructor: Prof. Elena Vasquez",
+          "date": "Meets Tue/Thu 2:00-3:30pm, Room 220",
           "style": "gradient"
         }
       }
     ]
   },
   "meta": {
-    "scaffold": "training",
-    "theme": "organic-teal",
+    "scaffold": "course-syllabus",
+    "theme": "editorial-navy",
     "recommendedAtoms": [
       "cover"
     ],
     "forbiddenAtoms": [],
     "tokenUsage": {
-      "input_tokens": 3931,
+      "input_tokens": 3942,
       "cache_creation_input_tokens": 13008,
       "cache_read_input_tokens": 0,
       "cache_creation": {
         "ephemeral_5m_input_tokens": 13008,
         "ephemeral_1h_input_tokens": 0
       },
-      "output_tokens": 170,
+      "output_tokens": 179,
       "service_tier": "standard",
       "inference_geo": "not_available"
     },
-    "costUSD": 0.063123,
-    "elapsedSec": 4.2,
-    "generatedAt": "2026-07-05T05:46:29.482Z",
+    "costUSD": 0.06329099999999999,
+    "elapsedSec": 9.5,
+    "generatedAt": "2026-07-05T06:02:04.641Z",
     "model": "claude-sonnet-4-5-20250929"
   }
 }

--- a/sdf-js/examples/scaffold-pipeline/eval-edu-course-intro/slots/slot-01-overview.json
+++ b/sdf-js/examples/scaffold-pipeline/eval-edu-course-intro/slots/slot-01-overview.json
@@ -1,0 +1,111 @@
+{
+  "slotIdx": 1,
+  "slotName": "overview",
+  "slotTitle": "Course Overview",
+  "slotPurpose": "What the course is about — topics, scope, prerequisites",
+  "sourceSlideIdx": 1,
+  "sourceSlideTitle": "Course Overview",
+  "sceneData": {
+    "name": "course-syllabus/overview",
+    "layout": "row",
+    "subjects": [
+      {
+        "type": "cover",
+        "x": 0,
+        "y": 0,
+        "w": 1280,
+        "h": 120,
+        "args": {
+          "title": "Course Overview",
+          "style": "gradient"
+        }
+      },
+      {
+        "type": "icon-grid",
+        "x": 80,
+        "y": 180,
+        "w": 1120,
+        "h": 480,
+        "args": {
+          "title": "Distributed Systems",
+          "items": [
+            {
+              "icon": "network",
+              "label": "Consensus",
+              "sublabel": "Agreement across machines"
+            },
+            {
+              "icon": "circuitry",
+              "label": "Replication",
+              "sublabel": "Data duplication strategies"
+            },
+            {
+              "icon": "cube-grid",
+              "label": "Partitioning",
+              "sublabel": "Data distribution patterns"
+            },
+            {
+              "icon": "shield-check",
+              "label": "Consistency",
+              "sublabel": "Model guarantees"
+            },
+            {
+              "icon": "lifebuoy",
+              "label": "Fault Tolerance",
+              "sublabel": "System resilience"
+            },
+            {
+              "icon": "calendar",
+              "label": "Format",
+              "sublabel": "2 lectures + lab + project"
+            }
+          ],
+          "cols": 3,
+          "iconStyle": "card",
+          "iconSize": "medium"
+        }
+      },
+      {
+        "type": "bullet-list",
+        "x": 80,
+        "y": 660,
+        "w": 1120,
+        "h": 40,
+        "args": {
+          "items": [
+            {
+              "icon": "graduation-cap",
+              "label": "Prerequisites: CS 240 + Go/Rust"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  "meta": {
+    "scaffold": "course-syllabus",
+    "theme": "editorial-navy",
+    "recommendedAtoms": [
+      "bullet-list",
+      "icon-grid",
+      "pillar-3up"
+    ],
+    "forbiddenAtoms": [],
+    "tokenUsage": {
+      "input_tokens": 3991,
+      "cache_creation_input_tokens": 0,
+      "cache_read_input_tokens": 13008,
+      "cache_creation": {
+        "ephemeral_5m_input_tokens": 0,
+        "ephemeral_1h_input_tokens": 0
+      },
+      "output_tokens": 541,
+      "service_tier": "standard",
+      "inference_geo": "not_available"
+    },
+    "costUSD": 0.0239904,
+    "elapsedSec": 8.9,
+    "generatedAt": "2026-07-05T06:02:13.540Z",
+    "model": "claude-sonnet-4-5-20250929"
+  }
+}

--- a/sdf-js/examples/scaffold-pipeline/eval-edu-course-intro/slots/slot-02-objectives.json
+++ b/sdf-js/examples/scaffold-pipeline/eval-edu-course-intro/slots/slot-02-objectives.json
@@ -1,0 +1,85 @@
+{
+  "slotIdx": 2,
+  "slotName": "objectives",
+  "slotTitle": "Learning Objectives",
+  "slotPurpose": "What students will be able to do by the end",
+  "sourceSlideIdx": 2,
+  "sourceSlideTitle": "Learning Objectives",
+  "sceneData": {
+    "name": "course-syllabus/objectives",
+    "layout": "row",
+    "subjects": [
+      {
+        "type": "cover",
+        "x": 0,
+        "y": 0,
+        "w": 1280,
+        "h": 120,
+        "args": {
+          "title": "Learning Objectives",
+          "style": "gradient"
+        }
+      },
+      {
+        "type": "number-list",
+        "x": 80,
+        "y": 180,
+        "w": 1120,
+        "h": 480,
+        "args": {
+          "items": [
+            {
+              "label": "Explain CAP theorem tradeoffs",
+              "sublabel": "Apply to real system designs"
+            },
+            {
+              "label": "Implement Raft consensus module",
+              "sublabel": "Working implementation from scratch"
+            },
+            {
+              "label": "Diagnose partition failure modes",
+              "sublabel": "Split-brain and network partitions"
+            },
+            {
+              "label": "Design sharded key-value store",
+              "sublabel": "Replicated architecture under failure"
+            },
+            {
+              "label": "Critique distributed systems papers",
+              "sublabel": "Read and analyze 3 seminal works"
+            }
+          ],
+          "numberStyle": "circle",
+          "numberColor": "rgb(38, 70, 130)"
+        }
+      }
+    ]
+  },
+  "meta": {
+    "scaffold": "course-syllabus",
+    "theme": "editorial-navy",
+    "recommendedAtoms": [
+      "number-list",
+      "numbered-grid",
+      "bullet-list",
+      "okr-tree"
+    ],
+    "forbiddenAtoms": [],
+    "tokenUsage": {
+      "input_tokens": 4006,
+      "cache_creation_input_tokens": 0,
+      "cache_read_input_tokens": 13008,
+      "cache_creation": {
+        "ephemeral_5m_input_tokens": 0,
+        "ephemeral_1h_input_tokens": 0
+      },
+      "output_tokens": 378,
+      "service_tier": "standard",
+      "inference_geo": "not_available"
+    },
+    "costUSD": 0.021590399999999996,
+    "elapsedSec": 7.1,
+    "generatedAt": "2026-07-05T06:02:20.609Z",
+    "model": "claude-sonnet-4-5-20250929"
+  }
+}

--- a/sdf-js/examples/scaffold-pipeline/eval-edu-course-intro/slots/slot-03-schedule.json
+++ b/sdf-js/examples/scaffold-pipeline/eval-edu-course-intro/slots/slot-03-schedule.json
@@ -1,0 +1,97 @@
+{
+  "slotIdx": 3,
+  "slotName": "schedule",
+  "slotTitle": "Schedule",
+  "slotPurpose": "Weekly topics / course timeline",
+  "sourceSlideIdx": 3,
+  "sourceSlideTitle": "Weekly Topics",
+  "sceneData": {
+    "name": "course-syllabus/schedule",
+    "layout": "row",
+    "subjects": [
+      {
+        "type": "cover",
+        "x": 0,
+        "y": 0,
+        "w": 1280,
+        "h": 120,
+        "args": {
+          "title": "Schedule",
+          "style": "gradient"
+        }
+      },
+      {
+        "type": "vertical-timeline",
+        "x": 80,
+        "y": 160,
+        "w": 1120,
+        "h": 520,
+        "args": {
+          "title": "Weekly Topics",
+          "events": [
+            {
+              "date": "Week 1-2",
+              "label": "Networking fundamentals + RPC"
+            },
+            {
+              "date": "Week 3-4",
+              "label": "Replication and consistency models"
+            },
+            {
+              "date": "Week 5-6",
+              "label": "Consensus — Paxos and Raft"
+            },
+            {
+              "date": "Week 7-8",
+              "label": "Partitioning and sharding"
+            },
+            {
+              "date": "Week 9-10",
+              "label": "Fault tolerance and failure detection"
+            },
+            {
+              "date": "Week 11-12",
+              "label": "Distributed transactions"
+            },
+            {
+              "date": "Week 13-14",
+              "label": "Case studies — Spanner, DynamoDB, Kafka"
+            },
+            {
+              "date": "Week 15",
+              "label": "Final project presentations"
+            }
+          ],
+          "axisLabel": "Course Timeline"
+        }
+      }
+    ]
+  },
+  "meta": {
+    "scaffold": "course-syllabus",
+    "theme": "editorial-navy",
+    "recommendedAtoms": [
+      "vertical-timeline",
+      "timeline",
+      "agenda-list",
+      "kanban-board"
+    ],
+    "forbiddenAtoms": [],
+    "tokenUsage": {
+      "input_tokens": 4050,
+      "cache_creation_input_tokens": 0,
+      "cache_read_input_tokens": 13008,
+      "cache_creation": {
+        "ephemeral_5m_input_tokens": 0,
+        "ephemeral_1h_input_tokens": 0
+      },
+      "output_tokens": 455,
+      "service_tier": "standard",
+      "inference_geo": "not_available"
+    },
+    "costUSD": 0.0228774,
+    "elapsedSec": 8.4,
+    "generatedAt": "2026-07-05T06:02:28.988Z",
+    "model": "claude-sonnet-4-5-20250929"
+  }
+}

--- a/sdf-js/examples/scaffold-pipeline/eval-edu-course-intro/slots/slot-04-grading.json
+++ b/sdf-js/examples/scaffold-pipeline/eval-edu-course-intro/slots/slot-04-grading.json
@@ -1,0 +1,111 @@
+{
+  "slotIdx": 4,
+  "slotName": "grading",
+  "slotTitle": "Grading",
+  "slotPurpose": "Assessment breakdown — components and percentages",
+  "sourceSlideIdx": 4,
+  "sourceSlideTitle": "Grading Breakdown",
+  "sceneData": {
+    "name": "course-syllabus/grading",
+    "layout": "stage",
+    "subjects": [
+      {
+        "type": "cover",
+        "x": 0,
+        "y": 0,
+        "w": 1280,
+        "h": 120,
+        "args": {
+          "title": "Grading",
+          "style": "gradient"
+        }
+      },
+      {
+        "type": "donut-with-center",
+        "x": 140,
+        "y": 180,
+        "w": 1000,
+        "h": 480,
+        "args": {
+          "centerValue": "100%",
+          "centerLabel": "Final Grade",
+          "segments": [
+            {
+              "label": "Group Project",
+              "value": 35,
+              "color": [
+                38,
+                70,
+                130
+              ]
+            },
+            {
+              "label": "Weekly Labs",
+              "value": 25,
+              "color": [
+                110,
+                95,
+                75
+              ]
+            },
+            {
+              "label": "Midterm Exam",
+              "value": 20,
+              "color": [
+                165,
+                130,
+                90
+              ]
+            },
+            {
+              "label": "Final Exam",
+              "value": 15,
+              "color": [
+                200,
+                195,
+                180
+              ]
+            },
+            {
+              "label": "Participation",
+              "value": 5,
+              "color": [
+                180,
+                175,
+                165
+              ]
+            }
+          ],
+          "showPct": true
+        }
+      }
+    ]
+  },
+  "meta": {
+    "scaffold": "course-syllabus",
+    "theme": "editorial-navy",
+    "recommendedAtoms": [
+      "donut-with-center",
+      "pie",
+      "segmented-bar",
+      "comparison-table"
+    ],
+    "forbiddenAtoms": [],
+    "tokenUsage": {
+      "input_tokens": 3991,
+      "cache_creation_input_tokens": 0,
+      "cache_read_input_tokens": 13008,
+      "cache_creation": {
+        "ephemeral_5m_input_tokens": 0,
+        "ephemeral_1h_input_tokens": 0
+      },
+      "output_tokens": 404,
+      "service_tier": "standard",
+      "inference_geo": "not_available"
+    },
+    "costUSD": 0.021935399999999997,
+    "elapsedSec": 7.5,
+    "generatedAt": "2026-07-05T06:02:36.494Z",
+    "model": "claude-sonnet-4-5-20250929"
+  }
+}

--- a/sdf-js/examples/scaffold-pipeline/eval-edu-course-intro/slots/slot-05-materials.json
+++ b/sdf-js/examples/scaffold-pipeline/eval-edu-course-intro/slots/slot-05-materials.json
@@ -1,0 +1,88 @@
+{
+  "slotIdx": 5,
+  "slotName": "materials",
+  "slotTitle": "Materials",
+  "slotPurpose": "Required reading, textbooks, tools, resources",
+  "sourceSlideIdx": 5,
+  "sourceSlideTitle": "Required Reading List",
+  "sceneData": {
+    "name": "course-syllabus/materials",
+    "layout": "row",
+    "subjects": [
+      {
+        "type": "cover",
+        "x": 0,
+        "y": 0,
+        "w": 1280,
+        "h": 120,
+        "args": {
+          "title": "Materials",
+          "style": "gradient"
+        }
+      },
+      {
+        "type": "bullet-list",
+        "x": 80,
+        "y": 180,
+        "w": 1120,
+        "h": 480,
+        "args": {
+          "title": "Required Reading",
+          "items": [
+            {
+              "icon": "book-open",
+              "label": "Designing Data-Intensive Applications",
+              "sublabel": "Martin Kleppmann (primary textbook)"
+            },
+            {
+              "icon": "file-text",
+              "label": "Raft Consensus Algorithm",
+              "sublabel": "Ongaro & Ousterhout"
+            },
+            {
+              "icon": "file-text",
+              "label": "Google File System",
+              "sublabel": "Ghemawat, Gobioff, Leung"
+            },
+            {
+              "icon": "file-text",
+              "label": "Dynamo Key-Value Store",
+              "sublabel": "DeCandia et al."
+            },
+            {
+              "icon": "calendar-check",
+              "label": "Weekly paper summaries",
+              "sublabel": "Posted before Thursday lectures"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  "meta": {
+    "scaffold": "course-syllabus",
+    "theme": "editorial-navy",
+    "recommendedAtoms": [
+      "bullet-list",
+      "number-list",
+      "feature-card-grid"
+    ],
+    "forbiddenAtoms": [],
+    "tokenUsage": {
+      "input_tokens": 4029,
+      "cache_creation_input_tokens": 0,
+      "cache_read_input_tokens": 13008,
+      "cache_creation": {
+        "ephemeral_5m_input_tokens": 0,
+        "ephemeral_1h_input_tokens": 0
+      },
+      "output_tokens": 413,
+      "service_tier": "standard",
+      "inference_geo": "not_available"
+    },
+    "costUSD": 0.0221844,
+    "elapsedSec": 8.4,
+    "generatedAt": "2026-07-05T06:02:44.898Z",
+    "model": "claude-sonnet-4-5-20250929"
+  }
+}

--- a/sdf-js/examples/scaffold-pipeline/eval-edu-course-intro/slots/slot-06-logistics.json
+++ b/sdf-js/examples/scaffold-pipeline/eval-edu-course-intro/slots/slot-06-logistics.json
@@ -1,0 +1,142 @@
+{
+  "slotIdx": 6,
+  "slotName": "logistics",
+  "slotTitle": "Logistics & Support",
+  "slotPurpose": "Office hours, contact channels, policies, where to get help",
+  "sourceSlideIdx": 6,
+  "sourceSlideTitle": "Office Hours & Support",
+  "sceneData": {
+    "name": "course-syllabus/logistics",
+    "layout": "grid",
+    "subjects": [
+      {
+        "type": "cover",
+        "x": 0,
+        "y": 0,
+        "w": 1280,
+        "h": 120,
+        "args": {
+          "title": "Logistics & Support",
+          "style": "gradient"
+        }
+      },
+      {
+        "type": "icon-grid",
+        "x": 40,
+        "y": 160,
+        "w": 600,
+        "h": 320,
+        "args": {
+          "title": "Office Hours",
+          "items": [
+            {
+              "icon": "user-circle",
+              "label": "Prof. Vasquez",
+              "sublabel": "Mon 10am-12pm, Wed 3-4pm"
+            },
+            {
+              "icon": "user",
+              "label": "TA Jordan Kim",
+              "sublabel": "Tue/Thu 4-5:30pm, Lab 105"
+            },
+            {
+              "icon": "user",
+              "label": "TA Priya Nair",
+              "sublabel": "Fri 1-3pm, Lab 105"
+            }
+          ],
+          "cols": 3,
+          "iconStyle": "card",
+          "iconSize": "medium",
+          "colorMode": "auto"
+        }
+      },
+      {
+        "type": "icon-row",
+        "x": 680,
+        "y": 160,
+        "w": 560,
+        "h": 200,
+        "args": {
+          "title": "Async Support",
+          "items": [
+            {
+              "icon": "brand:discord",
+              "label": "Course Discord",
+              "sublabel": "<24hr response"
+            }
+          ],
+          "iconStyle": "card",
+          "iconSize": "large",
+          "colorMode": "auto"
+        }
+      },
+      {
+        "type": "quote-pull",
+        "x": 680,
+        "y": 400,
+        "w": 560,
+        "h": 260,
+        "args": {
+          "quote": "Office hours saved me during the Raft implementation — the TAs actually debug with you line by line.",
+          "author": "Student evaluation",
+          "attribution": "Spring 2026",
+          "align": "left"
+        }
+      },
+      {
+        "type": "kpi-card",
+        "x": 40,
+        "y": 520,
+        "w": 280,
+        "h": 140,
+        "args": {
+          "value": "CS 412",
+          "label": "Office Location",
+          "icon": "building",
+          "style": "light"
+        }
+      },
+      {
+        "type": "kpi-card",
+        "x": 360,
+        "y": 520,
+        "w": 280,
+        "h": 140,
+        "args": {
+          "value": "Lab 105",
+          "label": "TA Sessions",
+          "icon": "users",
+          "style": "light"
+        }
+      }
+    ]
+  },
+  "meta": {
+    "scaffold": "course-syllabus",
+    "theme": "editorial-navy",
+    "recommendedAtoms": [
+      "icon-row",
+      "icon-grid",
+      "bullet-list",
+      "call-to-action"
+    ],
+    "forbiddenAtoms": [],
+    "tokenUsage": {
+      "input_tokens": 4062,
+      "cache_creation_input_tokens": 0,
+      "cache_read_input_tokens": 13008,
+      "cache_creation": {
+        "ephemeral_5m_input_tokens": 0,
+        "ephemeral_1h_input_tokens": 0
+      },
+      "output_tokens": 812,
+      "service_tier": "standard",
+      "inference_geo": "not_available"
+    },
+    "costUSD": 0.0282684,
+    "elapsedSec": 13.1,
+    "generatedAt": "2026-07-05T06:02:57.981Z",
+    "model": "claude-sonnet-4-5-20250929"
+  }
+}

--- a/sdf-js/examples/scaffold-pipeline/eval-swot-portfolio-2026/deck.json
+++ b/sdf-js/examples/scaffold-pipeline/eval-swot-portfolio-2026/deck.json
@@ -5,11 +5,11 @@
     "id": "investor-update",
     "label": "Investor Update",
     "description": "LP/seed-investor periodic update — quarterly cadence, metrics, wins, challenges",
-    "pickScore": 9,
+    "pickScore": 8,
     "pickSignals": [
-      "Deck is a quarterly portfolio review for an investment committee — classic LP/investor update format with metrics, portfolio status, wins (pivots completed, ARR growth), challenges (bottlenecks, threats), and forward-looking priorities",
-      "Structure maps perfectly to investor-update scaffold: TL;DR → metrics (AUM, ARR, holdings) → wins (exits, pivots, unicorns) → challenges (bottlenecks, weaknesses, threats) → next-quarter priorities (Series B prep, geographic expansion, Fund III close)",
-      "Audience is 'Investment Committee' — the internal board/LP audience that investor-update targets; slide count (estimated 7-9 sections) aligns with 8-slot scaffold; content is strategic portfolio reporting, not operational QBR"
+      "Deck is explicitly addressed to 'Investment Committee' and dated 'September 2026' — quarterly cadence pattern typical of LP/investor updates",
+      "Content matches investor-update structure: portfolio metrics (AUM, ARR, holdings), wins (exits, pivots), challenges (bottlenecks, threats), next-quarter priorities (Series B prep, geographic expansion, Fund III close)",
+      "Includes financial metrics (12 holdings, $420M AUM, $38M ARR, 62% YoY growth), strategic analysis (SWOT, value chain), and forward-looking priorities — all standard investor update components"
     ],
     "fallback": false,
     "pickerMethod": "llm"
@@ -95,10 +95,10 @@
       "error": null,
       "subjectTypes": [
         "cover",
+        "stat-banner",
         "kpi-card",
         "kpi-card",
-        "kpi-card",
-        "stat-banner"
+        "kpi-card"
       ]
     },
     {
@@ -140,22 +140,6 @@
       ]
     },
     {
-      "slotIdx": 4,
-      "slotName": "challenges",
-      "slotTitle": "Challenges",
-      "slotPurpose": "What did not go well and what we learned",
-      "sourceSlideIdx": -1,
-      "sourceSlideTitle": null,
-      "mappingScore": 0,
-      "mappingFallback": false,
-      "mappingEmpty": true,
-      "liftFile": null,
-      "cached": false,
-      "dryRun": false,
-      "error": null,
-      "subjectTypes": []
-    },
-    {
       "slotIdx": 5,
       "slotName": "next-quarter",
       "slotTitle": "Next Quarter",
@@ -173,48 +157,36 @@
         "cover",
         "kanban-board"
       ]
+    }
+  ],
+  "droppedSlots": [
+    {
+      "slotIdx": 4,
+      "slotName": "challenges",
+      "slotTitle": "Challenges",
+      "reason": "no-source-content"
     },
     {
       "slotIdx": 6,
       "slotName": "ask",
       "slotTitle": "Ask",
-      "slotPurpose": "What we need from LPs — intros, advice, resources",
-      "sourceSlideIdx": -1,
-      "sourceSlideTitle": null,
-      "mappingScore": 0,
-      "mappingFallback": false,
-      "mappingEmpty": true,
-      "liftFile": null,
-      "cached": false,
-      "dryRun": false,
-      "error": null,
-      "subjectTypes": []
+      "reason": "no-source-content"
     },
     {
       "slotIdx": 7,
       "slotName": "cap-table-burn",
       "slotTitle": "Financials",
-      "slotPurpose": "Burn rate, runway, cap table highlights",
-      "sourceSlideIdx": -1,
-      "sourceSlideTitle": null,
-      "mappingScore": 0,
-      "mappingFallback": false,
-      "mappingEmpty": true,
-      "liftFile": null,
-      "cached": false,
-      "dryRun": false,
-      "error": null,
-      "subjectTypes": []
+      "reason": "no-source-content"
     }
   ],
   "totals": {
     "slotsBaked": 5,
     "slotsEmpty": 3,
     "slotsErrored": 0,
-    "totalCostUSD": 0.10911599999999999
+    "totalCostUSD": 0.109101
   },
   "meta": {
-    "generatedAt": "2026-07-05T05:30:44.186Z",
+    "generatedAt": "2026-07-05T06:03:45.397Z",
     "model": "claude-sonnet-4-5-20250929",
     "pipelineVersion": "sprint-16-v1"
   }

--- a/sdf-js/examples/scaffold-pipeline/eval-swot-portfolio-2026/eval.json
+++ b/sdf-js/examples/scaffold-pipeline/eval-swot-portfolio-2026/eval.json
@@ -29,8 +29,8 @@
     "lifted_subject_rate": 1
   },
   "textBudget": {
-    "chars_per_slot": 222.4,
-    "max_slot_chars": 359
+    "chars_per_slot": 213.4,
+    "max_slot_chars": 339
   },
   "score": {
     "total": 88.1,
@@ -43,5 +43,5 @@
       "text": 10
     }
   },
-  "generatedAt": "2026-07-05T05:36:18.166Z"
+  "generatedAt": "2026-07-05T06:03:45.562Z"
 }

--- a/sdf-js/examples/scaffold-pipeline/eval-swot-portfolio-2026/slots/slot-00-cover.json
+++ b/sdf-js/examples/scaffold-pipeline/eval-swot-portfolio-2026/slots/slot-00-cover.json
@@ -46,7 +46,7 @@
     },
     "costUSD": 0.0181914,
     "elapsedSec": 3.9,
-    "generatedAt": "2026-07-05T05:30:12.536Z",
+    "generatedAt": "2026-07-05T06:03:13.105Z",
     "model": "claude-sonnet-4-5-20250929"
   }
 }

--- a/sdf-js/examples/scaffold-pipeline/eval-swot-portfolio-2026/slots/slot-01-tldr.json
+++ b/sdf-js/examples/scaffold-pipeline/eval-swot-portfolio-2026/slots/slot-01-tldr.json
@@ -21,25 +21,27 @@
         }
       },
       {
-        "type": "kpi-card",
+        "type": "stat-banner",
         "x": 40,
-        "y": 180,
-        "w": 360,
-        "h": 240,
+        "y": 160,
+        "w": 1200,
+        "h": 140,
         "args": {
-          "value": "$420M",
-          "label": "Total AUM",
-          "sublabel": "12 portfolio companies",
-          "icon": "briefcase",
-          "style": "light"
+          "value": "$420M AUM",
+          "label": "12 portfolio companies",
+          "bg": [
+            58,
+            138,
+            200
+          ]
         }
       },
       {
         "type": "kpi-card",
-        "x": 460,
-        "y": 180,
-        "w": 360,
-        "h": 240,
+        "x": 40,
+        "y": 340,
+        "w": 380,
+        "h": 320,
         "args": {
           "value": "$38M",
           "label": "Combined ARR",
@@ -52,32 +54,30 @@
       },
       {
         "type": "kpi-card",
-        "x": 880,
-        "y": 180,
-        "w": 360,
-        "h": 240,
+        "x": 450,
+        "y": 340,
+        "w": 380,
+        "h": 320,
         "args": {
           "value": "3",
-          "label": "Series B Ready",
+          "label": "Series B Track",
           "sublabel": "Next 18 months",
           "icon": "rocket-launch",
           "style": "light"
         }
       },
       {
-        "type": "stat-banner",
-        "x": 40,
-        "y": 460,
-        "w": 1200,
-        "h": 200,
+        "type": "kpi-card",
+        "x": 860,
+        "y": 340,
+        "w": 380,
+        "h": 320,
         "args": {
-          "value": "AI-native infrastructure + vertical SaaS convergence",
-          "label": "Investment Thesis",
-          "bg": [
-            58,
-            138,
-            200
-          ]
+          "value": "2",
+          "label": "Strategic Pivots",
+          "sublabel": "H1 2026 completed",
+          "icon": "arrows-clockwise",
+          "style": "light"
         }
       }
     ]
@@ -99,13 +99,13 @@
         "ephemeral_5m_input_tokens": 0,
         "ephemeral_1h_input_tokens": 0
       },
-      "output_tokens": 560,
+      "output_tokens": 559,
       "service_tier": "standard",
       "inference_geo": "not_available"
     },
-    "costUSD": 0.0243294,
-    "elapsedSec": 8.4,
-    "generatedAt": "2026-07-05T05:30:20.907Z",
+    "costUSD": 0.0243144,
+    "elapsedSec": 8.3,
+    "generatedAt": "2026-07-05T06:03:21.400Z",
     "model": "claude-sonnet-4-5-20250929"
   }
 }

--- a/sdf-js/examples/scaffold-pipeline/eval-swot-portfolio-2026/slots/slot-02-metrics.json
+++ b/sdf-js/examples/scaffold-pipeline/eval-swot-portfolio-2026/slots/slot-02-metrics.json
@@ -27,51 +27,32 @@
         "w": 1200,
         "h": 520,
         "args": {
+          "title": "Q3 2026 Portfolio Performance",
           "kpis": [
             {
               "value": "$420M",
               "label": "Total AUM",
-              "sublabel": "12 portfolio companies",
-              "trend": "neutral",
-              "color": [
-                58,
-                138,
-                200
-              ]
+              "sublabel": "12 companies",
+              "trend": "neutral"
             },
             {
               "value": "$38M",
               "label": "Combined ARR",
-              "sublabel": "Up 62% YoY",
+              "sublabel": "Across portfolio",
               "trend": "up",
-              "trendValue": "+62%",
-              "color": [
-                58,
-                138,
-                200
-              ]
+              "trendValue": "+62% YoY"
             },
             {
               "value": "3",
               "label": "Series B Track",
               "sublabel": "Next 18 months",
-              "trend": "up",
-              "color": [
-                100,
-                150,
-                200
-              ]
+              "trend": "up"
             },
             {
               "value": "2",
-              "label": "Strategic Pivots",
-              "sublabel": "H1 2026 completed",
-              "trend": "neutral",
-              "color": [
-                100,
-                150,
-                200
-              ]
+              "label": "Pivots Complete",
+              "sublabel": "H1 2026",
+              "trend": "neutral"
             }
           ]
         }
@@ -96,13 +77,13 @@
         "ephemeral_5m_input_tokens": 0,
         "ephemeral_1h_input_tokens": 0
       },
-      "output_tokens": 441,
+      "output_tokens": 396,
       "service_tier": "standard",
       "inference_geo": "not_available"
     },
-    "costUSD": 0.0225894,
+    "costUSD": 0.0219144,
     "elapsedSec": 7.3,
-    "generatedAt": "2026-07-05T05:30:28.165Z",
+    "generatedAt": "2026-07-05T06:03:28.711Z",
     "model": "claude-sonnet-4-5-20250929"
   }
 }

--- a/sdf-js/examples/scaffold-pipeline/eval-swot-portfolio-2026/slots/slot-03-wins.json
+++ b/sdf-js/examples/scaffold-pipeline/eval-swot-portfolio-2026/slots/slot-03-wins.json
@@ -31,11 +31,11 @@
           "strengths": [
             "Deep AI/ML expertise",
             "Strong co-investor network",
-            "Proprietary university deal flow",
+            "University spin-out deal flow",
             "3 unicorn exits (Fund I)"
           ],
           "weaknesses": [
-            "Bay Area geographic concentration",
+            "Bay Area concentration",
             "Limited late-stage reserves",
             "Single GP bottleneck"
           ],
@@ -45,7 +45,7 @@
             "Emerging market expansion"
           ],
           "threats": [
-            "Growth stage valuation compression",
+            "Growth valuation compression",
             "Mega-fund competition",
             "LP redemption pressure"
           ]
@@ -70,13 +70,13 @@
         "ephemeral_5m_input_tokens": 0,
         "ephemeral_1h_input_tokens": 0
       },
-      "output_tokens": 336,
+      "output_tokens": 334,
       "service_tier": "standard",
       "inference_geo": "not_available"
     },
-    "costUSD": 0.0210834,
-    "elapsedSec": 6.5,
-    "generatedAt": "2026-07-05T05:30:34.715Z",
+    "costUSD": 0.0210534,
+    "elapsedSec": 7.3,
+    "generatedAt": "2026-07-05T06:03:36.010Z",
     "model": "claude-sonnet-4-5-20250929"
   }
 }

--- a/sdf-js/examples/scaffold-pipeline/eval-swot-portfolio-2026/slots/slot-05-next-quarter.json
+++ b/sdf-js/examples/scaffold-pipeline/eval-swot-portfolio-2026/slots/slot-05-next-quarter.json
@@ -7,7 +7,7 @@
   "sourceSlideTitle": "Q4 2026 Portfolio Priorities",
   "sceneData": {
     "name": "investor-update/next-quarter",
-    "layout": "row",
+    "layout": "grid",
     "subjects": [
       {
         "type": "cover",
@@ -31,41 +31,56 @@
           "columns": [
             {
               "name": "Fundraising",
+              "color": [
+                58,
+                138,
+                200
+              ],
               "cards": [
                 {
-                  "title": "Series B bridge prep",
-                  "description": "ANTFUN + NovaTech",
+                  "title": "Fund III Final Close",
+                  "subtitle": "Target $300M by Dec 2026",
                   "priority": "high"
                 },
                 {
-                  "title": "Fund III final close",
-                  "description": "Target $300M by Dec 2026",
+                  "title": "Series B Bridge Prep",
+                  "subtitle": "ANTFUN + NovaTech",
                   "priority": "high"
                 }
               ]
             },
             {
               "name": "Portfolio Growth",
+              "color": [
+                100,
+                150,
+                200
+              ],
               "cards": [
                 {
-                  "title": "SE Asia LP program",
-                  "description": "Geographic expansion review",
+                  "title": "AI Transformation Audit",
+                  "subtitle": "All 12 portfolio companies",
                   "priority": "medium"
                 },
                 {
-                  "title": "AI transformation audit",
-                  "description": "All 12 portfolio companies",
+                  "title": "Geographic Expansion Review",
+                  "subtitle": "Southeast Asia LP program",
                   "priority": "medium"
                 }
               ]
             },
             {
-              "name": "Exit Planning",
+              "name": "Exits",
+              "color": [
+                180,
+                210,
+                235
+              ],
               "cards": [
                 {
-                  "title": "Fund I exit roadmap",
-                  "description": "3 candidates identified",
-                  "priority": "medium"
+                  "title": "Fund I Exit Roadmap",
+                  "subtitle": "3 candidates identified",
+                  "priority": "high"
                 }
               ]
             }
@@ -92,13 +107,13 @@
         "ephemeral_5m_input_tokens": 0,
         "ephemeral_1h_input_tokens": 0
       },
-      "output_tokens": 463,
+      "output_tokens": 510,
       "service_tier": "standard",
       "inference_geo": "not_available"
     },
-    "costUSD": 0.0229224,
-    "elapsedSec": 9.5,
-    "generatedAt": "2026-07-05T05:30:44.185Z",
+    "costUSD": 0.0236274,
+    "elapsedSec": 9.4,
+    "generatedAt": "2026-07-05T06:03:45.397Z",
     "model": "claude-sonnet-4-5-20250929"
   }
 }

--- a/sdf-js/scripts/eval-results/summary.json
+++ b/sdf-js/scripts/eval-results/summary.json
@@ -1,9 +1,9 @@
 {
-  "generatedAt": "2026-07-05T05:47:05.055Z",
+  "generatedAt": "2026-07-05T06:03:45.574Z",
   "corpusSize": 10,
   "scored": 10,
   "skipped": [],
-  "corpusMean": 95.3,
+  "corpusMean": 97.3,
   "decks": [
     {
       "deckName": "eval-qbr-q3-2026",
@@ -116,6 +116,34 @@
       "liftedSubjectRate": 1,
       "charsPerSlot": 142.85714285714286,
       "maxSlotChars": 180
+    },
+    {
+      "deckName": "eval-edu-course-intro",
+      "score": 100,
+      "scoreBreakdown": {
+        "structure": 25,
+        "variety": 15,
+        "hallucination": 15,
+        "twin": 20,
+        "lift": 15,
+        "text": 10
+      },
+      "fillRate": 1,
+      "scaffoldId": "course-syllabus",
+      "themeId": "editorial-navy",
+      "pickMethod": "llm",
+      "atomTypesDistinct": 8,
+      "unknownAtomCount": 0,
+      "unknownAtomTypes": [],
+      "argViolations": 0,
+      "argViolationsTopOffenders": [],
+      "twinCoverage": 1,
+      "untwinnedTypes": [],
+      "liftSuccess": 7,
+      "liftAttempted": 7,
+      "liftedSubjectRate": 1,
+      "charsPerSlot": 258.42857142857144,
+      "maxSlotChars": 364
     },
     {
       "deckName": "eval-nonprofit-annual-report",
@@ -260,36 +288,8 @@
       "liftSuccess": 5,
       "liftAttempted": 5,
       "liftedSubjectRate": 1,
-      "charsPerSlot": 222.4,
-      "maxSlotChars": 359
-    },
-    {
-      "deckName": "eval-edu-course-intro",
-      "score": 80,
-      "scoreBreakdown": {
-        "structure": 12.5,
-        "variety": 7.5,
-        "hallucination": 15,
-        "twin": 20,
-        "lift": 15,
-        "text": 10
-      },
-      "fillRate": 0.5,
-      "scaffoldId": "training",
-      "themeId": "organic-teal",
-      "pickMethod": "llm",
-      "atomTypesDistinct": 3,
-      "unknownAtomCount": 0,
-      "unknownAtomTypes": [],
-      "argViolations": 0,
-      "argViolationsTopOffenders": [],
-      "twinCoverage": 1,
-      "untwinnedTypes": [],
-      "liftSuccess": 4,
-      "liftAttempted": 4,
-      "liftedSubjectRate": 1,
-      "charsPerSlot": 254.25,
-      "maxSlotChars": 324
+      "charsPerSlot": 213.4,
+      "maxSlotChars": 339
     }
   ]
 }

--- a/sdf-js/scripts/test-scaffolds.mjs
+++ b/sdf-js/scripts/test-scaffolds.mjs
@@ -29,7 +29,7 @@ console.log('=== scaffolds registry smoke ===\n');
 
 console.log('--- registry shape ---');
 {
-  ok(SCAFFOLDS.length === 19, `19 scaffolds shipped (got ${SCAFFOLDS.length})`);
+  ok(SCAFFOLDS.length === 20, `20 scaffolds shipped (got ${SCAFFOLDS.length})`);
   const ids = new Set(SCAFFOLDS.map((s) => s.id));
   ok(ids.size === SCAFFOLDS.length, 'all scaffold ids unique');
 
@@ -57,10 +57,10 @@ console.log('\n--- helper functions ---');
 {
   ok(getScaffold('pitch-deck-vc') !== null, 'getScaffold resolves known id');
   ok(getScaffold('nonsense-deck') === null, 'getScaffold returns null for unknown');
-  ok(listScaffolds().length === 19, 'listScaffolds returns 19');
+  ok(listScaffolds().length === 20, 'listScaffolds returns 20');
   ok(totalSlots() > 50, `totalSlots > 50 (got ${totalSlots()})`);
   const stats = scaffoldStats();
-  ok(stats.scaffolds === 19, 'stats.scaffolds = 19');
+  ok(stats.scaffolds === 20, 'stats.scaffolds = 20');
   ok(stats.avgSlotsPerScaffold > 5, `stats.avgSlotsPerScaffold > 5 (${stats.avgSlotsPerScaffold})`);
   const themes = getThemeAffinity('pitch-deck-vc');
   ok(themes.length === 3, 'getThemeAffinity returns 3 themes for pitch-deck-vc');
@@ -83,7 +83,7 @@ console.log('\n--- picker: rank + pick ---');
     ],
   };
   const vcRanked = rankScaffolds(vcInput);
-  ok(vcRanked.length === 19, 'rankScaffolds returns all scaffolds');
+  ok(vcRanked.length === 20, 'rankScaffolds returns all scaffolds');
   ok(
     vcRanked[0].id === 'pitch-deck-vc',
     `VC input → pitch-deck-vc top (got ${vcRanked[0].id} score=${vcRanked[0].score})`,

--- a/sdf-js/src/present/scaffolds/mapper-llm.js
+++ b/sdf-js/src/present/scaffolds/mapper-llm.js
@@ -112,7 +112,7 @@ export async function mapSlidesToSlotsLLM(input, opts = {}) {
     `Rules:\n` +
     `- Return exactly ${slots.length} entries in assignments[], one per slot, in slot order\n` +
     `- Each entry MUST have slotIdx equal to its position (0, 1, 2, ...)\n` +
-    `- Each slide can map to AT MOST one slot (greedy 1:1, no duplicates unless absolutely necessary)\n` +
+    `- A slide may fill up to TWO slots — but ONLY when its content genuinely covers both slot purposes (e.g. a "Wins & Challenges" slide feeding both the wins slot and the challenges slot; the per-slot lift extracts the relevant half for each). Never stretch a slide across two slots just to avoid -1.\n` +
     `- slideIdx is 0..${slides.length - 1} or -1 for empty (no matching slide)\n` +
     `- Prefer assignment over -1 unless no slide fits (e.g. scaffold has ${slots.length} slots but only ${slides.length} source slides cover them)\n` +
     `- confidence 0-10: how well does this slide match this slot's purpose\n` +

--- a/sdf-js/src/present/scaffolds/registry.js
+++ b/sdf-js/src/present/scaffolds/registry.js
@@ -1388,6 +1388,66 @@ export const SCAFFOLDS = [
   },
 
   // ============================================================================
+  // course-syllabus — Sprint 24 iter3: course INTRO decks (syllabus / first-day
+  // lecture) are a different genre from training LESSONS. The eval corpus's
+  // edu-course-intro kept landing on `training` at high confidence but only
+  // filled 4/8 slots (no concept/example/exercise content in a syllabus).
+  // ============================================================================
+  {
+    id: 'course-syllabus',
+    label: 'Course Syllabus',
+    description:
+      'Course introduction / syllabus deck — overview, objectives, schedule, grading, materials, logistics. First-day-of-class, NOT a lesson.',
+    audience: 'students, teacher, faculty',
+    keywords: ['course', 'syllabus', 'semester', 'grading', 'curriculum', 'class', 'lecture'],
+    slots: [
+      {
+        name: 'cover',
+        title: 'Course Title',
+        purpose: 'Course code + name + term + instructor',
+        recommended_atoms: ['cover'],
+      },
+      {
+        name: 'overview',
+        title: 'Course Overview',
+        purpose: 'What the course is about — topics, scope, prerequisites',
+        recommended_atoms: ['bullet-list', 'icon-grid', 'pillar-3up'],
+      },
+      {
+        name: 'objectives',
+        title: 'Learning Objectives',
+        purpose: 'What students will be able to do by the end',
+        recommended_atoms: ['number-list', 'numbered-grid', 'bullet-list', 'okr-tree'],
+      },
+      {
+        name: 'schedule',
+        title: 'Schedule',
+        purpose: 'Weekly topics / course timeline',
+        recommended_atoms: ['vertical-timeline', 'timeline', 'agenda-list', 'kanban-board'],
+      },
+      {
+        name: 'grading',
+        title: 'Grading',
+        purpose: 'Assessment breakdown — components and percentages',
+        recommended_atoms: ['donut-with-center', 'pie', 'segmented-bar', 'comparison-table'],
+      },
+      {
+        name: 'materials',
+        title: 'Materials',
+        purpose: 'Required reading, textbooks, tools, resources',
+        recommended_atoms: ['bullet-list', 'number-list', 'feature-card-grid'],
+      },
+      {
+        name: 'logistics',
+        title: 'Logistics & Support',
+        purpose: 'Office hours, contact channels, policies, where to get help',
+        recommended_atoms: ['icon-row', 'icon-grid', 'bullet-list', 'call-to-action'],
+      },
+    ],
+    theme_affinity: ['editorial-navy', 'organic-teal', 'editorial-forest'],
+  },
+
+  // ============================================================================
   // generic-deck — Sprint 24 eval-iter1: the escape hatch for content that fits
   // NO specialized scaffold well. The eval baseline showed force-fits (e.g. a
   // recreational trip report shoved into analysis-report at picker confidence


### PR DESCRIPTION
## Summary

第三轮 eval 迭代, 攻 edu-course-intro 的 80 分 (iter2 后的最差 deck)。

## 根因 + 两个修法

**根因**: `training` scaffold 语义上是"教一堂课" (concept/example/exercise), 而 syllabus 是"课程介绍" — 不同 genre。picker 给了置信 9 但内容覆盖只有 50%。

1. **新 `course-syllabus` scaffold** (第 20 个): cover / overview / objectives / schedule / grading / materials / logistics — 7 slot 正好是第一堂课 deck 的自然形状。grading slot 推荐 donut/pie/segmented-bar 承接百分比拆分。

2. **Mapper 规则放宽**: 一张 slide 可填至多 2 个 slot — 仅当内容真覆盖两个 slot purpose (e.g. "Wins & Challenges" slide 同时喂 wins 和 challenges slot; per-slot lift 各取所需一半)。验证层本就容忍重复 slideIdx, lift 缓存按 slot 键控无碰撞。

## 结果 (真 bake 量化)

| 指标 | iter2 | iter3 |
|---|---|---|
| **edu-course-intro** | 80 (training@9, 4/8) | **100** (course-syllabus@**10**, 7/7, 8 atom 类型) ✅ |
| 语料均分 | 95.3 | **97.3** |
| 满分 deck | 5 | **6** |

swot-portfolio-2026 保持 88.1 — 其源**真的没有** challenges/ask/cap-table 内容, mapper 正确拒绝硬拆。诚实分数, 非缺陷。

## Tests

- 不变量测试: 73 recommended atoms → 72 precise + 1 generic + **0 dead-end** (course-syllabus 的推荐 atom 全部有 twin)
- npm test: **112/112**
- test-scaffolds count 19→20

Per CLAUDE.md: DO NOT merge. Awaiting user review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)