### PR TITLE
perf(glsl): data-as-uniforms — same scene shape never recompiles

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -28,6 +28,7 @@ const TESTS = [
   { category: 'smoke', file: 'sdf-js/test/smoke2d.mjs' },
   { category: 'smoke', file: 'sdf-js/test/scene-smoke.mjs' },
   { category: 'smoke', file: 'sdf-js/scripts/test-glsl-prune.mjs' },
+  { category: 'smoke', file: 'sdf-js/scripts/test-uniform-args.mjs' },
 
   // Geometry sanity checker (M5 prereq)
   { category: 'sanity', file: 'sdf-js/scripts/test-sanity.mjs' },

--- a/sdf-js/scenes/ir/funnel-growth.json
+++ b/sdf-js/scenes/ir/funnel-growth.json
@@ -1,0 +1,8 @@
+{
+  "structure": "sequence",
+  "nodes": ["Visitors", "Signups", "Trials", "Paid", "Renewed"],
+  "magnitude": [8000, 2100, 640, 180, 95],
+  "emphasis": [4],
+  "order": [0, 1, 2, 3, 4],
+  "title": "Growth Funnel"
+}

--- a/sdf-js/scripts/test-uniform-args.mjs
+++ b/sdf-js/scripts/test-uniform-args.mjs
@@ -1,0 +1,57 @@
+// sdf-js/scripts/test-uniform-args.mjs — data-as-uniforms GLSL emission.
+// Same scene SHAPE + different data must emit IDENTICAL GLSL (one compile per
+// structure, forever); the data rides in result.sdfArgs (vec4-packed floats).
+import { compileSDF3ToGLSL } from '../src/sdf/sdf3.compile.js';
+import { compile } from '../src/scene/index.js';
+import { expandStage } from '../src/scene/stage.js';
+import { renderSequence } from '../src/scene/render-sequence.js';
+
+let pass = 0,
+  fail = 0;
+const ok = (c, n) => (c ? (pass++, console.log(`  ✓ ${n}`)) : (fail++, console.log(`  ✗ ${n}`)));
+console.log('=== uniform-args (data → uniforms, zero-recompile) ===\n');
+
+const OPTS = { sceneFnName: 'sceneSDF', emitObjectIndex: true, uniformArgs: true };
+
+function funnelScene(magnitude) {
+  const ir = {
+    structure: 'sequence',
+    nodes: ['A', 'B', 'C', 'D'],
+    magnitude,
+    emphasis: [3],
+    title: 'T',
+  };
+  return compile(expandStage(renderSequence(ir)), {});
+}
+
+// ---- the headline invariant: same shape, different data → same source -------
+{
+  const a = compileSDF3ToGLSL(funnelScene([1000, 400, 150, 40]).sdf, OPTS);
+  const b = compileSDF3ToGLSL(funnelScene([900, 600, 300, 10]).sdf, OPTS);
+  ok(a.glsl != null && b.glsl != null, 'both compile');
+  ok(a.glsl === b.glsl, 'IDENTICAL GLSL for different magnitudes (zero recompile)');
+  ok(a.sdfArgs instanceof Float32Array && b.sdfArgs instanceof Float32Array, 'sdfArgs returned');
+  ok(a.sdfArgs?.length === b.sdfArgs?.length, 'same slot count');
+  ok(!!a.sdfArgs?.some((v, i) => v !== b.sdfArgs[i]), 'data differs in the args array');
+  ok(/uniform vec4 u_sdfArgs\[\d+\];/.test(a.glsl), 'declares u_sdfArgs sized for the scene');
+  ok(/u_sdfArgs\[\d+\]\.[xyzw]/.test(a.glsl), 'body references packed slots');
+}
+
+// ---- default path unchanged (no option → literals, no uniform decl) ---------
+{
+  const a = compileSDF3ToGLSL(funnelScene([1000, 400, 150, 40]).sdf, {
+    sceneFnName: 'sceneSDF',
+    emitObjectIndex: true,
+  });
+  ok(!/u_sdfArgs/.test(a.glsl), 'no option → literal emission (other renderers unchanged)');
+  ok(a.sdfArgs == null, 'no option → no sdfArgs');
+}
+
+// ---- CPU-side SDF unaffected (JS closures carry real values) ----------------
+{
+  const c = funnelScene([1000, 400, 150, 40]);
+  ok(c.sdf.f([0, 3, 0]) !== c.sdf.f([0, 99, 0]), 'CPU eval still works on real values');
+}
+
+console.log(`\n${pass} passed, ${fail} failed`);
+process.exit(fail ? 1 : 0);

--- a/sdf-js/src/render/studio.js
+++ b/sdf-js/src/render/studio.js
@@ -2054,6 +2054,7 @@ export function createStudioRenderer({
       sceneFnName: 'sceneSDF',
       includeLibrary: true,
       emitObjectIndex: true,
+      uniformArgs: true, // data -> u_sdfArgs uniforms: same scene shape never recompiles
       // Dead-code eliminate the library against the studio's own fragment code
       // (buildFragmentShader('') = the full template minus the scene) — unused
       // primitives never reach the driver. See glsl-prune.js.
@@ -2276,6 +2277,14 @@ export function createStudioRenderer({
     }
     if (uniformsCache['u_leafPattern[0]'] != null) {
       gl.uniform4fv(uniformsCache['u_leafPattern[0]'], patternLUT);
+    }
+
+    // Data-as-uniforms: the scene's numeric args (positions, radii, dims…)
+    // live in u_sdfArgs, not in the GLSL — a program-cache hit + this upload
+    // IS the whole "scene change" for same-shaped scenes. Zero recompile.
+    if (result.sdfArgs && result.sdfArgs.length) {
+      const loc = gl.getUniformLocation(program, 'u_sdfArgs[0]');
+      if (loc != null) gl.uniform4fv(loc, result.sdfArgs);
     }
   }
 
@@ -2694,6 +2703,7 @@ export function createStudioRenderer({
         sceneFnName: 'sceneSDF',
         includeLibrary: true,
         emitObjectIndex: true,
+        uniformArgs: true, // data -> u_sdfArgs uniforms (see _uploadSDF note)
         // library DCE against the studio fragment template — see _uploadSDF note
         prune: buildFragmentShader(''),
       });

--- a/sdf-js/src/sdf/sdf3.compile.js
+++ b/sdf-js/src/sdf/sdf3.compile.js
@@ -61,9 +61,29 @@ function emitTimeExpr(e) {
   throw new Error(`emitTimeExpr: unknown form '${e.form}'`);
 }
 
-// 统一 dispatch：number → literal；time-expr → GLSL expr
+// ---- data-as-uniforms (zero-recompile) --------------------------------------
+// When active (opts.uniformArgs), every number that would be baked into the
+// GLSL as a literal is instead allocated a slot in a packed `uniform vec4
+// u_sdfArgs[]` array — in strict WALK ORDER with NO value dedup, so the same
+// scene SHAPE always emits byte-identical GLSL regardless of the data. One
+// compiled program (and one Chrome disk-cache entry) serves every data
+// variation; changing the numbers is a gl.uniform4fv, not a shader compile.
+// Values ride out in result.sdfArgs (vec4-padded Float32Array). Time exprs +
+// _compileExtras stay literal (their text is data-independent). CPU-side
+// sdf.f() is untouched (JS closures carry the real values).
+let _uniformSlots = null; // number[] | null — active slot list
+const UNIFORM_ARGS_CAP = 1024; // floats (= 256 vec4); over budget → literal fallback
+
+function fltSlot(n) {
+  if (typeof n !== 'number' || !Number.isFinite(n)) return fltLit(n); // reuse validation/throw
+  const i = _uniformSlots.length;
+  _uniformSlots.push(n);
+  return `u_sdfArgs[${i >> 2}].${'xyzw'[i & 3]}`;
+}
+
+// 统一 dispatch：number → literal (或 uniform slot)；time-expr → GLSL expr
 function fltOrTime(x) {
-  if (typeof x === 'number') return fltLit(x);
+  if (typeof x === 'number') return _uniformSlots ? fltSlot(x) : fltLit(x);
   if (isTimeExpr(x)) return emitTimeExpr(x);
   throw new Error(`flt: expected number or time-expr, got ${typeof x} (${JSON.stringify(x)})`);
 }
@@ -185,15 +205,36 @@ export function compileSDF3ToGLSL(sdf, opts = {}) {
   try {
     let body,
       leafMaterials = null,
-      leafPatterns = null;
-    if (emitObjectIndex) {
-      const result = compileWithObjectIndex(sdf, sceneFnName);
-      body = result.body;
-      leafMaterials = result.leafMaterials;
-      leafPatterns = result.leafPatterns;
+      leafPatterns = null,
+      sdfArgs = null;
+    const emitBody = () => {
+      if (emitObjectIndex) {
+        const result = compileWithObjectIndex(sdf, sceneFnName);
+        leafMaterials = result.leafMaterials;
+        leafPatterns = result.leafPatterns;
+        return result.body;
+      }
+      return `float ${sceneFnName}(vec3 p) {\n  return ${walk(sdf, 'p')};\n}`;
+    };
+    if (opts.uniformArgs) {
+      _uniformSlots = [];
+      body = emitBody();
+      if (_uniformSlots.length > UNIFORM_ARGS_CAP) {
+        // over the uniform-component budget — fall back to baked literals
+        console.warn(
+          `[sdf3.compile] uniformArgs: ${_uniformSlots.length} slots exceeds cap ${UNIFORM_ARGS_CAP} — falling back to literal emission (scene recompiles on data change)`,
+        );
+        _uniformSlots = null;
+        body = emitBody();
+      } else {
+        const nVec4 = Math.max(1, Math.ceil(_uniformSlots.length / 4));
+        sdfArgs = new Float32Array(nVec4 * 4);
+        sdfArgs.set(_uniformSlots);
+        body = `uniform vec4 u_sdfArgs[${nVec4}];\n${body}`;
+        _uniformSlots = null;
+      }
     } else {
-      const expr = walk(sdf, 'p');
-      body = `float ${sceneFnName}(vec3 p) {\n  return ${expr};\n}`;
+      body = emitBody();
     }
     // Noise + Voronoi libs prepended first — SDF library functions (and
     // future domain-warped primitives) can call into them. Renderer shading
@@ -217,11 +258,12 @@ export function compileSDF3ToGLSL(sdf, opts = {}) {
     const prelude = includeLibrary
       ? `${library}\n${emitObjectIndex ? IMIN_GLSL : ''}\n${extrasCode}\n\n`
       : `${extrasCode}\n\n`;
-    return { glsl: prelude + body, error: null, leafMaterials, leafPatterns };
+    return { glsl: prelude + body, error: null, leafMaterials, leafPatterns, sdfArgs };
   } catch (e) {
-    return { glsl: null, error: e.message, leafMaterials: null, leafPatterns: null };
+    return { glsl: null, error: e.message, leafMaterials: null, leafPatterns: null, sdfArgs: null };
   } finally {
     _compileExtras = null;
+    _uniformSlots = null;
   }
 }
 


### PR DESCRIPTION
## What — the strategic compile fix: data-as-uniforms

Scene DATA (funnel radii, positions, dims — every number an emitter bakes) was emitted as **GLSL literals**, so ANY data change produced a brand-new shader = a fresh multi-second cold compile. This PR makes the same scene **shape** emit **byte-identical GLSL** regardless of the data — one compiled program serves every data variation, forever.

## How

- `compileSDF3ToGLSL` gains opt-in **`uniformArgs`**: `flt()` (the single choke point every emitter's numbers flow through) allocates a slot in a packed `uniform vec4 u_sdfArgs[]` instead of printing a literal. Slots are strict **walk-order, no value dedup** — that's what makes the source data-independent. Time exprs + `_compileExtras` stay literal (data-independent text); CPU `sdf.f()` untouched; **other renderers unchanged** (no option → literals, test-asserted).
- Over-budget guard: > 1024 float slots → warn + literal fallback.
- Studio: option on both call sites; `finishProgramSetup` uploads `result.sdfArgs` — **also on the program-cache-hit path**, so an in-page scene swap with the same shape = a uniform upload, **zero compile**.

## Verified

- Node: two magnitude sets → **identical 118KB source**, different `sdfArgs`. 10/10 unit tests; suite **114/114**.
- Browser: a steep growth funnel (8000→95) renders correctly on the SAME compiled source as the sales funnel (`funnel-growth.json` added as a second fixture — visibly different geometry, all uniform-driven).

## Measured + what remains

| case | before | after |
|---|---|---|
| change data, same page (deck flips) | full recompile | **milliseconds** |
| change data, new page load | full cold compile | ~13s |
| first-ever compile per machine per shape | ~24s | ~24s (once) |

The 13s floor = ANGLE's GLSL→HLSL **translation**, which repeats per page load and no cache covers. Next lever (follow-up): feature-gate the studio template's material branches per scene (`#if` preprocessor) — a funnel scene doesn't need sea/mountain/city/rune/glass branches in the source at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)