### PR TITLE
Sprint 26 round 2: fix 7 P0 atoms from visual scorecard

### DIFF
--- a/docs/superpowers/atom-visual-scorecard.md
+++ b/docs/superpowers/atom-visual-scorecard.md
@@ -7,17 +7,20 @@ args 渲染全部 101 atom (640×360, editorial-light palette), 9 chunk 截图,
 评分: ✅ 好 (PL 级) / 🟡 中 (可用但有硬伤) / 🔴 破 (视觉失败, 必修)。
 只列 🔴/🟡; 未列出的 ~70 atom 均 ✅。
 
-## 🔴 P0 — 视觉失败 (round 2 必修)
+## ✅ Fixed in round 2 (2026-07-05)
 
-| atom | 问题 |
+全部 7 个 P0 已修复, 每项均重渲 gallery + 多模态截图确认。详见各 commit message
+(branch `sprint-26-round2-p0-atoms`)。
+
+| atom | 修了什么 |
 |---|---|
-| `pyramid` | **语义倒置**: Maslow 例子 base 层 (Physiological) 渲染在顶部最宽, 塔尖朝下。惯例是 base 在底。且塔尖层 label 不可读 (白字压小三角)。⚠ 修渲染顺序是视觉契约变更 — 3D twin (pyramid-3d) 同步检查 |
-| `feature-card-grid` | 标题溢出卡片 ("Performance"/"Global Reach" 撞右边), body 文本截断到词中 ("with" / "50+") — 无 auto-shrink |
-| `gauge` | 指针方向/枢轴错 (指向右下 ~140°), 无数值显示 — 看起来根本没做完 |
-| `seven-s-model` | 六边形团簇过小挤在中心, 全部 label 截断 ("Sha…Val…" / "Str…" / "Sys…") 不可读 |
-| `numbered-grid` | huge 风格数字与 label 文字重叠 ("2Partner channel"), sublabel 被数字压住 |
-| `mindmap` | 节点 label 截断 ("ende." / "Compo…" / "Pipel."), 圆太小, 挤在中心 1/3 区域 |
-| `matrix-grid` + `nine-field-matrix` | bubbles arg 渲染在 cell label **之上**遮挡文字 ("Weaknesses" 被 "Stars" 泡遮住 / nine-field 左上 "Invest" 被遮) |
+| `pyramid` | 重写 `widthAtLayer` → `boundaryWidth(k)`(按 boundary 而非 pixel-row 计算宽度), layers[0]=base 现在正确渲染在底部最宽; `inverted` 只改上下位置不再影响哪层宽。塔尖 label 加"放不下就挪到金字塔外侧+连接线"的 fallback。顺带修了 spec `inverted.example: true` 意外把 gallery demo 强制渲成 funnel 朝向的 bug。确认 `pyramid-3d` twin 本来就是 base-bottom-widest, 2D 现在与之一致, 未改 3D。 |
+| `feature-card-grid` | 标题加 fitFontSize auto-shrink(min 12px), 不再溢出撞邻居卡片; body wrapText 升到 4 行 + 末行 ellipsis(整词丢弃优先, 单词内部才退化到字符级裁切), tokenizer 支持连字符断行("zero-knowledge"→"zero-"/"knowledge")。 |
+| `gauge` | 根因: arcRadius 贪心吃满剩余高度, 把数值文字/label 挤到 canvas 外(完全不可见)。改为先预留 bottomBlockH(数值字号+间距+可选 label)再算 arcRadius。指针角度数学本身没问题(0=左/0.5=顶/1=右, 向下开口的表盘), 之前"指针方向错"其实是表盘整体过大+数值裁切造成的观感。 |
+| `seven-s-model` | R 从 `min(w,h)*0.31` 改为按 FILL_FRAC(0.75)反推, 团簇现在占满~75%可用空间。label 从固定字号+ellipsis 换成 `fitLabelLines()`: 先降字号(9px 下限)→ 再 2-line 词换行 → 单词不可切分时用连字符 2-line 字符对半("Structure"→"Struc-"/"ture")。 |
+| `numbered-grid` | huge 数字列宽从 `numFontSize*0.65` 的猜测值改成 `ctx.measureText(numLabel)` 实测宽度 + 8px gap, label/sublabel 列从实测宽度之后起始, 不再压字。 |
+| `mindmap` | 固定半径常量(36/22/14)+ 保守 maxRadius 改成按 80% 可用半径动态计算; 分支/叶子节点缩成小圆点, label 移到圆外(沿节点相对根节点的角度径向偏移, 按左右自动切 textAlign), 字号 10px 下限自动收缩; 根节点保留内嵌 label 但改 auto-shrink 不再 ellipsis 截断。 |
+| `matrix-grid` + `nine-field-matrix` | 拆分 `drawCell` → `drawCellBg` + `drawCellLabel`, 渲染顺序改成: 背景 → 轴 → bubbles(半透明 fill α=0.32 + 实线描边)→ cell label(现在总在 bubble 之上)→ bubble 自己的 label 移到泡外(右下偏移, 避开 cell label 的水平中线), 深色小字。 |
 
 ## 🟡 P1 — 中等 (round 3 候选)
 
@@ -54,6 +57,6 @@ args 渲染全部 101 atom (640×360, editorial-light palette), 9 chunk 截图,
 
 ## 状态
 
-- [ ] Round 2: P0 × 7
+- [x] Round 2: P0 × 7 (2026-07-05, branch `sprint-26-round2-p0-atoms`)
 - [ ] Round 3: P1 × 12
 - [ ] Round 4: P2 清尾 + 复审全量

--- a/sdf-js/src/present/atoms-2d/charts/data/gauge.js
+++ b/sdf-js/src/present/atoms-2d/charts/data/gauge.js
@@ -61,9 +61,22 @@ export function drawPseudo3D(ctx, args, opts = {}) {
     plotTop = y + h * 0.16;
   }
 
+  // Reserve room BELOW the dial for the big value readout (+ optional label)
+  // before sizing the arc — previously arcRadius greedily ate the full
+  // remaining height, pushing the value text (and the pivot itself) off the
+  // bottom of the canvas entirely ("no value shown", "pivot displaced").
+  const valueFs = Math.round(h * 0.2);
+  const labelFs = Math.round(h * 0.055);
+  const valueGap = h * 0.05;
+  const labelGap = h * 0.02;
+  const bottomBlockH =
+    valueGap + valueFs * 1.15 + (label ? labelGap + labelFs * 1.2 : 0) + PAD * 0.5;
+
   const cx = x + w / 2;
-  const arcRadius = Math.min((w - PAD * 2) / 2, h - plotTop - PAD * 2);
-  const cy = plotTop + arcRadius + PAD * 0.4;
+  const maxRadiusW = (w - PAD * 2) / 2;
+  const maxRadiusH = y + h - PAD - bottomBlockH - plotTop;
+  const arcRadius = Math.max(20, Math.min(maxRadiusW, maxRadiusH));
+  const cy = plotTop + arcRadius;
   // Arc thickness: 14–16% of radius
   const tube = arcRadius * 0.15;
 
@@ -131,21 +144,23 @@ export function drawPseudo3D(ctx, args, opts = {}) {
     ctx.fillText(String(args.max), cx + arcRadius, cy + tube * 0.8);
   }
 
-  // Big value text: Inter 900, large, centered in gauge bowl
+  // Big value text: Inter 900, large, centered below the pivot in the
+  // reserved bottomBlockH budget (see above — always on-canvas).
   const valueText = format === 'percent' ? `${Math.round(value * 100)}%` : String(value.toFixed(2));
+  const valueY = cy + valueGap;
   ctx.fillStyle = rgbCss(fg);
-  ctx.font = `900 ${Math.round(h * 0.2)}px "Inter Display", Inter, system-ui, sans-serif`;
+  ctx.font = `900 ${valueFs}px "Inter Display", Inter, system-ui, sans-serif`;
   ctx.textAlign = 'center';
   ctx.textBaseline = 'top';
-  ctx.fillText(valueText, cx, cy + tube * 1.4);
+  ctx.fillText(valueText, cx, valueY);
 
   // Sublabel: Inter 500, small, below value
   if (label) {
     ctx.fillStyle = rgbaCss(fg, 0.6);
-    ctx.font = `500 ${Math.round(h * 0.055)}px Inter, system-ui, sans-serif`;
+    ctx.font = `500 ${labelFs}px Inter, system-ui, sans-serif`;
     ctx.textAlign = 'center';
     ctx.textBaseline = 'top';
-    ctx.fillText(String(label), cx, cy + tube * 1.4 + h * 0.22);
+    ctx.fillText(String(label), cx, valueY + valueFs * 1.15 + labelGap);
   }
 }
 

--- a/sdf-js/src/present/atoms-2d/charts/diagrams/mindmap.js
+++ b/sdf-js/src/present/atoms-2d/charts/diagrams/mindmap.js
@@ -47,9 +47,6 @@ export const spec = {
 
 const PAD = 14;
 const TITLE_FRAC = 0.1;
-const ROOT_RADIUS = 36;
-const BRANCH_RADIUS = 22;
-const LEAF_RADIUS = 14;
 
 export function drawPseudo3D(ctx, args, opts = {}) {
   const x = opts.x ?? 0;
@@ -84,16 +81,27 @@ export function drawPseudo3D(ctx, args, opts = {}) {
     plotTop = y + h * TITLE_FRAC + PAD;
   }
 
-  // Layout: radial — root at center, children on first ring, etc.
+  // Layout: radial — root at center, children on first ring, etc. Sized to
+  // use ~80% of the available radius (previously a conservative constant
+  // margin left the whole cluster cramped into the center third of the
+  // canvas).
   const cx = x + w / 2;
   const cy = plotTop + (y + h - plotTop) / 2;
-  const maxRadius = Math.min(w, y + h - plotTop) / 2 - LEAF_RADIUS - 24;
+  const availRadius = Math.min(w, y + h - plotTop) / 2;
+  const maxRadius = availRadius * 0.8;
+
+  // Node radii scale with the plot size but stay small — labels now render
+  // OUTSIDE the circles (radially offset), so nodes are just position
+  // markers, not label containers.
+  const ROOT_RADIUS = clamp(maxRadius * 0.16, 26, 46);
+  const BRANCH_RADIUS = clamp(maxRadius * 0.075, 10, 18);
+  const LEAF_RADIUS = clamp(maxRadius * 0.05, 6, 12);
 
   const branches = Array.isArray(root.children) ? root.children : [];
 
   // First-ring positions
-  const branchRing = maxRadius * 0.45;
-  const leafRing = maxRadius * 0.85;
+  const branchRing = maxRadius * 0.42;
+  const leafRing = maxRadius * 0.86;
   const branchPositions = [];
   for (let i = 0; i < branches.length; i++) {
     const angle = (i / branches.length) * Math.PI * 2 - Math.PI / 2;
@@ -118,7 +126,8 @@ export function drawPseudo3D(ctx, args, opts = {}) {
       const lx = cx + Math.cos(leafAngle) * leafRing;
       const ly = cy + Math.sin(leafAngle) * leafRing;
       drawCurvedConnector(ctx, bp.x, bp.y, lx, ly, bp.color);
-      drawNode(ctx, lx, ly, LEAF_RADIUS, leaves[j].label || '', bp.color, fg, false);
+      drawNode(ctx, lx, ly, LEAF_RADIUS, bp.color);
+      drawLabelOutside(ctx, lx, ly, leafAngle, LEAF_RADIUS, leaves[j].label || '', fg, 600, 12);
     }
   }
 
@@ -129,18 +138,26 @@ export function drawPseudo3D(ctx, args, opts = {}) {
 
   // Branch nodes
   for (const bp of branchPositions) {
-    drawNode(ctx, bp.x, bp.y, BRANCH_RADIUS, bp.node.label || '', bp.color, fg, false);
+    drawNode(ctx, bp.x, bp.y, BRANCH_RADIUS, bp.color);
+    drawLabelOutside(ctx, bp.x, bp.y, bp.angle, BRANCH_RADIUS, bp.node.label || '', fg, 700, 14);
   }
 
-  // Root node (largest, accent, drawn last so it sits on top)
-  drawNode(ctx, cx, cy, ROOT_RADIUS, root.label || '', accent, fg, true);
+  // Root node (largest, accent, drawn last so it sits on top). Root keeps
+  // its label INSIDE (it's the biggest circle and the one true "container"
+  // of this diagram) but auto-shrinks instead of truncating.
+  drawNode(ctx, cx, cy, ROOT_RADIUS, accent);
+  drawRootLabel(ctx, cx, cy, ROOT_RADIUS, root.label || '');
 }
 
-function drawNode(ctx, cx, cy, radius, label, color, fg, isRoot) {
+function clamp(v, lo, hi) {
+  return Math.max(lo, Math.min(hi, v));
+}
+
+function drawNode(ctx, cx, cy, radius, color) {
   ctx.save();
   ctx.shadowColor = rgbaCss([0, 0, 0], 0.18);
-  ctx.shadowBlur = isRoot ? 12 : 6;
-  ctx.shadowOffsetY = isRoot ? 4 : 2;
+  ctx.shadowBlur = radius > 24 ? 12 : 6;
+  ctx.shadowOffsetY = radius > 24 ? 4 : 2;
 
   // Radial gradient for pseudo-3D
   const grad = ctx.createRadialGradient(
@@ -159,18 +176,59 @@ function drawNode(ctx, cx, cy, radius, label, color, fg, isRoot) {
   ctx.arc(cx, cy, radius, 0, Math.PI * 2);
   ctx.fill();
   ctx.restore();
+}
 
-  // Label
+// Root label renders INSIDE the (largest) root circle, auto-shrunk to fit
+// rather than truncated with an ellipsis.
+function drawRootLabel(ctx, cx, cy, radius, label) {
+  const maxW = radius * 1.7;
+  let fontSize = 16;
+  const minFs = 10;
+  const text = String(label);
+  while (fontSize > minFs) {
+    ctx.font = `700 ${fontSize}px Inter, system-ui, sans-serif`;
+    if (ctx.measureText(text).width <= maxW) break;
+    fontSize--;
+  }
   ctx.fillStyle = 'rgba(255,255,255,1)';
-  const fontSize = Math.max(10, Math.min(15, radius * 0.55));
-  ctx.font = `${isRoot ? 700 : 600} ${fontSize}px Inter, system-ui, sans-serif`;
+  ctx.font = `700 ${fontSize}px Inter, system-ui, sans-serif`;
   ctx.textAlign = 'center';
   ctx.textBaseline = 'middle';
-  // For long labels, slight wrap is not supported here; truncate visually
+  ctx.fillText(text, cx, cy + 1);
+}
+
+// Branch/leaf labels render OUTSIDE their (small) node circle, radially
+// offset along the same angle the node sits at relative to the root, with
+// text alignment flipped depending on which side of the diagram the node
+// falls on (so labels grow away from the cluster, never overlapping it).
+// Auto-shrinks down to a 10px floor instead of truncating.
+function drawLabelOutside(ctx, nx, ny, angle, nodeRadius, label, fg, weight, targetFs) {
+  const gap = 6;
+  const lx = nx + Math.cos(angle) * (nodeRadius + gap);
+  const ly = ny + Math.sin(angle) * (nodeRadius + gap);
+  const cosA = Math.cos(angle);
+
+  let align = 'center';
+  if (cosA > 0.25) align = 'left';
+  else if (cosA < -0.25) align = 'right';
+
+  const maxW = 130;
+  const minFs = 10;
   const text = String(label);
-  const maxChars = Math.max(6, Math.floor(radius / 5));
-  const display = text.length > maxChars ? text.slice(0, maxChars - 1) + '…' : text;
-  ctx.fillText(display, cx, cy + 1);
+  let fontSize = targetFs;
+  while (fontSize > minFs) {
+    ctx.font = `${weight} ${fontSize}px Inter, system-ui, sans-serif`;
+    if (ctx.measureText(text).width <= maxW) break;
+    fontSize--;
+  }
+
+  ctx.save();
+  ctx.fillStyle = rgbCss(fg);
+  ctx.font = `${weight} ${fontSize}px Inter, system-ui, sans-serif`;
+  ctx.textAlign = align;
+  ctx.textBaseline = 'middle';
+  ctx.fillText(text, lx, ly);
+  ctx.restore();
 }
 
 function drawCurvedConnector(ctx, x0, y0, x1, y1, color) {

--- a/sdf-js/src/present/atoms-2d/charts/diagrams/seven-s-model.js
+++ b/sdf-js/src/present/atoms-2d/charts/diagrams/seven-s-model.js
@@ -94,41 +94,87 @@ function drawHex(ctx, cx, cy, r, label, subLabel, color, fg, isCenter) {
 
   ctx.restore();
 
-  // Label
+  // Label — auto-shrink to fit the hexagon width (min 9px); if it still
+  // doesn't fit at the minimum size, fall back to a 2-line wrap instead of
+  // truncating with an ellipsis (truncate() is now a last-resort-only path
+  // for a single unbreakable word).
   const labelColor = 'rgba(255,255,255,1)';
-  const fontSize = isCenter
-    ? Math.max(10, Math.min(14, r * 0.38))
-    : Math.max(9, Math.min(13, r * 0.38));
+  const targetFs = isCenter ? Math.min(16, r * 0.4) : Math.min(14, r * 0.4);
+  const minFs = 9;
+  const maxW = r * 1.5;
 
   ctx.fillStyle = labelColor;
   ctx.textAlign = 'center';
   ctx.textBaseline = 'middle';
 
   if (subLabel) {
-    // Two lines: label above, subLabel below
-    const mainSize = fontSize;
-    const subSize = Math.max(8, mainSize * 0.75);
-    const gap = mainSize * 0.6;
-    ctx.font = `700 ${mainSize}px Inter, system-ui, sans-serif`;
-    ctx.fillText(truncate(label, r, ctx), cx, cy - gap * 0.5);
-    ctx.font = `500 ${subSize}px Inter, system-ui, sans-serif`;
+    // Two lines: label above, subLabel below — each independently shrunk.
+    const main = fitLabelLines(ctx, label, maxW, targetFs, minFs, isCenter ? 700 : 600);
+    const sub = fitLabelLines(ctx, subLabel, r * 1.3, targetFs * 0.8, minFs - 1, 500);
+    const gap = main.fontSize * 0.65;
+    ctx.font = `${isCenter ? 700 : 600} ${main.fontSize}px Inter, system-ui, sans-serif`;
+    ctx.fillText(main.lines[0], cx, cy - gap * 0.5);
+    ctx.font = `500 ${sub.fontSize}px Inter, system-ui, sans-serif`;
     ctx.fillStyle = 'rgba(255,255,255,0.82)';
-    ctx.fillText(truncate(subLabel, r * 0.9, ctx), cx, cy + gap * 0.7);
+    ctx.fillText(sub.lines[0], cx, cy + gap * 0.7);
   } else {
-    ctx.font = `${isCenter ? 700 : 600} ${fontSize}px Inter, system-ui, sans-serif`;
-    // Wrap long labels across two lines if needed
-    const words = label.split(' ');
-    if (words.length > 1 && ctx.measureText(label).width > r * 1.5) {
-      const mid = Math.ceil(words.length / 2);
-      const line1 = words.slice(0, mid).join(' ');
-      const line2 = words.slice(mid).join(' ');
-      const lineH = fontSize * 1.15;
-      ctx.fillText(truncate(line1, r * 1.6, ctx), cx, cy - lineH * 0.5);
-      ctx.fillText(truncate(line2, r * 1.6, ctx), cx, cy + lineH * 0.5);
+    const fit = fitLabelLines(ctx, label, maxW, targetFs, minFs, isCenter ? 700 : 600);
+    ctx.font = `${isCenter ? 700 : 600} ${fit.fontSize}px Inter, system-ui, sans-serif`;
+    if (fit.lines.length === 2) {
+      const lineH = fit.fontSize * 1.15;
+      ctx.fillText(fit.lines[0], cx, cy - lineH * 0.5);
+      ctx.fillText(fit.lines[1], cx, cy + lineH * 0.5);
     } else {
-      ctx.fillText(truncate(label, r * 1.6, ctx), cx, cy + 1);
+      ctx.fillText(fit.lines[0], cx, cy + 1);
     }
   }
+}
+
+// Fit `text` inside `maxW`: try a single line shrinking font from targetFs
+// down to minFs; if it never fits, try a 2-line word-wrap (also shrinking
+// font); if even that can't fit at minFs, truncate the single unbreakable
+// remainder with an ellipsis as a last resort.
+function fitLabelLines(ctx, text, maxW, targetFs, minFs, weight) {
+  const t0 = Math.max(minFs, Math.round(targetFs));
+  for (let fs = t0; fs >= minFs; fs--) {
+    ctx.font = `${weight} ${fs}px Inter, system-ui, sans-serif`;
+    if (ctx.measureText(text).width <= maxW) return { lines: [text], fontSize: fs };
+  }
+
+  const words = String(text).split(' ');
+  if (words.length > 1) {
+    const mid = Math.ceil(words.length / 2);
+    const line1 = words.slice(0, mid).join(' ');
+    const line2 = words.slice(mid).join(' ');
+    for (let fs = t0; fs >= minFs; fs--) {
+      ctx.font = `${weight} ${fs}px Inter, system-ui, sans-serif`;
+      if (ctx.measureText(line1).width <= maxW && ctx.measureText(line2).width <= maxW) {
+        return { lines: [line1, line2], fontSize: fs };
+      }
+    }
+    ctx.font = `${weight} ${minFs}px Inter, system-ui, sans-serif`;
+    return { lines: [line1, line2], fontSize: minFs };
+  }
+
+  // Single unbreakable word (e.g. "Structure") — hyphenate a 2-line wrap
+  // rather than dropping straight to an ellipsis, so the full label reads.
+  if (words[0].length > 3) {
+    const word = words[0];
+    const mid = Math.ceil(word.length / 2);
+    const line1 = word.slice(0, mid) + '-';
+    const line2 = word.slice(mid);
+    for (let fs = t0; fs >= minFs; fs--) {
+      ctx.font = `${weight} ${fs}px Inter, system-ui, sans-serif`;
+      if (ctx.measureText(line1).width <= maxW && ctx.measureText(line2).width <= maxW) {
+        return { lines: [line1, line2], fontSize: fs };
+      }
+    }
+    ctx.font = `${weight} ${minFs}px Inter, system-ui, sans-serif`;
+    return { lines: [line1, line2], fontSize: minFs };
+  }
+
+  ctx.font = `${weight} ${minFs}px Inter, system-ui, sans-serif`;
+  return { lines: [truncate(text, maxW, ctx)], fontSize: minFs };
 }
 
 // ---------------------------------------------------------------------------
@@ -186,12 +232,18 @@ export function drawPseudo3D(ctx, args, opts = {}) {
   const plotH = y + h - plotTop;
   const cx = x + w / 2;
   const cy = plotTop + plotH / 2;
-  // Outer radius of the arrangement (center to satellite centers)
-  const R = Math.min(w, plotH) * 0.5 * 0.62;
+  // Outer radius of the arrangement (center to satellite centers). Sized so
+  // the full cluster (orbit + satellite hex) fills ~75% of the available
+  // space — previously R was ~0.31 * min(w,h), leaving the cluster
+  // occupying well under a third of the canvas.
+  const ORBIT_FRAC = 0.56; // orbitR / R
+  const SAT_HEX_FRAC = 0.16; // satHexR / R
+  const FILL_FRAC = 0.75; // fraction of min(w, plotH) the cluster diameter should fill
+  const R = (Math.min(w, plotH) * FILL_FRAC) / 2 / (ORBIT_FRAC + SAT_HEX_FRAC);
 
   const centerHexR = R * 0.19; // center hex radius
-  const satHexR = R * 0.16; // satellite hex radius
-  const orbitR = R * 0.56; // distance from center to satellite centers
+  const satHexR = R * SAT_HEX_FRAC; // satellite hex radius
+  const orbitR = R * ORBIT_FRAC; // distance from center to satellite centers
 
   // ---- Satellite positions (0° = top-right, 60° steps, pointy-top hex ring) ----
   // We use 30°, 90°, 150°, 210°, 270°, 330° so satellites sit at flat-edge midpoints

--- a/sdf-js/src/present/atoms-2d/charts/hierarchy/pyramid.js
+++ b/sdf-js/src/present/atoms-2d/charts/hierarchy/pyramid.js
@@ -48,7 +48,14 @@ export const spec = {
       ],
     },
     title: { type: 'string?', example: "Maslow's Hierarchy" },
-    inverted: { type: 'boolean?', default: false, example: true },
+    // NOTE: example intentionally false (matches default). The all-atoms
+    // gallery builds its demo args straight from each arg's `example` field
+    // (see demoArgsFor in all-atoms-gallery.html), so an `example: true` here
+    // would silently force every gallery render into the inverted/funnel
+    // orientation and hide the canonical base-at-bottom layout this atom
+    // defaults to. Toggle to `true` locally if you want to eyeball the
+    // inverted variant instead.
+    inverted: { type: 'boolean?', default: false, example: false },
   },
 };
 
@@ -113,35 +120,38 @@ export function drawPseudo3D(ctx, args, opts = {}) {
   const pyramidH = y + h - plotTop - PAD;
   const pyramidW = w - PAD * 2;
   const cx = x + w / 2;
+  const rightEdge = x + w - PAD;
   const layerH = (pyramidH - LAYER_GAP * (n - 1)) / n;
 
-  // Width tapering: bottom layer = pyramidW * 1.0, top layer = pyramidW * 0.2
-  // (taper exponentially for more visual interest)
+  // Width tapering by BOUNDARY (not by pixel row): boundary k=0 is the outer
+  // base edge (widest), boundary k=n is the apex tip (narrowest). This is a
+  // property of layer identity (layers[0]=base=widest ... layers[n-1]=apex=
+  // narrowest) and is independent of `inverted` — inverted only changes where
+  // the base/apex land vertically on the canvas, not which layer is wide.
   const minWidthFrac = 0.18;
   const maxWidthFrac = 1.0;
-  const widthAtLayer = (i) => {
-    // i=0 is base (bottom), i=n-1 is apex (top), unless inverted
-    const tIdx = inverted ? i : n - 1 - i; // tIdx=0 is apex (narrow)
-    const t = n === 1 ? 0.5 : tIdx / (n - 1);
-    return pyramidW * (minWidthFrac + (1 - t) * (maxWidthFrac - minWidthFrac));
-  };
+  const boundaryWidth = (k) => pyramidW * (maxWidthFrac - (k / n) * (maxWidthFrac - minWidthFrac));
 
-  // Draw layers (bottom → top in pixel space; layer index 0 is base by spec
-  // → at bottom when not inverted, at top when inverted)
+  // Draw layers. layers[0] = BASE → bottom of canvas + widest (default) or
+  // top of canvas + widest (inverted, funnel-like). layers[n-1] = APEX →
+  // opposite end + narrowest.
   for (let i = 0; i < n; i++) {
     const pixelRowFromTop = inverted ? i : n - 1 - i;
     const top = plotTop + pixelRowFromTop * (layerH + LAYER_GAP);
     const bottom = top + layerH;
-    const topW = widthAtLayer(inverted ? i + 1 : i); // upper edge width
-    const botW = widthAtLayer(inverted ? i : i + 1); // lower edge width
+    // Within each trapezoid, the edge closer to the base is wider than the
+    // edge closer to the apex — this holds regardless of orientation because
+    // boundaryWidth(i) [base-side of layer i] > boundaryWidth(i+1) [apex-side].
+    const topW = boundaryWidth(inverted ? i : i + 1);
+    const botW = boundaryWidth(inverted ? i + 1 : i);
     const color = layerColors[i % layerColors.length];
 
-    drawLayer(ctx, cx, top, bottom, topW, botW, color, layers[i], { fg, bg, i, n });
+    drawLayer(ctx, cx, top, bottom, topW, botW, color, layers[i], { fg, bg, i, n, rightEdge });
   }
 }
 
 function drawLayer(ctx, cx, top, bottom, topW, botW, color, layer, info) {
-  const { fg, bg } = info;
+  const { fg, bg, rightEdge } = info;
 
   // Trapezoid path
   const trapezoid = () => {
@@ -178,31 +188,80 @@ function drawLayer(ctx, cx, top, bottom, topW, botW, color, layer, info) {
   ctx.fill();
   ctx.restore();
 
-  // Label (centered) — Inter 700 white with 2px dark shadow for legibility
+  // Label — Inter 700 white with 2px dark shadow, centered inside the
+  // trapezoid IF it fits; otherwise fall back to a dark label BESIDE the
+  // pyramid (right of the widest edge) with a connector tick, so tiny apex
+  // layers never render illegible white-on-sliver text.
   const layerH = bottom - top;
-  const labelSize = Math.min(15, layerH * 0.32);
-  ctx.save();
-  ctx.shadowColor = 'rgba(0,0,0,0.5)';
-  ctx.shadowBlur = 2;
-  ctx.shadowOffsetY = 1;
-  ctx.fillStyle = 'rgba(255,255,255,1)';
-  ctx.font = `700 ${labelSize}px Inter, system-ui, sans-serif`;
-  ctx.textAlign = 'center';
-  ctx.textBaseline = layer.sublabel ? 'bottom' : 'middle';
   const cy = (top + bottom) / 2;
-  ctx.fillText(String(layer.label || ''), cx, layer.sublabel ? cy : cy + 2);
-  ctx.restore();
+  const labelText = String(layer.label || '');
+  const insideFs = Math.min(15, layerH * 0.32);
+  const avgW = (topW + botW) / 2;
+  const innerMaxW = avgW - 16;
+  ctx.font = `700 ${insideFs}px Inter, system-ui, sans-serif`;
+  const fitsInside = labelText === '' || ctx.measureText(labelText).width <= innerMaxW;
 
-  if (layer.sublabel) {
+  if (fitsInside) {
     ctx.save();
-    ctx.shadowColor = 'rgba(0,0,0,0.4)';
+    ctx.shadowColor = 'rgba(0,0,0,0.5)';
     ctx.shadowBlur = 2;
-    ctx.fillStyle = 'rgba(255,255,255,0.80)';
-    ctx.font = `500 ${Math.min(11, layerH * 0.2)}px Inter, system-ui, sans-serif`;
+    ctx.shadowOffsetY = 1;
+    ctx.fillStyle = 'rgba(255,255,255,1)';
+    ctx.font = `700 ${insideFs}px Inter, system-ui, sans-serif`;
     ctx.textAlign = 'center';
-    ctx.textBaseline = 'top';
-    ctx.fillText(String(layer.sublabel), cx, cy + 4);
+    ctx.textBaseline = layer.sublabel ? 'bottom' : 'middle';
+    ctx.fillText(labelText, cx, layer.sublabel ? cy : cy + 2);
     ctx.restore();
+
+    if (layer.sublabel) {
+      ctx.save();
+      ctx.shadowColor = 'rgba(0,0,0,0.4)';
+      ctx.shadowBlur = 2;
+      ctx.fillStyle = 'rgba(255,255,255,0.80)';
+      ctx.font = `500 ${Math.min(11, layerH * 0.2)}px Inter, system-ui, sans-serif`;
+      ctx.textAlign = 'center';
+      ctx.textBaseline = 'top';
+      ctx.fillText(String(layer.sublabel), cx, cy + 4);
+      ctx.restore();
+    }
+  } else {
+    const edgeX = cx + Math.max(topW, botW) / 2;
+    const tickLen = 10;
+    const textX = edgeX + tickLen + 4;
+    const maxLabelW = Math.max(20, rightEdge - textX);
+    let fs = insideFs;
+    ctx.font = `700 ${fs}px Inter, system-ui, sans-serif`;
+    while (fs > 9 && ctx.measureText(labelText).width > maxLabelW) {
+      fs--;
+      ctx.font = `700 ${fs}px Inter, system-ui, sans-serif`;
+    }
+
+    ctx.save();
+    ctx.strokeStyle = rgbaCss(fg, 0.35);
+    ctx.lineWidth = 1;
+    ctx.beginPath();
+    ctx.moveTo(edgeX, cy);
+    ctx.lineTo(edgeX + tickLen, cy);
+    ctx.stroke();
+    ctx.restore();
+
+    ctx.save();
+    ctx.fillStyle = rgbCss(fg);
+    ctx.font = `700 ${fs}px Inter, system-ui, sans-serif`;
+    ctx.textAlign = 'left';
+    ctx.textBaseline = layer.sublabel ? 'bottom' : 'middle';
+    ctx.fillText(labelText, textX, layer.sublabel ? cy : cy + 1);
+    ctx.restore();
+
+    if (layer.sublabel) {
+      ctx.save();
+      ctx.fillStyle = rgbaCss(fg, 0.6);
+      ctx.font = `500 ${Math.max(9, fs - 3)}px Inter, system-ui, sans-serif`;
+      ctx.textAlign = 'left';
+      ctx.textBaseline = 'top';
+      ctx.fillText(String(layer.sublabel), textX, cy + 3);
+      ctx.restore();
+    }
   }
 
   // Value (right side if present, slightly indented from edge)

--- a/sdf-js/src/present/atoms-2d/charts/lists/feature-card-grid.js
+++ b/sdf-js/src/present/atoms-2d/charts/lists/feature-card-grid.js
@@ -48,22 +48,51 @@ function lighten([r, g, b], amount = 0.85) {
   ];
 }
 
-function wrapText(ctx, text, maxW, maxLines = 3) {
-  const words = String(text).split(' ');
-  const lines = [];
+// Word-wrap `text` to `maxW`, capped at `maxLines`. Tokenizes on whitespace
+// AND after hyphens (so "zero-knowledge" can break to "zero-" / "knowledge"
+// like a real typesetter, instead of only ever breaking on spaces). If the
+// full text needs more lines than that, the LAST visible line gets an
+// ellipsis appended — dropping whole trailing tokens first so we never cut a
+// word in half; only falls back to a char-level trim if a single token alone
+// is wider than maxW.
+function wrapText(ctx, text, maxW, maxLines = 4) {
+  const tokens = String(text).match(/\S+?-|\S+/g) || [];
+  const allLines = [];
   let line = '';
-  for (const word of words) {
-    const test = line ? line + ' ' + word : word;
-    if (ctx.measureText(test).width > maxW && line) {
-      lines.push(line);
-      line = word;
-      if (lines.length >= maxLines) break;
+  for (const tok of tokens) {
+    const needsSpace = line !== '' && !line.endsWith('-');
+    const test = needsSpace ? line + ' ' + tok : line + tok;
+    if (line && ctx.measureText(test).width > maxW) {
+      allLines.push(line);
+      line = tok;
     } else {
       line = test;
     }
   }
-  if (line && lines.length < maxLines) lines.push(line);
-  return lines;
+  if (line) allLines.push(line);
+
+  if (allLines.length <= maxLines) return allLines;
+
+  const truncated = allLines.slice(0, maxLines);
+  let last = truncated[maxLines - 1];
+  while (last.length > 0 && ctx.measureText(last + '…').width > maxW) {
+    const idx = last.lastIndexOf(' ');
+    last = idx > 0 ? last.slice(0, idx) : last.slice(0, -1);
+  }
+  truncated[maxLines - 1] = last + '…';
+  return truncated;
+}
+
+// Auto-shrink font size until `text` fits `maxW` (no truncation). Mirrors the
+// fitFontSize pattern in charts/lists/numbered-grid.js.
+function fitFontSize(ctx, text, maxW, targetFs, minFs, fontSpec) {
+  let fs = targetFs;
+  while (fs > minFs) {
+    ctx.font = fontSpec(fs);
+    if (ctx.measureText(text).width <= maxW) return fs;
+    fs--;
+  }
+  return minFs;
 }
 
 function drawIconCentered(ctx, iconName, cx, cy, size, color) {
@@ -168,26 +197,37 @@ export function drawPseudo3D(ctx, args, opts = {}) {
     }
 
     let curY = iconCY + iconR + 8;
+    const textMaxW = cardW - cardPad * 2;
 
-    // Title
-    const titleFs = Math.round(rowH * 0.13);
-    ctx.font = `700 ${titleFs}px Inter, system-ui, sans-serif`;
-    ctx.fillStyle = rgbCss(fg);
-    ctx.textAlign = 'center';
-    ctx.textBaseline = 'top';
+    // Title — auto-shrink so long titles ("Performance", "Global Reach")
+    // never overflow the card into its neighbor.
     if (f.title) {
+      const titleTarget = Math.round(rowH * 0.13);
+      const titleFs = fitFontSize(
+        ctx,
+        f.title,
+        textMaxW,
+        titleTarget,
+        12,
+        (fs) => `700 ${fs}px Inter, system-ui, sans-serif`,
+      );
+      ctx.font = `700 ${titleFs}px Inter, system-ui, sans-serif`;
+      ctx.fillStyle = rgbCss(fg);
+      ctx.textAlign = 'center';
+      ctx.textBaseline = 'top';
       ctx.fillText(f.title, iconCX, curY);
       curY += titleFs + 6;
     }
 
-    // Body
+    // Body — word-wrap up to 4 lines; ellipsis (never mid-word) on the last
+    // line if the text doesn't fit.
     const bodyFs = Math.round(rowH * 0.09);
     ctx.font = `500 ${bodyFs}px Inter, system-ui`;
     ctx.fillStyle = rgbaCss(fg, 0.55);
     ctx.textAlign = 'center';
     ctx.textBaseline = 'top';
     if (f.body) {
-      const lines = wrapText(ctx, f.body, cardW - cardPad * 2, 3);
+      const lines = wrapText(ctx, f.body, textMaxW, 4);
       for (const line of lines) {
         ctx.fillText(line, iconCX, curY);
         curY += bodyFs + 2;

--- a/sdf-js/src/present/atoms-2d/charts/lists/numbered-grid.js
+++ b/sdf-js/src/present/atoms-2d/charts/lists/numbered-grid.js
@@ -126,10 +126,15 @@ export function drawPseudo3D(ctx, args, opts = {}) {
       ctx.textBaseline = 'top';
       const numX = cellX + cellPad + numFontSize * 0.05;
       const numY = cellY + cellPad;
+      // Reserve the number column's ACTUAL measured width (was a fixed
+      // numFontSize*0.65 guess that didn't match glyph metrics — digits like
+      // "2"/"4" at 900 weight measure wider than that, so the label text
+      // started underneath the glyph instead of after it).
+      const numW = ctx.measureText(numLabel).width;
       ctx.fillText(numLabel, numX, numY);
 
-      const textX = cellX + cellPad + numFontSize * 0.65;
-      const textMaxW = colW - cellPad - numFontSize * 0.65 - cardMargin;
+      const textX = numX + numW + 8;
+      const textMaxW = cellX + colW - cardMargin - cellPad - textX;
       const labelTarget = Math.round(rowH * 0.14);
       const labelFs = fitFontSize(
         ctx,

--- a/sdf-js/src/present/atoms-2d/charts/matrix/matrix-grid.js
+++ b/sdf-js/src/present/atoms-2d/charts/matrix/matrix-grid.js
@@ -98,7 +98,10 @@ export function drawPseudo3D(ctx, args, opts = {}) {
   const cellW = (gridR - gridL) / cols;
   const cellH = (gridB - gridT) / rows;
 
-  // Draw cells
+  // Cell backgrounds (+ icon) — drawn first, UNDER bubbles. Labels are drawn
+  // in a separate pass below, AFTER bubbles, so bubble overlays never
+  // obscure cell text (see bubbles block for why).
+  const cellRects = [];
   for (let r = 0; r < rows; r++) {
     for (let c = 0; c < cols; c++) {
       const idx = r * cols + c;
@@ -106,18 +109,12 @@ export function drawPseudo3D(ctx, args, opts = {}) {
       const color = cell.color || colors[idx % colors.length];
       const cx = gridL + c * cellW;
       const cy = gridT + r * cellH;
-      drawCell(
-        ctx,
-        cx + 6,
-        cy + 6,
-        cellW - 12,
-        cellH - 12,
-        cell.label,
-        cell.sublabel,
-        color,
-        fg,
-        cell.icon,
-      );
+      const rx = cx + 6;
+      const ry = cy + 6;
+      const rw = cellW - 12;
+      const rh = cellH - 12;
+      cellRects.push({ rx, ry, rw, rh, cell });
+      drawCellBg(ctx, rx, ry, rw, rh, color, fg, cell.icon);
     }
   }
 
@@ -214,6 +211,7 @@ export function drawPseudo3D(ctx, args, opts = {}) {
   // ---- bubbles — filled circle overlays per cell (BCG product units) ----
   if (Array.isArray(args.bubbles) && args.bubbles.length > 0) {
     const bubbleColors = palette.colors || colors;
+    const bubbleExternalLabels = [];
     for (let bi = 0; bi < args.bubbles.length; bi++) {
       const b = args.bubbles[bi];
       const bRow = clamp(Number(b.row) || 0, 0, rows - 1);
@@ -227,40 +225,67 @@ export function drawPseudo3D(ctx, args, opts = {}) {
 
       const bubbleColor = bubbleColors[(bRow * cols + bCol) % bubbleColors.length];
 
+      // Translucent fill (alpha <= 0.35) + solid stroke, so the cell label
+      // drawn on top afterward stays legible even where a bubble overlaps
+      // it — previously an opaque-ish gradient bubble (alpha 0.88-0.92)
+      // rendered AFTER (on top of) the label, obscuring it entirely.
       ctx.save();
-      ctx.shadowColor = rgbaCss([0, 0, 0], 0.25);
-      ctx.shadowBlur = 8;
-      ctx.shadowOffsetY = 3;
-      const grad = ctx.createRadialGradient(
-        cellCx - bubbleR * 0.25,
-        cellCy - bubbleR * 0.25,
-        0,
-        cellCx,
-        cellCy,
-        bubbleR,
-      );
-      grad.addColorStop(0, rgbaCss(lighten(bubbleColor, 0.3), 0.92));
-      grad.addColorStop(1, rgbaCss(bubbleColor, 0.88));
-      ctx.fillStyle = grad;
+      ctx.shadowColor = rgbaCss([0, 0, 0], 0.18);
+      ctx.shadowBlur = 6;
+      ctx.shadowOffsetY = 2;
+      ctx.fillStyle = rgbaCss(bubbleColor, 0.32);
       ctx.beginPath();
       ctx.arc(cellCx, cellCy, bubbleR, 0, Math.PI * 2);
       ctx.fill();
       ctx.restore();
 
-      // Bubble label
+      ctx.save();
+      ctx.strokeStyle = rgbaCss(bubbleColor, 0.95);
+      ctx.lineWidth = 2;
+      ctx.beginPath();
+      ctx.arc(cellCx, cellCy, bubbleR, 0, Math.PI * 2);
+      ctx.stroke();
+      ctx.restore();
+
+      // Bubble's own label renders OUTSIDE the bubble (offset right and
+      // slightly down), in small dark text — queued and drawn in its own
+      // pass after cell labels so it never gets buried under a neighboring
+      // bubble either. The extra downward nudge keeps it off the cell
+      // label's horizontal centerline (bubbles default to the cell center,
+      // same row as the cell's own label baseline).
       if (b.label) {
-        ctx.fillStyle = 'rgba(255,255,255,0.95)';
-        const labelSize = Math.max(9, Math.round(bubbleR * 0.45));
-        ctx.font = `700 ${labelSize}px Inter, system-ui, sans-serif`;
-        ctx.textAlign = 'center';
-        ctx.textBaseline = 'middle';
-        ctx.fillText(String(b.label), cellCx, cellCy);
+        bubbleExternalLabels.push({
+          x: cellCx + bubbleR + 6,
+          y: cellCy + bubbleR * 0.6,
+          text: String(b.label),
+        });
       }
+    }
+
+    // Cell labels/sublabels ON TOP of the (now-translucent) bubbles.
+    for (const { rx, ry, rw, rh, cell } of cellRects) {
+      drawCellLabel(ctx, rx, ry, rw, rh, cell.label, cell.sublabel);
+    }
+
+    // Bubble external labels, drawn last so they sit above everything.
+    for (const bl of bubbleExternalLabels) {
+      ctx.save();
+      ctx.fillStyle = rgbaCss(fg, 0.85);
+      ctx.font = `600 11px Inter, system-ui, sans-serif`;
+      ctx.textAlign = 'left';
+      ctx.textBaseline = 'middle';
+      ctx.fillText(bl.text, bl.x, bl.y);
+      ctx.restore();
+    }
+  } else {
+    // No bubbles — draw cell labels directly (no need to defer).
+    for (const { rx, ry, rw, rh, cell } of cellRects) {
+      drawCellLabel(ctx, rx, ry, rw, rh, cell.label, cell.sublabel);
     }
   }
 }
 
-function drawCell(ctx, x, y, w, h, label, sublabel, color, fg, iconName) {
+function drawCellBg(ctx, x, y, w, h, color, fg, iconName) {
   // Drop shadow — 10px blur, alpha 0.08, embedded feel
   ctx.save();
   ctx.shadowColor = rgbaCss([0, 0, 0], 0.08);
@@ -305,7 +330,11 @@ function drawCell(ctx, x, y, w, h, label, sublabel, color, fg, iconName) {
     }
     ctx.restore();
   }
+}
 
+// Label + sublabel, drawn in a separate pass from the cell background so
+// callers can interleave bubble overlays UNDER the text (see drawPseudo3D).
+function drawCellLabel(ctx, x, y, w, h, label, sublabel) {
   // Label — Inter 700 with generous inner breathing room
   if (label) {
     ctx.fillStyle = 'rgba(255,255,255,0.97)';
@@ -318,6 +347,7 @@ function drawCell(ctx, x, y, w, h, label, sublabel, color, fg, iconName) {
   if (sublabel) {
     ctx.fillStyle = 'rgba(255,255,255,0.78)';
     ctx.font = `500 ${Math.min(13, h * 0.1)}px Inter, system-ui, sans-serif`;
+    ctx.textAlign = 'center';
     ctx.textBaseline = 'top';
     ctx.fillText(sublabel, x + w / 2, y + h / 2 + 8);
   }

--- a/sdf-js/src/present/atoms-2d/charts/matrix/nine-field-matrix.js
+++ b/sdf-js/src/present/atoms-2d/charts/matrix/nine-field-matrix.js
@@ -101,7 +101,9 @@ export function drawPseudo3D(ctx, args, opts = {}) {
   const cellW = (gridR - gridL) / COLS;
   const cellH = (gridB - gridT) / ROWS;
 
-  // -- Draw cells --
+  // -- Draw cell backgrounds (+ icon) — labels drawn in a later pass so
+  // bubble overlays (drawn in between) never obscure them. --
+  const cellRects = [];
   for (let r = 0; r < ROWS; r++) {
     for (let c = 0; c < COLS; c++) {
       const idx = r * COLS + c;
@@ -110,17 +112,12 @@ export function drawPseudo3D(ctx, args, opts = {}) {
       const color = bandColorMap[bandName];
       const cx = gridL + c * cellW;
       const cy = gridT + r * cellH;
-      drawCell(
-        ctx,
-        cx + 4,
-        cy + 4,
-        cellW - 8,
-        cellH - 8,
-        cell.label,
-        cell.sublabel,
-        color,
-        cell.icon,
-      );
+      const rx = cx + 4;
+      const ry = cy + 4;
+      const rw = cellW - 8;
+      const rh = cellH - 8;
+      cellRects.push({ rx, ry, rw, rh, cell });
+      drawCellBg(ctx, rx, ry, rw, rh, color, cell.icon);
     }
   }
 
@@ -206,14 +203,10 @@ export function drawPseudo3D(ctx, args, opts = {}) {
     ctx.restore();
   }
 
-  // -- Bubbles overlay --
+  // -- Bubbles overlay — translucent fill (alpha <= 0.35) + solid ring, so
+  // cell labels (drawn AFTER, in the next pass) stay legible underneath. --
   if (Array.isArray(args.bubbles) && args.bubbles.length > 0) {
-    // Use a contrasting set for bubbles — white with border works over colored cells
-    const bubbleBaseColors = palette.colors || [
-      [255, 255, 255],
-      [240, 240, 255],
-      [255, 240, 220],
-    ];
+    const bubbleExternalLabels = [];
     for (let bi = 0; bi < args.bubbles.length; bi++) {
       const b = args.bubbles[bi];
       const bRow = clamp(Number(b.row) || 0, 0, ROWS - 1);
@@ -226,42 +219,57 @@ export function drawPseudo3D(ctx, args, opts = {}) {
 
       const bandName = BAND[bRow * COLS + bCol];
       const bandColor = bandColorMap[bandName];
-      // Bubble: white fill with subtle ring in band color for contrast
-      ctx.save();
-      ctx.shadowColor = rgbaCss([0, 0, 0], 0.28);
-      ctx.shadowBlur = 8;
-      ctx.shadowOffsetY = 3;
 
-      const grad = ctx.createRadialGradient(
-        cellCx - bubbleR * 0.25,
-        cellCy - bubbleR * 0.25,
-        0,
-        cellCx,
-        cellCy,
-        bubbleR,
-      );
-      grad.addColorStop(0, rgbaCss([255, 255, 255], 0.97));
-      grad.addColorStop(1, rgbaCss(lighten(bandColor, 0.5), 0.9));
-      ctx.fillStyle = grad;
+      ctx.save();
+      ctx.shadowColor = rgbaCss([0, 0, 0], 0.2);
+      ctx.shadowBlur = 6;
+      ctx.shadowOffsetY = 2;
+      ctx.fillStyle = rgbaCss([255, 255, 255], 0.32);
       ctx.beginPath();
       ctx.arc(cellCx, cellCy, bubbleR, 0, Math.PI * 2);
       ctx.fill();
+      ctx.restore();
 
       // Ring border in band color
-      ctx.strokeStyle = rgbaCss(bandColor, 0.8);
+      ctx.save();
+      ctx.strokeStyle = rgbaCss(bandColor, 0.9);
       ctx.lineWidth = 2;
+      ctx.beginPath();
+      ctx.arc(cellCx, cellCy, bubbleR, 0, Math.PI * 2);
       ctx.stroke();
       ctx.restore();
 
-      // Bubble label in dark text (legible over white bubble)
+      // Bubble's own label renders OUTSIDE the bubble (offset right and
+      // slightly down, to clear the cell label's horizontal centerline),
+      // dark text, in a pass after cell labels.
       if (b.label) {
-        ctx.fillStyle = rgbaCss(fg, 0.92);
-        const labelSize = Math.max(9, Math.round(bubbleR * 0.5));
-        ctx.font = `700 ${labelSize}px Inter, system-ui, sans-serif`;
-        ctx.textAlign = 'center';
-        ctx.textBaseline = 'middle';
-        ctx.fillText(String(b.label), cellCx, cellCy);
+        bubbleExternalLabels.push({
+          x: cellCx + bubbleR + 6,
+          y: cellCy + bubbleR * 0.6,
+          text: String(b.label),
+        });
       }
+    }
+
+    // Cell labels ON TOP of the translucent bubbles.
+    for (const { rx, ry, rw, rh, cell } of cellRects) {
+      drawCellLabel(ctx, rx, ry, rw, rh, cell.label, cell.sublabel);
+    }
+
+    // Bubble external labels, drawn last so they sit above everything.
+    for (const bl of bubbleExternalLabels) {
+      ctx.save();
+      ctx.fillStyle = rgbaCss(fg, 0.85);
+      ctx.font = `600 11px Inter, system-ui, sans-serif`;
+      ctx.textAlign = 'left';
+      ctx.textBaseline = 'middle';
+      ctx.fillText(bl.text, bl.x, bl.y);
+      ctx.restore();
+    }
+  } else {
+    // No bubbles — draw cell labels directly.
+    for (const { rx, ry, rw, rh, cell } of cellRects) {
+      drawCellLabel(ctx, rx, ry, rw, rh, cell.label, cell.sublabel);
     }
   }
 }
@@ -270,7 +278,7 @@ export function drawPseudo3D(ctx, args, opts = {}) {
 // Helpers
 // ---------------------------------------------------------------------------
 
-function drawCell(ctx, x, y, w, h, label, sublabel, color, iconName) {
+function drawCellBg(ctx, x, y, w, h, color, iconName) {
   ctx.save();
   ctx.shadowColor = rgbaCss([0, 0, 0], 0.18);
   ctx.shadowBlur = 8;
@@ -304,8 +312,11 @@ function drawCell(ctx, x, y, w, h, label, sublabel, color, iconName) {
     }
     ctx.restore();
   }
+}
 
-  // Label
+// Label + sublabel, drawn in a separate pass from the cell background so
+// callers can interleave bubble overlays UNDER the text.
+function drawCellLabel(ctx, x, y, w, h, label, sublabel) {
   if (label) {
     ctx.fillStyle = 'rgba(255,255,255,0.97)';
     ctx.font = `700 ${Math.min(20, h * 0.2)}px Inter, system-ui, sans-serif`;
@@ -316,6 +327,7 @@ function drawCell(ctx, x, y, w, h, label, sublabel, color, iconName) {
   if (sublabel) {
     ctx.fillStyle = 'rgba(255,255,255,0.78)';
     ctx.font = `500 ${Math.min(12, h * 0.1)}px Inter, system-ui, sans-serif`;
+    ctx.textAlign = 'center';
     ctx.textBaseline = 'top';
     ctx.fillText(String(sublabel), x + w / 2, y + h / 2 + 6);
   }


### PR DESCRIPTION
## Summary

Fixes all 7 P0 visual failures identified in `docs/superpowers/atom-visual-scorecard.md` (Sprint 26 baseline). One commit per atom; each verified by re-rendering `all-atoms-gallery.html` and visually reading the resulting screenshot (not just running tests).

| atom | before → after |
|---|---|
| `pyramid` | Semantic inversion fixed: `layers[0]` (base) now renders bottom-widest (was top-widest, upside-down Maslow). Apex label falls back to an external label+tick when it doesn't fit inside the trapezoid. Also fixed `spec.args.inverted.example: true`, which was silently forcing every gallery demo render into the funnel orientation. |
| `feature-card-grid` | Titles auto-shrink (was overflowing into neighboring cards); body wraps to 4 lines with an ellipsis on the last line only (was silently dropping words mid-sentence with no truncation marker) — hyphen-aware tokenizer avoids mid-word cuts. |
| `gauge` | Root cause: the dial's `arcRadius` consumed the full canvas height, pushing the value readout off-canvas entirely (it was being drawn, just invisible). Now reserves a layout budget for the value/label before sizing the dial. |
| `seven-s-model` | Hex cluster now fills ~75% of the canvas (was ~31%); labels auto-shrink → 2-line wrap → hyphenated split before ever truncating with an ellipsis. |
| `numbered-grid` | 'huge' number column now reserves its *measured* width instead of a fixed-ratio guess, so labels/sublabels never render underneath the digit. |
| `mindmap` | Radial layout now uses 80% of available radius (was cramped in the center third); branch/leaf labels moved outside their node circles with auto-shrink, instead of truncating inside tiny circles. |
| `matrix-grid` + `nine-field-matrix` | Bubble overlays now draw *under* cell labels (translucent fill + solid stroke) instead of on top obscuring them; bubble's own label moved outside the bubble. |

**pyramid ↔ pyramid-3d consistency**: confirmed `pyramid3dSDF` already stacks `levels[0]` bottom-most and widest — the 3D twin was already correct. 2D now matches it; no 3D changes made.

**Cache gotcha** (documented in the report, not part of the diff): the dev server running on :8001 during this session was a stock `python3 -m http.server` without cache headers, not the repo's `dev-server.py`. Restarting with the correct no-cache server (and restarting the browse browser to clear its disk cache) was necessary before visual verification reflected code changes.

## Test plan

- [x] `npm test` (repo root): 113/113 test files passed
- [x] Each of the 7 atoms re-rendered via `all-atoms-gallery.html` and screenshot visually confirmed (`screens/sprint26-gallery/fix-*.png`)
- [x] `docs/superpowers/atom-visual-scorecard.md` updated — all 7 P0 entries moved to a new "✅ Fixed in round 2" section
- [x] No test assertions needed updating (existing tests only check label-text presence, not layout/orientation)

Full per-atom before/after + screenshot paths: `.superpowers/sdd/sprint26-round2-report.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)