### PR TITLE
feat: deck assembly (P3) + camera shake fix (smooth sway, envelope, impact ramps)

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -148,6 +148,7 @@ const TESTS = [
   { category: 'scene', file: 'sdf-js/scripts/test-render-hierarchy.mjs' },
   { category: 'scene', file: 'sdf-js/scripts/test-render-network.mjs' },
   { category: 'scene', file: 'sdf-js/scripts/test-render-magnitude.mjs' },
+  { category: 'scene', file: 'sdf-js/scripts/test-assemble-deck.mjs' },
   { category: 'scene', file: 'sdf-js/scripts/test-scaffold-to-ir.mjs' },
   { category: 'scene', file: 'sdf-js/scripts/test-atom-3d-coverage.mjs' },
 

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -149,6 +149,7 @@ const TESTS = [
   { category: 'scene', file: 'sdf-js/scripts/test-render-network.mjs' },
   { category: 'scene', file: 'sdf-js/scripts/test-render-magnitude.mjs' },
   { category: 'scene', file: 'sdf-js/scripts/test-assemble-deck.mjs' },
+  { category: 'scene', file: 'sdf-js/scripts/test-camera-shake.mjs' },
   { category: 'scene', file: 'sdf-js/scripts/test-scaffold-to-ir.mjs' },
   { category: 'scene', file: 'sdf-js/scripts/test-atom-3d-coverage.mjs' },
 

--- a/sdf-js/apps/present/figure.js
+++ b/sdf-js/apps/present/figure.js
@@ -5,6 +5,7 @@
 import { createStudioRenderer } from '../../src/render/studio.js';
 import { applyStudioScene } from '../../src/runtime/apply-studio-scene.js';
 import { renderIR } from '../../src/scene/render-ir.js';
+import { assembleDeck } from '../../src/scene/assemble-deck.js';
 
 const wrap = document.getElementById('wrap');
 const canvas = document.getElementById('c');
@@ -44,9 +45,12 @@ window.addEventListener('resize', () => {
 window.__figStudio = studio;
 window.__figReplay = () => studio.setSequence(scene.cameraSequence);
 
+// ?deck=<name> assembles a multi-IR deck (one continuous world, stations along
+// the deck axis); ?ir=<name> renders a single structure.
+const deckName = params.get('deck');
 const name = params.get('ir') || 'funnel-sales';
-const ir = await (await fetch(`../../scenes/ir/${name}.json`)).json();
-const scene = renderIR(ir, { env }); // dispatches on ir.structure
+const ir = await (await fetch(`../../scenes/ir/${deckName || name}.json`)).json();
+const scene = deckName ? assembleDeck(ir, { env }) : renderIR(ir, { env });
 // applyStudioScene wires setSequence + setAnimated (subject.animation counts as
 // time content since the sceneHasTimeContent fix) — no manual overrides needed.
 applyStudioScene(studio, scene);

--- a/sdf-js/scenes/ir/deck-pitch.json
+++ b/sdf-js/scenes/ir/deck-pitch.json
@@ -1,0 +1,47 @@
+{
+  "title": "Atlas Pitch",
+  "slides": [
+    {
+      "structure": "magnitude",
+      "nodes": ["EMEA", "APAC", "Americas", "LATAM", "ANZ"],
+      "magnitude": [340, 620, 890, 150, 95],
+      "emphasis": [2],
+      "title": "Revenue by Region"
+    },
+    {
+      "structure": "sequence",
+      "nodes": ["Leads", "Qualified", "Proposal", "Negotiation", "Closed"],
+      "magnitude": [1200, 520, 240, 110, 45],
+      "emphasis": [4],
+      "order": [0, 1, 2, 3, 4],
+      "title": "Sales Funnel"
+    },
+    {
+      "structure": "hierarchy",
+      "nodes": [
+        "CEO",
+        "Product",
+        "Engineering",
+        "GTM",
+        "Design",
+        "Platform",
+        "Apps",
+        "Sales",
+        "Marketing"
+      ],
+      "relations": [
+        [0, 1],
+        [0, 2],
+        [0, 3],
+        [1, 4],
+        [2, 5],
+        [2, 6],
+        [3, 7],
+        [3, 8]
+      ],
+      "magnitude": [10, 5, 8, 5, 3, 4, 4, 3, 2],
+      "emphasis": [2],
+      "title": "Org Structure"
+    }
+  ]
+}

--- a/sdf-js/scripts/test-assemble-deck.mjs
+++ b/sdf-js/scripts/test-assemble-deck.mjs
@@ -60,7 +60,9 @@ const deck = JSON.parse(
   const shotCount =
     stations.reduce((s, st) => s + st.cameraSequence.shots.length, 0) + (deck.slides.length - 1);
   ok(scene.cameraSequence.shots.length === shotCount, 'shot count = stations + transits');
-  const transits = scene.cameraSequence.shots.filter((s) => (s.shake || 0) > 0.1 && s.fov === 50);
+  const transits = scene.cameraSequence.shots.filter(
+    (s) => (Array.isArray(s.shake) ? s.shake[0] : s.shake || 0) > 0.1 && s.fov === 50,
+  );
   ok(transits.length === 2, 'two transit shots (stage transitions)');
 
   // time: station k's build-ins start after station k-1's camera time has elapsed

--- a/sdf-js/scripts/test-assemble-deck.mjs
+++ b/sdf-js/scripts/test-assemble-deck.mjs
@@ -1,0 +1,96 @@
+// sdf-js/scripts/test-assemble-deck.mjs — deck assembly: N IRs → one world.
+import { readFileSync } from 'node:fs';
+import { assembleDeck, shiftBuildInExpr } from '../src/scene/assemble-deck.js';
+import { renderIR } from '../src/scene/render-ir.js';
+import { compile } from '../src/scene/index.js';
+
+let pass = 0,
+  fail = 0;
+const ok = (c, n) => (c ? (pass++, console.log(`  ✓ ${n}`)) : (fail++, console.log(`  ✗ ${n}`)));
+console.log('=== assemble-deck (N IRs → one continuous world) ===\n');
+
+// ---- expr shifting (the strict parser) ----------------------------------------
+{
+  ok(
+    shiftBuildInExpr('3.505 - 0.9 * smoothstep(0.25, 0.85, t)', 2, 10) ===
+      '5.505 - 0.9 * smoothstep(10.25, 10.85, t)',
+    'drop expr shifts in y and t',
+  );
+  ok(
+    shiftBuildInExpr('-1.500 + 2.000 * smoothstep(0.20, 0.80, t)', 0, 5.5) ===
+      '-1.500 + 2.000 * smoothstep(5.70, 6.30, t)',
+    'erupt expr shifts in t only',
+  );
+  let threw = false;
+  try {
+    shiftBuildInExpr('sin(t) * 3.0', 0, 1);
+  } catch {
+    threw = true;
+  }
+  ok(threw, 'unknown expr shape throws (fail loud)');
+}
+
+const deck = JSON.parse(
+  readFileSync(new URL('../scenes/ir/deck-pitch.json', import.meta.url), 'utf8'),
+);
+
+{
+  const scene = assembleDeck(deck);
+  const stations = deck.slides.map((ir) => renderIR(ir));
+
+  // subjects: sum of stations, prefixed, spatially separated by stride
+  const expected = stations.reduce((s, st) => s + st.subjects.length, 0);
+  ok(scene.subjects.length === expected, `all station subjects present (${expected})`);
+  ok(
+    scene.subjects.every((s) => /^s\d+-/.test(s.id)),
+    'ids prefixed per station (no collisions)',
+  );
+  const xOf = (pfx) => {
+    const xs = scene.subjects
+      .filter((s) => s.id.startsWith(pfx))
+      .map((s) => s.transform.translate[0]);
+    return xs.reduce((a, b) => a + b, 0) / xs.length;
+  };
+  ok(
+    xOf('s1-') - xOf('s0-') > 10 && xOf('s2-') - xOf('s1-') > 10,
+    'stations spaced along the deck axis',
+  );
+
+  // camera: all station shots + one transit between each pair
+  const shotCount =
+    stations.reduce((s, st) => s + st.cameraSequence.shots.length, 0) + (deck.slides.length - 1);
+  ok(scene.cameraSequence.shots.length === shotCount, 'shot count = stations + transits');
+  const transits = scene.cameraSequence.shots.filter((s) => (s.shake || 0) > 0.1 && s.fov === 50);
+  ok(transits.length === 2, 'two transit shots (stage transitions)');
+
+  // time: station k's build-ins start after station k-1's camera time has elapsed
+  const t0Of = (pfx) =>
+    Math.min(
+      ...scene.subjects
+        .filter((s) => s.id.startsWith(pfx) && s.animation)
+        .map((s) => Number(s.animation[0].expr.match(/smoothstep\((-?[\d.]+)/)[1])),
+    );
+  const dur0 = stations[0].cameraSequence.shots.reduce((s, sh) => s + sh.duration, 0);
+  ok(t0Of('s1-') >= dur0, 'station 2 build-ins wait for station 1 to play out');
+  ok(t0Of('s2-') > t0Of('s1-'), 'stations reveal in deck order');
+
+  // overlay: anchors moved with stations; titles reveal with their slide
+  const titles = scene.overlay.filter((o) => o.role === 'title');
+  ok(titles.length === 3 && titles[1].anchor[0] > 10, 'three station titles, placed at stations');
+  ok(titles[0].revealAt === 0 && titles[1].revealAt > 10, 'later titles reveal later');
+
+  // still ONE studio-compilable SceneData
+  try {
+    compile(scene, {});
+    ok(true, 'the whole deck compiles as one scene');
+  } catch (e) {
+    ok(false, `compile failed: ${e.message}`);
+  }
+
+  // deterministic
+  const again = assembleDeck(JSON.parse(JSON.stringify(deck)));
+  ok(JSON.stringify(again) === JSON.stringify(scene), 'deterministic');
+}
+
+console.log(`\n${pass} passed, ${fail} failed`);
+process.exit(fail ? 1 : 0);

--- a/sdf-js/scripts/test-camera-shake.mjs
+++ b/sdf-js/scripts/test-camera-shake.mjs
@@ -1,0 +1,79 @@
+// sdf-js/scripts/test-camera-shake.mjs — camera shake quality invariants.
+// Guards the fix for "镜头有抖动": shake must be SMOOTH sway (not white-noise
+// jitter), fade at blend-shot edges (no pop when a calm shot blends into a
+// shaky one), keep the instant hit on 'cut' shots, and support [from, to]
+// impact-then-settle ramps.
+import { evaluateCameraSequence } from '../src/scene/camera-sequence.js';
+
+let pass = 0,
+  fail = 0;
+const ok = (c, n) => (c ? (pass++, console.log(`  ✓ ${n}`)) : (fail++, console.log(`  ✗ ${n}`)));
+console.log('=== camera shake (smooth sway + envelope + ramp) ===\n');
+
+const BASE = { pos: [0, 2, 6], target: [0, 1, 0], fov: 46, ease: 'linear' };
+const dev = (state) => Math.hypot(state.target[0] - 0, state.target[1] - 1, state.target[2] - 0);
+
+// ---- smoothness: consecutive frames must be close (white noise was NOT) ------
+{
+  const seq = { shots: [{ ...BASE, duration: 10, shake: 1.0 }] };
+  let maxStep = 0;
+  let prev = null;
+  for (let t = 2; t < 8; t += 1 / 60) {
+    const s = evaluateCameraSequence(seq, t, {});
+    const d = [s.target[0], s.target[1], s.target[2]];
+    if (prev)
+      maxStep = Math.max(maxStep, Math.hypot(d[0] - prev[0], d[1] - prev[1], d[2] - prev[2]));
+    prev = d;
+  }
+  ok(
+    maxStep < 0.01,
+    `frame-to-frame shake step is small (${maxStep.toFixed(4)} — smooth sway, not jitter)`,
+  );
+  // and it actually moves (shake is alive)
+  const a = dev(evaluateCameraSequence(seq, 3.1, {}));
+  const b = dev(evaluateCameraSequence(seq, 4.3, {}));
+  ok(a > 0 || b > 0, 'shake displaces the target');
+}
+
+// ---- envelope: blend shot fades shake in at its start -------------------------
+{
+  const seq = {
+    shots: [
+      { ...BASE, duration: 4, shake: 0 },
+      { ...BASE, duration: 4, shake: 1.0, transition: 'blend' },
+    ],
+  };
+  const atBoundary = dev(evaluateCameraSequence(seq, 4.001, {}));
+  const midShot = Math.max(
+    dev(evaluateCameraSequence(seq, 5.9, {})),
+    dev(evaluateCameraSequence(seq, 6.1, {})),
+    dev(evaluateCameraSequence(seq, 6.35, {})),
+  );
+  ok(atBoundary < 0.002, `no pop at the blend boundary (${atBoundary.toFixed(4)})`);
+  ok(midShot > atBoundary * 5, 'shake ramps up inside the shot');
+}
+
+// ---- cut keeps the instant hit + [from,to] settles ----------------------------
+{
+  const seq = {
+    shots: [
+      { ...BASE, duration: 4, shake: 0 },
+      { ...BASE, duration: 4, shake: [1.0, 0.0], transition: 'cut' },
+    ],
+  };
+  // sample the peak sway near the cut vs near the end (sway oscillates, so take maxima)
+  const early = Math.max(
+    ...[4.05, 4.25, 4.45, 4.65].map((t) => dev(evaluateCameraSequence(seq, t, {}))),
+  );
+  const late = Math.max(
+    ...[7.2, 7.4, 7.6, 7.8].map((t) => dev(evaluateCameraSequence(seq, t, {}))),
+  );
+  ok(early > 0.005, `cut shot hits immediately (peak ${early.toFixed(4)})`);
+  ok(
+    late < early * 0.3,
+    `[from,to] ramp settles by the end (${late.toFixed(4)} vs ${early.toFixed(4)})`,
+  );
+}
+
+console.log(`\n${pass} passed, ${fail} failed`);
+process.exit(fail ? 1 : 0);

--- a/sdf-js/scripts/test-render-hierarchy.mjs
+++ b/sdf-js/scripts/test-render-hierarchy.mjs
@@ -71,7 +71,9 @@ ok(
   const peakIdx = ys.indexOf(Math.max(...ys));
   ok(ys[0] < ys[peakIdx], 'opens low (hero at the root), rises to the crane');
   ok(Math.min(...ys.slice(peakIdx)) < ys[peakIdx] - 2, 'descends through the levels');
-  const superShot = shots.find((s) => s.transition === 'cut' && (s.shake || 0) >= 0.2);
+  const superShot = shots.find(
+    (s) => s.transition === 'cut' && (Array.isArray(s.shake) ? s.shake[0] : s.shake || 0) >= 0.2,
+  );
   ok(
     !!superShot && Array.isArray(superShot.exposure),
     'super punch-in (cut + shake + exposure pop)',

--- a/sdf-js/scripts/test-render-magnitude.mjs
+++ b/sdf-js/scripts/test-render-magnitude.mjs
@@ -48,7 +48,9 @@ ok(
   // tracking: consecutive mid shots move along x
   const xs = shots.slice(2, 2 + 5).map((s) => s.pos[0]);
   ok(new Set(xs.map((x) => x.toFixed(2))).size === 5, 'tracking shot dollies along the row');
-  const superShot = shots.find((s) => s.transition === 'cut' && (s.shake || 0) >= 0.2);
+  const superShot = shots.find(
+    (s) => s.transition === 'cut' && (Array.isArray(s.shake) ? s.shake[0] : s.shake || 0) >= 0.2,
+  );
   ok(
     !!superShot && Array.isArray(superShot.exposure),
     'super punch-in (cut + shake + exposure pop)',

--- a/sdf-js/scripts/test-render-network.mjs
+++ b/sdf-js/scripts/test-render-network.mjs
@@ -66,7 +66,9 @@ ok(
   const ys = shots.map((s) => s.pos[1]);
   const peakIdx = ys.indexOf(Math.max(...ys));
   ok(peakIdx > 0 && peakIdx < shots.length - 1, 'crane peak mid-sequence (hero → crane → tour)');
-  const superShot = shots.find((s) => s.transition === 'cut' && (s.shake || 0) >= 0.2);
+  const superShot = shots.find(
+    (s) => s.transition === 'cut' && (Array.isArray(s.shake) ? s.shake[0] : s.shake || 0) >= 0.2,
+  );
   ok(
     !!superShot && Array.isArray(superShot.exposure),
     'super punch-in (cut + shake + exposure pop)',

--- a/sdf-js/scripts/test-render-sequence.mjs
+++ b/sdf-js/scripts/test-render-sequence.mjs
@@ -60,7 +60,9 @@ const ys = shots.map((s) => s.pos[1]);
 const peakIdx = ys.indexOf(Math.max(...ys));
 ok(ys[0] < ys[peakIdx], 'opens low (hero angle), rises to the crane peak');
 ok(Math.min(...ys.slice(peakIdx)) < ys[peakIdx] - 2, 'descends from the peak (fly-through)');
-const superShot = shots.find((s) => s.transition === 'cut' && (s.shake || 0) >= 0.2);
+const superShot = shots.find(
+  (s) => s.transition === 'cut' && (Array.isArray(s.shake) ? s.shake[0] : s.shake || 0) >= 0.2,
+);
 ok(!!superShot, 'has a hard-cut punch-in with heavy shake (the super)');
 ok(Array.isArray(superShot?.exposure), 'super shot pops exposure (ramp)');
 ok(

--- a/sdf-js/src/scene/assemble-deck.js
+++ b/sdf-js/src/scene/assemble-deck.js
@@ -72,7 +72,7 @@ export function assembleDeck(deck, opts = {}) {
         transition: 'blend',
         aperture: 0,
         focalDistance: stride * 0.8,
-        shake: 0.12,
+        shake: [0.14, 0.05], // sling settles as the next station arrives
         ease: 'inout',
       });
       clock += dur;

--- a/sdf-js/src/scene/assemble-deck.js
+++ b/sdf-js/src/scene/assemble-deck.js
@@ -1,0 +1,142 @@
+// sdf-js/src/scene/assemble-deck.js
+// P3 — deck assembly: MULTIPLE IRs → ONE continuous 3D world (one SceneData).
+//
+// The thesis move: a deck is not N slides, it is one world with N stations.
+// Each slide's structure renders at its own station along the deck axis; the
+// camera plays each station's five-beat grammar in place, then a TRANSIT shot
+// whips to the next station (the fighting-game stage transition — one arena
+// finishes, the camera slings to the next).
+//
+// Division of labour: structure renderers stay pure (they render at the origin
+// on their own clock); THIS module owns placement — it shifts each station's
+// subjects/labels in SPACE (station origin) and its build-ins/reveals/camera
+// in TIME (station start). Build-in exprs are strings the renderers bake, so
+// the shift rewrites them with a STRICT parser that throws on any unknown
+// shape (fail loud, never silently mis-animate).
+import { renderIR } from './render-ir.js';
+import { getEnvironment } from './environments.js';
+
+// Every structure renderer emits build-ins of exactly this shape:
+//   "<A> - <D> * smoothstep(<t0>, <t1>, t)"   (drop from above)
+//   "<A> + <D> * smoothstep(<t0>, <t1>, t)"   (erupt from below)
+// Shift: A += dy (the y-channel constant), t0/t1 += dt.
+const EXPR_RE = /^(-?[\d.]+) (\+|-) ([\d.]+) \* smoothstep\((-?[\d.]+), (-?[\d.]+), t\)$/;
+export function shiftBuildInExpr(expr, dy, dt) {
+  const m = String(expr).match(EXPR_RE);
+  if (!m) throw new Error(`assemble-deck: unrecognized build-in expr shape: "${expr}"`);
+  const [, A, sign, D, t0, t1] = m;
+  return `${(Number(A) + dy).toFixed(3)} ${sign} ${D} * smoothstep(${(Number(t0) + dt).toFixed(2)}, ${(Number(t1) + dt).toFixed(2)}, t)`;
+}
+
+const addV = (a, b) => [a[0] + b[0], a[1] + b[1], a[2] + b[2]];
+const seqDuration = (shots) => shots.reduce((s, sh) => s + (sh.duration || 0), 0);
+
+/**
+ * assembleDeck(deck, opts) → SceneData
+ * @param {object} deck  { title?, slides: IR[] }
+ * @param {object} opts  { env?, stride?: station spacing (default 16) }
+ */
+export function assembleDeck(deck, opts = {}) {
+  if (!deck || !Array.isArray(deck.slides) || deck.slides.length === 0)
+    throw new Error('assembleDeck: deck.slides must be a non-empty array of IRs');
+  const env = getEnvironment(opts.env);
+  const stride = opts.stride ?? 16;
+
+  const subjects = [];
+  const overlay = [];
+  const shots = [];
+  let clock = 0;
+  let prevPayoff = null;
+
+  deck.slides.forEach((ir, k) => {
+    // Render the station at the origin on its own clock, then transplant.
+    const st = renderIR(ir); // no env here — the deck owns the world
+    const origin = [k * stride, 0, 0];
+
+    // Transit shot: whip from the previous station's payoff toward this one's
+    // hero position (fast lateral sling, a touch of shake — the stage change).
+    const hero = st.cameraSequence.shots[0];
+    const heroPos = addV(hero.pos, origin);
+    const heroTarget = addV(hero.target, origin);
+    if (k > 0) {
+      const dur = 1.2;
+      shots.push({
+        duration: dur,
+        pos: [
+          (prevPayoff.pos[0] + heroPos[0]) / 2,
+          Math.max(prevPayoff.pos[1], heroPos[1]) + 1.6,
+          Math.max(prevPayoff.pos[2], heroPos[2]) + 2.0,
+        ],
+        target: [(prevPayoff.target[0] + heroTarget[0]) / 2, heroTarget[1], heroTarget[2]],
+        fov: 50,
+        transition: 'blend',
+        aperture: 0,
+        focalDistance: stride * 0.8,
+        shake: 0.12,
+        ease: 'inout',
+      });
+      clock += dur;
+    }
+
+    // Subjects: shift origin (static translate) + rewrite build-ins (y & time).
+    for (const s of st.subjects) {
+      const moved = JSON.parse(JSON.stringify(s));
+      moved.id = `s${k}-${s.id}`;
+      moved.transform = moved.transform || {};
+      moved.transform.translate = addV(moved.transform.translate || [0, 0, 0], origin);
+      if (Array.isArray(moved.animation)) {
+        moved.animation = moved.animation.map((a) => ({
+          ...a,
+          expr: shiftBuildInExpr(
+            a.expr,
+            a.channel === 'transform.translate.y' ? origin[1] : 0,
+            clock,
+          ),
+        }));
+      }
+      subjects.push(moved);
+    }
+
+    // Overlay: shift anchors + reveal times; station titles reveal with their slide.
+    for (const o of st.overlay || []) {
+      overlay.push({
+        ...o,
+        anchor: addV(o.anchor, origin),
+        revealAt: (o.revealAt ?? 0) + clock,
+      });
+    }
+
+    // Camera: shift shots in space + append (time shift is implicit — durations chain).
+    st.cameraSequence.shots.forEach((sh) => {
+      shots.push({ ...sh, pos: addV(sh.pos, origin), target: addV(sh.target, origin) });
+    });
+    const stationDur = seqDuration(st.cameraSequence.shots);
+    clock += stationDur;
+    const last = st.cameraSequence.shots[st.cameraSequence.shots.length - 1];
+    prevPayoff = { pos: addV(last.pos, origin), target: addV(last.target, origin) };
+  });
+
+  return {
+    v: 1,
+    name: `(deck) ${deck.title || `${deck.slides.length} stations`}${env ? ' · alpine' : ''}`,
+    subjects: env ? [...subjects, ...env.subjects] : subjects,
+    overlay,
+    cameraSequence: { loop: false, shots },
+    // One shared open world — no per-station stage room (walls would slice the
+    // deck axis). Ground/sky come from the environment or the page defaults.
+    defaults: env
+      ? env.defaults
+      : {
+          camera: {
+            yaw: 0,
+            pitch: -0.1,
+            distance: 12,
+            focal: 1.2,
+            targetX: 0,
+            targetY: 2,
+            targetZ: 0,
+          },
+          light: { azimuth: 0.5, altitude: 0.7, distance: 40, intensity: 1.1 },
+        },
+  };
+}

--- a/sdf-js/src/scene/camera-sequence.js
+++ b/sdf-js/src/scene/camera-sequence.js
@@ -65,12 +65,18 @@ function dofValue(v, eased, blendedFallback) {
 }
 
 /**
- * Hash-noise for camera shake. Tiny + deterministic.
- * Returns [-1, 1] for shake offset.
+ * Smooth handheld sway for camera shake. The old hash noise was WHITE noise —
+ * successive frames were uncorrelated, which reads as electric jitter / a
+ * broken camera. Real handheld energy is low-frequency: a sum of three
+ * incommensurate sines (mostly ~1.7rad/s sway, a touch of mid/high texture)
+ * gives a C∞-smooth, deterministic [-1,1] drift instead.
  */
-function shakeNoise(seed) {
-  const x = Math.sin(seed * 12.9898 + 78.233) * 43758.5453;
-  return (x - Math.floor(x)) * 2 - 1;
+function shakeSway(t, phase) {
+  return (
+    Math.sin(t * 1.7 + phase) * 0.55 +
+    Math.sin(t * 3.9 + phase * 2.1) * 0.3 +
+    Math.sin(t * 7.3 + phase * 4.2) * 0.15
+  );
 }
 
 /**
@@ -213,14 +219,24 @@ export function evaluateCameraSequence(seq, tSec, ctx) {
   out.aperture = dofValue(shot.aperture, blend, out.aperture);
   out.focalDistance = dofValue(shot.focalDistance, blend, out.focalDistance);
 
-  // Sprint 4: resolved shake (number OR {amount, velocityScale, scaleWith})
-  const shakeAmt = resolveShake(shot.shake, subjectOffsets);
+  // Shake: number (constant) OR [from, to] intra-shot ramp (the super's
+  // impact-then-settle) OR legacy {amount, ...}. An edge ENVELOPE fades shake
+  // in/out near shot boundaries so it never pops on when a calm shot blends
+  // into a shaky one — EXCEPT fade-in on 'cut' shots, where the instant hit IS
+  // the point (the impact frame).
+  const shakeAmt = Array.isArray(shot.shake)
+    ? lerp(Number(shot.shake[0]) || 0, Number(shot.shake[1]) || 0, clamp01(shotT))
+    : resolveShake(shot.shake, subjectOffsets);
   if (shakeAmt > 0) {
+    const edge = (x) => smoothstep(x / 0.15); // 15% of the shot to ramp, C¹-smooth
+    const fadeIn = shot.transition === 'cut' || idx === 0 ? 1 : edge(shotT);
+    const fadeOut = edge(1 - shotT);
+    const env = Math.min(fadeIn, fadeOut);
     const d = Math.max(1, distance(out.pos, out.target));
-    const k = (shakeAmt * 0.05) / d;
-    out.target[0] += shakeNoise(tSec * 9.7 + 1.0) * k;
-    out.target[1] += shakeNoise(tSec * 11.3 + 2.0) * k;
-    out.target[2] += shakeNoise(tSec * 13.1 + 3.0) * k;
+    const k = (shakeAmt * env * 0.05) / d;
+    out.target[0] += shakeSway(tSec, 1.0) * k;
+    out.target[1] += shakeSway(tSec, 2.6) * k;
+    out.target[2] += shakeSway(tSec, 4.9) * k;
   }
 
   return out;

--- a/sdf-js/src/scene/render-hierarchy.js
+++ b/sdf-js/src/scene/render-hierarchy.js
@@ -190,7 +190,7 @@ export function renderHierarchy(ir, opts = {}) {
       transition: 'blend',
       aperture: 0,
       focalDistance: dist,
-      shake: 0.08,
+      shake: 0.05,
       ease: 'smooth',
     });
   }
@@ -203,7 +203,7 @@ export function renderHierarchy(ir, opts = {}) {
     transition: 'cut',
     aperture: 0,
     focalDistance: 1.7,
-    shake: 0.3,
+    shake: [0.5, 0.06], // impact-then-settle
     exposure: [1.45, 1.0],
     ease: 'out',
   });

--- a/sdf-js/src/scene/render-magnitude.js
+++ b/sdf-js/src/scene/render-magnitude.js
@@ -128,7 +128,7 @@ export function renderMagnitude(ir, opts = {}) {
       transition: 'blend',
       aperture: 0,
       focalDistance: 2.7,
-      shake: 0.08,
+      shake: 0.05,
       ease: 'smooth',
     });
   });
@@ -141,7 +141,7 @@ export function renderMagnitude(ir, opts = {}) {
     transition: 'cut',
     aperture: 0,
     focalDistance: 1.8,
-    shake: 0.3,
+    shake: [0.5, 0.06], // impact-then-settle
     exposure: [1.45, 1.0],
     ease: 'out',
   });

--- a/sdf-js/src/scene/render-network.js
+++ b/sdf-js/src/scene/render-network.js
@@ -223,7 +223,7 @@ export function renderNetwork(ir, opts = {}) {
       transition: 'blend',
       aperture: 0,
       focalDistance: dist,
-      shake: 0.07,
+      shake: 0.05,
       ease: 'smooth',
     });
   }
@@ -236,7 +236,7 @@ export function renderNetwork(ir, opts = {}) {
     transition: 'cut',
     aperture: 0,
     focalDistance: 1.6,
-    shake: 0.3,
+    shake: [0.5, 0.06], // impact-then-settle
     exposure: [1.45, 1.0],
     ease: 'out',
   });

--- a/sdf-js/src/scene/render-sequence.js
+++ b/sdf-js/src/scene/render-sequence.js
@@ -135,7 +135,7 @@ export function renderSequence(ir, opts = {}) {
       transition: 'blend',
       aperture: 0,
       focalDistance: dist,
-      shake: 0.08,
+      shake: 0.05,
       ease: 'smooth',
     });
   }
@@ -150,7 +150,7 @@ export function renderSequence(ir, opts = {}) {
     transition: 'cut',
     aperture: 0,
     focalDistance: 2,
-    shake: 0.3,
+    shake: [0.5, 0.06], // impact-then-settle
     exposure: [1.45, 1.0],
     ease: 'out',
   });

--- a/sdf-js/src/scene/spec.js
+++ b/sdf-js/src/scene/spec.js
@@ -1395,10 +1395,14 @@ function validateCameraSequence(seq, errors, warnings) {
     if (shot.transition != null && !SHOT_TRANSITIONS.has(shot.transition)) {
       errors.push(`${tag}.transition: must be one of ${[...SHOT_TRANSITIONS].join(' | ')}`);
     }
-    // Sprint 4: shake can be number (legacy) OR { amount, velocityScale, scaleWith }
+    // shake: number (legacy) OR [from, to] intra-shot ramp (impact-then-settle)
+    // OR { amount, velocityScale, scaleWith }
     if (shot.shake != null) {
       if (typeof shot.shake === 'number') {
         if (shot.shake < 0) errors.push(`${tag}.shake: must be a non-negative number`);
+      } else if (Array.isArray(shot.shake)) {
+        if (shot.shake.length !== 2 || shot.shake.some((x) => typeof x !== 'number' || x < 0))
+          errors.push(`${tag}.shake: array form must be [from, to] non-negative numbers`);
       } else if (typeof shot.shake === 'object') {
         if (typeof shot.shake.amount !== 'number' || shot.shake.amount < 0) {
           errors.push(`${tag}.shake.amount: required non-negative number`);


### PR DESCRIPTION
## What — P3 lands: N IRs assembled into ONE continuous world

The thesis move: **a deck is not N slides, it is one world with N stations.** `assembleDeck({title, slides: [IR...]})` transplants each slide's structure to its own station along the deck axis and chains the cameras into a single timeline — each station plays its five-beat fighting-game grammar in place, then a **TRANSIT shot whips to the next station** (the stage-transition sling: elevated midpoint, fov 50, shake 0.12). One SceneData, one compile, one 35s sequence for the 3-station demo.

## Division of labour (the clean seam)

Structure renderers stay **pure** — they render at the origin on their own clock. The assembler owns placement: subjects/labels shifted in SPACE (station origin), build-ins/reveals shifted in TIME (station start). Build-in exprs are renderer-baked strings, so the shift rewrites them with a **strict parser** (`shiftBuildInExpr`) that throws on any unknown shape — fail loud, never silently mis-animate. Station titles reveal with their slide.

## Try

`apps/present/figure.html?deck=deck-pitch` — monolith row → *transit* → funnel → *transit* → cone tree, 35 seconds, one world. (`?ir=` still renders single structures; `&env=alpine` works for decks too.)

## Verified

14/14 new tests (expr shifting incl. fail-loud / station spacing / shot count = stations + transits / cross-station time ordering / title reveals / whole-deck single-scene compile / determinism). Full suite **119/119**; lint clean. In-browser: the 35s deck plays; transit frame captured (leaving the monolith station across the open plain), station 2 verified assembled on arrival.

## Note

The pre-push guard (#211) earned its keep during this work: `gh pr merge 212` in the shared working copy switched the checkout to main again mid-session — the deck commit landed on local main and **the hook blocked the push**; recovered to this branch cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)