### PR TITLE
perf(glsl): library dead-code elimination — scenes compile only what they call

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -27,6 +27,7 @@ const TESTS = [
   { category: 'smoke', file: 'sdf-js/test/smoke.mjs' },
   { category: 'smoke', file: 'sdf-js/test/smoke2d.mjs' },
   { category: 'smoke', file: 'sdf-js/test/scene-smoke.mjs' },
+  { category: 'smoke', file: 'sdf-js/scripts/test-glsl-prune.mjs' },
 
   // Geometry sanity checker (M5 prereq)
   { category: 'sanity', file: 'sdf-js/scripts/test-sanity.mjs' },

--- a/sdf-js/scripts/test-glsl-prune.mjs
+++ b/sdf-js/scripts/test-glsl-prune.mjs
@@ -1,0 +1,99 @@
+// sdf-js/scripts/test-glsl-prune.mjs — GLSL library dead-code elimination.
+import { pruneGLSL } from '../src/sdf/glsl-prune.js';
+import { NOISE_GLSL } from '../src/sdf/noise.glsl.js';
+import { VORONOI_GLSL } from '../src/sdf/voronoi.glsl.js';
+import { SDF3_GLSL } from '../src/sdf/sdf3.glsl.js';
+import { SDF2_GLSL } from '../src/sdf/sdf2.glsl.js';
+
+let pass = 0,
+  fail = 0;
+const ok = (c, n) => (c ? (pass++, console.log(`  ✓ ${n}`)) : (fail++, console.log(`  ✗ ${n}`)));
+console.log('=== glsl-prune (library dead-code elimination) ===\n');
+
+// ---- synthetic library: chains + overloads + non-function chunks ----
+const LIB = `
+uniform float u_time;
+#define TAU 6.2831853
+
+float helperA(float x) { return x * 2.0; }
+
+// overload pair — must live or die together
+float dup(vec2 v) { return v.x; }
+float dup(vec3 v) { return v.x + helperA(v.y); }
+
+// unused chain
+float deadInner(float x) { return x + 1.0; }
+float deadOuter(float x) { return deadInner(x) * 3.0; }
+
+// used chain: root -> mid -> leaf
+float leaf(float x) { return x - 1.0; }
+float mid(float x) { return leaf(x) * 0.5; }
+`;
+
+{
+  const out = pruneGLSL(LIB, 'void main(){ float a = mid(dup(vec3(1.0))); }');
+  ok(out.includes('float mid('), 'directly-referenced fn kept');
+  ok(out.includes('float leaf('), 'transitive dep kept (mid -> leaf)');
+  ok(out.includes('float helperA('), 'transitive dep through overload kept (dup(vec3) -> helperA)');
+  ok(out.includes('dup(vec2 v)') && out.includes('dup(vec3 v)'), 'overloads kept together');
+  ok(!out.includes('deadOuter') && !out.includes('deadInner'), 'unused chain dropped');
+  ok(out.includes('uniform float u_time;'), 'non-function chunks (uniforms) always kept');
+  ok(out.includes('#define TAU'), 'defines always kept');
+}
+
+{
+  // nothing referenced -> only non-function chunks remain
+  const out = pruneGLSL(LIB, 'void main(){}');
+  ok(!out.includes('float mid(') && !out.includes('dup('), 'no roots -> all fns dropped');
+}
+
+// ---- the real library: prune for a simple sphere scene ----
+{
+  const FULL = [NOISE_GLSL, VORONOI_GLSL, SDF3_GLSL, SDF2_GLSL].join('\n');
+  const roots = 'float scene(vec3 p){ return sdSphere(p, 1.0); } void main(){ scene(vec3(0.0)); }';
+  const out = pruneGLSL(FULL, roots);
+  ok(out.includes('float sdSphere('), 'real lib: sdSphere kept');
+  ok(!out.includes('sdArchBridge'), 'real lib: arch-bridge dropped');
+  ok(!out.includes('sdTerrainElevated'), 'real lib: terrain dropped');
+  ok(!out.includes('sdProceduralCity'), 'real lib: city dropped');
+  ok(out.length < FULL.length * 0.35, `real lib: >65% smaller (${out.length} vs ${FULL.length})`);
+  // definition-completeness: every called identifier that looks like a lib fn is defined
+  const defined = new Set(
+    [...out.matchAll(/^\s*(?:float|vec[234]|int|bool|void|mat[234])\s+(\w+)\s*\(/gm)].map(
+      (m) => m[1],
+    ),
+  );
+  const BUILTINS = new Set(
+    'length,dot,cross,normalize,abs,min,max,clamp,mix,step,smoothstep,floor,fract,ceil,mod,sign,pow,exp,exp2,log,log2,sqrt,inversesqrt,sin,cos,tan,asin,acos,atan,radians,degrees,vec2,vec3,vec4,mat2,mat3,mat4,texture2D,textureLod,reflect,refract,ivec2,ivec3,int,float,bool,any,all,not,lessThan,greaterThan,equal'.split(
+      ',',
+    ),
+  );
+  const code = out.replace(/\/\/[^\n]*/g, ''); // strip comments — prose like "offset (" is not a call
+  const called = new Set(
+    [...code.matchAll(/\b(\w+)\s*\(/g)].map((m) => m[1]).filter((n) => !BUILTINS.has(n)),
+  );
+  const missing = [...called].filter(
+    (n) => !defined.has(n) && !new RegExp(`#define\\s+${n}\\b`).test(out) && n !== 'scene',
+  );
+  ok(
+    missing.length === 0,
+    `real lib: no dangling calls (missing: ${missing.slice(0, 5).join(',') || 'none'})`,
+  );
+}
+
+// ---- terrain scene keeps the noise chain across library files ----
+{
+  const FULL = [NOISE_GLSL, VORONOI_GLSL, SDF3_GLSL, SDF2_GLSL].join('\n');
+  const out = pruneGLSL(
+    FULL,
+    'float scene(vec3 p){ return sdTerrainElevated(p, 35.0, 0.035, 2.0, 0.3); }',
+  );
+  ok(out.includes('sdTerrainElevated'), 'terrain scene: terrain kept');
+  ok(
+    /atlasNoised|noised|atlasFbm|fbm/.test(out),
+    'terrain scene: noise chain kept (cross-file dep)',
+  );
+}
+
+console.log(`\n${pass} passed, ${fail} failed`);
+process.exit(fail ? 1 : 0);

--- a/sdf-js/src/render/studio.js
+++ b/sdf-js/src/render/studio.js
@@ -2046,6 +2046,10 @@ export function createStudioRenderer({
       sceneFnName: 'sceneSDF',
       includeLibrary: true,
       emitObjectIndex: true,
+      // Dead-code eliminate the library against the studio's own fragment code
+      // (buildFragmentShader('') = the full template minus the scene) — unused
+      // primitives never reach the driver. See glsl-prune.js.
+      prune: buildFragmentShader(''),
     });
     if (result.error) throw new Error(`compileSDF3ToGLSL: ${result.error}`);
 
@@ -2682,6 +2686,8 @@ export function createStudioRenderer({
         sceneFnName: 'sceneSDF',
         includeLibrary: true,
         emitObjectIndex: true,
+        // library DCE against the studio fragment template — see _uploadSDF note
+        prune: buildFragmentShader(''),
       });
       if (result.error) throw new Error(`compileSDF3ToGLSL: ${result.error}`);
       const fragSource = buildFragmentShader(result.glsl);

--- a/sdf-js/src/sdf/glsl-prune.js
+++ b/sdf-js/src/sdf/glsl-prune.js
@@ -1,0 +1,137 @@
+// =============================================================================
+// glsl-prune.js — GLSL library dead-code elimination.
+// -----------------------------------------------------------------------------
+// The SDF GLSL library (~130KB across noise/voronoi/sdf3/sdf2) is prepended to
+// EVERY scene shader, but a typical scene calls a handful of primitives. The
+// driver still compiles all of it — the dominant cost behind multi-second (30s+
+// for terrain scenes) cold shader compiles.
+//
+// pruneGLSL(source, roots) keeps only the top-level FUNCTIONS that are
+// (transitively) referenced from `roots` (the emitted scene body + the
+// renderer's own fragment code) — everything else (uniforms, #defines, consts,
+// globals, comments outside functions) is always kept; those are bytes-cheap
+// and may be referenced in ways reference-scanning can't see (macros, samplers).
+//
+// Parsing is a line/brace chunker, not a real grammar: it relies on the
+// library's regular shape (top-level `retType name(args) { ... }` definitions,
+// braces balanced, no function-local `}` at column-anything tricks — true for
+// all four library files). Overloads (same name, different signature) live or
+// die together. Chunks keep their original order, so declare-before-use is
+// preserved automatically.
+// =============================================================================
+
+// Matches the START of a top-level function definition (return type + name +
+// open paren). The opening brace may sit on the same or a following line.
+const FN_START = /^\s*(?:float|vec[234]|int|bool|void|mat[234])\s+(\w+)\s*\(/;
+
+/**
+ * Split GLSL source into chunks: { kind: 'fn', name, text } for function
+ * definitions (with their immediately-preceding comment block), and
+ * { kind: 'keep', text } for everything else.
+ */
+export function chunkGLSL(source) {
+  const lines = source.split('\n');
+  const chunks = [];
+  let keepBuf = [];
+  let i = 0;
+
+  const flushKeep = () => {
+    if (keepBuf.length) {
+      chunks.push({ kind: 'keep', text: keepBuf.join('\n') + '\n' });
+      keepBuf = [];
+    }
+  };
+
+  while (i < lines.length) {
+    const m = lines[i].match(FN_START);
+    if (!m) {
+      keepBuf.push(lines[i]);
+      i++;
+      continue;
+    }
+    // Pull the fn's contiguous preceding comment/blank lines out of keepBuf so
+    // a dropped fn takes its own comments with it.
+    const attached = [];
+    while (keepBuf.length) {
+      const prev = keepBuf[keepBuf.length - 1];
+      if (/^\s*(\/\/.*)?$/.test(prev)) attached.unshift(keepBuf.pop());
+      else break;
+    }
+    // drop leading blank lines of the attached block (keep spacing in 'keep')
+    while (attached.length && /^\s*$/.test(attached[0])) {
+      keepBuf.push(attached.shift());
+    }
+    flushKeep();
+
+    // Brace-match to the end of the function body.
+    const fnLines = [...attached];
+    let depth = 0;
+    let sawBrace = false;
+    while (i < lines.length) {
+      const line = lines[i];
+      fnLines.push(line);
+      for (const ch of line) {
+        if (ch === '{') {
+          depth++;
+          sawBrace = true;
+        } else if (ch === '}') depth--;
+      }
+      i++;
+      if (sawBrace && depth === 0) break;
+    }
+    chunks.push({ kind: 'fn', name: m[1], text: fnLines.join('\n') + '\n' });
+  }
+  flushKeep();
+  return chunks;
+}
+
+/**
+ * Dead-code-eliminate a GLSL library against root text(s).
+ * @param {string} source  the library GLSL
+ * @param {string|string[]} roots  code that calls into the library (scene body,
+ *   renderer fragment code, …)
+ * @returns {string} the pruned library (non-function chunks + reachable fns)
+ */
+export function pruneGLSL(source, roots) {
+  const chunks = chunkGLSL(source);
+  const fnNames = new Set(chunks.filter((c) => c.kind === 'fn').map((c) => c.name));
+  if (fnNames.size === 0) return source;
+
+  // Bodies per fn name (overloads concatenated — they share reachability).
+  const bodyByName = new Map();
+  for (const c of chunks) {
+    if (c.kind !== 'fn') continue;
+    bodyByName.set(c.name, (bodyByName.get(c.name) || '') + c.text);
+  }
+
+  // Roots = caller text + every non-function chunk (macros may call functions).
+  const rootText =
+    (Array.isArray(roots) ? roots.join('\n') : String(roots || '')) +
+    '\n' +
+    chunks
+      .filter((c) => c.kind === 'keep')
+      .map((c) => c.text)
+      .join('\n');
+
+  const calledIn = (text, name) => new RegExp(`\\b${name}\\s*\\(`).test(text);
+
+  const needed = new Set();
+  let frontier = [...fnNames].filter((n) => calledIn(rootText, n));
+  while (frontier.length) {
+    const next = [];
+    for (const n of frontier) {
+      if (needed.has(n)) continue;
+      needed.add(n);
+      const body = bodyByName.get(n);
+      for (const m of fnNames) {
+        if (!needed.has(m) && calledIn(body, m)) next.push(m);
+      }
+    }
+    frontier = next;
+  }
+
+  return chunks
+    .filter((c) => c.kind !== 'fn' || needed.has(c.name))
+    .map((c) => c.text)
+    .join('');
+}

--- a/sdf-js/src/sdf/sdf3.compile.js
+++ b/sdf-js/src/sdf/sdf3.compile.js
@@ -23,6 +23,7 @@ import { NOISE_GLSL } from './noise.glsl.js';
 import { VORONOI_GLSL } from './voronoi.glsl.js';
 import { SDF2, SDF3 } from './core.js';
 import { isTimeExpr, mulT } from './time.js';
+import { pruneGLSL } from './glsl-prune.js';
 
 // ---- format helpers --------------------------------------------------------
 
@@ -155,10 +156,20 @@ function _hashPoints(points) {
  *     side-effect 模式 emit；scene 函数变成多语句，跟 Autoscope 一样维护
  *     `objectIndex` / `minIndex` globals → BOB GPU 上色用。需要 caller 自己 prelude
  *     IMIN_GLSL 字符串（提供 globals + imin / ismoothUnion）。
+ *   @param {string} [opts.prune] 死代码消除（opt-in）：库里只保留从
+ *     (emitted body + extras + 这段调用方 GLSL) 可达的函数。调用方把自己的
+ *     fragment 模板传进来（e.g. studio 的 buildFragmentShader('')），场景没用到
+ *     的 primitive（terrain/city/bridge…）不再进 driver 编译 —— 冷编译从 30s+
+ *     降到秒级的关键。不传 = 整库照旧（其余 renderer 不受影响）。
  * @returns {{ glsl: string|null, error: string|null }}
  */
 export function compileSDF3ToGLSL(sdf, opts = {}) {
-  const { includeLibrary = true, sceneFnName = 'scene', emitObjectIndex = false } = opts;
+  const {
+    includeLibrary = true,
+    sceneFnName = 'scene',
+    emitObjectIndex = false,
+    prune = null,
+  } = opts;
 
   if (!(sdf instanceof SDF3)) {
     return { glsl: null, error: 'not an SDF3 instance' };
@@ -189,8 +200,22 @@ export function compileSDF3ToGLSL(sdf, opts = {}) {
     // code uses them for surface texture (fbm) and patterns (voronoi/brick/hex).
     // SDF2_GLSL provides 2D helpers used by revolve/extrude ops.
     const extrasCode = Array.from(_compileExtras.values()).join('\n\n');
+    let library = includeLibrary
+      ? `${NOISE_GLSL}\n${VORONOI_GLSL}\n${SDF3_GLSL}\n${SDF2_GLSL}`
+      : '';
+    if (includeLibrary && prune != null) {
+      // Dead-code eliminate the library against everything that can call into
+      // it: the emitted scene body, the compile extras, imin helpers, and the
+      // caller's own fragment code (opts.prune).
+      library = pruneGLSL(library, [
+        body,
+        extrasCode,
+        emitObjectIndex ? IMIN_GLSL : '',
+        String(prune),
+      ]);
+    }
     const prelude = includeLibrary
-      ? `${NOISE_GLSL}\n${VORONOI_GLSL}\n${SDF3_GLSL}\n${SDF2_GLSL}\n${emitObjectIndex ? IMIN_GLSL : ''}\n${extrasCode}\n\n`
+      ? `${library}\n${emitObjectIndex ? IMIN_GLSL : ''}\n${extrasCode}\n\n`
       : `${extrasCode}\n\n`;
     return { glsl: prelude + body, error: null, leafMaterials, leafPatterns };
   } catch (e) {


### PR DESCRIPTION
## What — GLSL library dead-code elimination (the "首屏编译" root-cause work)

New `src/sdf/glsl-prune.js`: `pruneGLSL(source, roots)` keeps only the library functions (transitively) reachable from the callers. Line/brace chunker over the library's regular top-level shape; **overloads live or die together**; non-function chunks (uniforms / defines / consts) always kept; original order preserved (declare-before-use holds automatically).

`compileSDF3ToGLSL` gains an **opt-in** `prune: <caller GLSL>`. The studio passes `buildFragmentShader('')` — its full fragment template minus the scene — so its own sky / pattern / material-branch calls stay live. Other renderers untouched.

## Measured

- Plain funnel scene: emitted GLSL **118KB → 23KB (−80%)**.
- Pruned alpine renders **pixel-identical** to unpruned (payoff frame compared).
- 16/16 unit tests, incl. a definition-completeness scan (no dangling calls in pruned output — every called identifier is defined, a builtin, or a #define). Full suite 113/113.

## Honest caveat on compile TIME (and the real finding)

On this machine the wall-clock win is **inconclusive**, because the bottleneck turned out to be elsewhere: **Chrome runs on the Intel iGPU via ANGLE D3D11** (`ANGLE (Intel, 0x7D67 Direct3D11)` — verified via UNMASKED_RENDERER), not the RTX 5090. Alpine's 1-2min cold compile is fxc chewing the terrain loops the scene actually USES — DCE can't remove used code, and the weak iGPU multiplies everything. Smaller source can only help (simple scenes ship 80% less GLSL to the driver), but the highest-leverage fix is **assigning Chrome to the 5090 in Windows graphics preferences** — see PR comment / follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)