### PR TITLE
feat(structures): hierarchy cone tree + network constellation + magnitude monolith row (fighting-game grammar)

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -147,6 +147,7 @@ const TESTS = [
   { category: 'scene', file: 'sdf-js/scripts/test-render-sequence.mjs' },
   { category: 'scene', file: 'sdf-js/scripts/test-render-hierarchy.mjs' },
   { category: 'scene', file: 'sdf-js/scripts/test-render-network.mjs' },
+  { category: 'scene', file: 'sdf-js/scripts/test-render-magnitude.mjs' },
   { category: 'scene', file: 'sdf-js/scripts/test-scaffold-to-ir.mjs' },
   { category: 'scene', file: 'sdf-js/scripts/test-atom-3d-coverage.mjs' },
 

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -146,6 +146,7 @@ const TESTS = [
   { category: 'scene', file: 'sdf-js/scripts/test-ir.mjs' },
   { category: 'scene', file: 'sdf-js/scripts/test-render-sequence.mjs' },
   { category: 'scene', file: 'sdf-js/scripts/test-render-hierarchy.mjs' },
+  { category: 'scene', file: 'sdf-js/scripts/test-render-network.mjs' },
   { category: 'scene', file: 'sdf-js/scripts/test-scaffold-to-ir.mjs' },
   { category: 'scene', file: 'sdf-js/scripts/test-atom-3d-coverage.mjs' },
 

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -145,6 +145,7 @@ const TESTS = [
   { category: 'scene', file: 'sdf-js/scripts/test-lift-scaffold.mjs' },
   { category: 'scene', file: 'sdf-js/scripts/test-ir.mjs' },
   { category: 'scene', file: 'sdf-js/scripts/test-render-sequence.mjs' },
+  { category: 'scene', file: 'sdf-js/scripts/test-render-hierarchy.mjs' },
   { category: 'scene', file: 'sdf-js/scripts/test-scaffold-to-ir.mjs' },
   { category: 'scene', file: 'sdf-js/scripts/test-atom-3d-coverage.mjs' },
 

--- a/sdf-js/apps/present/figure.html
+++ b/sdf-js/apps/present/figure.html
@@ -2,7 +2,7 @@
 <html>
   <head>
     <meta charset="utf-8" />
-    <title>Atlas Figure — sequence/funnel</title>
+    <title>Atlas Figure</title>
     <style>
       html,
       body {

--- a/sdf-js/apps/present/figure.js
+++ b/sdf-js/apps/present/figure.js
@@ -4,7 +4,7 @@
 // scenes/ir/<name>.json.
 import { createStudioRenderer } from '../../src/render/studio.js';
 import { applyStudioScene } from '../../src/runtime/apply-studio-scene.js';
-import { renderSequence } from '../../src/scene/render-sequence.js';
+import { renderIR } from '../../src/scene/render-ir.js';
 
 const wrap = document.getElementById('wrap');
 const canvas = document.getElementById('c');
@@ -46,7 +46,7 @@ window.__figReplay = () => studio.setSequence(scene.cameraSequence);
 
 const name = params.get('ir') || 'funnel-sales';
 const ir = await (await fetch(`../../scenes/ir/${name}.json`)).json();
-const scene = renderSequence(ir, { env });
+const scene = renderIR(ir, { env }); // dispatches on ir.structure
 // applyStudioScene wires setSequence + setAnimated (subject.animation counts as
 // time content since the sceneHasTimeContent fix) — no manual overrides needed.
 applyStudioScene(studio, scene);

--- a/sdf-js/scenes/ir/ecosystem.json
+++ b/sdf-js/scenes/ir/ecosystem.json
@@ -1,0 +1,33 @@
+{
+  "structure": "network",
+  "nodes": [
+    "Atlas",
+    "Engine",
+    "Present",
+    "Compositor",
+    "Lift LLM",
+    "Atoms",
+    "Studio",
+    "PDF Parser",
+    "Deck Player",
+    "Gallery"
+  ],
+  "relations": [
+    [0, 1],
+    [0, 2],
+    [1, 3],
+    [1, 6],
+    [2, 8],
+    [2, 7],
+    [3, 5],
+    [1, 5],
+    [4, 5],
+    [4, 7],
+    [2, 4],
+    [8, 6],
+    [9, 5],
+    [9, 2]
+  ],
+  "magnitude": [10, 8, 8, 5, 6, 7, 6, 4, 4, 3],
+  "title": "Atlas Ecosystem"
+}

--- a/sdf-js/scenes/ir/org-tree.json
+++ b/sdf-js/scenes/ir/org-tree.json
@@ -1,0 +1,27 @@
+{
+  "structure": "hierarchy",
+  "nodes": [
+    "CEO",
+    "Product",
+    "Engineering",
+    "GTM",
+    "Design",
+    "Platform",
+    "Apps",
+    "Sales",
+    "Marketing"
+  ],
+  "relations": [
+    [0, 1],
+    [0, 2],
+    [0, 3],
+    [1, 4],
+    [2, 5],
+    [2, 6],
+    [3, 7],
+    [3, 8]
+  ],
+  "magnitude": [10, 5, 8, 5, 3, 4, 4, 3, 2],
+  "emphasis": [2],
+  "title": "Org Structure"
+}

--- a/sdf-js/scenes/ir/revenue-regions.json
+++ b/sdf-js/scenes/ir/revenue-regions.json
@@ -1,0 +1,7 @@
+{
+  "structure": "magnitude",
+  "nodes": ["EMEA", "APAC", "Americas", "LATAM", "ANZ"],
+  "magnitude": [340, 620, 890, 150, 95],
+  "emphasis": [2],
+  "title": "Revenue by Region"
+}

--- a/sdf-js/scripts/test-render-hierarchy.mjs
+++ b/sdf-js/scripts/test-render-hierarchy.mjs
@@ -1,0 +1,124 @@
+// sdf-js/scripts/test-render-hierarchy.mjs — hierarchy → cone tree renderer.
+import { readFileSync } from 'node:fs';
+import { renderHierarchy, coneTreeLayout } from '../src/scene/render-hierarchy.js';
+import { renderIR } from '../src/scene/render-ir.js';
+import { validateIR } from '../src/scene/ir.js';
+import { compile } from '../src/scene/index.js';
+import { expandStage } from '../src/scene/stage.js';
+
+let pass = 0,
+  fail = 0;
+const ok = (c, n) => (c ? (pass++, console.log(`  ✓ ${n}`)) : (fail++, console.log(`  ✗ ${n}`)));
+console.log('=== render-hierarchy (cone tree) ===\n');
+
+const ir = JSON.parse(readFileSync(new URL('../scenes/ir/org-tree.json', import.meta.url), 'utf8'));
+
+// ---- IR validation ------------------------------------------------------------
+ok(validateIR(ir).ok, 'org-tree fixture validates');
+ok(
+  !validateIR({ structure: 'hierarchy', nodes: ['a', 'b'] }).ok,
+  'hierarchy without relations rejected',
+);
+ok(
+  !validateIR({ structure: 'hierarchy', nodes: ['a', 'b', 'c'], relations: [[0, 1]] }).ok,
+  'two roots rejected (exactly one root)',
+);
+ok(
+  !validateIR({ structure: 'hierarchy', nodes: ['a', 'b'], relations: [[0, 5]] }).ok,
+  'out-of-range relation rejected',
+);
+
+// ---- cone-tree layout ----------------------------------------------------------
+{
+  const { pos, level, root, maxLevel } = coneTreeLayout(ir);
+  ok(root === 0, 'root found (no parent)');
+  ok(maxLevel === 2, 'depth = 2 for the org fixture');
+  ok(pos[0][1] > pos[1][1] && pos[1][1] > pos[4][1], 'levels descend in y (root on top)');
+  // siblings fan AROUND the parent — the three VPs must not be collinear in x
+  // (the 2D-org-chart failure mode); at least one uses the z axis.
+  const vps = [1, 2, 3].map((i) => pos[i]);
+  ok(
+    vps.some((p) => Math.abs(p[2]) > 0.3),
+    'siblings occupy z (true 3D fan, not a flat line)',
+  );
+  ok(level[5] === 2 && level[8] === 2, 'grandchildren on level 2');
+}
+
+// ---- scene shape ---------------------------------------------------------------
+{
+  const scene = renderHierarchy(ir);
+  const nodeSubjects = scene.subjects.filter((s) => s.id.startsWith('node-'));
+  ok(nodeSubjects.length === 9, 'one subject per node');
+  ok(
+    nodeSubjects.every(
+      (s) => Array.isArray(s.animation) && s.animation[0].channel === 'transform.translate.y',
+    ),
+    'every node has a translate.y build-in',
+  );
+  // edges ride with the CHILD subject (union: ball + up-link capsule)
+  const withLink = nodeSubjects.filter((s) => s.children.some((c) => c.type === 'capsule'));
+  ok(withLink.length === 8, 'every non-root node carries its up-link capsule');
+  // root reveals first, deeper levels later
+  const t0 = (s) => Number(s.animation[0].expr.match(/smoothstep\(([\d.]+)/)[1]);
+  ok(
+    t0(nodeSubjects[0]) < t0(nodeSubjects[4]),
+    'root lands before grandchildren (per-level cascade)',
+  );
+
+  // fighting-game grammar: rises to a crane peak, descends, has the super, ends wide
+  const shots = scene.cameraSequence.shots;
+  const ys = shots.map((s) => s.pos[1]);
+  const peakIdx = ys.indexOf(Math.max(...ys));
+  ok(ys[0] < ys[peakIdx], 'opens low (hero at the root), rises to the crane');
+  ok(Math.min(...ys.slice(peakIdx)) < ys[peakIdx] - 2, 'descends through the levels');
+  const superShot = shots.find((s) => s.transition === 'cut' && (s.shake || 0) >= 0.2);
+  ok(
+    !!superShot && Array.isArray(superShot.exposure),
+    'super punch-in (cut + shake + exposure pop)',
+  );
+  ok((shots[shots.length - 1].focalDistance || 0) > 5, 'ends on a wide payoff frame');
+
+  // labels: one card per node, level-staggered reveals; no baked SDF text
+  const cards = scene.overlay.filter((o) => o.role === 'card');
+  ok(
+    cards.length === 9 && cards.every((o) => typeof o.revealAt === 'number'),
+    '9 reveal-tagged cards',
+  );
+  ok(
+    scene.subjects.every((s) => !/text/.test(s.type)),
+    'no baked SDF text',
+  );
+
+  // deterministic from IR
+  const again = renderHierarchy(JSON.parse(JSON.stringify(ir)));
+  ok(JSON.stringify(again.subjects) === JSON.stringify(scene.subjects), 'deterministic from IR');
+
+  // compiles end-to-end
+  try {
+    compile(expandStage(scene), {});
+    ok(true, 'compiles to SDF (studio-ready)');
+  } catch (e) {
+    ok(false, `compile failed: ${e.message}`);
+  }
+}
+
+// ---- dispatcher ----------------------------------------------------------------
+{
+  ok(renderIR(ir).name.startsWith('(hierarchy)'), 'renderIR dispatches hierarchy');
+  ok(
+    renderIR({ structure: 'sequence', nodes: ['A', 'B'], magnitude: [2, 1] }).name.startsWith(
+      '(sequence)',
+    ),
+    'renderIR dispatches sequence',
+  );
+  let threw = false;
+  try {
+    renderIR({ structure: 'nope', nodes: ['A'] });
+  } catch {
+    threw = true;
+  }
+  ok(threw, 'renderIR throws on unknown structure');
+}
+
+console.log(`\n${pass} passed, ${fail} failed`);
+process.exit(fail ? 1 : 0);

--- a/sdf-js/scripts/test-render-magnitude.mjs
+++ b/sdf-js/scripts/test-render-magnitude.mjs
@@ -1,0 +1,82 @@
+// sdf-js/scripts/test-render-magnitude.mjs — magnitude → monolith row renderer.
+import { readFileSync } from 'node:fs';
+import { renderMagnitude } from '../src/scene/render-magnitude.js';
+import { renderIR } from '../src/scene/render-ir.js';
+import { validateIR } from '../src/scene/ir.js';
+import { compile } from '../src/scene/index.js';
+import { expandStage } from '../src/scene/stage.js';
+
+let pass = 0,
+  fail = 0;
+const ok = (c, n) => (c ? (pass++, console.log(`  ✓ ${n}`)) : (fail++, console.log(`  ✗ ${n}`)));
+console.log('=== render-magnitude (monolith row) ===\n');
+
+const ir = JSON.parse(
+  readFileSync(new URL('../scenes/ir/revenue-regions.json', import.meta.url), 'utf8'),
+);
+
+ok(validateIR(ir).ok, 'revenue fixture validates');
+ok(
+  !validateIR({ structure: 'magnitude', nodes: ['a', 'b'] }).ok,
+  'magnitude without a magnitude array rejected',
+);
+
+{
+  const scene = renderMagnitude(ir);
+  const monos = scene.subjects.filter((s) => s.id.startsWith('mono-'));
+  ok(monos.length === 5, 'one monolith per category');
+  // honest encoding: height linear in magnitude, equal footprints
+  const h = Object.fromEntries(monos.map((s) => [s.id, s.args.dims[1]]));
+  ok(Math.abs(h['mono-2'] / h['mono-1'] - 890 / 620) < 0.01, 'heights linear in magnitude');
+  ok(
+    monos.every((s) => s.args.dims[0] === monos[0].args.dims[0]),
+    'equal footprints',
+  );
+  // rise-not-drop: animated y starts BELOW the final position
+  const startsBelow = monos.every((s) => {
+    const m = s.animation[0].expr.match(/^(-?[\d.]+) \+ ([\d.]+) \* smoothstep/);
+    return m && Number(m[1]) < s.transform.translate[1];
+  });
+  ok(startsBelow, 'monoliths ERUPT from underground (rise, not drop)');
+
+  // fighting-game grammar: hero low at the champion → crane → tracking beats → super → wide
+  const shots = scene.cameraSequence.shots;
+  ok(shots[0].pos[1] < 1 && shots[0].target[1] > 1, 'hero shot looks UP at the champion');
+  const ys = shots.map((s) => s.pos[1]);
+  const peakIdx = ys.indexOf(Math.max(...ys));
+  ok(peakIdx === 1, 'crane peak is beat 2');
+  // tracking: consecutive mid shots move along x
+  const xs = shots.slice(2, 2 + 5).map((s) => s.pos[0]);
+  ok(new Set(xs.map((x) => x.toFixed(2))).size === 5, 'tracking shot dollies along the row');
+  const superShot = shots.find((s) => s.transition === 'cut' && (s.shake || 0) >= 0.2);
+  ok(
+    !!superShot && Array.isArray(superShot.exposure),
+    'super punch-in (cut + shake + exposure pop)',
+  );
+  ok(superShot.target[1] > superShot.pos[1], 'super looks UP the emphasis monolith');
+  ok((shots[shots.length - 1].focalDistance || 0) > 5, 'ends on a wide payoff frame');
+
+  // labels: 5 name cards + 5 value chips, reveal-tagged
+  const cards = scene.overlay.filter((o) => o.role === 'card');
+  const values = scene.overlay.filter((o) => o.role === 'value');
+  ok(cards.length === 5 && values.length === 5, '5 cards + 5 values');
+  ok(
+    [...cards, ...values].every((o) => typeof o.revealAt === 'number'),
+    'all reveal-tagged',
+  );
+
+  // deterministic + compiles
+  const again = renderMagnitude(JSON.parse(JSON.stringify(ir)));
+  ok(JSON.stringify(again.subjects) === JSON.stringify(scene.subjects), 'deterministic from IR');
+  try {
+    compile(expandStage(scene), {});
+    ok(true, 'compiles to SDF (studio-ready)');
+  } catch (e) {
+    ok(false, `compile failed: ${e.message}`);
+  }
+}
+
+ok(renderIR(ir).name.startsWith('(magnitude)'), 'renderIR dispatches magnitude');
+
+console.log(`\n${pass} passed, ${fail} failed`);
+process.exit(fail ? 1 : 0);

--- a/sdf-js/scripts/test-render-network.mjs
+++ b/sdf-js/scripts/test-render-network.mjs
@@ -1,0 +1,94 @@
+// sdf-js/scripts/test-render-network.mjs — network → constellation renderer.
+import { readFileSync } from 'node:fs';
+import { renderNetwork, constellationLayout } from '../src/scene/render-network.js';
+import { renderIR } from '../src/scene/render-ir.js';
+import { validateIR } from '../src/scene/ir.js';
+import { compile } from '../src/scene/index.js';
+import { expandStage } from '../src/scene/stage.js';
+
+let pass = 0,
+  fail = 0;
+const ok = (c, n) => (c ? (pass++, console.log(`  ✓ ${n}`)) : (fail++, console.log(`  ✗ ${n}`)));
+console.log('=== render-network (constellation) ===\n');
+
+const ir = JSON.parse(
+  readFileSync(new URL('../scenes/ir/ecosystem.json', import.meta.url), 'utf8'),
+);
+
+// ---- IR validation ------------------------------------------------------------
+ok(validateIR(ir).ok, 'ecosystem fixture validates');
+ok(!validateIR({ structure: 'network', nodes: ['a', 'b'] }).ok, 'network without edges rejected');
+ok(
+  !validateIR({ structure: 'network', nodes: ['a', 'b'], relations: [[1, 1]] }).ok,
+  'self-loop rejected',
+);
+
+// ---- layout ---------------------------------------------------------------------
+{
+  const { pos, degree, hub } = constellationLayout(ir);
+  ok(hub === 5 || degree[hub] === Math.max(...degree), 'hub = highest-degree node');
+  ok(
+    pos.every((p) => p[1] > 0.3),
+    'whole cloud floats above the floor',
+  );
+  // true 3D: nodes must occupy all three axes
+  const spread = (k) => Math.max(...pos.map((p) => p[k])) - Math.min(...pos.map((p) => p[k]));
+  ok(spread(0) > 1 && spread(1) > 0.8 && spread(2) > 1, 'cloud spreads in x, y AND z');
+  // determinism
+  const again = constellationLayout(JSON.parse(JSON.stringify(ir)));
+  ok(JSON.stringify(again.pos) === JSON.stringify(pos), 'layout deterministic');
+  // connected nodes end up nearer than the cloud diameter (springs worked)
+  const d = (a, b) =>
+    Math.hypot(pos[a][0] - pos[b][0], pos[a][1] - pos[b][1], pos[a][2] - pos[b][2]);
+  const dia = Math.max(...ir.relations.map(([a, b]) => d(a, b)));
+  ok(dia < 6, `edges reasonably short after relaxation (max ${dia.toFixed(2)})`);
+}
+
+// ---- scene shape ----------------------------------------------------------------
+{
+  const scene = renderNetwork(ir);
+  const nodesS = scene.subjects.filter((s) => s.id.startsWith('net-node-'));
+  const edgesS = scene.subjects.filter((s) => s.id.startsWith('net-edge-'));
+  ok(nodesS.length === 10, 'one subject per node');
+  ok(edgesS.length === 14, 'one subject per edge');
+  ok(
+    [...nodesS, ...edgesS].every(
+      (s) => Array.isArray(s.animation) && s.animation[0].channel === 'transform.translate.y',
+    ),
+    'every node AND edge has a build-in',
+  );
+  // wiring order: all nodes land before the first edge starts
+  const t0 = (s) => Number(s.animation[0].expr.match(/smoothstep\(([\d.]+)/)[1]);
+  ok(Math.max(...nodesS.map(t0)) < Math.min(...edgesS.map(t0)), 'edges wire AFTER nodes land');
+
+  // fighting-game grammar
+  const shots = scene.cameraSequence.shots;
+  const ys = shots.map((s) => s.pos[1]);
+  const peakIdx = ys.indexOf(Math.max(...ys));
+  ok(peakIdx > 0 && peakIdx < shots.length - 1, 'crane peak mid-sequence (hero → crane → tour)');
+  const superShot = shots.find((s) => s.transition === 'cut' && (s.shake || 0) >= 0.2);
+  ok(
+    !!superShot && Array.isArray(superShot.exposure),
+    'super punch-in (cut + shake + exposure pop)',
+  );
+  ok((shots[shots.length - 1].focalDistance || 0) > 4, 'ends on a wide payoff frame');
+
+  const cards = scene.overlay.filter((o) => o.role === 'card');
+  ok(
+    cards.length === 10 && cards.every((o) => typeof o.revealAt === 'number'),
+    '10 reveal-tagged cards',
+  );
+
+  try {
+    compile(expandStage(scene), {});
+    ok(true, 'compiles to SDF (studio-ready)');
+  } catch (e) {
+    ok(false, `compile failed: ${e.message}`);
+  }
+}
+
+// ---- dispatcher -------------------------------------------------------------------
+ok(renderIR(ir).name.startsWith('(network)'), 'renderIR dispatches network');
+
+console.log(`\n${pass} passed, ${fail} failed`);
+process.exit(fail ? 1 : 0);

--- a/sdf-js/src/scene/environments.js
+++ b/sdf-js/src/scene/environments.js
@@ -1,0 +1,91 @@
+// sdf-js/src/scene/environments.js
+// Shared world presets for structure renderers. A structure keeps its form /
+// camera grammar / labels in ANY environment; env only swaps the WORLD around
+// it (a renderer-axis choice, not an IR field — the same IR renders in the
+// studio or on a mountainside). Extracted from render-sequence.js when the
+// hierarchy renderer arrived (every structure renderer shares these).
+//
+// Contract: getEnvironment(name) → null (studio default: the caller provides
+// its own stage defaults) or { subjects, defaults, payoffZoom }.
+//   subjects   — world geometry appended after the structure's own subjects
+//   defaults   — full scene defaults (camera fallback + light + shadow + postFx)
+//   payoffZoom — multiplier for the ending pull-back distance (reveal the world)
+
+const SNOWY_STONE = { hue: 0.07, sat: 0.3, value: 0.62, metal: 0, glow: 0, kind: 'snowy' };
+const SNOWY_PINE = { hue: 0.3, sat: 0.55, value: 0.3, metal: 0, glow: 0, kind: 'snowy' };
+
+function alpineEnvironment() {
+  return {
+    subjects: [
+      {
+        id: 'env-terrain',
+        type: 'terrain-elevated',
+        args: { maxHeight: 35.0, scale: 0.035, ridgePower: 2.0, mountainness: 0.3 },
+        transform: { translate: [0, -8, 0] },
+      },
+      {
+        id: 'env-snow-base',
+        type: 'box',
+        args: { dims: [400, 0.4, 400] },
+        transform: { translate: [0, -7.9, 0] },
+        material: { hue: 0.6, sat: 0.04, value: 0.94, metal: 0, glow: 0, kind: 'snowy' },
+      },
+      // the hero backdrop: the snowy stone bridge, spanning the frame behind the structure
+      {
+        id: 'env-bridge',
+        type: 'arch-bridge',
+        args: { bridgeLen: 30.0, bridgeWidth: 4.0, archH: 6.0, railH: 1.5, cornerOff: 10.0 },
+        transform: { translate: [0, -1.2, -16], rotate: [0, 1.5708, 0] },
+        material: SNOWY_STONE,
+      },
+      {
+        id: 'env-pine-L',
+        type: 'tree-pine',
+        args: { trunkHeight: 4.4, trunkRadius: 0.18, foliageRadius: 1.3 },
+        transform: { translate: [-9, -1.5, -4] },
+        material: SNOWY_PINE,
+      },
+      {
+        id: 'env-pine-R',
+        type: 'tree-pine',
+        args: { trunkHeight: 3.8, trunkRadius: 0.16, foliageRadius: 1.1 },
+        transform: { translate: [8, -1.5, -7] },
+        material: SNOWY_PINE,
+      },
+      {
+        id: 'env-pine-far',
+        type: 'tree-pine',
+        args: { trunkHeight: 5.0, trunkRadius: 0.2, foliageRadius: 1.6 },
+        transform: { translate: [-14, -1.5, -12] },
+        material: SNOWY_PINE,
+      },
+    ],
+    defaults: {
+      // static fallback only — the cameraSequence drives the actual camera
+      camera: {
+        yaw: 0,
+        pitch: -0.1,
+        distance: 10,
+        focal: 1.2,
+        targetX: 0,
+        targetY: 2,
+        targetZ: 0,
+      },
+      light: { azimuth: -0.6, altitude: 0.3, distance: 60, intensity: 1.15 },
+      shadow: { enabled: true, mode: 'darken', strength: 0.42 },
+      postFx: {
+        exposure: 1.05,
+        vignetteStrength: 0.4,
+        bloomMix: 0.22,
+        bloomThreshold: 0.85,
+        lensFlareStrength: 0.1,
+        motionBlurStrength: 0.45,
+      },
+    },
+    payoffZoom: 1.35, // pull the ending frame further back — reveal the world
+  };
+}
+
+export function getEnvironment(name) {
+  return name === 'alpine' ? alpineEnvironment() : null;
+}

--- a/sdf-js/src/scene/ir.js
+++ b/sdf-js/src/scene/ir.js
@@ -6,7 +6,9 @@
 //   sequence  — ordered stages (funnel): nodes + magnitude drive stage widths.
 //   hierarchy — parent→child tree (org chart / taxonomy): relations carry the
 //               edges as [parentIndex, childIndex] pairs; exactly one root.
-export const STRUCTURES = ['sequence', 'hierarchy'];
+//   network   — arbitrary graph (ecosystem / dependencies): relations are
+//               undirected edges; hubs emerge from degree, no root required.
+export const STRUCTURES = ['sequence', 'hierarchy', 'network'];
 
 export function validateIR(ir) {
   const errors = [];
@@ -52,6 +54,12 @@ export function validateIR(ir) {
       if (roots.length !== 1)
         errors.push(`hierarchy requires exactly one root (found ${roots.length})`);
     }
+  }
+  if (ir.structure === 'network') {
+    const rels = Array.isArray(ir.relations) ? ir.relations : [];
+    if (rels.length === 0) errors.push('network requires relations (edges)');
+    else if (rels.some((r) => Array.isArray(r) && r[0] === r[1]))
+      errors.push('network edges must not be self-loops');
   }
   return { ok: errors.length === 0, errors };
 }

--- a/sdf-js/src/scene/ir.js
+++ b/sdf-js/src/scene/ir.js
@@ -1,7 +1,12 @@
 // sdf-js/src/scene/ir.js
 // Intermediate Representation: the neutral "what structure does this content have"
-// that decouples input (scaffold / text) from 3D rendering. v0, grown from the funnel.
-export const STRUCTURES = ['sequence'];
+// that decouples input (scaffold / text) from 3D rendering. Grown structure by
+// structure — a field earns its place when a renderer needs it (YAGNI).
+//
+//   sequence  — ordered stages (funnel): nodes + magnitude drive stage widths.
+//   hierarchy — parent→child tree (org chart / taxonomy): relations carry the
+//               edges as [parentIndex, childIndex] pairs; exactly one root.
+export const STRUCTURES = ['sequence', 'hierarchy'];
 
 export function validateIR(ir) {
   const errors = [];
@@ -9,12 +14,44 @@ export function validateIR(ir) {
   if (!STRUCTURES.includes(ir.structure)) errors.push(`unknown structure "${ir.structure}"`);
   if (!Array.isArray(ir.nodes) || ir.nodes.length === 0)
     errors.push('nodes must be a non-empty array');
+  const N = Array.isArray(ir.nodes) ? ir.nodes.length : 0;
   if (ir.magnitude != null) {
     if (!Array.isArray(ir.magnitude)) errors.push('magnitude must be an array');
-    else if (Array.isArray(ir.nodes) && ir.magnitude.length !== ir.nodes.length)
+    else if (N && ir.magnitude.length !== N)
       errors.push('magnitude length must match nodes length');
   }
-  if (ir.order != null && (!Array.isArray(ir.order) || ir.order.length !== (ir.nodes || []).length))
+  if (ir.order != null && (!Array.isArray(ir.order) || ir.order.length !== N))
     errors.push('order length must match nodes length');
+  if (ir.relations != null) {
+    if (!Array.isArray(ir.relations)) errors.push('relations must be an array');
+    else {
+      for (const r of ir.relations) {
+        if (
+          !Array.isArray(r) ||
+          r.length !== 2 ||
+          !Number.isInteger(r[0]) ||
+          !Number.isInteger(r[1])
+        ) {
+          errors.push('each relation must be an [fromIndex, toIndex] integer pair');
+          break;
+        }
+        if (r[0] < 0 || r[0] >= N || r[1] < 0 || r[1] >= N) {
+          errors.push(`relation [${r[0]},${r[1]}] references a node out of range`);
+          break;
+        }
+      }
+    }
+  }
+  if (ir.structure === 'hierarchy') {
+    const rels = Array.isArray(ir.relations) ? ir.relations : [];
+    if (rels.length === 0) errors.push('hierarchy requires relations (parent→child edges)');
+    else {
+      const hasParent = new Set(rels.map((r) => r[1]));
+      const roots = [];
+      for (let i = 0; i < N; i++) if (!hasParent.has(i)) roots.push(i);
+      if (roots.length !== 1)
+        errors.push(`hierarchy requires exactly one root (found ${roots.length})`);
+    }
+  }
   return { ok: errors.length === 0, errors };
 }

--- a/sdf-js/src/scene/ir.js
+++ b/sdf-js/src/scene/ir.js
@@ -8,7 +8,9 @@
 //               edges as [parentIndex, childIndex] pairs; exactly one root.
 //   network   — arbitrary graph (ecosystem / dependencies): relations are
 //               undirected edges; hubs emerge from degree, no root required.
-export const STRUCTURES = ['sequence', 'hierarchy', 'network'];
+//   magnitude — quantities compared as volumetric masses (monolith row):
+//               magnitude is REQUIRED; nodes are the category names.
+export const STRUCTURES = ['sequence', 'hierarchy', 'network', 'magnitude'];
 
 export function validateIR(ir) {
   const errors = [];
@@ -54,6 +56,10 @@ export function validateIR(ir) {
       if (roots.length !== 1)
         errors.push(`hierarchy requires exactly one root (found ${roots.length})`);
     }
+  }
+  if (ir.structure === 'magnitude') {
+    if (!Array.isArray(ir.magnitude) || ir.magnitude.length === 0)
+      errors.push('magnitude structure requires a magnitude array');
   }
   if (ir.structure === 'network') {
     const rels = Array.isArray(ir.relations) ? ir.relations : [];

--- a/sdf-js/src/scene/render-hierarchy.js
+++ b/sdf-js/src/scene/render-hierarchy.js
@@ -1,0 +1,250 @@
+// sdf-js/src/scene/render-hierarchy.js
+// Structure renderer #2: hierarchy → CONE TREE. Reads the IR ONLY (never 2D x/y).
+//
+// Why a cone tree is the native 3D form for hierarchy (the "3D earns its
+// existence" move): a 2D org chart crams every level onto one line — wide
+// levels collide, deep trees squash. In 3D each node is the apex of a cone and
+// its children fan out on a CIRCLE beneath it; sibling crowds spread around
+// the azimuth instead of fighting for x-axis room, and depth reads as literal
+// depth. (Robertson/Mackinlay/Card's classic Cone Tree, recast in Atlas atoms.)
+//
+// Fighting-game grammar (the house style), hierarchy variation:
+//   1. hero low-angle at the ROOT (the boss intro)
+//   2. crane over the crown
+//   3. orbit descent LEVEL BY LEVEL (each level = one camera beat; nodes of
+//      that level cascade in as the camera arrives — arena assembles per floor)
+//   4. the SUPER: hard cut punch-in on the emphasis node + shake + exposure pop
+//   5. payoff pull-back — the whole tree in one frame
+//
+// Build-in staging differs from the funnel on purpose: the funnel assembles its
+// WHOLE form during the intro (a monument), while the tree grows floor by floor
+// with the tour — hierarchy IS the narration, so geometry and narration land
+// together, level by level.
+import { validateIR } from './ir.js';
+import { getEnvironment } from './environments.js';
+
+const label = (n) => (typeof n === 'string' ? n : (n && (n.label ?? n.name)) || '');
+
+/**
+ * Cone-tree layout from IR relations. Returns per-node {pos, level, parent}.
+ * Root at the top; each node's children distributed on a circle beneath it,
+ * child cone radius shrinking with depth. Deterministic (no randomness).
+ */
+export function coneTreeLayout(ir, opts = {}) {
+  const N = ir.nodes.length;
+  const levelHeight = opts.levelHeight ?? 1.15;
+  const rootRadius = opts.rootRadius ?? 1.9;
+  const parent = new Array(N).fill(-1);
+  const children = Array.from({ length: N }, () => []);
+  for (const [p, c] of ir.relations) {
+    parent[c] = p;
+    children[p].push(c);
+  }
+  const root = parent.indexOf(-1);
+
+  const level = new Array(N).fill(0);
+  const pos = new Array(N);
+  const maxLevel = { v: 0 };
+
+  // Recursive placement: node at (x, z), children on a circle of radius r
+  // beneath it. Each child's own cone shrinks; the child circle is rotated by
+  // the parent's azimuth so sub-trees interleave instead of stacking.
+  const place = (i, x, z, lvl, r, baseAngle) => {
+    level[i] = lvl;
+    maxLevel.v = Math.max(maxLevel.v, lvl);
+    pos[i] = [x, 0, z]; // y assigned after depth known
+    const kids = children[i];
+    if (!kids.length) return;
+    const step = (2 * Math.PI) / kids.length;
+    kids.forEach((c, k) => {
+      const a = baseAngle + step * k + (kids.length > 1 ? 0 : Math.PI / 5);
+      place(c, x + Math.cos(a) * r, z + Math.sin(a) * r, lvl + 1, r * 0.45, a + Math.PI / 3);
+    });
+  };
+  place(root, 0, 0, 0, rootRadius, -Math.PI / 2);
+
+  const topY = 1.4 + maxLevel.v * levelHeight * 0.5 + 0.6;
+  for (let i = 0; i < N; i++) pos[i][1] = topY - level[i] * levelHeight;
+
+  return { pos, level, parent, root, maxLevel: maxLevel.v, topY, levelHeight };
+}
+
+// Cool cyan→indigo by depth (matches the funnel family), emphasis in warm gold.
+const nodeMat = (lvl, maxLvl, emphasized) => {
+  if (emphasized)
+    return { hue: 0.11, sat: 0.78, value: 0.95, kind: 'normal', roughness: 0.22, clearcoat: 0.6 };
+  const k = maxLvl > 0 ? lvl / maxLvl : 0;
+  return {
+    hue: 0.55 + 0.09 * k,
+    sat: 0.62 + 0.16 * k,
+    value: 0.85 - 0.28 * k,
+    kind: 'normal',
+    roughness: 0.3,
+    clearcoat: 0.45,
+  };
+};
+
+export function renderHierarchy(ir, opts = {}) {
+  const v = validateIR(ir);
+  if (!v.ok) throw new Error(`renderHierarchy: invalid IR — ${v.errors.join('; ')}`);
+  if (ir.structure !== 'hierarchy')
+    throw new Error(`renderHierarchy: expected structure 'hierarchy', got '${ir.structure}'`);
+  const env = getEnvironment(opts.env);
+
+  const nodes = ir.nodes.map(label);
+  const N = nodes.length;
+  const mag = ir.magnitude || nodes.map(() => 1);
+  const mMax = Math.max(...mag.map((x) => Number(x) || 0), 1);
+  const emphasis = new Set(ir.emphasis || []);
+  const layout = coneTreeLayout(ir);
+  const { pos, level, parent, root, maxLevel, topY, levelHeight } = layout;
+
+  // Node size: magnitude-scaled sphere (root reads as the crown by position,
+  // not just size). Edges: capsules parent→child, owned by the CHILD subject so
+  // node + its up-link build in as one piece.
+  const nodeR = (i) => 0.22 + 0.2 * Math.sqrt((Number(mag[i]) || 1) / mMax);
+
+  // Per-level reveal: level l lands as the camera's level-l beat begins.
+  const introLead = 2.1; // hero 0.9 + crane 1.2
+  const holdEach = 1.5; // seconds per level beat
+  const levelRevealStart = (l) => introLead + l * holdEach - 0.55; // land slightly before the beat
+  const drop = 1.0;
+
+  const subjects = [];
+  for (let i = 0; i < N; i++) {
+    const p = pos[i];
+    const t0 = Math.max(0.2, levelRevealStart(level[i]));
+    const t1 = t0 + 0.55;
+    const children = [
+      {
+        id: `node-ball-${i}`,
+        type: 'sphere',
+        args: { radius: nodeR(i) },
+        transform: { translate: [0, 0, 0] },
+      },
+    ];
+    if (parent[i] >= 0) {
+      // Up-link capsule in the CHILD's local frame (subject origin = node pos):
+      // from the node to its parent's position.
+      const pp = pos[parent[i]];
+      children.push({
+        id: `node-link-${i}`,
+        type: 'capsule',
+        args: { a: [0, 0, 0], b: [pp[0] - p[0], pp[1] - p[1], pp[2] - p[2]], radius: 0.045 },
+        transform: { translate: [0, 0, 0] },
+      });
+    }
+    subjects.push({
+      id: `node-${i}`,
+      type: 'union',
+      children,
+      transform: { translate: p },
+      material: nodeMat(level[i], maxLevel, emphasis.has(i)),
+      animation: [
+        {
+          channel: 'transform.translate.y',
+          expr: `${(p[1] + drop).toFixed(3)} - ${drop} * smoothstep(${t0.toFixed(2)}, ${t1.toFixed(2)}, t)`,
+        },
+      ],
+    });
+  }
+
+  // ---- camera: five beats, hierarchy variation -------------------------------
+  const treeSpan = 1.9 * 2.4; // rough crown diameter for framing
+  const midY = topY - (maxLevel * levelHeight) / 2;
+  const emphasisIdx = ir.emphasis && ir.emphasis.length ? ir.emphasis[0] : root;
+  const gp = pos[emphasisIdx];
+  const shots = [
+    // 1 — hero low angle at the root (boss intro)
+    {
+      duration: 0.9,
+      pos: [2.1, Math.max(topY - 2.2, 0.5), 4.8],
+      target: [0, topY, 0],
+      fov: 52,
+      aperture: 0,
+      focalDistance: 5,
+      ease: 'out',
+    },
+    // 2 — crane over the crown
+    {
+      duration: 1.2,
+      pos: [0.8, topY + 2.4, 3.8],
+      target: [0, topY - 0.4, 0],
+      fov: 48,
+      transition: 'blend',
+      aperture: 0,
+      focalDistance: 4.4,
+      ease: 'inout',
+    },
+  ];
+  // 3 — orbit descent, one beat per level
+  for (let l = 0; l <= maxLevel; l++) {
+    const y = topY - l * levelHeight;
+    const theta = 1.1 * (l + 1);
+    const dist = 3.2 + l * 1.1; // lower levels are wider — back off as we descend
+    shots.push({
+      duration: holdEach,
+      pos: [Math.sin(theta) * dist, y + 0.9, Math.cos(theta) * dist],
+      target: [0, y, 0],
+      fov: 46,
+      transition: 'blend',
+      aperture: 0,
+      focalDistance: dist,
+      shake: 0.08,
+      ease: 'smooth',
+    });
+  }
+  // 4 — the super: hard cut punch-in on the emphasis node
+  shots.push({
+    duration: 1.0,
+    pos: [gp[0] + 0.5, Math.max(gp[1] - 0.1, 0.14), gp[2] + 1.6],
+    target: [gp[0], gp[1] + 0.08, gp[2]],
+    fov: 40,
+    transition: 'cut',
+    aperture: 0,
+    focalDistance: 1.7,
+    shake: 0.3,
+    exposure: [1.45, 1.0],
+    ease: 'out',
+  });
+  // 5 — payoff pull-back: the whole tree
+  const payoffDist = (treeSpan + maxLevel * 1.6 + 3.4) * (env ? env.payoffZoom : 1);
+  shots.push({
+    duration: 2.4,
+    pos: [1.6, midY + 1.4 + (env ? 0.5 : 0), payoffDist],
+    target: [0, midY, 0],
+    fov: 44,
+    transition: 'blend',
+    aperture: 0,
+    focalDistance: payoffDist,
+    ease: 'out',
+  });
+
+  // labels: node name cards revealed with their level's beat
+  const overlay = [
+    {
+      text: String(ir.title || nodes[root]).toUpperCase(),
+      anchor: [0, topY + 1.3, 0],
+      role: 'title',
+    },
+  ];
+  for (let i = 0; i < N; i++) {
+    const p = pos[i];
+    overlay.push({
+      text: nodes[i],
+      anchor: [p[0] + nodeR(i) + 0.32, p[1], p[2]],
+      role: 'card',
+      align: 'left',
+      revealAt: introLead + level[i] * holdEach + 0.35,
+    });
+  }
+
+  return {
+    v: 1,
+    name: `(hierarchy) ${ir.title || nodes[root]}${env ? ' · alpine' : ''}`,
+    subjects: env ? [...subjects, ...env.subjects] : subjects,
+    overlay,
+    cameraSequence: { loop: false, shots },
+    defaults: env ? env.defaults : { stage: { size: [16, 12, 12] } },
+  };
+}

--- a/sdf-js/src/scene/render-ir.js
+++ b/sdf-js/src/scene/render-ir.js
@@ -1,0 +1,21 @@
+// sdf-js/src/scene/render-ir.js
+// The structure-renderer dispatcher: IR in, studio SceneData out. This is the
+// seam the spec's architecture diagram draws — input adapters produce an IR,
+// renderIR picks the structure renderer by ir.structure, and everything
+// downstream (studio, camera sequencing, overlay) is shared.
+import { renderSequence } from './render-sequence.js';
+import { renderHierarchy } from './render-hierarchy.js';
+
+const RENDERERS = {
+  sequence: renderSequence,
+  hierarchy: renderHierarchy,
+};
+
+export function renderIR(ir, opts = {}) {
+  const r = RENDERERS[ir?.structure];
+  if (!r)
+    throw new Error(
+      `renderIR: no structure renderer for '${ir?.structure}' (have: ${Object.keys(RENDERERS).join(', ')})`,
+    );
+  return r(ir, opts);
+}

--- a/sdf-js/src/scene/render-ir.js
+++ b/sdf-js/src/scene/render-ir.js
@@ -6,11 +6,13 @@
 import { renderSequence } from './render-sequence.js';
 import { renderHierarchy } from './render-hierarchy.js';
 import { renderNetwork } from './render-network.js';
+import { renderMagnitude } from './render-magnitude.js';
 
 const RENDERERS = {
   sequence: renderSequence,
   hierarchy: renderHierarchy,
   network: renderNetwork,
+  magnitude: renderMagnitude,
 };
 
 export function renderIR(ir, opts = {}) {

--- a/sdf-js/src/scene/render-ir.js
+++ b/sdf-js/src/scene/render-ir.js
@@ -5,10 +5,12 @@
 // downstream (studio, camera sequencing, overlay) is shared.
 import { renderSequence } from './render-sequence.js';
 import { renderHierarchy } from './render-hierarchy.js';
+import { renderNetwork } from './render-network.js';
 
 const RENDERERS = {
   sequence: renderSequence,
   hierarchy: renderHierarchy,
+  network: renderNetwork,
 };
 
 export function renderIR(ir, opts = {}) {

--- a/sdf-js/src/scene/render-magnitude.js
+++ b/sdf-js/src/scene/render-magnitude.js
@@ -1,0 +1,196 @@
+// sdf-js/src/scene/render-magnitude.js
+// Structure renderer #4: magnitude → MONOLITH ROW. Reads the IR ONLY (never 2D x/y).
+//
+// Why monoliths are the native 3D form for magnitude: a 2D bar chart is read
+// from OUTSIDE — the eye compares heights on paper. In 3D the camera walks AMONG
+// the quantities: a low-angle tracking shot makes the biggest value physically
+// tower over you (the body-scale read no flat chart has), while equal footprints
+// keep the comparison honest (height stays the linear encoding; the DOM value
+// labels carry the exact numbers).
+//
+// Fighting-game grammar, magnitude variation — the CHARACTER-SELECT ROW:
+//   1. hero — low angle at the tallest monolith (the champion)
+//   2. crane — up and over: the whole lineup
+//   3. TRACKING SHOT — the camera dollies along the row; each monolith ERUPTS
+//      from the ground as the camera passes it (rise, not drop — growth reads
+//      upward). One beat per monolith.
+//   4. the SUPER — hard cut punch-in at the emphasis monolith's base, looking
+//      UP its full height + shake + exposure pop
+//   5. payoff pull-back — the whole skyline in one frame
+import { validateIR } from './ir.js';
+import { getEnvironment } from './environments.js';
+
+const label = (n) => (typeof n === 'string' ? n : (n && (n.label ?? n.name)) || '');
+
+const monoMat = (i, N, emphasized) => {
+  if (emphasized)
+    return { hue: 0.11, sat: 0.78, value: 0.95, kind: 'normal', roughness: 0.22, clearcoat: 0.6 };
+  const k = N > 1 ? i / (N - 1) : 0;
+  return {
+    hue: 0.55 + 0.09 * k,
+    sat: 0.62 + 0.14 * k,
+    value: 0.82 - 0.22 * k,
+    kind: 'normal',
+    roughness: 0.3,
+    clearcoat: 0.45,
+  };
+};
+
+export function renderMagnitude(ir, opts = {}) {
+  const v = validateIR(ir);
+  if (!v.ok) throw new Error(`renderMagnitude: invalid IR — ${v.errors.join('; ')}`);
+  if (ir.structure !== 'magnitude')
+    throw new Error(`renderMagnitude: expected structure 'magnitude', got '${ir.structure}'`);
+  const env = getEnvironment(opts.env);
+
+  const nodes = ir.nodes.map(label);
+  const N = nodes.length;
+  const mag = ir.magnitude;
+  const mMax = Math.max(...mag.map((x) => Number(x) || 0), 1e-9);
+  const order = ir.order && ir.order.length === N ? ir.order : nodes.map((_, i) => i);
+  let tallest = 0;
+  for (let i = 1; i < N; i++) if (mag[i] > mag[tallest]) tallest = i;
+  const emphasisIdx = ir.emphasis && ir.emphasis.length ? ir.emphasis[0] : tallest;
+  const emphasis = new Set(ir.emphasis && ir.emphasis.length ? ir.emphasis : [tallest]);
+
+  // Row layout: equal footprints, height = linear encoding (honest comparison).
+  const W = 0.72; // monolith footprint
+  const gapX = 0.55;
+  const stride = W + gapX;
+  const H_MAX = 3.4;
+  const height = (i) => Math.max(0.12, (Number(mag[i]) / mMax) * H_MAX);
+  const xOf = (i) => (i - (N - 1) / 2) * stride;
+
+  // Tracking-beat timing: monolith i erupts as the camera's beat i begins.
+  const introLead = 2.1; // hero 0.9 + crane 1.2
+  const holdEach = 1.1;
+  const riseStart = (k) => introLead + k * holdEach - 0.45;
+
+  const subjects = [];
+  order.forEach((i, k) => {
+    const H = height(i);
+    const yFinal = H / 2; // box centre when standing on the floor
+    const buried = H + 0.3; // start fully underground, then erupt
+    const t0 = Math.max(0.2, riseStart(k));
+    const t1 = t0 + 0.6;
+    subjects.push({
+      id: `mono-${i}`,
+      type: 'box',
+      args: { dims: [W, H, W] },
+      transform: { translate: [xOf(i), yFinal, 0] },
+      material: monoMat(i, N, emphasis.has(i)),
+      animation: [
+        {
+          channel: 'transform.translate.y',
+          expr: `${(yFinal - buried).toFixed(3)} + ${buried.toFixed(3)} * smoothstep(${t0.toFixed(2)}, ${t1.toFixed(2)}, t)`,
+        },
+      ],
+    });
+  });
+
+  // ---- camera: five beats, magnitude variation --------------------------------
+  const rowSpan = (N - 1) * stride + W;
+  const tallH = height(tallest);
+  const gx = xOf(emphasisIdx);
+  const gH = height(emphasisIdx);
+  const shots = [
+    // 1 — hero low angle at the tallest (the champion)
+    {
+      duration: 0.9,
+      pos: [xOf(tallest) + 1.6, 0.5, 3.6],
+      target: [xOf(tallest), tallH * 0.72, 0],
+      fov: 54,
+      aperture: 0,
+      focalDistance: 4,
+      ease: 'out',
+    },
+    // 2 — crane over the lineup
+    {
+      duration: 1.2,
+      pos: [0.6, tallH + 2.2, rowSpan * 0.5 + 2.6],
+      target: [0, tallH * 0.45, 0],
+      fov: 48,
+      transition: 'blend',
+      aperture: 0,
+      focalDistance: rowSpan * 0.6 + 3,
+      ease: 'inout',
+    },
+  ];
+  // 3 — tracking shot along the row (low, close — the walk among giants)
+  order.forEach((i) => {
+    const x = xOf(i);
+    const H = height(i);
+    shots.push({
+      duration: holdEach,
+      pos: [x + 0.9, Math.min(1.1, H * 0.55 + 0.35), 2.5],
+      target: [x, Math.max(H * 0.55, 0.5), 0],
+      fov: 46,
+      transition: 'blend',
+      aperture: 0,
+      focalDistance: 2.7,
+      shake: 0.08,
+      ease: 'smooth',
+    });
+  });
+  // 4 — the super: at the emphasis monolith's base, looking UP its height
+  shots.push({
+    duration: 1.0,
+    pos: [gx + 0.75, 0.35, 1.35],
+    target: [gx, gH * 0.85, 0],
+    fov: 44,
+    transition: 'cut',
+    aperture: 0,
+    focalDistance: 1.8,
+    shake: 0.3,
+    exposure: [1.45, 1.0],
+    ease: 'out',
+  });
+  // 5 — payoff pull-back: the whole skyline
+  const payoffDist = (rowSpan * 0.85 + 3.2) * (env ? env.payoffZoom : 1);
+  shots.push({
+    duration: 2.4,
+    pos: [1.2, tallH * 0.55 + 1.0 + (env ? 0.5 : 0), payoffDist],
+    target: [0, tallH * 0.4, 0],
+    fov: 44,
+    transition: 'blend',
+    aperture: 0,
+    focalDistance: payoffDist,
+    ease: 'out',
+  });
+
+  // labels: name card + value chip per monolith, revealed with its beat
+  const overlay = [
+    {
+      text: String(ir.title || nodes[tallest]).toUpperCase(),
+      anchor: [0, tallH + 1.3, 0],
+      role: 'title',
+    },
+  ];
+  order.forEach((i, k) => {
+    const x = xOf(i);
+    const H = height(i);
+    const revealAt = introLead + k * holdEach + 0.35;
+    overlay.push({
+      text: nodes[i],
+      anchor: [x, -0.02, W * 0.5 + 0.35],
+      role: 'card',
+      revealAt,
+    });
+    overlay.push({
+      text: String(mag[i]),
+      anchor: [x, H + 0.32, 0],
+      role: 'value',
+      radius: emphasis.has(i) ? 0.5 : 0.36,
+      revealAt,
+    });
+  });
+
+  return {
+    v: 1,
+    name: `(magnitude) ${ir.title || nodes[tallest]}${env ? ' · alpine' : ''}`,
+    subjects: env ? [...subjects, ...env.subjects] : subjects,
+    overlay,
+    cameraSequence: { loop: false, shots },
+    defaults: env ? env.defaults : { stage: { size: [Math.max(16, rowSpan + 6), 12, 12] } },
+  };
+}

--- a/sdf-js/src/scene/render-network.js
+++ b/sdf-js/src/scene/render-network.js
@@ -1,0 +1,284 @@
+// sdf-js/src/scene/render-network.js
+// Structure renderer #3: network → CONSTELLATION. Reads the IR ONLY (never 2D x/y).
+//
+// Why a constellation is the native 3D form for a graph: 2D force layouts fight
+// edge crossings — in a dense graph the hairball is unreadable. In 3D the graph
+// gets a whole extra axis to untangle in; hubs sit deep in the cloud, leaves at
+// the shell, and an ORBITING camera turns parallax into structure (nodes that
+// are far apart in the graph visibly separate as the view swings).
+//
+// Layout is deterministic (no randomness, resume-safe): nodes start on a golden-
+// angle sphere (radius shrinks with degree — hubs pulled toward the center),
+// then a fixed number of spring-relaxation iterations (attract along edges,
+// repel all pairs). Same IR → same constellation, always.
+//
+// Fighting-game grammar, network variation:
+//   1. hero — inside the cloud, looking through it at the hub (in the arena)
+//   2. crane — pull up and out: the whole constellation revealed
+//   3. orbit tour — the camera circles while the network WIRES ITSELF:
+//      nodes cascade in first, then edges land in waves (assembly = spectacle)
+//   4. the SUPER — hard cut punch-in on the hub + shake + exposure pop
+//   5. payoff pull-back — the settled constellation in one frame
+import { validateIR } from './ir.js';
+import { getEnvironment } from './environments.js';
+
+const label = (n) => (typeof n === 'string' ? n : (n && (n.label ?? n.name)) || '');
+
+/**
+ * Deterministic 3D constellation layout. Returns { pos, degree, hub }.
+ */
+export function constellationLayout(ir, opts = {}) {
+  const N = ir.nodes.length;
+  const radius = opts.radius ?? 2.0;
+  const iterations = opts.iterations ?? 60;
+
+  const degree = new Array(N).fill(0);
+  for (const [a, b] of ir.relations) {
+    degree[a]++;
+    degree[b]++;
+  }
+  const maxDeg = Math.max(...degree, 1);
+  let hub = 0;
+  for (let i = 1; i < N; i++) if (degree[i] > degree[hub]) hub = i;
+
+  // Golden-angle sphere seed: well-spread, deterministic. Hubs start closer in.
+  const GA = Math.PI * (3 - Math.sqrt(5));
+  const pos = [];
+  for (let i = 0; i < N; i++) {
+    const t = N > 1 ? i / (N - 1) : 0.5;
+    const y = 1 - 2 * t;
+    const rXZ = Math.sqrt(Math.max(0, 1 - y * y));
+    const a = GA * i;
+    const shell = radius * (1.05 - 0.55 * (degree[i] / maxDeg)); // hubs inward
+    pos.push([Math.cos(a) * rXZ * shell, y * shell * 0.8, Math.sin(a) * rXZ * shell]);
+  }
+
+  // Spring relaxation: attract along edges toward restLen, repel all pairs.
+  const restLen = radius * 0.85;
+  for (let it = 0; it < iterations; it++) {
+    const force = pos.map(() => [0, 0, 0]);
+    for (const [a, b] of ir.relations) {
+      const d = [pos[b][0] - pos[a][0], pos[b][1] - pos[a][1], pos[b][2] - pos[a][2]];
+      const len = Math.hypot(d[0], d[1], d[2]) || 1e-6;
+      const f = (len - restLen) * 0.02;
+      for (let k = 0; k < 3; k++) {
+        force[a][k] += (d[k] / len) * f;
+        force[b][k] -= (d[k] / len) * f;
+      }
+    }
+    for (let i = 0; i < N; i++) {
+      for (let j = i + 1; j < N; j++) {
+        const d = [pos[j][0] - pos[i][0], pos[j][1] - pos[i][1], pos[j][2] - pos[i][2]];
+        const len2 = d[0] * d[0] + d[1] * d[1] + d[2] * d[2] || 1e-6;
+        const f = Math.min(0.06, 0.12 / len2);
+        const len = Math.sqrt(len2);
+        for (let k = 0; k < 3; k++) {
+          force[i][k] -= (d[k] / len) * f;
+          force[j][k] += (d[k] / len) * f;
+        }
+      }
+    }
+    for (let i = 0; i < N; i++) for (let k = 0; k < 3; k++) pos[i][k] += force[i][k];
+  }
+
+  // Recenter on the hub and clamp the cloud above the floor.
+  const c = pos[hub];
+  for (let i = 0; i < N; i++) {
+    pos[i] = [pos[i][0] - c[0], pos[i][1] - c[1], pos[i][2] - c[2]];
+  }
+  let minY = Infinity;
+  for (const p of pos) minY = Math.min(minY, p[1]);
+  const lift = 1.6 - Math.min(0, minY + 1.0); // keep lowest node ≥ ~0.6
+  for (const p of pos) p[1] += lift;
+
+  return { pos, degree, hub };
+}
+
+const nodeMatN = (deg, maxDeg, emphasized) => {
+  if (emphasized)
+    return { hue: 0.11, sat: 0.78, value: 0.95, kind: 'normal', roughness: 0.22, clearcoat: 0.6 };
+  const k = maxDeg > 0 ? deg / maxDeg : 0; // hubs lighter, leaves deeper
+  return {
+    hue: 0.64 - 0.09 * k,
+    sat: 0.78 - 0.16 * k,
+    value: 0.55 + 0.3 * k,
+    kind: 'normal',
+    roughness: 0.3,
+    clearcoat: 0.45,
+  };
+};
+
+const EDGE_MAT = {
+  hue: 0.58,
+  sat: 0.25,
+  value: 0.8,
+  kind: 'normal',
+  roughness: 0.35,
+  clearcoat: 0.3,
+};
+
+export function renderNetwork(ir, opts = {}) {
+  const v = validateIR(ir);
+  if (!v.ok) throw new Error(`renderNetwork: invalid IR — ${v.errors.join('; ')}`);
+  if (ir.structure !== 'network')
+    throw new Error(`renderNetwork: expected structure 'network', got '${ir.structure}'`);
+  const env = getEnvironment(opts.env);
+
+  const nodes = ir.nodes.map(label);
+  const N = nodes.length;
+  const mag = ir.magnitude || nodes.map(() => 1);
+  const mMax = Math.max(...mag.map((x) => Number(x) || 0), 1);
+  const { pos, degree, hub } = constellationLayout(ir);
+  const maxDeg = Math.max(...degree, 1);
+  const emphasisIdx = ir.emphasis && ir.emphasis.length ? ir.emphasis[0] : hub;
+  const emphasis = new Set(ir.emphasis && ir.emphasis.length ? ir.emphasis : [hub]);
+
+  const nodeR = (i) => 0.16 + 0.18 * Math.sqrt((Number(mag[i]) || 1) / mMax);
+
+  // Assembly: nodes cascade in a quick wave, then edges land in waves — the
+  // network wires itself while the camera orbits.
+  const drop = 1.1;
+  const nodeT0 = (i) => 0.25 + i * 0.12;
+  const edgesStart = 0.25 + N * 0.12 + 0.2;
+  const subjects = [];
+  for (let i = 0; i < N; i++) {
+    const p = pos[i];
+    const t0 = nodeT0(i);
+    subjects.push({
+      id: `net-node-${i}`,
+      type: 'sphere',
+      args: { radius: nodeR(i) },
+      transform: { translate: p },
+      material: nodeMatN(degree[i], maxDeg, emphasis.has(i)),
+      animation: [
+        {
+          channel: 'transform.translate.y',
+          expr: `${(p[1] + drop).toFixed(3)} - ${drop} * smoothstep(${t0.toFixed(2)}, ${(t0 + 0.5).toFixed(2)}, t)`,
+        },
+      ],
+    });
+  }
+  ir.relations.forEach(([a, b], e) => {
+    const pa = pos[a];
+    const t0 = edgesStart + e * 0.14;
+    subjects.push({
+      id: `net-edge-${e}`,
+      type: 'capsule',
+      args: {
+        a: [0, 0, 0],
+        b: [pos[b][0] - pa[0], pos[b][1] - pa[1], pos[b][2] - pa[2]],
+        radius: 0.035,
+      },
+      transform: { translate: pa },
+      material: EDGE_MAT,
+      animation: [
+        {
+          channel: 'transform.translate.y',
+          expr: `${(pa[1] + drop).toFixed(3)} - ${drop} * smoothstep(${t0.toFixed(2)}, ${(t0 + 0.45).toFixed(2)}, t)`,
+        },
+      ],
+    });
+  });
+
+  // ---- camera: five beats, network variation ---------------------------------
+  const hubP = pos[hub];
+  const gp = pos[emphasisIdx];
+  const cloudR = Math.max(...pos.map((p) => Math.hypot(p[0], p[2]))) + 0.6;
+  const midY = pos.reduce((s, p) => s + p[1], 0) / N;
+  const wireDone = edgesStart + ir.relations.length * 0.14 + 0.45;
+  const shots = [
+    // 1 — hero: inside the cloud, looking at the hub
+    {
+      duration: 1.0,
+      pos: [hubP[0] + cloudR * 0.5, Math.max(hubP[1] - 0.6, 0.4), hubP[2] + cloudR * 0.55],
+      target: [hubP[0], hubP[1], hubP[2]],
+      fov: 56,
+      aperture: 0,
+      focalDistance: cloudR * 0.7,
+      ease: 'out',
+    },
+    // 2 — crane up and out: the whole constellation
+    {
+      duration: 1.3,
+      pos: [1.0, midY + cloudR * 1.2, cloudR * 1.7],
+      target: [0, midY, 0],
+      fov: 48,
+      transition: 'blend',
+      aperture: 0,
+      focalDistance: cloudR * 1.9,
+      ease: 'inout',
+    },
+  ];
+  // 3 — orbit tour while the network wires itself (duration covers the waves)
+  const orbitBeats = 3;
+  const orbitDur = Math.max(1.2, (wireDone - 2.3) / orbitBeats);
+  for (let k = 0; k < orbitBeats; k++) {
+    const theta = 1.5 + k * 1.4;
+    const dist = cloudR * 1.9;
+    shots.push({
+      duration: orbitDur,
+      pos: [Math.sin(theta) * dist, midY + 0.9 - k * 0.25, Math.cos(theta) * dist],
+      target: [0, midY, 0],
+      fov: 46,
+      transition: 'blend',
+      aperture: 0,
+      focalDistance: dist,
+      shake: 0.07,
+      ease: 'smooth',
+    });
+  }
+  // 4 — the super: hard cut punch-in on the hub/emphasis node
+  shots.push({
+    duration: 1.0,
+    pos: [gp[0] + 0.5, Math.max(gp[1] - 0.1, 0.14), gp[2] + 1.5],
+    target: [gp[0], gp[1] + 0.06, gp[2]],
+    fov: 40,
+    transition: 'cut',
+    aperture: 0,
+    focalDistance: 1.6,
+    shake: 0.3,
+    exposure: [1.45, 1.0],
+    ease: 'out',
+  });
+  // 5 — payoff pull-back
+  const payoffDist = (cloudR * 2.6 + 1.5) * (env ? env.payoffZoom : 1);
+  shots.push({
+    duration: 2.4,
+    pos: [1.4, midY + 1.2 + (env ? 0.5 : 0), payoffDist],
+    target: [0, midY, 0],
+    fov: 44,
+    transition: 'blend',
+    aperture: 0,
+    focalDistance: payoffDist,
+    ease: 'out',
+  });
+
+  // labels: reveal with each node's landing
+  const topYLabel = Math.max(...pos.map((p) => p[1]));
+  const overlay = [
+    {
+      text: String(ir.title || nodes[hub]).toUpperCase(),
+      anchor: [0, topYLabel + 1.2, 0],
+      role: 'title',
+    },
+  ];
+  for (let i = 0; i < N; i++) {
+    const p = pos[i];
+    overlay.push({
+      text: nodes[i],
+      anchor: [p[0] + nodeR(i) + 0.3, p[1], p[2]],
+      role: 'card',
+      align: 'left',
+      revealAt: nodeT0(i) + 0.6,
+    });
+  }
+
+  return {
+    v: 1,
+    name: `(network) ${ir.title || nodes[hub]}${env ? ' · alpine' : ''}`,
+    subjects: env ? [...subjects, ...env.subjects] : subjects,
+    overlay,
+    cameraSequence: { loop: false, shots },
+    defaults: env ? env.defaults : { stage: { size: [16, 12, 12] } },
+  };
+}

--- a/sdf-js/src/scene/render-sequence.js
+++ b/sdf-js/src/scene/render-sequence.js
@@ -4,6 +4,7 @@
 // subject that drops into place via a transform.translate.y smoothstep window, staggered
 // by order — needs the expr builtins from #193) + revealAt-tagged overlay labels.
 import { validateIR } from './ir.js';
+import { getEnvironment } from './environments.js';
 
 const label = (n) => (typeof n === 'string' ? n : (n && (n.label ?? n.name)) || '');
 
@@ -35,91 +36,10 @@ const stageMat = (i, N, emphasized) => {
   };
 };
 
-// ---- Environments -----------------------------------------------------------
-// The structure keeps its form/camera/labels in ANY environment; env only swaps
-// the WORLD around it (a renderer-axis choice, not an IR field — same IR renders
-// in the studio or on a mountainside). 'studio' = the neutral stage room.
-// 'alpine' = open snow-mountain world (terrain-elevated + snowy arch-bridge
-// backdrop + pines — the shipped snow-bridge recipe), warm low sun, film postFx.
-const SNOWY_STONE = { hue: 0.07, sat: 0.3, value: 0.62, metal: 0, glow: 0, kind: 'snowy' };
-const SNOWY_PINE = { hue: 0.3, sat: 0.55, value: 0.3, metal: 0, glow: 0, kind: 'snowy' };
-
-function alpineEnvironment() {
-  return {
-    subjects: [
-      {
-        id: 'env-terrain',
-        type: 'terrain-elevated',
-        args: { maxHeight: 35.0, scale: 0.035, ridgePower: 2.0, mountainness: 0.3 },
-        transform: { translate: [0, -8, 0] },
-      },
-      {
-        id: 'env-snow-base',
-        type: 'box',
-        args: { dims: [400, 0.4, 400] },
-        transform: { translate: [0, -7.9, 0] },
-        material: { hue: 0.6, sat: 0.04, value: 0.94, metal: 0, glow: 0, kind: 'snowy' },
-      },
-      // the hero backdrop: the snowy stone bridge, spanning the frame behind the funnel
-      {
-        id: 'env-bridge',
-        type: 'arch-bridge',
-        args: { bridgeLen: 30.0, bridgeWidth: 4.0, archH: 6.0, railH: 1.5, cornerOff: 10.0 },
-        transform: { translate: [0, -1.2, -16], rotate: [0, 1.5708, 0] },
-        material: SNOWY_STONE,
-      },
-      {
-        id: 'env-pine-L',
-        type: 'tree-pine',
-        args: { trunkHeight: 4.4, trunkRadius: 0.18, foliageRadius: 1.3 },
-        transform: { translate: [-9, -1.5, -4] },
-        material: SNOWY_PINE,
-      },
-      {
-        id: 'env-pine-R',
-        type: 'tree-pine',
-        args: { trunkHeight: 3.8, trunkRadius: 0.16, foliageRadius: 1.1 },
-        transform: { translate: [8, -1.5, -7] },
-        material: SNOWY_PINE,
-      },
-      {
-        id: 'env-pine-far',
-        type: 'tree-pine',
-        args: { trunkHeight: 5.0, trunkRadius: 0.2, foliageRadius: 1.6 },
-        transform: { translate: [-14, -1.5, -12] },
-        material: SNOWY_PINE,
-      },
-    ],
-    defaults: {
-      // static fallback only — the cameraSequence drives the actual camera
-      camera: {
-        yaw: 0,
-        pitch: -0.1,
-        distance: 10,
-        focal: 1.2,
-        targetX: 0,
-        targetY: 2,
-        targetZ: 0,
-      },
-      light: { azimuth: -0.6, altitude: 0.3, distance: 60, intensity: 1.15 },
-      shadow: { enabled: true, mode: 'darken', strength: 0.42 },
-      postFx: {
-        exposure: 1.05,
-        vignetteStrength: 0.4,
-        bloomMix: 0.22,
-        bloomThreshold: 0.85,
-        lensFlareStrength: 0.1,
-        motionBlurStrength: 0.45,
-      },
-    },
-    payoffZoom: 1.35, // pull the ending frame further back — reveal the world
-  };
-}
-
 export function renderSequence(ir, opts = {}) {
   const v = validateIR(ir);
   if (!v.ok) throw new Error(`renderSequence: invalid IR — ${v.errors.join('; ')}`);
-  const env = opts.env === 'alpine' ? alpineEnvironment() : null;
+  const env = getEnvironment(opts.env);
 
   const nodes = ir.nodes.map(label);
   const N = nodes.length;


### PR DESCRIPTION
## What — structures #2/#3/#4, one commit each (DO NOT MERGE until user returns)

The GO-validated pattern (funnel blind test) extended to the remaining three structures from the spec, each with its **native 3D form** + a **fighting-game camera variation** of the house five-beat grammar (hero → crane → tour → SUPER → payoff).

| structure | native 3D form | why 3D earns its existence | grammar variation |
|---|---|---|---|
| **hierarchy** | **cone tree** | siblings fan around the azimuth — no 2D level-crowding; depth = literal depth | boss-intro at the root; **tree grows floor by floor with the tour** |
| **network** | **constellation** | a whole extra axis to untangle the hairball; hubs deep, leaves at the shell; orbit turns parallax into structure | hero inside the cloud; **the network wires itself** (nodes cascade, then edges land in waves — test-asserted ordering) |
| **magnitude** | **monolith row** | camera walks AMONG the quantities — the tallest towers over you (body-scale read) | **character-select tracking shot**; monoliths ERUPT from the ground as the camera passes; super = worm's-eye up the champion |

## Shared infrastructure

- `renderIR` dispatcher (`render-ir.js`) — figure page renders ANY structure via `?ir=`.
- `environments.js` extracted — the alpine world now works for every structure (`&env=alpine`).
- IR grows per structure with validation: `hierarchy` (relations + exactly one root), `network` (edges, no self-loops), `magnitude` (magnitude required).
- All layouts **deterministic** (golden-angle seed + fixed-iteration relaxation for the constellation; recursive cone placement; row arithmetic) — same IR → same scene, test-asserted.
- Honest-encoding invariants tested: monolith heights linear in magnitude, equal footprints.

## Verified

59 new tests across the three slices (24 + 18 + 17); full suite **118/118**; lint clean. In-browser captures: cone-tree crane close-up + payoff (9 labels tracking, 3D fan visible), constellation payoff (gold hub central, shadows reading the layout), monolith super (worm's-eye up the gold champion) + skyline payoff.

## Try

- `apps/present/figure.html?ir=org-tree` — cone tree
- `apps/present/figure.html?ir=ecosystem` — constellation
- `apps/present/figure.html?ir=revenue-regions` — monolith row
- append `&env=alpine` to any of them

🤖 Generated with [Claude Code](https://claude.com/claude-code)