### PR TITLE
Sprint 26: entity recall metric + all-atoms gallery + visual scorecard baseline

### DIFF
--- a/docs/superpowers/atom-visual-scorecard.md
+++ b/docs/superpowers/atom-visual-scorecard.md
@@ -1,0 +1,59 @@
+# Atom Visual Quality Scorecard — Sprint 26 baseline (2026-07-05)
+
+Loop 2 (视觉质量循环) 第一次全量评审。方法: `all-atoms-gallery.html` 以 spec.example
+args 渲染全部 101 atom (640×360, editorial-light palette), 9 chunk 截图,
+多模态逐个对照 PL 质量基准评审。截图: `screens/sprint26-gallery/chunk-*.png`。
+
+评分: ✅ 好 (PL 级) / 🟡 中 (可用但有硬伤) / 🔴 破 (视觉失败, 必修)。
+只列 🔴/🟡; 未列出的 ~70 atom 均 ✅。
+
+## 🔴 P0 — 视觉失败 (round 2 必修)
+
+| atom | 问题 |
+|---|---|
+| `pyramid` | **语义倒置**: Maslow 例子 base 层 (Physiological) 渲染在顶部最宽, 塔尖朝下。惯例是 base 在底。且塔尖层 label 不可读 (白字压小三角)。⚠ 修渲染顺序是视觉契约变更 — 3D twin (pyramid-3d) 同步检查 |
+| `feature-card-grid` | 标题溢出卡片 ("Performance"/"Global Reach" 撞右边), body 文本截断到词中 ("with" / "50+") — 无 auto-shrink |
+| `gauge` | 指针方向/枢轴错 (指向右下 ~140°), 无数值显示 — 看起来根本没做完 |
+| `seven-s-model` | 六边形团簇过小挤在中心, 全部 label 截断 ("Sha…Val…" / "Str…" / "Sys…") 不可读 |
+| `numbered-grid` | huge 风格数字与 label 文字重叠 ("2Partner channel"), sublabel 被数字压住 |
+| `mindmap` | 节点 label 截断 ("ende." / "Compo…" / "Pipel."), 圆太小, 挤在中心 1/3 区域 |
+| `matrix-grid` + `nine-field-matrix` | bubbles arg 渲染在 cell label **之上**遮挡文字 ("Weaknesses" 被 "Stars" 泡遮住 / nine-field 左上 "Invest" 被遮) |
+
+## 🟡 P1 — 中等 (round 3 候选)
+
+| atom | 问题 |
+|---|---|
+| `stat-banner` | trend chip 与 label 文本重叠 ("Annual Recurring Revenue" 被 "+117% YoY" 压住尾部) |
+| `flow-chart` | 节点 label 截断 ("Onboard" / "Purchas") — 需 auto-shrink |
+| `timeline` | 首卡片左边缘裁切 ("eed Round") |
+| `icon-grid` | 4 item 换行后第 1 行 label 被第 2 行圆遮住 ("Security" 藏在 "Care" 圆后) |
+| `funnel` | 级间 % chip 一半藏在梯形后 ("↓ 88%" 只露一半) |
+| `fishbone` | 左侧枝 label 出画布 ("nel mix" 被裁) |
+| `isotype-stat-comparison` | 图标行挤压变形, "FUll-time" 大小写渲染错误 |
+| `bullet-list` | 空心圆环 bullet 视觉未完成感; 行间距过大留白多 |
+| `bubble` | 气泡内 label 不可读 (深底深字), 图表稀疏 |
+| `infinity-loop-flow` | 节点/loop 挤在中心, 画布利用率 <30% |
+| `relationship-graph` | 3 节点偏下, 大片死区; "uses" 边标签过小 |
+| `org-vs-org-matrix` | org label 太小, "Acme (us)" 在气泡内难读, 右半象限灰底对比不足 |
+
+## 🟢 P2 — 小瑕疵 (顺手修)
+
+- `bar`: targetLine "Target" 标签与图标题碰撞
+- `histogram`: 标题与 "Median" 标注轻微重叠
+- `arrow` / `diamond`: 单形状 + caption, hero 表现力弱 (设计层面, 非 bug)
+- `radial-spoke`: 各 spoke 无差异化数值显示
+- `sphere-network` / `sphere-tree`: 球面 label 偏小
+- `image` / `image-split`: example 是 1px data URI 故渲染空白 (预期; gallery example 可换更大 demo 图)
+
+## Round 2 计划
+
+1. 修 7 个 P0 (pyramid 倒置需先确认视觉契约 + 3D twin 一致性)
+2. 通用修法优先: auto-shrink helper 已存在 (fitFontSize), P0 里 feature-card-grid /
+   numbered-grid / mindmap / seven-s-model / flow-chart 都是同一类 "无 shrink" 病
+3. 重渲 gallery → 对照本 scorecard 复核 → 更新状态
+
+## 状态
+
+- [ ] Round 2: P0 × 7
+- [ ] Round 3: P1 × 12
+- [ ] Round 4: P2 清尾 + 复审全量

--- a/sdf-js/examples/atoms-2d-demo/all-atoms-gallery.html
+++ b/sdf-js/examples/atoms-2d-demo/all-atoms-gallery.html
@@ -1,0 +1,93 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Atlas 2D — ALL Atoms Gallery (Sprint 26 visual-quality loop)</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;900&family=IBM+Plex+Mono:wght@400;500;700&display=swap" rel="stylesheet">
+  <style>
+    body { margin: 16px; font-family: 'Inter', system-ui; background: #f2f0ec; color: #1e1b1e; }
+    h1 { margin: 0 0 2px; font-size: 18px; }
+    h1 + p { margin: 0 0 16px; color: #666; font-size: 12px; }
+    .grid { display: grid; grid-template-columns: repeat(2, 1fr); gap: 14px; }
+    .sample { background: #fff; border-radius: 6px; border: 1px solid #ddd; overflow: hidden; }
+    .sample h3 { margin: 0; padding: 6px 10px; font-size: 12px; font-weight: 700; background: #1e1b1e; color: #fff; font-family: 'IBM Plex Mono', monospace; }
+    .sample canvas { display: block; width: 100%; height: auto; }
+    .sample .err { padding: 20px; color: #a00; font-size: 12px; font-family: monospace; }
+  </style>
+</head>
+<body>
+  <h1>ALL Atoms Gallery</h1>
+  <p>Every registered atom rendered with its spec example args. <code>?from=0&amp;to=12</code> slices for chunked screenshots. <code>?theme=dark</code> renders on editorial-navy-style dark palette.</p>
+  <div id="grid" class="grid"></div>
+
+  <script type="module">
+    import { listAtomTypes, getAtomSpec, renderAtom } from '/src/present/atoms-2d/registry.js';
+
+    const params = new URLSearchParams(location.search);
+    const FROM = parseInt(params.get('from') ?? '0', 10);
+    const TO = parseInt(params.get('to') ?? '999', 10);
+    const DARK = params.get('theme') === 'dark';
+
+    // Neutral demo palettes — light editorial + dark pitch
+    const PALETTE_LIGHT = {
+      bg: [248, 246, 240],
+      accent: [38, 70, 130],
+      colors: [[38, 70, 130], [165, 130, 90], [90, 140, 110], [190, 90, 80], [120, 110, 160]],
+      silhouetteColor: [30, 27, 30],
+    };
+    const PALETTE_DARK = {
+      bg: [22, 28, 40],
+      accent: [80, 150, 220],
+      colors: [[80, 150, 220], [220, 170, 90], [110, 200, 160], [220, 110, 100], [160, 140, 220]],
+      silhouetteColor: [240, 242, 246],
+    };
+    const palette = DARK ? PALETTE_DARK : PALETTE_LIGHT;
+
+    // Build demo args from the spec's per-arg `example` values.
+    function demoArgsFor(spec) {
+      const args = {};
+      for (const [key, def] of Object.entries(spec.args || {})) {
+        if (def && def.example !== undefined && def.example !== null) args[key] = def.example;
+      }
+      return args;
+    }
+
+    const grid = document.getElementById('grid');
+    const types = listAtomTypes().sort();
+    const slice = types.slice(FROM, TO);
+
+    for (const type of slice) {
+      const cell = document.createElement('div');
+      cell.className = 'sample';
+      const h = document.createElement('h3');
+      h.textContent = `${types.indexOf(type)}. ${type}`;
+      cell.appendChild(h);
+      const canvas = document.createElement('canvas');
+      canvas.width = 640;
+      canvas.height = 360;
+      cell.appendChild(canvas);
+      grid.appendChild(cell);
+
+      const ctx = canvas.getContext('2d');
+      ctx.fillStyle = `rgb(${palette.bg.join(',')})`;
+      ctx.fillRect(0, 0, 640, 360);
+
+      try {
+        const spec = await getAtomSpec(type);
+        const args = demoArgsFor(spec);
+        await renderAtom(ctx, type, args, 'pseudo3d', { x: 0, y: 0, w: 640, h: 360, palette });
+      } catch (e) {
+        const err = document.createElement('div');
+        err.className = 'err';
+        err.textContent = `RENDER ERROR: ${e.message}`;
+        cell.appendChild(err);
+        console.error(`[gallery] ${type}:`, e);
+      }
+    }
+    console.log(`[gallery] rendered ${slice.length} atoms (${FROM}..${Math.min(TO, types.length)})`);
+    window.__galleryDone = true;
+  </script>
+</body>
+</html>

--- a/sdf-js/scripts/eval-corpus.mjs
+++ b/sdf-js/scripts/eval-corpus.mjs
@@ -143,15 +143,19 @@ function padNum(str, n) {
 }
 
 console.log(
-  `\n${pad('deck', 26)}${padNum('score', 6)}  ${pad('fill', 6)}${padNum('types', 6)}${padNum('unk', 5)}${padNum('twin%', 7)}  ${pad('lift', 6)}${padNum('chars/slot', 11)}${padNum('facts%', 8)}`,
+  `\n${pad('deck', 26)}${padNum('score', 6)}  ${pad('fill', 6)}${padNum('types', 6)}${padNum('unk', 5)}${padNum('twin%', 7)}  ${pad('lift', 6)}${padNum('chars/slot', 11)}${padNum('facts%', 8)}${padNum('ents%', 7)}`,
 );
 
 for (const r of rows) {
   const fillStr = `${r.structure.slots_baked}/${r.structure.slots_total}`;
   const liftStr = `${r.threeDReadiness.lift_success}/${r.structure.slots_baked}`;
   const factsStr = r.fidelity ? Math.round(r.fidelity.number_recall * 100) + '%' : '—';
+  const entsStr =
+    r.fidelity && r.fidelity.entity_recall != null
+      ? Math.round(r.fidelity.entity_recall * 100) + '%'
+      : '—';
   console.log(
-    `${pad(r.deckName, 26)}${padNum(r.score.total, 6)}  ${pad(fillStr, 6)}${padNum(r.atomQuality.atom_types_distinct, 6)}${padNum(r.atomQuality.unknown_atom_count, 5)}${padNum(Math.round(r.threeDReadiness.twin_coverage * 100) + '%', 7)}  ${pad(liftStr, 6)}${padNum(Math.round(r.textBudget.chars_per_slot), 11)}${padNum(factsStr, 8)}`,
+    `${pad(r.deckName, 26)}${padNum(r.score.total, 6)}  ${pad(fillStr, 6)}${padNum(r.atomQuality.atom_types_distinct, 6)}${padNum(r.atomQuality.unknown_atom_count, 5)}${padNum(Math.round(r.threeDReadiness.twin_coverage * 100) + '%', 7)}  ${pad(liftStr, 6)}${padNum(Math.round(r.textBudget.chars_per_slot), 11)}${padNum(factsStr, 8)}${padNum(entsStr, 7)}`,
   );
 }
 
@@ -161,8 +165,13 @@ const fidelityMean =
   fidelityRows.length > 0
     ? fidelityRows.reduce((s, r) => s + r.fidelity.number_recall, 0) / fidelityRows.length
     : null;
+const entityRows = rows.filter((r) => r.fidelity && r.fidelity.entity_recall != null);
+const entityMean =
+  entityRows.length > 0
+    ? entityRows.reduce((s, r) => s + r.fidelity.entity_recall, 0) / entityRows.length
+    : null;
 console.log(
-  `\n${pad('CORPUS MEAN', 26)}${padNum(corpusMean.toFixed(1), 6)}${fidelityMean != null ? `   facts recall mean: ${(fidelityMean * 100).toFixed(1)}%` : ''}`,
+  `\n${pad('CORPUS MEAN', 26)}${padNum(corpusMean.toFixed(1), 6)}${fidelityMean != null ? `   facts recall mean: ${(fidelityMean * 100).toFixed(1)}%` : ''}${entityMean != null ? `   entity recall mean: ${(entityMean * 100).toFixed(1)}%` : ''}`,
 );
 if (skipped.length) console.log(`\nskipped (not baked): ${skipped.join(', ')}`);
 
@@ -177,6 +186,7 @@ const summary = {
   skipped,
   corpusMean: Math.round(corpusMean * 10) / 10,
   factsRecallMean: fidelityMean != null ? Math.round(fidelityMean * 1000) / 1000 : null,
+  entityRecallMean: entityMean != null ? Math.round(entityMean * 1000) / 1000 : null,
   decks: rows.map((r) => ({
     deckName: r.deckName,
     score: r.score.total,
@@ -198,6 +208,8 @@ const summary = {
     charsPerSlot: r.textBudget.chars_per_slot,
     maxSlotChars: r.textBudget.max_slot_chars,
     numberRecall: r.fidelity ? r.fidelity.number_recall : null,
+    entityRecall: r.fidelity && r.fidelity.entity_recall != null ? r.fidelity.entity_recall : null,
+    missingEntities: r.fidelity ? r.fidelity.missing_entities || [] : [],
     missingNumbers: r.fidelity ? r.fidelity.missing_numbers : [],
   })),
 };

--- a/sdf-js/scripts/eval-deck-quality.mjs
+++ b/sdf-js/scripts/eval-deck-quality.mjs
@@ -115,6 +115,40 @@ export function extractKeyNumbers(text) {
   return [...new Set(cleaned)];
 }
 
+// Leading words that make a capitalized 2+-word run a sentence fragment, not
+// a proper noun ("The Team", "Our Mission", "How It Works" …).
+const ENTITY_STOP_PREFIX =
+  /^(The|Our|A|An|This|That|These|Those|How|What|Why|When|Where|And|But|Or|If|We|You|It|They|New|Every|All|Each|More|Most|Key|Total|First|Next|Last)\s/;
+
+// Extract proper-noun candidates (people / orgs / products) from source
+// slides. BODY lines only: slide titles are headings by nature ("Financial
+// Breakdown", "Thank You") and pollute the entity set with title-case
+// fragments; real entities overwhelmingly live in body prose ("interviewed
+// Village Chief Amara Kessy", "per Gartner Magic Quadrant"). Extraction is
+// PER-LINE so runs never cross field boundaries. Deterministic — no NLP.
+export function extractKeyEntities(slides) {
+  const out = new Set();
+  const lines = [];
+  for (const s of slides) {
+    for (const b of s.body || []) {
+      lines.push(typeof b === 'string' ? b : b.text || '');
+    }
+  }
+  for (const line of lines) {
+    const runs = line.match(/\b[A-Z][a-z]+(?: [A-Z][a-z]+)+\b/g) || [];
+    for (let run of runs) {
+      // strip sentence-fragment prefixes repeatedly ("The New Sarah Chen" → "Sarah Chen")
+      let prev;
+      do {
+        prev = run;
+        run = run.replace(ENTITY_STOP_PREFIX, '');
+      } while (run !== prev && / /.test(run));
+      if (/ /.test(run)) out.add(run); // still 2+ words after stripping
+    }
+  }
+  return [...out];
+}
+
 export async function scoreDeckQuality(deckDir) {
   const dir = resolve(deckDir);
   const deckJsonPath = join(dir, 'deck.json');
@@ -278,11 +312,26 @@ export async function scoreDeckQuality(deckDir) {
       if (deckText.includes(n) || deckTextNorm.includes(n.replace(/,/g, ''))) found.push(n);
       else missing.push(n);
     }
+    // Entity recall (Sprint 26): people / orgs / products. Case-insensitive
+    // match (covers uppercase "SARAH CHEN" in section titles).
+    const srcEntities = extractKeyEntities(srcSlides);
+    const deckTextLower = deckText.toLowerCase();
+    const entFound = [];
+    const entMissing = [];
+    for (const e of srcEntities) {
+      if (deckTextLower.includes(e.toLowerCase())) entFound.push(e);
+      else entMissing.push(e);
+    }
+
     fidelity = {
       numbers_total: srcNumbers.length,
       numbers_found: found.length,
       number_recall: srcNumbers.length > 0 ? found.length / srcNumbers.length : 1,
       missing_numbers: missing.slice(0, 12),
+      entities_total: srcEntities.length,
+      entities_found: entFound.length,
+      entity_recall: srcEntities.length > 0 ? entFound.length / srcEntities.length : 1,
+      missing_entities: entMissing.slice(0, 12),
     };
   }
 
@@ -380,6 +429,9 @@ function printHumanTable(result) {
     console.log('\nCONTENT FIDELITY');
     console.log(
       `  numbers: ${f.numbers_found}/${f.numbers_total} preserved (recall ${(f.number_recall * 100).toFixed(0)}%)${f.missing_numbers.length ? '  missing: ' + f.missing_numbers.join(', ') : ''}`,
+    );
+    console.log(
+      `  entities: ${f.entities_found}/${f.entities_total} preserved (recall ${(f.entity_recall * 100).toFixed(0)}%)${f.missing_entities.length ? '  missing: ' + f.missing_entities.join(', ') : ''}`,
     );
   }
   console.log('\nTEXT BUDGET');

--- a/sdf-js/scripts/eval-results/summary.json
+++ b/sdf-js/scripts/eval-results/summary.json
@@ -1,10 +1,11 @@
 {
-  "generatedAt": "2026-07-05T07:10:56.610Z",
+  "generatedAt": "2026-07-05T10:32:16.232Z",
   "corpusSize": 10,
   "scored": 10,
   "skipped": [],
   "corpusMean": 97,
   "factsRecallMean": 0.958,
+  "entityRecallMean": 0.848,
   "decks": [
     {
       "deckName": "eval-qbr-q3-2026",
@@ -34,6 +35,10 @@
       "charsPerSlot": 179.28571428571428,
       "maxSlotChars": 285,
       "numberRecall": 0.9655172413793104,
+      "entityRecall": 0.5,
+      "missingEntities": [
+        "Product Award"
+      ],
       "missingNumbers": [
         "3.2"
       ]
@@ -66,6 +71,10 @@
       "charsPerSlot": 264.75,
       "maxSlotChars": 466,
       "numberRecall": 0.9,
+      "entityRecall": 0.8,
+      "missingEntities": [
+        "Gartner Magic Quadrant"
+      ],
       "missingNumbers": [
         "2025"
       ]
@@ -98,6 +107,8 @@
       "charsPerSlot": 142.85714285714286,
       "maxSlotChars": 180,
       "numberRecall": 1,
+      "entityRecall": 1,
+      "missingEntities": [],
       "missingNumbers": []
     },
     {
@@ -128,6 +139,12 @@
       "charsPerSlot": 261.57142857142856,
       "maxSlotChars": 346,
       "numberRecall": 1,
+      "entityRecall": 0.7692307692307693,
+      "missingEntities": [
+        "In Search",
+        "Understandable Consensus Algorithm",
+        "Highly Available Key"
+      ],
       "missingNumbers": []
     },
     {
@@ -158,6 +175,8 @@
       "charsPerSlot": 314,
       "maxSlotChars": 489,
       "numberRecall": 0.9565217391304348,
+      "entityRecall": 1,
+      "missingEntities": [],
       "missingNumbers": [
         "43"
       ]
@@ -190,6 +209,10 @@
       "charsPerSlot": 181.55555555555554,
       "maxSlotChars": 271,
       "numberRecall": 0.8888888888888888,
+      "entityRecall": 0.8,
+      "missingEntities": [
+        "Google Slides"
+      ],
       "missingNumbers": [
         "$0",
         "$120K",
@@ -224,6 +247,14 @@
       "charsPerSlot": 303.14285714285717,
       "maxSlotChars": 477,
       "numberRecall": 1,
+      "entityRecall": 0.7727272727272727,
+      "missingEntities": [
+        "Company Overview",
+        "Team Heritage",
+        "Potential User Groups",
+        "Custodial Strategy",
+        "Connect With Us"
+      ],
       "missingNumbers": []
     },
     {
@@ -260,6 +291,8 @@
       "charsPerSlot": 262.1666666666667,
       "maxSlotChars": 340,
       "numberRecall": 1,
+      "entityRecall": 1,
+      "missingEntities": [],
       "missingNumbers": []
     },
     {
@@ -290,6 +323,10 @@
       "charsPerSlot": 242,
       "maxSlotChars": 541,
       "numberRecall": 0.9,
+      "entityRecall": 0.8333333333333334,
+      "missingEntities": [
+        "Village Chief Amara Kessy"
+      ],
       "missingNumbers": [
         "2025",
         "9%",
@@ -330,6 +367,8 @@
       "charsPerSlot": 229.33333333333334,
       "maxSlotChars": 442,
       "numberRecall": 0.9666666666666667,
+      "entityRecall": 1,
+      "missingEntities": [],
       "missingNumbers": [
         "31"
       ]


### PR DESCRIPTION
## Summary

两个 user 指定的循环同时开工:

## Loop 1 — 实体保真 (metric shipped, baseline 84.8%)

- `extractKeyEntities()`: body 行的大写 2+词序列 (标题是 heading 天然噪音, body-only 把测量从虚 71.5% 提纯到实 84.8%), 句首碎片前缀反复剥离, 按行抽取不跨界
- eval 表加 `ents%` 列, summary.json 加 entityRecallMean
- 基线: **84.8%** — 剩余 miss ~60% 是抽取噪音 (heading 式 body 行/论文标题片段), ~40% 真实 (奖项名截断/阅读清单丢失), 提纯抽取器留给后续轮

## Loop 2 — 视觉质量 (instrument + 第一次全量评审)

**测量仪器**: [all-atoms-gallery.html](sdf-js/examples/atoms-2d-demo/all-atoms-gallery.html) — 101 atom × spec.example args 全量渲染, `?from/?to` 分片截图, `?theme=dark` 暗色审查

**第一次全量评审** (9 chunk 截图 + 多模态逐个对照 PL 基准): [atom-visual-scorecard.md](docs/superpowers/atom-visual-scorecard.md)

| 等级 | 数量 | 例子 |
|---|---|---|
| ✅ PL 级 | ~70 | kpi-card / donut-with-center / funnel-with-conversion / okr-tree / risk-heatmap... |
| 🔴 P0 视觉失败 | **7** | **pyramid 语义倒置** (Maslow base 渲染在顶) / gauge 指针坏 / feature-card-grid 标题溢出 / numbered-grid 数字压字 / mindmap+seven-s 全截断 / matrix bubbles 遮 label |
| 🟡 P1 中等 | 12 | stat-banner chip 压字 / flow-chart 节点截断 / timeline 首卡裁切... |

**P0 根因聚类**: 大半是同一种 "无 auto-shrink" 病 — Sprint 21 的 fitFontSize helper 已在别处治愈, round 2 推广即可。

## 循环状态

- Loop 1: 指标已并入 harness, 每次 `npm run eval` 自动测
- Loop 2: round 2 = 修 7 个 P0 → 重渲 gallery → scorecard 复核 (pyramid 倒置涉及视觉契约 + 3D twin 一致性, 先确认再修)

## Tests

npm test: **113/113**

Per CLAUDE.md: DO NOT merge. Awaiting user review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)