### PR TITLE
Sprint 26 round 4: P2 cleanup + full gallery certification

### DIFF
--- a/docs/superpowers/atom-visual-scorecard.md
+++ b/docs/superpowers/atom-visual-scorecard.md
@@ -42,14 +42,26 @@ args 渲染全部 101 atom (640×360, editorial-light palette), 9 chunk 截图,
 | `relationship-graph` | 圆形布局按角度均分对小 N 不对称(3 节点=1 上 2 下), 改为算出真实 bbox 后居中+缩放到可用区域 ~85%; 边标签 10px→11px 并加白色描边光晕。 |
 | `org-vs-org-matrix` | 所有 org label 统一深色(之前 isUs 用白字, 但位置早已在气泡外, 白字对亮背景几乎不可见); 字号下限提到 12px; 4 个象限改成 4 种不同色相的淡色调(之前 3 个象限共用同一种灰, 只有右上象限略深)。 |
 
-## 🟢 P2 — 小瑕疵 (顺手修)
+## ✅ Fixed in round 4 (2026-07-05)
 
-- `bar`: targetLine "Target" 标签与图标题碰撞
-- `histogram`: 标题与 "Median" 标注轻微重叠
-- `arrow` / `diamond`: 单形状 + caption, hero 表现力弱 (设计层面, 非 bug)
-- `radial-spoke`: 各 spoke 无差异化数值显示
-- `sphere-network` / `sphere-tree`: 球面 label 偏小
-- `image` / `image-split`: example 是 1px data URI 故渲染空白 (预期; gallery example 可换更大 demo 图)
+全部 6 个 P2 已修复, 外加全量复审中发现的 2 个新问题, 每项均重渲 gallery + 多模态
+截图确认。详见各 commit message (branch `sprint-26-round4-p2-cleanup`)。
+
+| atom | 修了什么 |
+|---|---|
+| `bar` | targetLine 的竖直参考线永远贴着 title band 顶部绘制标签, 与标题碰撞。改为在图表底部预留一个小 band(bars 布局用缩小后的 chartHeight), 参考线 + 其"Target"标签移到最后一根 bar 下方, 不再挨着标题也不再压在 bar 上。 |
+| `histogram` | 标题高度只按固定 h*TITLE_FRAC 预留, milestone 标注("Median")又画在 plotT 上方, 双重挤压导致标题被压。改为按标题实际字号预留 band, 再为 milestone 标签额外加高度预留, 标注本身从"画在 plotT 上方"改成"画在 plotT 下方"(标题区域内绝不会再出现标注文字)。 |
+| `arrow` / `diamond` | 单形状+caption 作为 hero 表现力弱。形状目标尺寸改为画布高度的 ~55%(此前受限于过度保守的 caption band, 实际远小于此); caption 换成 Inter 700 / ~h*0.07 大字号 + 强调色下划线条, 两个孪生 atom 统一处理。 |
+| `radial-spoke` | 各 spoke 只有分类 label, 看不出具体数值。沿着每根 spoke 的辐条方向、在靠近端点前(不越过端点)渲染该 spoke 的值(0-1 归一化 → 百分比), 白色描边光晕(strokeText)保证在任何 spoke 颜色上都可读, 内嵌位置避免与外侧分类 label 重叠。 |
+| `sphere-network` / `sphere-tree` | 球面上的 label(hub label / 大节点内嵌 label)固定用白色填充, 在浅色球体上几乎不可见。改成: 深色前景字 + 白色描边光晕(strokeText, 3px, alpha 0.8)在填充下方, 无论球体本身颜色深浅都能读。同时给所有 label(hub / satellite / tree node)设 11px 最小字号下限。 |
+| `image` / `image-split` | spec example 的 src 是 1×1 data URI PNG, gallery 格子渲染空白。换成一个小的内联 SVG(渐变天空 + 山脉剪影, ~300 字节, 显式 width/height 让 naturalWidth/naturalHeight 在 'cover' fit 下正确解析)。**仅改了 example, atom 代码本身未动** — 但验证时顺手发现 image.js 只在 borderRadius>0 时才裁剪到自己的 [x,y,w,h] 盒子, 'cover' fit 天然会画到盒子外(最明显的是 image-split 里图片会画到文字侧面板上), 因此额外修了: 始终裁剪(borderRadius=0 时用矩形裁剪)。 |
+
+**全量复审(见下)额外发现并修复的 2 个新问题**(非原 P2 清单, 属于本轮 fix-forward):
+
+| atom | 修了什么 |
+|---|---|
+| `strategy-map` | `fitFontSize` 字号收缩到 9px 下限后仍不截断 —— 旋转 90° 的透视 label("Internal Process" / "Learning & Growth")在 9px 时依然超出行高约束(maxW=rowH), 导致文字溢出到相邻行。新增 `truncateToWidth()` ellipsis 截断, 作为 fitFontSize 之后的兜底, row label 和卡片 item 文本都套用。 |
+| `change-curve-chart` | 首尾 phase 的点恰好落在 plotL/plotR 上, 居中绘制的 label/description 在文字较长时("Integration" / "New normal achieved")会溢出画布边缘, 被 gallery 格子裁掉。改为首尾 anchor 到内侧(textAlign left/right)而非居中; 同时给每个 phase 的 label/description 按可用 slot 宽度(相邻 phase 间距, 居中的拿满宽度的一半在每一侧, 边界的按同样单侧预算)做 ellipsis 截断 —— 只改 anchor 不截断会把溢出问题转移到相邻 phase 的地盘, 必须两者都做。 |
 
 ## Round 2 计划
 
@@ -58,8 +70,27 @@ args 渲染全部 101 atom (640×360, editorial-light palette), 9 chunk 截图,
    numbered-grid / mindmap / seven-s-model / flow-chart 都是同一类 "无 shrink" 病
 3. 重渲 gallery → 对照本 scorecard 复核 → 更新状态
 
+## 认证状态 (2026-07-05 full re-audit)
+
+Round 4 结束后对全部 101 个 atom 做了完整复审: 9 个 chunk(from/to 步长 12, 最后一个
+11 个 atom)全部重渲 + 1400×2400 截图 + 逐张多模态人工看图, 截图见
+`screens/sprint26-gallery/audit2-*-*.png`。
+
+**101/101 atoms ✅ PL-grade** — 复审中发现的 2 个新问题(strategy-map 行 label 溢出、
+change-curve-chart 首尾 phase label 溢出画布)已在本轮当场修复并重新截图验证(不留到
+下一轮)。
+
+已知的、评估后判定为"设计层面可接受, 非 bug"、不阻塞认证的细节:
+
+- `nine-field-matrix` / `matrix-grid`: bubble 的外置 label(如 "A")紧贴 bubble 右下角,
+  与所在 cell 的大号 label 尾部略有视觉拥挤, 但两者颜色/字重区分明显, 依然可读。
+  round 2 已做过一次这类修复(bubble label 移到泡外), 这是同一设计下的正常边界情况,
+  不是新退化。
+- `segmented-bar`: 窄分段(如 10% 的 "Other")不显示条内 label, 只在下方图例出现 ——
+  这是 `MIN_LABEL_W` 保护性 fallback 的预期行为(避免文字挤爆过窄的分段), 不是 bug。
+
 ## 状态
 
 - [x] Round 2: P0 × 7 (2026-07-05, branch `sprint-26-round2-p0-atoms`)
 - [x] Round 3: P1 × 12 (2026-07-05, branch `sprint-26-round3-p1-atoms`)
-- [ ] Round 4: P2 清尾 + 复审全量
+- [x] Round 4: P2 × 6 + 全量复审认证 101/101 (2026-07-05, branch `sprint-26-round4-p2-cleanup`)

--- a/sdf-js/scripts/test-atoms-2d-framework.mjs
+++ b/sdf-js/scripts/test-atoms-2d-framework.mjs
@@ -2035,6 +2035,7 @@ function stubCtx(recorded) {
     'quadraticCurveTo',
     'bezierCurveTo',
     'arc',
+    'rect',
     'stroke',
     'fill',
     'fillRect',
@@ -2047,6 +2048,7 @@ function stubCtx(recorded) {
   c.createLinearGradient = () => ({ addColorStop: noop });
   c.createRadialGradient = () => ({ addColorStop: noop });
   c.fillText = (t) => recorded.push(t);
+  c.strokeText = noop;
   for (const p of [
     'fillStyle',
     'strokeStyle',

--- a/sdf-js/scripts/test-atoms-image.mjs
+++ b/sdf-js/scripts/test-atoms-image.mjs
@@ -52,6 +52,7 @@ const stubCtx = {
   lineTo() {},
   quadraticCurveTo() {},
   closePath() {},
+  rect() {},
   clip() {},
   fillRect() {},
   fillText() {},

--- a/sdf-js/src/present/atoms-2d/charts/data/bar.js
+++ b/sdf-js/src/present/atoms-2d/charts/data/bar.js
@@ -92,7 +92,14 @@ export function drawPseudo3D(ctx, args, opts = {}) {
     ctx.fillText(title, x + 20, y + 16);
     chartTop = y + h * DEFAULT_TITLE_FRAC;
   }
-  const chartHeight = y + h - chartTop;
+  // Reserve a small band at the very bottom for the targetLine label (if
+  // any) so it never has to compete with the title OR overlap the last
+  // bar's row — bars are laid out inside the shrunk chartHeight, and the
+  // reference line + its label live in the reserved band below them.
+  const hasTargetLabel = args.targetLine != null && Boolean(args.targetLine.label);
+  const targetLabelSize = Math.max(10, Math.round(h * 0.055));
+  const targetLabelReserve = hasTargetLabel ? targetLabelSize + 10 : 0;
+  const chartHeight = y + h - chartTop - targetLabelReserve;
 
   // ---- Compute label width (longest label) — Inter 600, 14-18px range ----
   const labelSize = Math.max(14, Math.min(18, Math.round((chartHeight / n) * 0.32)));
@@ -157,7 +164,7 @@ export function drawPseudo3D(ctx, args, opts = {}) {
     ctx.fillText(formatted[i], barAreaLeft + barW + VALUE_GAP, cy + barHeight / 2);
   }
 
-  // ---- targetLine — horizontal dashed reference (optional) ----
+  // ---- targetLine — vertical dashed reference (optional) ----
   if (args.targetLine != null && max > 0) {
     const tValue = Number(args.targetLine.value);
     if (Number.isFinite(tValue)) {
@@ -165,9 +172,12 @@ export function drawPseudo3D(ctx, args, opts = {}) {
       const tFrac = tValue / max;
       const tX = barAreaLeft + barAreaW * tFrac;
 
-      // Vertical span: from chartTop to chartTop+chartHeight (full bar area height)
+      // Bars are laid out inside chartHeight, which already excludes the
+      // targetLabelReserve band at the bottom. The dashed line spans just
+      // the bar area; the label lives in the reserved band right below it,
+      // clear of both the title (above) and the last bar's row.
       const lineTop = chartTop;
-      const lineBottom = chartTop + chartHeight;
+      const chartBottom = chartTop + chartHeight;
 
       // Accent color: palette accent or a distinguishable red-orange
       const accentColor = palette.accentColor || [210, 80, 60];
@@ -179,18 +189,17 @@ export function drawPseudo3D(ctx, args, opts = {}) {
       ctx.lineCap = 'round';
       ctx.beginPath();
       ctx.moveTo(tX, lineTop);
-      ctx.lineTo(tX, lineBottom);
+      ctx.lineTo(tX, chartBottom);
       ctx.stroke();
       ctx.restore();
 
-      // Label above the line at the top, right-aligned to line
-      if (args.targetLine.label) {
-        const labelFontSize = Math.max(10, Math.round(chartHeight * 0.08));
+      // Label just below the line's bottom end, clear of the title and bars.
+      if (hasTargetLabel) {
         ctx.fillStyle = rgbaCss(accentColor, 0.9);
-        ctx.font = `600 ${labelFontSize}px Inter, system-ui, sans-serif`;
+        ctx.font = `600 ${targetLabelSize}px Inter, system-ui, sans-serif`;
         ctx.textAlign = 'center';
-        ctx.textBaseline = 'bottom';
-        ctx.fillText(String(args.targetLine.label), tX, lineTop - 2);
+        ctx.textBaseline = 'top';
+        ctx.fillText(String(args.targetLine.label), tX, chartBottom + 4);
       }
     }
   }

--- a/sdf-js/src/present/atoms-2d/charts/data/change-curve-chart.js
+++ b/sdf-js/src/present/atoms-2d/charts/data/change-curve-chart.js
@@ -4,6 +4,21 @@
 
 import { rgbCss, rgbaCss } from '../../renderer.js';
 
+// Last-resort ellipsis truncation so a phase label/description never bleeds
+// into a neighboring phase's slot. Assumes ctx.font is already set.
+function truncateToWidth(ctx, text, maxW) {
+  if (ctx.measureText(text).width <= maxW) return text;
+  let lo = 0;
+  let hi = text.length;
+  while (lo < hi) {
+    const mid = Math.ceil((lo + hi) / 2);
+    const candidate = text.slice(0, mid) + '…';
+    if (ctx.measureText(candidate).width <= maxW) lo = mid;
+    else hi = mid - 1;
+  }
+  return lo > 0 ? text.slice(0, lo) + '…' : '…';
+}
+
 export const spec = {
   type: 'change-curve-chart',
   category: 'charts/data',
@@ -197,26 +212,44 @@ export function drawPseudo3D(ctx, args, opts = {}) {
   // Phase labels in zone below curve
   const labelFontSize = Math.min(Math.round(phaseLabelH * 0.22), Math.round(plotW / N / 5.5), 12);
   const descFontSize = Math.max(8, Math.round(labelFontSize * 0.75));
+  // Available width per phase before it reaches the next phase's dot. A
+  // centered (middle) label reaches spacing/2 in EACH direction, so its
+  // total budget is `spacing`. First/last dots sit exactly at plotL/plotR
+  // and anchor their text to the inside edge instead of centering (so it
+  // doesn't overflow past the canvas) — but that's a ONE-directional reach,
+  // so to stay within the same spacing/2 budget its neighbor assumes on
+  // that side, its cap must be half of the centered budget, not the full
+  // width. Truncate (ellipsis) whatever doesn't fit either way.
+  const spacing = N > 1 ? plotW / (N - 1) : plotW;
+  const centerMaxW = Math.max(20, spacing - 8);
+  const edgeMaxW = Math.max(20, spacing / 2 - 8);
 
   for (let i = 0; i < N; i++) {
     const { px } = points[i];
     const labelY = curveB + 6;
+    const isEdge = i === 0 || i === N - 1;
+    const align = i === 0 ? 'left' : i === N - 1 ? 'right' : 'center';
+    const slotMaxW = isEdge ? edgeMaxW : centerMaxW;
 
     ctx.save();
     ctx.fillStyle = rgbCss(fg);
     ctx.font = `700 ${labelFontSize}px Inter, system-ui, sans-serif`;
-    ctx.textAlign = 'center';
+    ctx.textAlign = align;
     ctx.textBaseline = 'top';
-    ctx.fillText(String(phases[i].label || ''), px, labelY);
+    ctx.fillText(truncateToWidth(ctx, String(phases[i].label || ''), slotMaxW), px, labelY);
     ctx.restore();
 
     if (phases[i].description) {
       ctx.save();
       ctx.fillStyle = rgbaCss(fg, 0.55);
       ctx.font = `500 ${descFontSize}px Inter, system-ui, sans-serif`;
-      ctx.textAlign = 'center';
+      ctx.textAlign = align;
       ctx.textBaseline = 'top';
-      ctx.fillText(String(phases[i].description), px, labelY + labelFontSize * 1.3);
+      ctx.fillText(
+        truncateToWidth(ctx, String(phases[i].description), slotMaxW),
+        px,
+        labelY + labelFontSize * 1.3,
+      );
       ctx.restore();
     }
   }

--- a/sdf-js/src/present/atoms-2d/charts/data/histogram.js
+++ b/sdf-js/src/present/atoms-2d/charts/data/histogram.js
@@ -66,6 +66,9 @@ export function drawPseudo3D(ctx, args, opts = {}) {
   if (n === 0) return;
 
   // ---- Title ----
+  const hasMilestoneLabels =
+    Array.isArray(args.milestones) && args.milestones.some((m) => m && m.label);
+
   let chartTop = y + PAD_TOP;
   if (args.title) {
     const titleSize = Math.round(h * 0.07);
@@ -74,7 +77,18 @@ export function drawPseudo3D(ctx, args, opts = {}) {
     ctx.textAlign = 'left';
     ctx.textBaseline = 'top';
     ctx.fillText(String(args.title), x, y);
-    chartTop = y + h * TITLE_FRAC;
+    // Reserve room for the actual title glyph height (not just the fixed
+    // TITLE_FRAC band), so a tall title never bleeds into the plot area.
+    chartTop = y + Math.max(h * TITLE_FRAC, titleSize + PAD_TOP + 6);
+  }
+  // Milestone annotation labels (e.g. "Median") used to render ABOVE plotT,
+  // i.e. back up into the title band — reserve extra headroom for them here
+  // instead, then draw them BELOW plotT (inside the plot, near its top).
+  if (hasMilestoneLabels) {
+    // Slightly generous vs. the actual milestone label font (plotH * 0.07,
+    // computed later from a necessarily-smaller plotH) so it always clears.
+    const msLabelSize = Math.max(10, Math.round(h * 0.06));
+    chartTop += msLabelSize + 8;
   }
 
   // ---- Plot area ----
@@ -294,7 +308,10 @@ function drawBellCurve(
 }
 
 /**
- * Draw milestone dashed lines (value in data space) with top label.
+ * Draw milestone dashed lines (value in data space) with a label.
+ * Label renders just BELOW plotT (inside the plot, near its top) rather
+ * than above it — chartTop already reserves headroom for this so the
+ * label never collides with the title.
  */
 function drawMilestones(ctx, milestones, xMin, xSpan, plotL, plotT, plotB, plotW, plotH, fg) {
   const labelSize = Math.max(10, Math.round(plotH * 0.07));
@@ -323,8 +340,8 @@ function drawMilestones(ctx, milestones, xMin, xSpan, plotL, plotT, plotB, plotW
       ctx.fillStyle = rgbaCss(milestoneColor, 0.95);
       ctx.font = `600 ${labelSize}px Inter, system-ui, sans-serif`;
       ctx.textAlign = 'center';
-      ctx.textBaseline = 'bottom';
-      ctx.fillText(String(ms.label), mx, plotT - 2);
+      ctx.textBaseline = 'top';
+      ctx.fillText(String(ms.label), mx, plotT + 2);
       ctx.restore();
     }
   }

--- a/sdf-js/src/present/atoms-2d/charts/data/radial-spoke.js
+++ b/sdf-js/src/present/atoms-2d/charts/data/radial-spoke.js
@@ -118,6 +118,27 @@ export function drawPseudo3D(ctx, args, opts = {}) {
       ctx.textBaseline = Math.sin(a) > 0.3 ? 'top' : Math.sin(a) < -0.3 ? 'bottom' : 'middle';
       ctx.fillText(String(labels[i]), lx, ly);
     }
+
+    // Per-spoke value — small dark text placed INLINE along the spoke, just
+    // short of the tip node, so it never collides with the outer category
+    // label (which sits beyond the tip). White halo keeps it legible over
+    // the colored spoke/node.
+    if (Number.isFinite(values[i])) {
+      const valR = Math.max(hubR + nodeR + 6, len - nodeR - 12);
+      const vx = cx + Math.cos(a) * valR;
+      const vy = cy + Math.sin(a) * valR;
+      const valueText = formatSpokeValue(values[i]);
+      ctx.save();
+      ctx.font = '700 11px Inter, system-ui, sans-serif';
+      ctx.textAlign = 'center';
+      ctx.textBaseline = 'middle';
+      ctx.lineWidth = 3;
+      ctx.strokeStyle = 'rgba(255,255,255,0.8)';
+      ctx.strokeText(valueText, vx, vy);
+      ctx.fillStyle = rgbCss(fg);
+      ctx.fillText(valueText, vx, vy);
+      ctx.restore();
+    }
   }
 
   // Hub
@@ -137,6 +158,11 @@ export function drawPseudo3D(ctx, args, opts = {}) {
 
 function clamp(v, lo, hi) {
   return Math.max(lo, Math.min(hi, v));
+}
+
+// values[] are 0..1 normalized lengths — display as a percentage.
+function formatSpokeValue(v) {
+  return `${Math.round(v * 100)}%`;
 }
 
 function lighten(rgb, amt) {

--- a/sdf-js/src/present/atoms-2d/charts/diagrams/strategy-map.js
+++ b/sdf-js/src/present/atoms-2d/charts/diagrams/strategy-map.js
@@ -41,6 +41,24 @@ function fitFontSize(ctx, text, maxW, target, min, specFn) {
   return min;
 }
 
+// fitFontSize bottoms out at `min` and gives up — long text (e.g. "Learning
+// & Growth" in the rotated perspective label, where maxW is bounded by the
+// row height) can still overflow past that at the floor size. Truncate with
+// an ellipsis as a last resort so it never bleeds into a neighboring row/card.
+// Assumes ctx.font is already set to the size being used.
+function truncateToWidth(ctx, text, maxW) {
+  if (ctx.measureText(text).width <= maxW) return text;
+  let lo = 0;
+  let hi = text.length;
+  while (lo < hi) {
+    const mid = Math.ceil((lo + hi) / 2);
+    const candidate = text.slice(0, mid) + '…';
+    if (ctx.measureText(candidate).width <= maxW) lo = mid;
+    else hi = mid - 1;
+  }
+  return lo > 0 ? text.slice(0, lo) + '…' : '…';
+}
+
 function lighten(rgb, amt) {
   return [
     Math.min(255, rgb[0] + (255 - rgb[0]) * amt),
@@ -115,7 +133,8 @@ export function drawPseudo3D(ctx, args, opts = {}) {
     ctx.fillStyle = rgbCss([255, 255, 255]);
     ctx.textAlign = 'center';
     ctx.textBaseline = 'middle';
-    ctx.fillText(p.label ?? '', 0, 0);
+    const labelText = truncateToWidth(ctx, p.label ?? '', rowH - 8);
+    ctx.fillText(labelText, 0, 0);
     ctx.restore();
 
     // Item cards in the right area
@@ -156,7 +175,8 @@ export function drawPseudo3D(ctx, args, opts = {}) {
         ctx.fillStyle = rgbCss(fg);
         ctx.textAlign = 'center';
         ctx.textBaseline = 'middle';
-        ctx.fillText(itemText, cardX + cardW / 2, cardY + cardH / 2);
+        const displayItemText = truncateToWidth(ctx, itemText, cardW - 12);
+        ctx.fillText(displayItemText, cardX + cardW / 2, cardY + cardH / 2);
       }
     }
 

--- a/sdf-js/src/present/atoms-2d/media/image-split.js
+++ b/sdf-js/src/present/atoms-2d/media/image-split.js
@@ -26,8 +26,10 @@ export const spec = {
     src: {
       type: 'string (data: URI or parser-emitted relative path)',
       required: true,
+      // See image.js spec — same synthetic SVG stand-in so the gallery
+      // example renders a real image instead of a blank 1x1 placeholder.
       example:
-        'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVQIHWNgIBb8BwABKAEBwGDOlAAAAABJRU5ErkJggg==',
+        "data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='640' height='360' viewBox='0 0 640 360'><defs><linearGradient id='g' x1='0' y1='0' x2='0' y2='1'><stop offset='0' stop-color='%23ffb066'/><stop offset='1' stop-color='%23c65a4a'/></linearGradient></defs><rect width='640' height='360' fill='url(%23g)'/><polygon fill='%23332244' points='0,360 120,180 220,260 340,160 460,250 560,140 640,220 640,360'/></svg>",
     },
     title: { type: 'string', required: true, example: 'Our Mission' },
     body: { type: 'string?', example: 'Make on-chain trading natural.' },

--- a/sdf-js/src/present/atoms-2d/media/image.js
+++ b/sdf-js/src/present/atoms-2d/media/image.js
@@ -28,8 +28,13 @@ export const spec = {
     src: {
       type: 'string (data: URI or parser-emitted relative path)',
       required: true,
+      // Small inline SVG (gradient sky + mountain silhouette) — a stand-in
+      // for a parser-emitted embedded photo. Only the *example* here is a
+      // synthetic SVG so the gallery renders something real; production
+      // src values are always data: URIs or relative paths lifted verbatim
+      // from the source document (see spec description above).
       example:
-        'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVQIHWNgIBb8BwABKAEBwGDOlAAAAABJRU5ErkJggg==',
+        "data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='640' height='360' viewBox='0 0 640 360'><defs><linearGradient id='g' x1='0' y1='0' x2='0' y2='1'><stop offset='0' stop-color='%23ffb066'/><stop offset='1' stop-color='%23c65a4a'/></linearGradient></defs><rect width='640' height='360' fill='url(%23g)'/><polygon fill='%23332244' points='0,360 120,180 220,260 340,160 460,250 560,140 640,220 640,360'/></svg>",
     },
     fit: { type: "'cover'|'contain'|'fill'?", default: "'cover'", example: 'cover' },
     caption: { type: 'string?', example: 'Slide 3 photo' },
@@ -186,8 +191,16 @@ export async function drawPseudo3D(ctx, args, opts = {}) {
 
   ctx.save();
 
+  // Always clip to the atom's own box — 'cover' fit intentionally
+  // over-scales the image to fill the box and can render outside [x,y,w,h]
+  // (e.g. inside image-split, this used to bleed into the text panel next
+  // door). borderRadius just picks rounded vs. rectangular clip.
   if (borderRadius > 0) {
     clipRoundRect(ctx, x, y, w, h, borderRadius);
+  } else {
+    ctx.beginPath();
+    ctx.rect(x, y, w, h);
+    ctx.clip();
   }
 
   // Node env: no Image constructor → draw placeholder

--- a/sdf-js/src/present/atoms-2d/shapes/arrow.js
+++ b/sdf-js/src/present/atoms-2d/shapes/arrow.js
@@ -24,7 +24,8 @@ export const spec = {
 };
 
 const PAD = 14;
-const LABEL_FRAC = 0.18;
+const CAPTION_FRAC = 0.2; // reserve for caption text + accent underline bar
+const HERO_SIZE_FRAC = 0.55; // shape target size as a fraction of canvas height
 
 export function drawPseudo3D(ctx, args, opts = {}) {
   const x = opts.x ?? 0;
@@ -36,22 +37,39 @@ export function drawPseudo3D(ctx, args, opts = {}) {
   const color = args.color || palette.colors?.[0] || [60, 100, 200];
   const label = args.label;
 
-  const labelH = label ? h * LABEL_FRAC : 0;
+  const captionH = label ? h * CAPTION_FRAC : 0;
   const shapeAreaW = w - PAD * 2;
-  const shapeAreaH = h - PAD * 2 - labelH;
+  const shapeAreaH = h - PAD * 2 - captionH;
   const cx = x + w / 2;
   const cy = y + PAD + shapeAreaH / 2;
-  const size = Math.min(shapeAreaW, shapeAreaH);
+  const size = Math.min(shapeAreaW, shapeAreaH, h * HERO_SIZE_FRAC);
 
   drawArrow(ctx, cx, cy, size, color, args.direction || 'right');
 
   if (label) {
-    ctx.fillStyle = rgbCss(fg);
-    ctx.font = `600 ${Math.min(18, labelH * 0.55)}px Inter, system-ui, sans-serif`;
-    ctx.textAlign = 'center';
-    ctx.textBaseline = 'middle';
-    ctx.fillText(String(label), cx, y + h - labelH / 2 - PAD / 2);
+    drawCaption(ctx, String(label), cx, y, h, captionH, shapeAreaW, fg, color);
   }
+}
+
+/**
+ * Hero caption: larger Inter 700 type + accent underline bar (shared look
+ * with diamond.js — both are single-shape "iconic" atoms).
+ */
+function drawCaption(ctx, text, cx, y, h, captionH, shapeAreaW, fg, accentColor) {
+  const captionSize = Math.max(14, Math.round(h * 0.07));
+  ctx.font = `700 ${captionSize}px Inter, system-ui, sans-serif`;
+  const textW = ctx.measureText(text).width;
+  const textY = y + h - captionH / 2 - captionSize * 0.25;
+
+  ctx.fillStyle = rgbCss(fg);
+  ctx.textAlign = 'center';
+  ctx.textBaseline = 'middle';
+  ctx.fillText(text, cx, textY);
+
+  const underlineW = Math.min(textW + 24, shapeAreaW * 0.6);
+  const underlineY = textY + captionSize * 0.62;
+  ctx.fillStyle = rgbCss(accentColor);
+  ctx.fillRect(cx - underlineW / 2, underlineY, underlineW, 3);
 }
 
 function buildArrowPoints(stemW, stemH, headW, headH) {

--- a/sdf-js/src/present/atoms-2d/shapes/diamond.js
+++ b/sdf-js/src/present/atoms-2d/shapes/diamond.js
@@ -22,7 +22,8 @@ export const spec = {
 };
 
 const PAD = 14;
-const LABEL_FRAC = 0.18;
+const CAPTION_FRAC = 0.2; // reserve for caption text + accent underline bar
+const HERO_SIZE_FRAC = 0.55; // shape target size as a fraction of canvas height
 
 export function drawPseudo3D(ctx, args, opts = {}) {
   const x = opts.x ?? 0;
@@ -34,22 +35,39 @@ export function drawPseudo3D(ctx, args, opts = {}) {
   const color = args.color || palette.colors?.[0] || [60, 100, 200];
   const label = args.label;
 
-  const labelH = label ? h * LABEL_FRAC : 0;
+  const captionH = label ? h * CAPTION_FRAC : 0;
   const shapeAreaW = w - PAD * 2;
-  const shapeAreaH = h - PAD * 2 - labelH;
+  const shapeAreaH = h - PAD * 2 - captionH;
   const cx = x + w / 2;
   const cy = y + PAD + shapeAreaH / 2;
-  const size = Math.min(shapeAreaW, shapeAreaH);
+  const size = Math.min(shapeAreaW, shapeAreaH, h * HERO_SIZE_FRAC);
 
   drawDiamond(ctx, cx, cy, size, color);
 
   if (label) {
-    ctx.fillStyle = rgbCss(fg);
-    ctx.font = `600 ${Math.min(18, labelH * 0.55)}px Inter, system-ui, sans-serif`;
-    ctx.textAlign = 'center';
-    ctx.textBaseline = 'middle';
-    ctx.fillText(String(label), cx, y + h - labelH / 2 - PAD / 2);
+    drawCaption(ctx, String(label), cx, y, h, captionH, shapeAreaW, fg, color);
   }
+}
+
+/**
+ * Hero caption: larger Inter 700 type + accent underline bar (shared look
+ * with arrow.js — both are single-shape "iconic" atoms).
+ */
+function drawCaption(ctx, text, cx, y, h, captionH, shapeAreaW, fg, accentColor) {
+  const captionSize = Math.max(14, Math.round(h * 0.07));
+  ctx.font = `700 ${captionSize}px Inter, system-ui, sans-serif`;
+  const textW = ctx.measureText(text).width;
+  const textY = y + h - captionH / 2 - captionSize * 0.25;
+
+  ctx.fillStyle = rgbCss(fg);
+  ctx.textAlign = 'center';
+  ctx.textBaseline = 'middle';
+  ctx.fillText(text, cx, textY);
+
+  const underlineW = Math.min(textW + 24, shapeAreaW * 0.6);
+  const underlineY = textY + captionSize * 0.62;
+  ctx.fillStyle = rgbCss(accentColor);
+  ctx.fillRect(cx - underlineW / 2, underlineY, underlineW, 3);
 }
 
 function drawDiamond(ctx, cx, cy, size, color) {

--- a/sdf-js/src/present/atoms-2d/shapes/sphere-network.js
+++ b/sdf-js/src/present/atoms-2d/shapes/sphere-network.js
@@ -93,13 +93,13 @@ export function drawPseudo3D(ctx, args, opts = {}) {
     const color = s.color || baseColors[(i + 1) % baseColors.length] || accent;
     drawNode(ctx, sx, sy, satR, color, null, fg, false);
 
-    // Label outside satellite (radial direction)
+    // Label outside satellite (radial direction) — min 11px for legibility.
     if (s.label) {
       const lr = orbitR + satR + 12;
       const lx = cx + Math.cos(a) * lr;
       const ly = cy + Math.sin(a) * lr;
       ctx.fillStyle = rgbCss(fg);
-      ctx.font = `600 ${Math.round(h * 0.04)}px Inter, system-ui, sans-serif`;
+      ctx.font = `600 ${Math.max(11, Math.round(h * 0.04))}px Inter, system-ui, sans-serif`;
       ctx.textAlign = Math.cos(a) > 0.3 ? 'left' : Math.cos(a) < -0.3 ? 'right' : 'center';
       ctx.textBaseline = Math.sin(a) > 0.3 ? 'top' : Math.sin(a) < -0.3 ? 'bottom' : 'middle';
       ctx.fillText(String(s.label), lx, ly);
@@ -150,10 +150,17 @@ function drawNode(ctx, cx, cy, r, color, label, fg, isHub) {
   ctx.restore();
 
   if (label && isHub) {
-    ctx.fillStyle = 'white';
-    ctx.font = `700 ${Math.round(r * 0.62)}px Inter, system-ui, sans-serif`;
+    // On-sphere label: dark fg text + white halo (strokeText under fill)
+    // reads reliably regardless of the sphere's own color/lightness —
+    // more robust than a fixed white fill, which vanished on light spheres.
+    const fontSize = Math.max(11, Math.round(r * 0.62));
+    ctx.font = `700 ${fontSize}px Inter, system-ui, sans-serif`;
     ctx.textAlign = 'center';
     ctx.textBaseline = 'middle';
+    ctx.lineWidth = 3;
+    ctx.strokeStyle = 'rgba(255,255,255,0.8)';
+    ctx.strokeText(String(label), cx, cy);
+    ctx.fillStyle = rgbCss(fg);
     ctx.fillText(String(label), cx, cy);
   }
 }

--- a/sdf-js/src/present/atoms-2d/shapes/sphere-tree.js
+++ b/sdf-js/src/present/atoms-2d/shapes/sphere-tree.js
@@ -156,18 +156,23 @@ export function drawPseudo3D(ctx, args, opts = {}) {
         ctx.restore();
       }
 
-      // Label (inside node if large enough; else below)
+      // Label (inside node if large enough; else below) — min 11px, and
+      // on-sphere labels get a white halo so they read on any node color.
       if (node.label) {
         const insideOk = nr > 18;
         if (insideOk) {
-          ctx.fillStyle = 'white';
-          ctx.font = `700 ${Math.round(nr * 0.5)}px Inter, system-ui, sans-serif`;
+          const fontSize = Math.max(11, Math.round(nr * 0.5));
+          ctx.font = `700 ${fontSize}px Inter, system-ui, sans-serif`;
           ctx.textAlign = 'center';
           ctx.textBaseline = 'middle';
+          ctx.lineWidth = 3;
+          ctx.strokeStyle = 'rgba(255,255,255,0.8)';
+          ctx.strokeText(String(node.label), nx, ny);
+          ctx.fillStyle = rgbCss(fg);
           ctx.fillText(String(node.label), nx, ny);
         } else {
           ctx.fillStyle = rgbCss(fg);
-          ctx.font = `600 ${Math.round(h * 0.034)}px Inter, system-ui, sans-serif`;
+          ctx.font = `600 ${Math.max(11, Math.round(h * 0.034))}px Inter, system-ui, sans-serif`;
           ctx.textAlign = 'center';
           ctx.textBaseline = 'top';
           ctx.fillText(String(node.label), nx, ny + nr + 4);


### PR DESCRIPTION
## Summary
- Fixes all 6 P2 minor issues from the round-2/3 visual scorecard backlog: `bar` targetLine/title collision, `histogram` title/"Median" overlap, `arrow`/`diamond` hero polish (bigger shape + bolder caption), `radial-spoke` per-spoke values, `sphere-network`/`sphere-tree` on-sphere label contrast, `image`/`image-split` blank gallery example (+ a real box-clip bleed bug found while verifying).
- Full re-audit of all 101 atoms (9 gallery chunks, screenshot + multimodal review each) to certify the library end-to-end — **101/101 PL-grade**.
- Found and fixed 2 new issues during the re-audit rather than deferring them: `strategy-map` row-label bleeding into neighboring rows, `change-curve-chart` edge phase labels overflowing the canvas.
- `docs/superpowers/atom-visual-scorecard.md` updated with round-4 fixes + certification section.

## Test plan
- [x] `npm test` — 118/118 test files passed
- [x] Every fixed atom re-rendered via `all-atoms-gallery.html` and visually confirmed (before/after screenshots in local report)
- [x] Full 9-chunk gallery re-audit read end-to-end after all fixes landed, including the 2 new fixes, to confirm no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)