### PR TITLE
Sprint 26 round 3: fix 12 P1 atoms from visual scorecard

### DIFF
--- a/docs/superpowers/atom-visual-scorecard.md
+++ b/docs/superpowers/atom-visual-scorecard.md
@@ -22,22 +22,25 @@ args 渲染全部 101 atom (640×360, editorial-light palette), 9 chunk 截图,
 | `mindmap` | 固定半径常量(36/22/14)+ 保守 maxRadius 改成按 80% 可用半径动态计算; 分支/叶子节点缩成小圆点, label 移到圆外(沿节点相对根节点的角度径向偏移, 按左右自动切 textAlign), 字号 10px 下限自动收缩; 根节点保留内嵌 label 但改 auto-shrink 不再 ellipsis 截断。 |
 | `matrix-grid` + `nine-field-matrix` | 拆分 `drawCell` → `drawCellBg` + `drawCellLabel`, 渲染顺序改成: 背景 → 轴 → bubbles(半透明 fill α=0.32 + 实线描边)→ cell label(现在总在 bubble 之上)→ bubble 自己的 label 移到泡外(右下偏移, 避开 cell label 的水平中线), 深色小字。 |
 
-## 🟡 P1 — 中等 (round 3 候选)
+## ✅ Fixed in round 3 (2026-07-05)
 
-| atom | 问题 |
+全部 12 个 P1 已修复, 每项均重渲 gallery + 多模态截图确认。详见各 commit message
+(branch `sprint-26-round3-p1-atoms`)。
+
+| atom | 修了什么 |
 |---|---|
-| `stat-banner` | trend chip 与 label 文本重叠 ("Annual Recurring Revenue" 被 "+117% YoY" 压住尾部) |
-| `flow-chart` | 节点 label 截断 ("Onboard" / "Purchas") — 需 auto-shrink |
-| `timeline` | 首卡片左边缘裁切 ("eed Round") |
-| `icon-grid` | 4 item 换行后第 1 行 label 被第 2 行圆遮住 ("Security" 藏在 "Care" 圆后) |
-| `funnel` | 级间 % chip 一半藏在梯形后 ("↓ 88%" 只露一半) |
-| `fishbone` | 左侧枝 label 出画布 ("nel mix" 被裁) |
-| `isotype-stat-comparison` | 图标行挤压变形, "FUll-time" 大小写渲染错误 |
-| `bullet-list` | 空心圆环 bullet 视觉未完成感; 行间距过大留白多 |
-| `bubble` | 气泡内 label 不可读 (深底深字), 图表稀疏 |
-| `infinity-loop-flow` | 节点/loop 挤在中心, 画布利用率 <30% |
-| `relationship-graph` | 3 节点偏下, 大片死区; "uses" 边标签过小 |
-| `org-vs-org-matrix` | org label 太小, "Acme (us)" 在气泡内难读, 右半象限灰底对比不足 |
+| `stat-banner` | chip 尺寸/位置先算, label 用 `fitLabelSize` 自动收缩(min 11px)让出 chip 空间; 收缩到底仍撞则把 chip 挪到右上角、label 独占整行。 |
+| `flow-chart` | 节点 label 加 `fitFontSize` 自动收缩(min 9px), 缩到底仍放不下则换行到 2 行, 不再截断("Onboard"/"Purchase" 现在完整显示)。 |
+| `timeline` | 卡片中心 x 夹在 `[x+PAD+half, x+w-PAD-half]` 内, 首/末卡片向内挤而不是居中裁切; connector 线随之变成斜线。 |
+| `icon-grid` | icon 半径/字号改为基于列宽(不再基于行高, 消除循环依赖); row pitch 取 `max(均分高度, 实测 label+sublabel 内容高度)`; 若整体仍溢出画布则统一按比例缩小 icon+字号+间距。 |
+| `funnel` | 几何先算好, 分两遍绘制(全部梯形→全部 label/chip), chip 加白底+描边, 消除"后画的梯形盖住前一个 gap 的 chip"问题。 |
+| `fishbone` | sub-cause label 右对齐锚点若会越过画布左边界, 改锚到更靠近脊柱的分支点; branch label 锚点同样夹在画布内。 |
+| `isotype-stat-comparison` | mini icon 上限 30→20, 超出显示"×N"比例注记替代省略号; icon 行与 label 之间预留间距; caption 加粗+提高不透明度提升可读性(代码审计未发现真实大小写 bug, "FUll-time" 是小字号误读)。 |
+| `bullet-list` | 无 `status` 的默认项渲染成实心 accent 圆点(不再默认走 hollow ring); hollow ring 保留给显式 `status:'todo'`; row pitch 收紧 ~15% 并整体居中。 |
+| `bubble` | label 一律移到气泡外(右侧偏移+深色字); 气泡改半透明填充+实线描边(不再需要装深色底托白字); 最小半径提到 14px。 |
+| `infinity-loop-flow` | 发现节点 t 值分布 bug: n=4(最常见 step 数)时全部落在 π/2 整数倍上, 导致两个节点重叠在中心("Plan" 被"Measure"完全遮住); 加半步偏移修复。同时半轴目标改为画布宽高的 ~70%, 节点/字号按画布尺寸缩放。 |
+| `relationship-graph` | 圆形布局按角度均分对小 N 不对称(3 节点=1 上 2 下), 改为算出真实 bbox 后居中+缩放到可用区域 ~85%; 边标签 10px→11px 并加白色描边光晕。 |
+| `org-vs-org-matrix` | 所有 org label 统一深色(之前 isUs 用白字, 但位置早已在气泡外, 白字对亮背景几乎不可见); 字号下限提到 12px; 4 个象限改成 4 种不同色相的淡色调(之前 3 个象限共用同一种灰, 只有右上象限略深)。 |
 
 ## 🟢 P2 — 小瑕疵 (顺手修)
 
@@ -58,5 +61,5 @@ args 渲染全部 101 atom (640×360, editorial-light palette), 9 chunk 截图,
 ## 状态
 
 - [x] Round 2: P0 × 7 (2026-07-05, branch `sprint-26-round2-p0-atoms`)
-- [ ] Round 3: P1 × 12
+- [x] Round 3: P1 × 12 (2026-07-05, branch `sprint-26-round3-p1-atoms`)
 - [ ] Round 4: P2 清尾 + 复审全量

--- a/sdf-js/src/present/atoms-2d/charts/data/bubble.js
+++ b/sdf-js/src/present/atoms-2d/charts/data/bubble.js
@@ -41,8 +41,9 @@ export const spec = {
 
 const PAD = 14;
 const AXIS_LABEL_GUTTER = 28;
-// Label is drawn inside the bubble when radius is at least this many pixels
-const INSIDE_LABEL_THRESHOLD = 20;
+// Slightly larger min bubble radius so small-size points don't shrink to
+// near-invisible dots (a sparse-looking chart with barely-there bubbles).
+const MIN_RADIUS = 14;
 
 export function drawPseudo3D(ctx, args, opts = {}) {
   const x = opts.x ?? 0;
@@ -110,8 +111,9 @@ export function drawPseudo3D(ctx, args, opts = {}) {
   for (const { p, i } of sorted) {
     const px = plotL + clamp(Number(p.x) || 0, 0, 1) * plotW;
     const py = plotB - clamp(Number(p.y) || 0, 0, 1) * plotH;
-    const radius = clamp(Number(p.size) || 0, 0, 1) * sizeScale;
-    if (radius < 1) continue;
+    const sizeNorm = clamp(Number(p.size) || 0, 0, 1);
+    if (sizeNorm <= 0) continue;
+    const radius = Math.max(MIN_RADIUS, sizeNorm * sizeScale);
 
     const color = p.color ? p.color : baseColors[i % baseColors.length];
 
@@ -121,18 +123,30 @@ export function drawPseudo3D(ctx, args, opts = {}) {
     ctx.shadowBlur = radius * 0.6;
     ctx.shadowOffsetY = radius * 0.25;
 
-    // Pseudo-3D radial gradient: lighter toward top-left
+    // Semi-transparent fill with a solid stroke — labels now always render
+    // OUTSIDE the bubble (dark-on-light background), so the fill no longer
+    // needs to be dark/opaque enough to host white text; a lighter,
+    // see-through fill + a crisp solid outline reads better against any bg.
     const glowX = px - radius * 0.32;
     const glowY = py - radius * 0.32;
     const grad = ctx.createRadialGradient(glowX, glowY, 0, px, py, radius);
-    grad.addColorStop(0, rgbaCss(lighten(color, 0.45), 0.9));
-    grad.addColorStop(0.5, rgbaCss(color, 0.82));
-    grad.addColorStop(1, rgbaCss(darken(color, 0.2), 0.78));
+    grad.addColorStop(0, rgbaCss(lighten(color, 0.45), 0.55));
+    grad.addColorStop(0.5, rgbaCss(color, 0.42));
+    grad.addColorStop(1, rgbaCss(darken(color, 0.1), 0.38));
     ctx.fillStyle = grad;
 
     ctx.beginPath();
     ctx.arc(px, py, radius, 0, Math.PI * 2);
     ctx.fill();
+    ctx.restore();
+
+    // Solid stroke outline
+    ctx.save();
+    ctx.strokeStyle = rgbCss(color);
+    ctx.lineWidth = 2;
+    ctx.beginPath();
+    ctx.arc(px, py, radius, 0, Math.PI * 2);
+    ctx.stroke();
     ctx.restore();
 
     // Subtle specular highlight — small white circle at top-left
@@ -150,39 +164,33 @@ export function drawPseudo3D(ctx, args, opts = {}) {
     ctx.fill();
     ctx.restore();
 
-    // Label rendering
+    // Label rendering — ALWAYS outside the bubble (dark text, right offset).
+    // Previously large bubbles centered a white label INSIDE the fill, but
+    // the fill is a mid-tone accent color, not dark, so white-on-accent
+    // often read as illegible "dark on dark" (esp. with darker palettes).
     if (p.label) {
       const label = String(p.label);
-      const fontSize = Math.round(Math.max(10, Math.min(radius * 0.55, h * 0.038)));
+      const fontSize = Math.round(Math.max(11, Math.min(radius * 0.4, h * 0.036)));
       ctx.font = `600 ${fontSize}px Inter, system-ui, sans-serif`;
 
-      if (radius >= INSIDE_LABEL_THRESHOLD) {
-        // Label centered inside bubble
-        ctx.fillStyle = rgbaCss([255, 255, 255], 0.9);
-        ctx.textAlign = 'center';
-        ctx.textBaseline = 'middle';
-        ctx.fillText(label, px, py);
-      } else {
-        // Label outside with a short leader line
-        const offsetX = radius + 6;
-        const labelX = px + offsetX;
-        const labelY = py;
+      const offsetX = radius + 6;
+      const labelX = px + offsetX;
+      const labelY = py;
 
-        // Leader line
-        ctx.save();
-        ctx.strokeStyle = rgbaCss(fg, 0.35);
-        ctx.lineWidth = 1;
-        ctx.beginPath();
-        ctx.moveTo(px + radius, py);
-        ctx.lineTo(px + radius + 4, py);
-        ctx.stroke();
-        ctx.restore();
+      // Leader line
+      ctx.save();
+      ctx.strokeStyle = rgbaCss(fg, 0.35);
+      ctx.lineWidth = 1;
+      ctx.beginPath();
+      ctx.moveTo(px + radius, py);
+      ctx.lineTo(px + radius + 4, py);
+      ctx.stroke();
+      ctx.restore();
 
-        ctx.fillStyle = rgbaCss(fg, 0.8);
-        ctx.textAlign = 'left';
-        ctx.textBaseline = 'middle';
-        ctx.fillText(label, labelX, labelY);
-      }
+      ctx.fillStyle = rgbaCss(fg, 0.85);
+      ctx.textAlign = 'left';
+      ctx.textBaseline = 'middle';
+      ctx.fillText(label, labelX, labelY);
     }
   }
 

--- a/sdf-js/src/present/atoms-2d/charts/data/funnel.js
+++ b/sdf-js/src/present/atoms-2d/charts/data/funnel.js
@@ -106,13 +106,28 @@ export function drawPseudo3D(ctx, args, opts = {}) {
     return [maxW + (minW - maxW) * t0, maxW + (minW - maxW) * t1];
   };
 
+  // Compute geometry for every stage up front, then draw in TWO passes:
+  // all trapezoids first, then all labels/value columns/drop-rate chips on
+  // top. Previously each stage's trapezoid was drawn interleaved with the
+  // *previous* gap's drop-rate chip, so stage i+1's trapezoid (painted right
+  // after the i→i+1 chip) silently overdrew the bottom half of that chip —
+  // the tiny STAGE_GAP (6px) is smaller than the chip's own text height, so
+  // chips always bled into the neighboring trapezoid ("↓ 88%" half-hidden).
+  const geoms = [];
   for (let i = 0; i < n; i++) {
     const [wTop, wBot] = widthAt(i);
     const topEdgeY = topY + i * (stageH + STAGE_GAP);
     const botEdgeY = topEdgeY + stageH;
-    const color = makeStageColor(i);
-    drawStage(ctx, cx, topEdgeY, botEdgeY, wTop, wBot, color);
+    geoms.push({ wTop, wBot, topEdgeY, botEdgeY, color: makeStageColor(i) });
+  }
 
+  for (let i = 0; i < n; i++) {
+    const { wTop, wBot, topEdgeY, botEdgeY, color } = geoms[i];
+    drawStage(ctx, cx, topEdgeY, botEdgeY, wTop, wBot, color);
+  }
+
+  for (let i = 0; i < n; i++) {
+    const { topEdgeY, botEdgeY } = geoms[i];
     // Label + value + percentage inside stage
     const labelText = stages[i].label || '';
     const valueText = stages[i].value != null ? formatValue(stages[i].value, format) : '';
@@ -162,19 +177,39 @@ export function drawPseudo3D(ctx, args, opts = {}) {
       ctx.fillText(valueText, cx + plotW / 2 + 12, stageCy);
     }
 
-    // Drop-rate annotation between stages: "↓ XX%" in Inter 500 italic, small
+    // Drop-rate annotation between stages: "↓ XX%" chip, drawn in this final
+    // pass (after ALL trapezoids) so it always sits on top, with a white
+    // chip bg + hairline border so it reads against any stage color.
     if (i < n - 1 && stages[i].value != null && stages[i + 1].value != null) {
       const dropPct = Math.round((1 - Number(stages[i + 1].value) / Number(stages[i].value)) * 100);
       if (!isNaN(dropPct)) {
         const gapY = botEdgeY + STAGE_GAP / 2;
-        ctx.fillStyle = rgbaCss(fg, 0.45);
-        ctx.font = `500 italic ${Math.min(10, stageH * 0.2)}px Inter, system-ui, sans-serif`;
-        ctx.textAlign = 'center';
-        ctx.textBaseline = 'middle';
-        ctx.fillText(`↓ ${dropPct}%`, cx, gapY);
+        drawDropChip(ctx, cx, gapY, `↓ ${dropPct}%`, fg);
       }
     }
   }
+}
+
+function drawDropChip(ctx, cx, cy, text, fg) {
+  const fontSize = 10;
+  ctx.save();
+  ctx.font = `700 ${fontSize}px Inter, system-ui, sans-serif`;
+  const padX = 7;
+  const padY = 3;
+  const chipW = ctx.measureText(text).width + padX * 2;
+  const chipH = fontSize + padY * 2;
+  ctx.fillStyle = 'rgba(255,255,255,0.95)';
+  ctx.strokeStyle = rgbaCss(fg, 0.2);
+  ctx.lineWidth = 1;
+  ctx.beginPath();
+  ctx.roundRect(cx - chipW / 2, cy - chipH / 2, chipW, chipH, chipH / 2);
+  ctx.fill();
+  ctx.stroke();
+  ctx.fillStyle = rgbaCss(fg, 0.8);
+  ctx.textAlign = 'center';
+  ctx.textBaseline = 'middle';
+  ctx.fillText(text, cx, cy + 0.5);
+  ctx.restore();
 }
 
 function drawStage(ctx, cx, topY, botY, wTop, wBot, color) {

--- a/sdf-js/src/present/atoms-2d/charts/data/isotype-stat-comparison.js
+++ b/sdf-js/src/present/atoms-2d/charts/data/isotype-stat-comparison.js
@@ -60,7 +60,10 @@ export const SAMPLES = [
 ];
 
 const PAD = 20;
-const ICON_MINI_MAX = 30;
+// Capped lower than the old 30 — at high counts (e.g. 100) the mini icons
+// squished down to unrecognizable slivers within the fixed miniIconAreaW.
+// Above the cap we show a "×N" ratio note instead of drawing more icons.
+const ICON_MINI_MAX = 20;
 
 export function drawPseudo3D(ctx, args, opts = {}) {
   const x = opts.x ?? 0;
@@ -99,11 +102,12 @@ export function drawPseudo3D(ctx, args, opts = {}) {
   // Min/max row height guards
   const effectiveRowH = Math.max(40, Math.min(120, rowH));
 
-  // Layout: [count col] [single icon] [mini icons row] [label col]
+  // Layout: [count col] [single icon] [mini icons row] [gap] [label col]
   const countColW = Math.round(w * 0.18);
   const singleIconW = Math.round(w * 0.1);
   const labelColW = Math.round(w * 0.22);
-  const miniIconAreaW = w - PAD * 2 - countColW - singleIconW - labelColW;
+  const labelGap = 14; // breathing room so mini icons never touch the label text
+  const miniIconAreaW = w - PAD * 2 - countColW - singleIconW - labelColW - labelGap;
   const miniIconStartX = x + PAD + countColW + singleIconW;
 
   for (let i = 0; i < stats.length; i++) {
@@ -146,16 +150,27 @@ export function drawPseudo3D(ctx, args, opts = {}) {
     drawPhosphorIcon(ctx, iconName, iconX, iconY, iconSize, accent);
 
     // --- Mini icon row ---
+    // Cap at ICON_MINI_MAX so icons never squish into unrecognizable
+    // slivers at high counts; when capped, show a "×N" ratio note (each
+    // icon represents N units) instead of an ambiguous ellipsis.
     const displayCount = Math.min(count, ICON_MINI_MAX);
-    const showEllipsis = count > ICON_MINI_MAX;
+    const isCapped = count > ICON_MINI_MAX;
+    const ratioText = isCapped ? `×${Math.max(2, Math.round(count / ICON_MINI_MAX))}` : '';
+    const ratioFontSize = Math.round(effectiveRowH * 0.22);
 
     if (displayCount > 0) {
+      ctx.save();
+      ctx.font = `700 ${ratioFontSize}px Inter, system-ui, sans-serif`;
+      const ratioW = ratioText ? ctx.measureText(ratioText).width + 8 : 0;
+      ctx.restore();
+
+      const usableW = miniIconAreaW - ratioW;
       const miniSize = Math.min(
         Math.round(effectiveRowH * 0.32),
-        Math.round((miniIconAreaW - (showEllipsis ? 20 : 0)) / displayCount),
+        Math.round(usableW / displayCount),
       );
       const miniSize2 = Math.max(8, Math.min(miniSize, 24));
-      const miniGap = Math.min(miniSize2 * 1.2, miniIconAreaW / displayCount);
+      const miniGap = Math.min(miniSize2 * 1.2, usableW / displayCount);
 
       for (let j = 0; j < displayCount; j++) {
         const mx = miniIconStartX + j * miniGap;
@@ -163,13 +178,13 @@ export function drawPseudo3D(ctx, args, opts = {}) {
         drawPhosphorIcon(ctx, iconName, mx, my, miniSize2, accent, 0.7);
       }
 
-      if (showEllipsis) {
+      if (ratioText) {
         ctx.save();
-        ctx.fillStyle = rgbaCss(fg, 0.5);
-        ctx.font = `600 ${Math.round(effectiveRowH * 0.28)}px Inter, system-ui, sans-serif`;
+        ctx.fillStyle = rgbaCss(fg, 0.55);
+        ctx.font = `700 ${ratioFontSize}px Inter, system-ui, sans-serif`;
         ctx.textAlign = 'left';
         ctx.textBaseline = 'middle';
-        ctx.fillText('…', miniIconStartX + displayCount * miniGap + 2, rowMidY);
+        ctx.fillText(ratioText, miniIconStartX + displayCount * miniGap + 4, rowMidY);
         ctx.restore();
       }
     }
@@ -184,8 +199,8 @@ export function drawPseudo3D(ctx, args, opts = {}) {
     ctx.fillText(label, labelX, caption ? rowMidY - 1 : rowMidY);
 
     if (caption) {
-      ctx.fillStyle = rgbaCss(fg, 0.5);
-      ctx.font = `500 ${Math.round(effectiveRowH * 0.24)}px Inter, system-ui, sans-serif`;
+      ctx.fillStyle = rgbaCss(fg, 0.6);
+      ctx.font = `600 ${Math.round(effectiveRowH * 0.24)}px Inter, system-ui, sans-serif`;
       ctx.textBaseline = 'top';
       ctx.fillText(caption, labelX, rowMidY + 2);
     }

--- a/sdf-js/src/present/atoms-2d/charts/data/stat-banner.js
+++ b/sdf-js/src/present/atoms-2d/charts/data/stat-banner.js
@@ -76,19 +76,69 @@ export function drawPseudo3D(ctx, args, opts = {}) {
   const labelPad = PAD * 1.5;
   const labelX = x + PAD + valueW + labelPad;
 
-  // Label — smaller, middle
-  const labelFontSize = Math.round(bannerH * 0.2);
-  const labelAvailW = trend ? w * 0.45 : w - (labelX - x) - PAD;
+  // Trend chip metrics computed FIRST (chip size only depends on trend text,
+  // not on the label) so the label can reserve exactly the space that's left
+  // over — previously labelAvailW was a fixed w*0.45 guess that had no
+  // relation to the chip's actual width/position, so long labels ("Annual
+  // Recurring Revenue") ran straight under the chip.
+  const chipPad = 10;
+  const chipFontSize = Math.round(bannerH * 0.2);
+  const chipGap = PAD * 0.6;
+  let chipW = 0;
+  let chipH = 0;
+  if (trend) {
+    ctx.save();
+    ctx.font = `700 ${chipFontSize}px Inter, system-ui, sans-serif`;
+    chipW = ctx.measureText(trend).width + chipPad * 2.5;
+    chipH = chipFontSize * 1.8;
+    ctx.restore();
+  }
 
-  // word-wrap label to fit
-  ctx.save();
-  ctx.font = `500 ${labelFontSize}px Inter, system-ui, sans-serif`;
-  const labelLines = wrapText(ctx, label, labelAvailW, 2);
-  ctx.restore();
+  // Label — smaller, middle. Shrink font (down to labelMinFs) until it fits
+  // the space before the chip; if it STILL doesn't fit at min size, fall
+  // back to moving the chip to the top-right corner (above the label) so
+  // the label can reclaim the full row width.
+  const labelTarget = Math.round(bannerH * 0.2);
+  const labelMinFs = 11;
+  const inlineAvailW = trend ? x + w - PAD - chipW - chipGap - labelX : w - (labelX - x) - PAD;
+
+  let { fs: labelFontSize, lines: labelLines } = fitLabelSize(
+    ctx,
+    label,
+    inlineAvailW,
+    labelTarget,
+    labelMinFs,
+    2,
+  );
+
+  let chipMode = 'inline';
+  if (trend) {
+    ctx.save();
+    ctx.font = `500 ${labelFontSize}px Inter, system-ui, sans-serif`;
+    const stillOverlaps = labelLines.some((l) => ctx.measureText(l).width > inlineAvailW);
+    ctx.restore();
+    if (stillOverlaps) {
+      chipMode = 'top-right';
+      const fullAvailW = w - (labelX - x) - PAD;
+      ({ fs: labelFontSize, lines: labelLines } = fitLabelSize(
+        ctx,
+        label,
+        fullAvailW,
+        labelTarget,
+        labelMinFs,
+        2,
+      ));
+    }
+  }
 
   const lineH = labelFontSize * 1.3;
   const labelBlockH = labelLines.length * lineH;
-  const labelTop = cy - labelBlockH / 2;
+  const topPad = 6;
+  const chipYInline = cy - chipH / 2;
+  const labelTop =
+    chipMode === 'top-right'
+      ? Math.max(cy - labelBlockH / 2, bannerY + topPad + chipH + 6)
+      : cy - labelBlockH / 2;
 
   ctx.save();
   ctx.fillStyle = 'rgba(255,255,255,0.85)';
@@ -100,21 +150,17 @@ export function drawPseudo3D(ctx, args, opts = {}) {
   });
   ctx.restore();
 
-  // Trend chip — right-aligned
+  // Trend chip — right-aligned; inline (vertically centered) unless the
+  // label collided even at min font size, in which case it moves to the
+  // top-right corner, above the label line.
   if (trend) {
-    const chipPad = 10;
-    const chipFontSize = Math.round(bannerH * 0.2);
     const chipBg = dir === 'up' ? [50, 200, 130] : dir === 'down' ? [220, 80, 60] : [140, 155, 170];
     const chipText = trend;
-
-    ctx.save();
-    ctx.font = `700 ${chipFontSize}px Inter, system-ui, sans-serif`;
-    const chipW = ctx.measureText(chipText).width + chipPad * 2.5;
-    const chipH = chipFontSize * 1.8;
     const chipX = x + w - PAD - chipW;
-    const chipY = cy - chipH / 2;
+    const chipY = chipMode === 'top-right' ? bannerY + topPad : chipYInline;
     const chipR = chipH / 2;
 
+    ctx.save();
     // Rounded pill
     ctx.fillStyle = rgbCss(chipBg);
     ctx.beginPath();
@@ -130,9 +176,27 @@ export function drawPseudo3D(ctx, args, opts = {}) {
     ctx.font = `700 ${chipFontSize}px Inter, system-ui, sans-serif`;
     ctx.textAlign = 'center';
     ctx.textBaseline = 'middle';
-    ctx.fillText(chipText, chipX + chipW / 2, cy);
+    ctx.fillText(chipText, chipX + chipW / 2, chipY + chipH / 2);
     ctx.restore();
   }
+}
+
+// Auto-shrink label font size (down to minFs) until wrapText produces lines
+// that all fit within maxW without dropping words. Returns { fs, lines }.
+function fitLabelSize(ctx, label, maxW, targetFs, minFs, maxLines) {
+  const totalWords = String(label).split(/\s+/).filter(Boolean).length;
+  let best = null;
+  for (let fs = targetFs; fs >= minFs; fs--) {
+    ctx.save();
+    ctx.font = `500 ${fs}px Inter, system-ui, sans-serif`;
+    const lines = wrapText(ctx, label, maxW, maxLines);
+    const allFit = lines.every((l) => ctx.measureText(l).width <= maxW);
+    const consumedWords = lines.join(' ').split(/\s+/).filter(Boolean).length;
+    ctx.restore();
+    best = { fs, lines };
+    if (allFit && consumedWords >= totalWords) return best;
+  }
+  return best;
 }
 
 function wrapText(ctx, text, maxW, maxLines) {

--- a/sdf-js/src/present/atoms-2d/charts/diagrams/fishbone.js
+++ b/sdf-js/src/present/atoms-2d/charts/diagrams/fishbone.js
@@ -154,12 +154,15 @@ export function drawPseudo3D(ctx, args, opts = {}) {
     ctx.stroke();
     ctx.restore();
 
-    // Branch label at rib end — Inter 700, slightly larger
+    // Branch label at rib end — Inter 700, slightly larger. Left-aligned so
+    // it grows rightward from the anchor; clamp the anchor itself so it
+    // never starts left of the canvas edge.
     ctx.fillStyle = rgbCss(fg);
     ctx.font = `700 ${Math.round(h * 0.046)}px Inter, system-ui, sans-serif`;
     ctx.textAlign = 'left';
     ctx.textBaseline = up ? 'bottom' : 'top';
-    ctx.fillText(String(b.label || ''), ribEndX - 12, ribEndY + (up ? -8 : 8));
+    const labelAnchorX = Math.max(x + 4, ribEndX - 12);
+    ctx.fillText(String(b.label || ''), labelAnchorX, ribEndY + (up ? -8 : 8));
 
     // Sub-causes — short stems off the rib with better spacing
     const causes = Array.isArray(b.causes) ? b.causes.slice(0, 4) : [];
@@ -184,12 +187,24 @@ export function drawPseudo3D(ctx, args, opts = {}) {
         ctx.stroke();
         ctx.restore();
 
-        // Sub-cause text — Inter 500, small, with gap from stem
+        // Sub-cause text — Inter 500, small, with gap from stem. Right-aligned
+        // ending at the stem tip (text grows LEFTWARD from there), which for
+        // left-most branches ran the text's left edge past the canvas edge
+        // ("Channel mix" → "nel mix", "Chan" clipped off-canvas). Clamp: if
+        // the natural right-aligned position would overflow left, right-align
+        // to the branch point (stemBaseX, closer to the spine) instead.
         ctx.fillStyle = rgbaCss(fg, 0.72);
         ctx.font = `500 ${Math.round(h * 0.032)}px Inter, system-ui, sans-serif`;
         ctx.textAlign = 'right';
         ctx.textBaseline = 'middle';
-        ctx.fillText(String(causes[j]), stemEndX - 6, stemEndY);
+        const causeText = String(causes[j]);
+        const causeTextW = ctx.measureText(causeText).width;
+        const canvasLeft = x + 4;
+        let causeAnchorX = stemEndX - 6;
+        if (causeAnchorX - causeTextW < canvasLeft) {
+          causeAnchorX = Math.max(causeAnchorX, stemBaseX - 6, canvasLeft + causeTextW);
+        }
+        ctx.fillText(causeText, causeAnchorX, stemEndY);
       }
     }
   }

--- a/sdf-js/src/present/atoms-2d/charts/diagrams/flow-chart.js
+++ b/sdf-js/src/present/atoms-2d/charts/diagrams/flow-chart.js
@@ -191,21 +191,77 @@ function drawNode(ctx, nx, ny, nw, nh, idx, label, sublabel, isHighlight, colorC
   ctx.textBaseline = 'middle';
   ctx.fillText(String(idx), circleCx, circleCy + 1);
 
-  // Label — Inter 700 white, centered in remaining space, with generous inner padding
+  // Label — Inter 700 white, centered in remaining space, with generous inner
+  // padding. Auto-shrink to fit the node's width (min 9px); if even the min
+  // size doesn't fit, wrap to 2 lines instead of letting it run off/get
+  // clipped ("Onboard" / "Purchas" truncation).
   const textX = nx + circleR * 2 + NODE_PADDING;
-  const textY = ny + nh / 2;
+  const maxTextW = nx + nw - textX - NODE_PADDING * 0.5;
+  const targetFs = Math.min(15, nh * 0.22);
+  const minFs = 9;
+  const labelStr = String(label);
+  const labelFs = fitFontSize(
+    ctx,
+    labelStr,
+    maxTextW,
+    targetFs,
+    minFs,
+    (fs) => `700 ${fs}px Inter, system-ui, sans-serif`,
+  );
+  ctx.font = `700 ${labelFs}px Inter, system-ui, sans-serif`;
+  let labelLines = [labelStr];
+  if (ctx.measureText(labelStr).width > maxTextW) {
+    labelLines = wrapText(ctx, labelStr, maxTextW, 2);
+  }
+
+  const labelLineH = labelFs * 1.15;
+  const subFs = Math.min(12, nh * 0.16);
+  const blockH = labelLines.length * labelLineH + (sublabel ? subFs * 1.3 + 2 : 0);
+  const blockTop = ny + nh / 2 - blockH / 2;
+
   ctx.fillStyle = 'rgba(255,255,255,0.97)';
-  ctx.font = `700 ${Math.min(15, nh * 0.22)}px Inter, system-ui, sans-serif`;
+  ctx.font = `700 ${labelFs}px Inter, system-ui, sans-serif`;
   ctx.textAlign = 'left';
-  ctx.textBaseline = sublabel ? 'bottom' : 'middle';
-  ctx.fillText(String(label), textX, sublabel ? textY : textY + 1);
+  ctx.textBaseline = 'top';
+  labelLines.forEach((line, i) => {
+    ctx.fillText(line, textX, blockTop + i * labelLineH);
+  });
 
   if (sublabel) {
     ctx.fillStyle = 'rgba(255,255,255,0.7)';
-    ctx.font = `500 ${Math.min(12, nh * 0.16)}px Inter, system-ui, sans-serif`;
-    ctx.textBaseline = 'top';
-    ctx.fillText(String(sublabel), textX, textY + 4);
+    ctx.font = `500 ${subFs}px Inter, system-ui, sans-serif`;
+    ctx.fillText(String(sublabel), textX, blockTop + labelLines.length * labelLineH + 2);
   }
+}
+
+// Auto-shrink font size until text fits in maxW. Returns the font-size that
+// fits (or minFs if nothing fits). Caller still must ctx.font = ... after.
+function fitFontSize(ctx, text, maxW, targetFs, minFs, fontSpec) {
+  let fs = targetFs;
+  while (fs > minFs) {
+    ctx.font = fontSpec(fs);
+    if (ctx.measureText(text).width <= maxW) return fs;
+    fs--;
+  }
+  return minFs;
+}
+
+function wrapText(ctx, text, maxW, maxLines) {
+  const words = String(text).split(/\s+/);
+  const lines = [];
+  let cur = '';
+  for (const word of words) {
+    const test = cur ? cur + ' ' + word : word;
+    if (ctx.measureText(test).width > maxW && cur) {
+      lines.push(cur);
+      if (lines.length >= maxLines) break;
+      cur = word;
+    } else {
+      cur = test;
+    }
+  }
+  if (cur && lines.length < maxLines) lines.push(cur);
+  return lines;
 }
 
 function drawArrow(ctx, x0, y0, x1, y1, color) {

--- a/sdf-js/src/present/atoms-2d/charts/diagrams/infinity-loop-flow.js
+++ b/sdf-js/src/present/atoms-2d/charts/diagrams/infinity-loop-flow.js
@@ -114,11 +114,19 @@ export function drawPseudo3D(ctx, args, opts = {}) {
   const cx = x + w / 2;
   const cy = plotTop + plotH / 2;
 
-  // Semi-axes: keep nodes inside canvas with padding for node rect half-size
-  const halfNodeW = NODE_W / 2 + 6;
-  const halfNodeH = NODE_H / 2 + 6;
-  const a = Math.min(w / 2 - halfNodeW - PAD, (w / 2) * 0.42);
-  const b = Math.min(plotH / 2 - halfNodeH - PAD, (plotH / 2) * 0.72);
+  // Node pills scale with canvas size (previously a fixed 84x34 regardless
+  // of h — on a large canvas that read as tiny relative to everything else).
+  const nodeScale = Math.max(0.9, Math.min(2.2, h / 300));
+  const nodeW = NODE_W * nodeScale;
+  const nodeH = NODE_H * nodeScale;
+
+  // Semi-axes: target the loop spanning ~70% of canvas width/height
+  // (previously capped at 0.42/0.72 of the HALF-extent, i.e. the loop only
+  // used well under 30% of the canvas), clamped so nodes stay inside canvas.
+  const halfNodeW = nodeW / 2 + 6;
+  const halfNodeH = nodeH / 2 + 6;
+  const a = Math.min(w / 2 - halfNodeW - PAD, w * 0.35);
+  const b = Math.min(plotH / 2 - halfNodeH - PAD, plotH * 0.35);
 
   // ---- Draw infinity curve ----
   ctx.save();
@@ -138,9 +146,14 @@ export function drawPseudo3D(ctx, args, opts = {}) {
   ctx.restore();
 
   // ---- Compute step node positions ----
-  // Distribute n nodes evenly, starting at t = π/2 so first node is at
-  // top of left lobe (visually intuitive start for left-to-right reading).
-  const startT = Math.PI / 2;
+  // Distribute n nodes evenly. The lemniscate passes through the center
+  // (self-intersection point) TWICE per full loop, at t = π/2 and t = 3π/2 —
+  // starting exactly at t = π/2 with a step of 2π/n means that whenever n
+  // divides 4 evenly (n=4 is the most common step count!), every sampled t
+  // lands exactly on a multiple of π/2, so TWO nodes get placed on top of
+  // each other at dead-center and one silently disappears behind the other.
+  // A half-step offset keeps every node's t off those exact crossing angles.
+  const startT = Math.PI / 2 + Math.PI / (2 * n);
   const positions = [];
   for (let i = 0; i < n; i++) {
     const t = startT + (i / n) * Math.PI * 2;
@@ -167,7 +180,7 @@ export function drawPseudo3D(ctx, args, opts = {}) {
     const ux = dx / len;
     const uy = dy / len;
     // Offset start so arrow doesn't overlap with node rects
-    const arrowTip = { x: next.px - ux * (NODE_W / 2 + 4), y: next.py - uy * (NODE_H / 2 + 2) };
+    const arrowTip = { x: next.px - ux * (nodeW / 2 + 4), y: next.py - uy * (nodeH / 2 + 2) };
     const arrowBase = { x: arrowTip.x - ux * 18, y: arrowTip.y - uy * 18 };
     drawArrow(ctx, arrowBase.x, arrowBase.y, arrowTip.x, arrowTip.y, accent);
   }
@@ -175,7 +188,7 @@ export function drawPseudo3D(ctx, args, opts = {}) {
   // ---- Draw step nodes on top of curve / arrows ----
   for (let i = 0; i < n; i++) {
     const { px, py } = positions[i];
-    drawNode(ctx, px, py, NODE_W, NODE_H, CORNER_R, steps[i], accent, fg);
+    drawNode(ctx, px, py, nodeW, nodeH, CORNER_R * nodeScale, steps[i], accent, fg);
   }
 }
 
@@ -203,8 +216,8 @@ function drawNode(ctx, cx, cy, nw, nh, r, step, accent, fg) {
   ctx.fill();
   ctx.restore();
 
-  // Label
-  const textSize = Math.min(13, nh * 0.34);
+  // Label — sized proportionally to the (now canvas-scaled) node height
+  const textSize = Math.min(22, nh * 0.34);
   ctx.fillStyle = 'rgba(255,255,255,0.97)';
   ctx.font = `700 ${textSize}px Inter, system-ui, sans-serif`;
   ctx.textAlign = 'center';

--- a/sdf-js/src/present/atoms-2d/charts/diagrams/org-vs-org-matrix.js
+++ b/sdf-js/src/present/atoms-2d/charts/diagrams/org-vs-org-matrix.js
@@ -95,12 +95,18 @@ export function drawPseudo3D(ctx, args, opts = {}) {
   const bl = [gridX, midY, gridW / 2, gridH / 2];
   const br = [midX, midY, gridW / 2, gridH / 2];
 
-  // Top-right (leaders) slightly brighter tint
-  ctx.fillStyle = rgbaCss(accent, 0.1);
-  ctx.fillRect(...tr);
-  ctx.fillStyle = rgbaCss(fg, 0.04);
+  // Quadrant tints — distinct hues per quadrant (previously top-right got a
+  // faint accent tint and the other three were an identical neutral 0.04
+  // grey, so the "4 quadrants" read as barely-differentiated background
+  // noise). Kept subtle (0.06-0.1 alpha) but now each quadrant is visibly
+  // its own region.
+  ctx.fillStyle = rgbaCss([90, 140, 210], 0.07); // top-left — cool blue
   ctx.fillRect(...tl);
+  ctx.fillStyle = rgbaCss([70, 170, 120], 0.09); // top-right — green (leaders)
+  ctx.fillRect(...tr);
+  ctx.fillStyle = rgbaCss([150, 150, 160], 0.06); // bottom-left — neutral
   ctx.fillRect(...bl);
+  ctx.fillStyle = rgbaCss([210, 150, 70], 0.08); // bottom-right — amber
   ctx.fillRect(...br);
 
   // Grid border
@@ -184,10 +190,15 @@ export function drawPseudo3D(ctx, args, opts = {}) {
     if (org.isUs) ctx.stroke();
     ctx.restore();
 
-    // Name label
+    // Name label — ALWAYS outside the bubble (offset right, or left when too
+    // close to the right edge), min 12px, and always dark text. The isUs
+    // bubble previously used white label text on the assumption it sat ON
+    // the (accent-filled) bubble, but the offset math already placed it
+    // OUTSIDE the bubble against the light quadrant tint — white-on-light
+    // was nearly invisible ("Acme (us)" unreadable).
     if (org.name) {
-      const labelSize = Math.min(12, Math.round(r * 0.7));
-      ctx.fillStyle = org.isUs ? rgbCss([255, 255, 255]) : rgbaCss(fg, 0.9);
+      const labelSize = Math.max(12, Math.round(r * 0.7));
+      ctx.fillStyle = rgbaCss(fg, 0.9);
       ctx.font = `700 ${labelSize}px Inter, system-ui, sans-serif`;
       const onRight = ox < 0.75;
       ctx.textAlign = onRight ? 'left' : 'right';

--- a/sdf-js/src/present/atoms-2d/charts/diagrams/relationship-graph.js
+++ b/sdf-js/src/present/atoms-2d/charts/diagrams/relationship-graph.js
@@ -94,6 +94,7 @@ export function drawPseudo3D(ctx, args, opts = {}) {
   const cy = plotTop + (y + h - plotTop) / 2;
   const radius = Math.min(w, y + h - plotTop) / 2 - NODE_RADIUS - 24;
   const positions = {};
+  const hasExplicitCoords = nodes.some((n) => typeof n.x === 'number' && typeof n.y === 'number');
   for (let i = 0; i < nodes.length; i++) {
     const n = nodes[i];
     if (typeof n.x === 'number' && typeof n.y === 'number') {
@@ -105,6 +106,43 @@ export function drawPseudo3D(ctx, args, opts = {}) {
         y: cy + Math.sin(angle) * radius,
         node: n,
       };
+    }
+  }
+
+  // Re-center + scale the auto (circular) layout to actually use ~70% of the
+  // canvas. A circle evenly spaced by angle doesn't fill its own bounding
+  // circle symmetrically for small/odd N — e.g. 3 nodes at angles -90/30/150
+  // puts ONE node up top and TWO down low, so the true bounding box of the
+  // node circles is bottom-heavy with a lot of dead space above. Normalizing
+  // against the actual bbox (not the nominal layout circle) fixes both the
+  // dead-space AND the "graph looks small" complaints in one pass. Skipped
+  // when any node has explicit x/y (that's an author-provided custom layout,
+  // not ours to rescale).
+  if (!hasExplicitCoords) {
+    let minX = Infinity;
+    let maxX = -Infinity;
+    let minY = Infinity;
+    let maxY = -Infinity;
+    for (const id in positions) {
+      const p = positions[id];
+      const r = p.node.size ? Math.max(12, Math.min(36, p.node.size * NODE_RADIUS)) : NODE_RADIUS;
+      minX = Math.min(minX, p.x - r);
+      maxX = Math.max(maxX, p.x + r);
+      minY = Math.min(minY, p.y - r);
+      maxY = Math.max(maxY, p.y + r);
+    }
+    const bboxW = maxX - minX || 1;
+    const bboxH = maxY - minY || 1;
+    const bboxCx = (minX + maxX) / 2;
+    const bboxCy = (minY + maxY) / 2;
+    const availW = w - PAD * 2;
+    const availH = y + h - plotTop - PAD * 2;
+    const FILL_FRAC = 0.85;
+    const scale = Math.min((availW * FILL_FRAC) / bboxW, (availH * FILL_FRAC) / bboxH);
+    for (const id in positions) {
+      const p = positions[id];
+      p.x = cx + (p.x - bboxCx) * scale;
+      p.y = cy + (p.y - bboxCy) * scale;
     }
   }
 
@@ -141,11 +179,18 @@ function drawEdge(ctx, x0, y0, x1, y1, color, weight, label) {
   if (label) {
     const mx = (x0 + x1) / 2;
     const my = (y0 + y1) / 2;
-    ctx.fillStyle = rgbaCss(color, 0.7);
-    ctx.font = '500 10px Inter, system-ui, sans-serif';
+    ctx.save();
+    ctx.font = '600 11px Inter, system-ui, sans-serif';
     ctx.textAlign = 'center';
     ctx.textBaseline = 'middle';
+    // White halo (stroke) so the label reads over any edge/node it crosses
+    ctx.lineWidth = 3;
+    ctx.strokeStyle = 'rgba(255,255,255,0.9)';
+    ctx.lineJoin = 'round';
+    ctx.strokeText(String(label), mx, my - 6);
+    ctx.fillStyle = rgbaCss(color, 0.85);
     ctx.fillText(String(label), mx, my - 6);
+    ctx.restore();
   }
 }
 

--- a/sdf-js/src/present/atoms-2d/charts/diagrams/relationship-graph.js
+++ b/sdf-js/src/present/atoms-2d/charts/diagrams/relationship-graph.js
@@ -183,11 +183,14 @@ function drawEdge(ctx, x0, y0, x1, y1, color, weight, label) {
     ctx.font = '600 11px Inter, system-ui, sans-serif';
     ctx.textAlign = 'center';
     ctx.textBaseline = 'middle';
-    // White halo (stroke) so the label reads over any edge/node it crosses
-    ctx.lineWidth = 3;
-    ctx.strokeStyle = 'rgba(255,255,255,0.9)';
-    ctx.lineJoin = 'round';
-    ctx.strokeText(String(label), mx, my - 6);
+    // White halo (stroke) so the label reads over any edge/node it crosses.
+    // Guarded: the Node test-env canvas stub doesn't implement strokeText.
+    if (typeof ctx.strokeText === 'function') {
+      ctx.lineWidth = 3;
+      ctx.strokeStyle = 'rgba(255,255,255,0.9)';
+      ctx.lineJoin = 'round';
+      ctx.strokeText(String(label), mx, my - 6);
+    }
     ctx.fillStyle = rgbaCss(color, 0.85);
     ctx.fillText(String(label), mx, my - 6);
     ctx.restore();

--- a/sdf-js/src/present/atoms-2d/charts/diagrams/timeline.js
+++ b/sdf-js/src/present/atoms-2d/charts/diagrams/timeline.js
@@ -116,14 +116,24 @@ export function drawPseudo3D(ctx, args, opts = {}) {
 
     const cardCy = above ? axisY - cardOffsetY - cardH / 2 : axisY + cardOffsetY + cardH / 2;
 
-    // Connector line from marker to card (hairline, subtle)
+    // Clamp the card's horizontal center so it never renders outside
+    // [x+PAD, x+w-PAD] — the first/last cards used to center directly on
+    // their (edge-of-axis) dot and get clipped by the canvas edge
+    // ("eed Round" instead of "Seed Round"). They now shift inward instead.
+    const half = cardW / 2;
+    const minCx = x + PAD + half;
+    const maxCx = x + w - PAD - half;
+    const cardCx = Math.min(maxCx, Math.max(minCx, mx));
+
+    // Connector line from marker to card (hairline, subtle) — diagonal when
+    // the card has been shifted inward off the marker's x position.
     ctx.save();
     ctx.strokeStyle = rgbaCss(fg, 0.22);
     ctx.lineWidth = 1;
     ctx.setLineDash([]);
     ctx.beginPath();
     ctx.moveTo(mx, axisY + (above ? -MARKER_RADIUS : MARKER_RADIUS));
-    ctx.lineTo(mx, cardCy + (above ? cardH / 2 : -cardH / 2));
+    ctx.lineTo(cardCx, cardCy + (above ? cardH / 2 : -cardH / 2));
     ctx.stroke();
     ctx.restore();
 
@@ -157,7 +167,7 @@ export function drawPseudo3D(ctx, args, opts = {}) {
     ctx.restore();
 
     // Event card
-    drawEventCard(ctx, mx, cardCy, cardW, cardH, events[i], { fg, bg, accent });
+    drawEventCard(ctx, cardCx, cardCy, cardW, cardH, events[i], { fg, bg, accent });
   }
 }
 

--- a/sdf-js/src/present/atoms-2d/charts/lists/bullet-list.js
+++ b/sdf-js/src/present/atoms-2d/charts/lists/bullet-list.js
@@ -73,18 +73,36 @@ export function drawPseudo3D(ctx, args, opts = {}) {
   }
 
   const plotH = y + h - plotTop - PAD;
-  const rowH = plotH / N;
+  // Tighten row pitch ~15% vs. a naive full-height stretch (evenly dividing
+  // plotH across N rows made short lists look sparse/unfinished with
+  // excessive whitespace between bullets) — then center the tighter block
+  // vertically within the available plot area.
+  const rowH = (plotH / N) * 0.85;
+  const blockH = rowH * N;
+  const blockTop = plotTop + (plotH - blockH) / 2;
   const bulletR = Math.min(rowH * 0.18, 14);
   const bulletX = x + PAD + bulletR + 4;
   const textX = bulletX + bulletR + 16;
 
   for (let i = 0; i < N; i++) {
     const it = items[i] || {};
-    const rowCY = plotTop + rowH * (i + 0.5);
-    const status = it.status || 'todo';
+    const rowCY = blockTop + rowH * (i + 0.5);
+    // status is left undefined for a plain item (no explicit semantic) —
+    // that now renders as a small FILLED accent dot, not a hollow ring.
+    // The hollow ring is reserved for an EXPLICIT status:'todo' (a
+    // deliberate "not done yet" checklist marker) so a plain bullet list
+    // with no status args doesn't look like an unfinished checklist.
+    const status = it.status;
     const bulletColor =
-      status === 'highlight' ? accent : status === 'done' ? darken(accent, 0.2) : [200, 200, 205];
-    const isFilled = status !== 'todo';
+      status === 'highlight'
+        ? accent
+        : status === 'done'
+          ? darken(accent, 0.2)
+          : status === 'todo'
+            ? [200, 200, 205]
+            : accent;
+    const isRing = status === 'todo';
+    const isFilled = !isRing;
 
     // Bullet OR icon (Sprint 18: icon → small filled badge like PL style)
     ctx.save();

--- a/sdf-js/src/present/atoms-2d/icons/icon-grid.js
+++ b/sdf-js/src/present/atoms-2d/icons/icon-grid.js
@@ -88,11 +88,58 @@ export function drawPseudo3D(ctx, args, opts = {}) {
   }
   const rows = Math.ceil(N / cols);
   const colW = (w - PAD * 2) / cols;
-  const rowH = (y + h - plotTop - PAD) / rows;
-  const baseIconR = Math.min(rowH * 0.25, colW * 0.18, 48);
-  // Auto-boost on large hero slots (h ≥ 360 = BIG slot)
-  const heroBoost = h >= 360 ? 1.3 : 1.0;
-  const iconR = baseIconR * iconSizeMultiplier * heroBoost;
+
+  // Icon radius + label font targets are based on column width, NOT row
+  // height — the old rowH*0.25 icon radius created a circular dependency
+  // where a naive availH/rows division could shrink the row pitch below
+  // what the label text actually needed, so row-2 icons overlapped row-1
+  // labels (e.g. 4 items wrapping 3+1: "Security" hidden behind "Care").
+  const heroBoost = h >= 360 ? 1.3 : 1.0; // Auto-boost on large hero slots (h ≥ 360 = BIG slot)
+  const baseIconR = Math.min(colW * 0.22, 48);
+  let iconR = baseIconR * iconSizeMultiplier * heroBoost;
+  let labelFsTarget = Math.max(11, Math.min(18, Math.round(colW * 0.085)));
+  const labelFsMin = 9;
+  let subFsTarget = Math.max(9, Math.min(14, Math.round(colW * 0.06)));
+  const subFsMin = 8;
+  const hasAnySublabel = items.some((it) => it && it.sublabel);
+
+  // Row pitch reserves the full measured label(+sublabel) block height below
+  // each icon, then takes whichever is larger: that reserved content height,
+  // or an even division of the available space (so rows still spread out
+  // nicely when there's plenty of room).
+  let iconTopGap = 12;
+  let iconLabelGap = 10;
+  let labelSubGap = 4;
+  let bottomPad = 10;
+  const contentHeightOf = () =>
+    iconTopGap +
+    iconR * 2 +
+    iconLabelGap +
+    labelFsTarget * 1.2 +
+    (hasAnySublabel ? labelSubGap + subFsTarget * 1.2 : 0) +
+    bottomPad;
+
+  const availH = y + h - plotTop - PAD;
+  let contentH = contentHeightOf();
+
+  // If reserving the full content height for every row would overflow the
+  // canvas (many rows / large icons), scale icon radius + fonts + gaps down
+  // uniformly so rows*contentH fits — reserving space is only useful if the
+  // grid still renders inside its bounds instead of clipping the last row.
+  if (rows * contentH > availH) {
+    const scale = Math.max(0.4, availH / (rows * contentH));
+    iconR *= scale;
+    labelFsTarget = Math.max(labelFsMin, Math.round(labelFsTarget * scale));
+    subFsTarget = Math.max(subFsMin, Math.round(subFsTarget * scale));
+    iconTopGap *= scale;
+    iconLabelGap *= scale;
+    labelSubGap *= scale;
+    bottomPad *= scale;
+    contentH = contentHeightOf();
+  }
+
+  const evenRowH = availH / rows;
+  const rowH = Math.max(evenRowH, contentH);
 
   for (let i = 0; i < N; i++) {
     const it = items[i] || {};
@@ -117,7 +164,7 @@ export function drawPseudo3D(ctx, args, opts = {}) {
     const badgeColor = Array.isArray(it.color) ? it.color : iconColor;
 
     // ---- Badge (circle/square/plain) ----
-    const iconCy = cellY + iconR + 12;
+    const iconCy = cellY + iconR + iconTopGap;
     if (iconStyle === 'circle') {
       drawCircleBadge(ctx, cellCx, iconCy, iconR, badgeColor);
     } else if (iconStyle === 'square') {
@@ -141,15 +188,15 @@ export function drawPseudo3D(ctx, args, opts = {}) {
         ctx,
         String(it.label),
         colW - 16,
-        Math.round(rowH * 0.11),
-        Math.max(9, Math.round(rowH * 0.07)),
+        labelFsTarget,
+        labelFsMin,
         (fs) => `700 ${fs}px Inter, system-ui, sans-serif`,
       );
       ctx.fillStyle = rgbCss(fg);
       ctx.font = `700 ${gridLabelFs}px Inter, system-ui, sans-serif`;
       ctx.textAlign = 'center';
       ctx.textBaseline = 'top';
-      const labelY = iconCy + iconR + 10;
+      const labelY = iconCy + iconR + iconLabelGap;
       ctx.fillText(String(it.label), cellCx, labelY);
 
       if (it.sublabel) {
@@ -157,13 +204,13 @@ export function drawPseudo3D(ctx, args, opts = {}) {
           ctx,
           String(it.sublabel),
           colW - 16,
-          Math.round(rowH * 0.075),
-          Math.max(8, Math.round(rowH * 0.05)),
+          subFsTarget,
+          subFsMin,
           (fs) => `500 ${fs}px Inter, system-ui, sans-serif`,
         );
         ctx.fillStyle = rgbaCss(fg, 0.55);
         ctx.font = `500 ${gridSubFs}px Inter, system-ui, sans-serif`;
-        ctx.fillText(String(it.sublabel), cellCx, labelY + gridLabelFs + 4);
+        ctx.fillText(String(it.sublabel), cellCx, labelY + gridLabelFs + labelSubGap);
       }
     }
   }


### PR DESCRIPTION
## Summary

Fixes all 12 P1-severity visual issues from the Sprint 26 atom visual
scorecard (`docs/superpowers/atom-visual-scorecard.md`), same discipline
as round 2 (#210): one commit per atom, each fix verified by re-rendering
`all-atoms-gallery.html` and reading the screenshot.

| atom | fix |
|---|---|
| `stat-banner` | chip metrics computed first; label auto-shrinks (min 11px) to fit before it; falls back to moving the chip to top-right if still colliding |
| `flow-chart` | node label auto-shrinks (min 9px), wraps to 2 lines if still too wide — no more "Onboard"/"Purchas" truncation |
| `timeline` | card center x clamped to `[x+PAD+half, x+w-PAD-half]` so first/last cards shift inward instead of clipping off-canvas |
| `icon-grid` | icon radius/font now based on column width (not row height, breaking a circular dependency); row pitch reserves measured label+sublabel height; overflow triggers a uniform scale-down |
| `funnel` | geometry computed up front, drawn in two passes (all trapezoids, then all labels/chips) so a later trapezoid can't overdraw an earlier gap's chip; chips get a white pill bg + border |
| `fishbone` | sub-cause/branch label anchors clamped so they can't render past the canvas left edge ("Channel mix" was clipped to "nel mix") |
| `isotype-stat-comparison` | icon cap 30→20 with a "×N" ratio note when capped; reserved gap between icon row and label; caption legibility bump |
| `bullet-list` | default (no `status`) now renders a filled accent dot instead of a hollow ring (hollow ring reserved for explicit `status:'todo'`); row pitch tightened ~15% |
| `bubble` | labels always render outside the bubble (dark text); fill switched to semi-transparent + solid stroke; min radius raised to 14px |
| `infinity-loop-flow` | found + fixed a node-overlap bug (n=4 landed all t-values on exact π/2 multiples, hiding one node behind another); loop now targets ~70% canvas, nodes/fonts scale with canvas size |
| `relationship-graph` | auto-circular layout re-centers + scales to its actual node bbox (fixes bottom-heavy dead space for small N); edge labels bumped to 11px with a white halo |
| `org-vs-org-matrix` | org labels always dark (were white-on-light for the `isUs` bubble), min 12px; 4 quadrants now get distinct subtle hues instead of 3 identical greys |

Plus one follow-up commit guarding `relationship-graph`'s new
`ctx.strokeText` call behind a `typeof` check — the Node test-env canvas
stub doesn't implement it, which broke the atoms-2d framework smoke test.

## Test plan

- [x] Each of the 12 atoms re-rendered via the gallery and visually confirmed (screenshots in `screens/sprint26-gallery/fix-*.png`)
- [x] Full chunk re-renders (`final-chunk-*.png`) confirm no regressions in neighboring atoms
- [x] `npm test` — 115/115 test files passing
- [x] `docs/superpowers/atom-visual-scorecard.md` updated: 12 items moved from 🟡 P1 to ✅ Fixed round 3

🤖 Generated with [Claude Code](https://claude.com/claude-code)