### PR TITLE
feat(render-sequence): environment axis — alpine world (snow terrain + arch-bridge backdrop)

### DIFF
--- a/sdf-js/apps/present/figure.js
+++ b/sdf-js/apps/present/figure.js
@@ -14,6 +14,13 @@ function size() {
 }
 size();
 
+// ?env=alpine swaps the studio room for an open world (snow mountains + the
+// arch-bridge backdrop). Outdoor envs bring their own terrain — the studio's
+// flat ground plane + checker must be off or they slice through the landscape.
+const params = new URLSearchParams(location.search);
+const env = params.get('env') || 'studio';
+const outdoor = env !== 'studio';
+
 const studio = createStudioRenderer({
   canvas,
   getControls: () => ({
@@ -22,8 +29,8 @@ const studio = createStudioRenderer({
     lightDist: 30,
     fov: 1.5,
     shadowsOn: true,
-    groundOn: true,
-    checkerOn: true,
+    groundOn: !outdoor,
+    checkerOn: !outdoor,
   }),
   onFps: () => {},
 });
@@ -37,9 +44,9 @@ window.addEventListener('resize', () => {
 window.__figStudio = studio;
 window.__figReplay = () => studio.setSequence(scene.cameraSequence);
 
-const name = new URLSearchParams(location.search).get('ir') || 'funnel-sales';
+const name = params.get('ir') || 'funnel-sales';
 const ir = await (await fetch(`../../scenes/ir/${name}.json`)).json();
-const scene = renderSequence(ir);
+const scene = renderSequence(ir, { env });
 // applyStudioScene wires setSequence + setAnimated (subject.animation counts as
 // time content since the sceneHasTimeContent fix) — no manual overrides needed.
 applyStudioScene(studio, scene);

--- a/sdf-js/src/scene/render-sequence.js
+++ b/sdf-js/src/scene/render-sequence.js
@@ -35,9 +35,91 @@ const stageMat = (i, N, emphasized) => {
   };
 };
 
-export function renderSequence(ir) {
+// ---- Environments -----------------------------------------------------------
+// The structure keeps its form/camera/labels in ANY environment; env only swaps
+// the WORLD around it (a renderer-axis choice, not an IR field — same IR renders
+// in the studio or on a mountainside). 'studio' = the neutral stage room.
+// 'alpine' = open snow-mountain world (terrain-elevated + snowy arch-bridge
+// backdrop + pines — the shipped snow-bridge recipe), warm low sun, film postFx.
+const SNOWY_STONE = { hue: 0.07, sat: 0.3, value: 0.62, metal: 0, glow: 0, kind: 'snowy' };
+const SNOWY_PINE = { hue: 0.3, sat: 0.55, value: 0.3, metal: 0, glow: 0, kind: 'snowy' };
+
+function alpineEnvironment() {
+  return {
+    subjects: [
+      {
+        id: 'env-terrain',
+        type: 'terrain-elevated',
+        args: { maxHeight: 35.0, scale: 0.035, ridgePower: 2.0, mountainness: 0.3 },
+        transform: { translate: [0, -8, 0] },
+      },
+      {
+        id: 'env-snow-base',
+        type: 'box',
+        args: { dims: [400, 0.4, 400] },
+        transform: { translate: [0, -7.9, 0] },
+        material: { hue: 0.6, sat: 0.04, value: 0.94, metal: 0, glow: 0, kind: 'snowy' },
+      },
+      // the hero backdrop: the snowy stone bridge, spanning the frame behind the funnel
+      {
+        id: 'env-bridge',
+        type: 'arch-bridge',
+        args: { bridgeLen: 30.0, bridgeWidth: 4.0, archH: 6.0, railH: 1.5, cornerOff: 10.0 },
+        transform: { translate: [0, -1.2, -16], rotate: [0, 1.5708, 0] },
+        material: SNOWY_STONE,
+      },
+      {
+        id: 'env-pine-L',
+        type: 'tree-pine',
+        args: { trunkHeight: 4.4, trunkRadius: 0.18, foliageRadius: 1.3 },
+        transform: { translate: [-9, -1.5, -4] },
+        material: SNOWY_PINE,
+      },
+      {
+        id: 'env-pine-R',
+        type: 'tree-pine',
+        args: { trunkHeight: 3.8, trunkRadius: 0.16, foliageRadius: 1.1 },
+        transform: { translate: [8, -1.5, -7] },
+        material: SNOWY_PINE,
+      },
+      {
+        id: 'env-pine-far',
+        type: 'tree-pine',
+        args: { trunkHeight: 5.0, trunkRadius: 0.2, foliageRadius: 1.6 },
+        transform: { translate: [-14, -1.5, -12] },
+        material: SNOWY_PINE,
+      },
+    ],
+    defaults: {
+      // static fallback only — the cameraSequence drives the actual camera
+      camera: {
+        yaw: 0,
+        pitch: -0.1,
+        distance: 10,
+        focal: 1.2,
+        targetX: 0,
+        targetY: 2,
+        targetZ: 0,
+      },
+      light: { azimuth: -0.6, altitude: 0.3, distance: 60, intensity: 1.15 },
+      shadow: { enabled: true, mode: 'darken', strength: 0.42 },
+      postFx: {
+        exposure: 1.05,
+        vignetteStrength: 0.4,
+        bloomMix: 0.22,
+        bloomThreshold: 0.85,
+        lensFlareStrength: 0.1,
+        motionBlurStrength: 0.45,
+      },
+    },
+    payoffZoom: 1.35, // pull the ending frame further back — reveal the world
+  };
+}
+
+export function renderSequence(ir, opts = {}) {
   const v = validateIR(ir);
   if (!v.ok) throw new Error(`renderSequence: invalid IR — ${v.errors.join('; ')}`);
+  const env = opts.env === 'alpine' ? alpineEnvironment() : null;
 
   const nodes = ir.nodes.map(label);
   const N = nodes.length;
@@ -152,15 +234,17 @@ export function renderSequence(ir) {
     exposure: [1.45, 1.0],
     ease: 'out',
   });
-  // 5 — payoff pull-back: the whole funnel, every stage revealed, gold in context
+  // 5 — payoff pull-back: the whole funnel, every stage revealed, gold in context.
+  // In an open-world env, pull back further — the reveal includes the WORLD.
+  const payoffDist = (totalH * 1.7 + radii[0] * 2.6) * (env ? env.payoffZoom : 1);
   shots.push({
     duration: 2.4,
-    pos: [1.4, midY + 1.1, totalH * 1.7 + radii[0] * 2.6],
+    pos: [1.4, midY + 1.1 + (env ? 0.5 : 0), payoffDist],
     target: [0, midY + 0.2, 0],
     fov: 44,
     transition: 'blend',
     aperture: 0,
-    focalDistance: totalH * 1.7 + radii[0] * 2.6,
+    focalDistance: payoffDist,
     ease: 'out',
   });
 
@@ -191,11 +275,11 @@ export function renderSequence(ir) {
 
   return {
     v: 1,
-    name: `(sequence) ${ir.title || 'funnel'}`,
-    subjects,
+    name: `(sequence) ${ir.title || 'funnel'}${env ? ' · alpine' : ''}`,
+    subjects: env ? [...subjects, ...env.subjects] : subjects,
     overlay,
     cameraSequence: { loop: false, shots },
-    defaults: { stage: { size: [16, 12, 11] } },
+    defaults: env ? env.defaults : { stage: { size: [16, 12, 11] } },
   };
 }
 


### PR DESCRIPTION
## What — the funnel leaves the studio

`?env=alpine`: the figure renders in an open snow-mountain world — terrain-elevated peaks, snowy ground, **the arch-bridge spanning the frame behind the funnel**, pines, warm low sun + film postFx (the shipped snow-bridge recipe, recomposed).

The payoff pull-back goes 1.35× further out, and the ending frame turned out better than designed: **the funnel sits inside the bridge arch** with snow peaks behind — the arch reads as a natural frame around the data.

## Design

`renderSequence(ir, {env})` gains an **environment axis**. The structure keeps its form / camera grammar / labels in ANY environment; env only swaps the world around it. Deliberately a render-side option, **not** an IR field (same IR renders in the studio or on a mountainside). `'studio'` default = unchanged, byte-identical scenes.

Figure page passes `?env=` through; outdoor envs disable the studio ground plane + checker (they would slice through the terrain).

## Known cost (flagged, not fixed here)

First-ever compile of the alpine shader is **slow (~30s cold** on this machine — terrain/bridge/snowy paths make a big program). The async pipeline (#200) keeps the page alive with the spinner, and Chrome's disk shader cache makes every later load fast — but first-viewer latency is real. Proper fix = GLSL dead-code elimination of the library (backlog; known "首屏编译" thread).

## Verified

Headless: alpine compiles + renders (hero + payoff frames pinned); studio default unchanged. 112/112; lint clean.

## Try it

- `apps/present/figure.html?ir=funnel-sales&env=alpine` (first load: expect the spinner ~30s, then instant on reload)
- `apps/present/figure.html?ir=funnel-sales` (studio, unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)