### PR TITLE
feat(text-to-ir): the thesis loop closes — describe it, Atlas builds the world

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -150,6 +150,7 @@ const TESTS = [
   { category: 'scene', file: 'sdf-js/scripts/test-render-magnitude.mjs' },
   { category: 'scene', file: 'sdf-js/scripts/test-assemble-deck.mjs' },
   { category: 'scene', file: 'sdf-js/scripts/test-camera-shake.mjs' },
+  { category: 'scene', file: 'sdf-js/scripts/test-text-to-ir.mjs' },
   { category: 'scene', file: 'sdf-js/scripts/test-scaffold-to-ir.mjs' },
   { category: 'scene', file: 'sdf-js/scripts/test-atom-3d-coverage.mjs' },
 

--- a/sdf-js/apps/present/author.html
+++ b/sdf-js/apps/present/author.html
@@ -1,0 +1,166 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>Atlas Author — text → world</title>
+    <style>
+      html,
+      body {
+        margin: 0;
+        height: 100%;
+        background: #0e0f12;
+        overflow: hidden;
+      }
+      #wrap {
+        position: fixed;
+        inset: 0;
+      }
+      #c {
+        display: block;
+        width: 100%;
+        height: 100%;
+      }
+      .lbl {
+        position: fixed;
+        transform: translate(-50%, -50%);
+        pointer-events: none;
+        font:
+          600 13px -apple-system,
+          Inter,
+          sans-serif;
+        color: #fff;
+        padding: 4px 10px;
+        border-radius: 5px;
+        background: rgba(30, 32, 40, 0.82);
+        opacity: 0;
+        transition: opacity 0.5s;
+        white-space: nowrap;
+      }
+      .lbl.value {
+        background: rgba(40, 116, 196, 0.92);
+        font-weight: 700;
+      }
+      /* author bar — the one input that turns words into a world */
+      #bar {
+        position: fixed;
+        left: 50%;
+        bottom: 22px;
+        transform: translateX(-50%);
+        width: min(760px, calc(100vw - 40px));
+        display: flex;
+        gap: 8px;
+        z-index: 20;
+        font-family: -apple-system, Inter, sans-serif;
+      }
+      #prompt {
+        flex: 1;
+        resize: none;
+        height: 52px;
+        padding: 14px 16px;
+        border-radius: 10px;
+        border: 1px solid rgba(255, 255, 255, 0.16);
+        background: rgba(20, 22, 28, 0.92);
+        color: #fff;
+        font: 500 14px -apple-system, Inter, sans-serif;
+        outline: none;
+      }
+      #prompt:focus {
+        border-color: rgba(90, 150, 250, 0.7);
+      }
+      #go {
+        padding: 0 22px;
+        border-radius: 10px;
+        border: 0;
+        background: #2d6fd6;
+        color: #fff;
+        font: 700 14px -apple-system, Inter, sans-serif;
+        cursor: pointer;
+      }
+      #go:disabled {
+        opacity: 0.5;
+        cursor: wait;
+      }
+      #status {
+        position: fixed;
+        left: 50%;
+        bottom: 84px;
+        transform: translateX(-50%);
+        font: 500 12px -apple-system, Inter, sans-serif;
+        color: rgba(255, 255, 255, 0.6);
+        z-index: 20;
+        max-width: min(760px, calc(100vw - 40px));
+        text-align: center;
+      }
+      #status.err {
+        color: #ff9a8a;
+      }
+      #keyrow {
+        position: fixed;
+        right: 14px;
+        top: 12px;
+        z-index: 20;
+        display: flex;
+        gap: 6px;
+      }
+      #key {
+        width: 220px;
+        padding: 6px 10px;
+        border-radius: 7px;
+        border: 1px solid rgba(255, 255, 255, 0.14);
+        background: rgba(20, 22, 28, 0.9);
+        color: #ccc;
+        font: 400 11px monospace;
+        outline: none;
+      }
+      #loading {
+        position: fixed;
+        inset: 0;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        gap: 14px;
+        background: #0e0f12;
+        transition: opacity 0.4s;
+        z-index: 10;
+      }
+      #loading.done {
+        opacity: 0;
+        pointer-events: none;
+      }
+      #loading .ring {
+        width: 34px;
+        height: 34px;
+        border-radius: 50%;
+        border: 3px solid rgba(255, 255, 255, 0.14);
+        border-top-color: rgba(255, 255, 255, 0.85);
+        animation: spin 0.9s linear infinite;
+      }
+      #loading .msg {
+        font:
+          500 12px -apple-system,
+          Inter,
+          sans-serif;
+        color: rgba(255, 255, 255, 0.55);
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+      }
+      @keyframes spin {
+        to {
+          transform: rotate(360deg);
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <div id="wrap"><canvas id="c"></canvas></div>
+    <div id="loading" class="done"><div class="ring"></div><div class="msg">compiling scene</div></div>
+    <div id="keyrow"><input id="key" type="password" placeholder="Anthropic API key (BYOK, stays local)" /></div>
+    <div id="status">describe what you want to present — Atlas builds the world</div>
+    <div id="bar">
+      <textarea id="prompt" placeholder="e.g. our Q3: revenue by region (Americas leads at 890), the sales funnel from 1200 leads to 45 closed, and the new org under the CEO"></textarea>
+      <button id="go">Generate</button>
+    </div>
+    <script type="module" src="./author.js"></script>
+  </body>
+</html>

--- a/sdf-js/apps/present/author.js
+++ b/sdf-js/apps/present/author.js
@@ -1,0 +1,53 @@
+// author.js — the "text → world" page: describe the presentation, textToIR
+// turns it into a validated deck of IRs, assembleDeck builds ONE continuous
+// world, and the camera flies it. The full thesis loop in one input box.
+import { textToIR } from '../../src/scene/text-to-ir.js';
+import { assembleDeck } from '../../src/scene/assemble-deck.js';
+import { createFigure } from './figure-core.js';
+
+const STORAGE_KEY = 'atlas-anthropic-key'; // shared with the compositor's lift
+
+const params = new URLSearchParams(location.search);
+const env = params.get('env') || 'studio';
+const { show } = createFigure({ outdoor: env !== 'studio' });
+
+const promptEl = document.getElementById('prompt');
+const goEl = document.getElementById('go');
+const statusEl = document.getElementById('status');
+const keyEl = document.getElementById('key');
+const loading = document.getElementById('loading');
+
+keyEl.value = localStorage.getItem(STORAGE_KEY) || '';
+keyEl.addEventListener('change', () => localStorage.setItem(STORAGE_KEY, keyEl.value.trim()));
+
+const setStatus = (msg, err = false) => {
+  statusEl.textContent = msg;
+  statusEl.className = err ? 'err' : '';
+};
+
+async function generate() {
+  const text = promptEl.value.trim();
+  const apiKey = keyEl.value.trim();
+  if (!text) return setStatus('write what you want to present first', true);
+  if (!apiKey)
+    return setStatus('paste your Anthropic API key (top right — it stays in your browser)', true);
+  goEl.disabled = true;
+  try {
+    setStatus('thinking… (text → structures)');
+    const deck = await textToIR(text, apiKey);
+    setStatus(
+      `building ${deck.slides.length} station${deck.slides.length > 1 ? 's' : ''}: ${deck.slides.map((s) => s.structure).join(' → ')}`,
+    );
+    loading.classList.remove('done'); // shader may recompile for a new shape
+    show(assembleDeck(deck, { env }));
+  } catch (e) {
+    setStatus(e.message, true);
+  } finally {
+    goEl.disabled = false;
+  }
+}
+
+goEl.addEventListener('click', generate);
+promptEl.addEventListener('keydown', (e) => {
+  if ((e.metaKey || e.ctrlKey) && e.key === 'Enter') generate();
+});

--- a/sdf-js/apps/present/figure-core.js
+++ b/sdf-js/apps/present/figure-core.js
@@ -1,0 +1,96 @@
+// figure-core.js — the shared live-figure mount: studio renderer + boot loader
+// + reveal-timed label overlay. Used by figure.js (?ir= / ?deck= viewer) and
+// author.js (text → IR → deck). One mount per page.
+import { createStudioRenderer } from '../../src/render/studio.js';
+import { applyStudioScene } from '../../src/runtime/apply-studio-scene.js';
+
+/**
+ * createFigure({ outdoor }) → { studio, show(sceneData) }.
+ * `show` may be called repeatedly (the author page regenerates in place) —
+ * old overlay labels are removed and the new scene's sequence starts fresh.
+ */
+export function createFigure({ outdoor = false } = {}) {
+  const wrap = document.getElementById('wrap');
+  const canvas = document.getElementById('c');
+  const size = () => {
+    canvas.width = Math.max(1, wrap.clientWidth || window.innerWidth);
+    canvas.height = Math.max(1, wrap.clientHeight || window.innerHeight);
+  };
+  size();
+
+  const studio = createStudioRenderer({
+    canvas,
+    getControls: () => ({
+      lightAzim: 0.5,
+      lightAlt: 0.7,
+      lightDist: 30,
+      fov: 1.5,
+      shadowsOn: true,
+      // Outdoor envs bring their own terrain — the studio's flat ground plane
+      // + checker must be off or they slice through the landscape.
+      groundOn: !outdoor,
+      checkerOn: !outdoor,
+    }),
+    onFps: () => {},
+  });
+  window.addEventListener('resize', () => {
+    size();
+    if (studio.requestRender) studio.requestRender();
+  });
+
+  // test hooks (Playwright verification): replay restarts the fly-through;
+  // pinning setSequenceTime in a loop freezes a moment for capture.
+  window.__figStudio = studio;
+
+  let items = [];
+  let els = [];
+  const loading = document.getElementById('loading');
+
+  function show(scene) {
+    for (const el of els) el.remove();
+    // Reveal-timed overlay: labels fade in as the sequence clock passes each
+    // item's revealAt (makeOverlay isn't reused — it has no reveal timing).
+    items = (scene.overlay || []).filter((o) => o.anchor && o.text);
+    els = items.map((o) => {
+      const d = document.createElement('div');
+      d.className = 'lbl' + (o.role === 'value' ? ' value' : '');
+      d.textContent = o.text;
+      if (o.role === 'title') {
+        d.style.fontSize = '20px';
+        d.style.fontWeight = '900';
+        d.style.background = 'none';
+      }
+      document.body.appendChild(d);
+      return d;
+    });
+    window.__figReplay = () => studio.setSequence(scene.cameraSequence);
+    // applyStudioScene wires setSequence + setAnimated (subject.animation counts
+    // as time content) — no manual overrides needed.
+    applyStudioScene(studio, scene);
+  }
+
+  function tick() {
+    // Dismiss the boot loader on the first drawn frame (the async shader
+    // compile keeps the main thread free, so the spinner animates while we wait).
+    if (loading && !loading.classList.contains('done') && studio.hasDrawn && studio.hasDrawn()) {
+      loading.classList.add('done');
+    }
+    const t = studio.getSequenceTime ? studio.getSequenceTime() : 1e9;
+    for (let i = 0; i < items.length; i++) {
+      const o = items[i],
+        el = els[i];
+      const p = studio.project(o.anchor);
+      if (!p || !p.visible) {
+        el.style.opacity = 0;
+        continue;
+      }
+      el.style.left = `${p.x * canvas.clientWidth}px`;
+      el.style.top = `${p.y * canvas.clientHeight}px`;
+      el.style.opacity = o.revealAt == null || t >= o.revealAt ? 1 : 0;
+    }
+    requestAnimationFrame(tick);
+  }
+  requestAnimationFrame(tick);
+
+  return { studio, show };
+}

--- a/sdf-js/apps/present/figure.js
+++ b/sdf-js/apps/present/figure.js
@@ -1,96 +1,17 @@
-// figure.js — standalone live "figure": one structure-rendered scene (IR → renderSequence)
-// mounted in the studio, camera fly-through playing, labels fading in by sequence time.
-// The embeddable unit of the structure-aware spatialization slice (P1). ?ir=<name> loads
-// scenes/ir/<name>.json.
-import { createStudioRenderer } from '../../src/render/studio.js';
-import { applyStudioScene } from '../../src/runtime/apply-studio-scene.js';
+// figure.js — standalone live "figure" viewer. ?ir=<name> renders one structure
+// from scenes/ir/<name>.json; ?deck=<name> assembles a multi-IR deck (one
+// continuous world, stations along the deck axis). ?env=alpine swaps the studio
+// room for the open snow-mountain world. Mounting lives in figure-core.js
+// (shared with the author page).
 import { renderIR } from '../../src/scene/render-ir.js';
 import { assembleDeck } from '../../src/scene/assemble-deck.js';
+import { createFigure } from './figure-core.js';
 
-const wrap = document.getElementById('wrap');
-const canvas = document.getElementById('c');
-function size() {
-  canvas.width = Math.max(1, wrap.clientWidth || window.innerWidth);
-  canvas.height = Math.max(1, wrap.clientHeight || window.innerHeight);
-}
-size();
-
-// ?env=alpine swaps the studio room for an open world (snow mountains + the
-// arch-bridge backdrop). Outdoor envs bring their own terrain — the studio's
-// flat ground plane + checker must be off or they slice through the landscape.
 const params = new URLSearchParams(location.search);
 const env = params.get('env') || 'studio';
-const outdoor = env !== 'studio';
+const { show } = createFigure({ outdoor: env !== 'studio' });
 
-const studio = createStudioRenderer({
-  canvas,
-  getControls: () => ({
-    lightAzim: 0.5,
-    lightAlt: 0.7,
-    lightDist: 30,
-    fov: 1.5,
-    shadowsOn: true,
-    groundOn: !outdoor,
-    checkerOn: !outdoor,
-  }),
-  onFps: () => {},
-});
-window.addEventListener('resize', () => {
-  size();
-  if (studio.requestRender) studio.requestRender();
-});
-
-// test hooks (Playwright verification + future figure e2e tests): replay restarts
-// the fly-through; pinning setSequenceTime in a loop freezes a moment for capture.
-window.__figStudio = studio;
-window.__figReplay = () => studio.setSequence(scene.cameraSequence);
-
-// ?deck=<name> assembles a multi-IR deck (one continuous world, stations along
-// the deck axis); ?ir=<name> renders a single structure.
 const deckName = params.get('deck');
 const name = params.get('ir') || 'funnel-sales';
 const ir = await (await fetch(`../../scenes/ir/${deckName || name}.json`)).json();
-const scene = deckName ? assembleDeck(ir, { env }) : renderIR(ir, { env });
-// applyStudioScene wires setSequence + setAnimated (subject.animation counts as
-// time content since the sceneHasTimeContent fix) — no manual overrides needed.
-applyStudioScene(studio, scene);
-
-// Our own reveal-timed overlay: labels fade in as the sequence clock passes each
-// item's revealAt (makeOverlay isn't reused — it has no reveal timing).
-const items = (scene.overlay || []).filter((o) => o.anchor && o.text);
-const els = items.map((o) => {
-  const d = document.createElement('div');
-  d.className = 'lbl' + (o.role === 'value' ? ' value' : '');
-  d.textContent = o.text;
-  if (o.role === 'title') {
-    d.style.fontSize = '20px';
-    d.style.fontWeight = '900';
-    d.style.background = 'none';
-  }
-  document.body.appendChild(d);
-  return d;
-});
-// Dismiss the boot loader on the first drawn frame (the async shader compile
-// keeps the main thread free, so the spinner animates while we wait).
-const loading = document.getElementById('loading');
-function tick() {
-  if (loading && !loading.classList.contains('done') && studio.hasDrawn && studio.hasDrawn()) {
-    loading.classList.add('done');
-  }
-  const t = studio.getSequenceTime ? studio.getSequenceTime() : 1e9;
-  for (let i = 0; i < items.length; i++) {
-    const o = items[i],
-      el = els[i];
-    const p = studio.project(o.anchor);
-    if (!p || !p.visible) {
-      el.style.opacity = 0;
-      continue;
-    }
-    el.style.left = `${p.x * canvas.clientWidth}px`;
-    el.style.top = `${p.y * canvas.clientHeight}px`;
-    const revealed = o.revealAt == null || t >= o.revealAt;
-    el.style.opacity = revealed ? 1 : 0;
-  }
-  requestAnimationFrame(tick);
-}
-requestAnimationFrame(tick);
+show(deckName ? assembleDeck(ir, { env }) : renderIR(ir, { env }));

--- a/sdf-js/scripts/test-text-to-ir.mjs
+++ b/sdf-js/scripts/test-text-to-ir.mjs
@@ -1,0 +1,90 @@
+// sdf-js/scripts/test-text-to-ir.mjs — the text → IR adapter's parse/validate
+// path (the LLM call itself is BYOK browser-side; CI tests the contract).
+import { parseIRResponse, TEXT_TO_IR_SYSTEM } from '../src/scene/text-to-ir.js';
+import { assembleDeck } from '../src/scene/assemble-deck.js';
+import { compile } from '../src/scene/index.js';
+
+let pass = 0,
+  fail = 0;
+const ok = (c, n) => (c ? (pass++, console.log(`  ✓ ${n}`)) : (fail++, console.log(`  ✗ ${n}`)));
+console.log('=== text-to-ir (parse + validate + end-to-end) ===\n');
+
+const GOOD = JSON.stringify({
+  title: 'Q3',
+  slides: [
+    {
+      structure: 'magnitude',
+      nodes: ['EMEA', 'APAC', 'Americas'],
+      magnitude: [340, 620, 890],
+      emphasis: [2],
+      title: 'Revenue',
+    },
+    {
+      structure: 'sequence',
+      nodes: ['Leads', 'Closed'],
+      magnitude: [1200, 45],
+      emphasis: [1],
+      title: 'Funnel',
+    },
+  ],
+});
+
+// ---- happy path + fence/prose tolerance ---------------------------------------
+ok(parseIRResponse(GOOD).slides.length === 2, 'clean JSON parses');
+ok(parseIRResponse('```json\n' + GOOD + '\n```').slides.length === 2, 'fenced JSON parses');
+ok(parseIRResponse('Here is your deck:\n' + GOOD).slides.length === 2, 'leading prose tolerated');
+
+// ---- failure modes -------------------------------------------------------------
+{
+  let e = null;
+  try {
+    parseIRResponse('I cannot do that.');
+  } catch (x) {
+    e = x;
+  }
+  ok(e && /not JSON|must be/.test(e.message), 'non-JSON reply throws clearly');
+}
+{
+  let e = null;
+  try {
+    parseIRResponse(
+      JSON.stringify({
+        title: 'bad',
+        slides: [{ structure: 'hierarchy', nodes: ['a', 'b'], title: 'no relations' }],
+      }),
+    );
+  } catch (x) {
+    e = x;
+  }
+  ok(
+    e && Array.isArray(e.validationErrors),
+    'invalid IR throws with validationErrors (retry fuel)',
+  );
+  ok(e && /hierarchy/.test(e.message), 'error names the failing slide');
+}
+
+// ---- the whole loop: parsed deck → assembled world → compiles -------------------
+{
+  const deck = parseIRResponse(GOOD);
+  const scene = assembleDeck(deck);
+  ok(scene.subjects.length > 0 && scene.cameraSequence.shots.length > 5, 'deck assembles');
+  try {
+    compile(scene, {});
+    ok(true, 'text → IR → deck → ONE compiled scene (thesis loop closes)');
+  } catch (x) {
+    ok(false, `compile failed: ${x.message}`);
+  }
+}
+
+// ---- prompt hygiene (repo rule: prompts stay SHORT) ------------------------------
+ok(
+  TEXT_TO_IR_SYSTEM.length < 2200,
+  `system prompt stays short (${TEXT_TO_IR_SYSTEM.length} chars)`,
+);
+ok(
+  ['sequence', 'hierarchy', 'network', 'magnitude'].every((s) => TEXT_TO_IR_SYSTEM.includes(s)),
+  'all four structures documented',
+);
+
+console.log(`\n${pass} passed, ${fail} failed`);
+process.exit(fail ? 1 : 0);

--- a/sdf-js/src/scene/text-to-ir.js
+++ b/sdf-js/src/scene/text-to-ir.js
@@ -1,0 +1,115 @@
+// sdf-js/src/scene/text-to-ir.js
+// The text → IR input adapter: natural language in, a validated deck of IRs
+// out. This is the seam the IR architecture promised — the renderers never
+// change; a prompt front-end just plugs in. BYOK, browser-direct Anthropic
+// call (same pattern + localStorage key as the compositor's lift).
+//
+// Contract: the model ALWAYS returns a deck shape {title, slides: [IR...]} —
+// a single topic is a one-slide deck — so the caller has exactly one path
+// (assembleDeck). Every slide is validated with validateIR; on failure we
+// retry ONCE, feeding the validator errors back to the model.
+import { validateIR, STRUCTURES } from './ir.js';
+
+export const TEXT_TO_IR_MODEL = 'claude-sonnet-4-6';
+
+// Kept deliberately SHORT (repo rule): schema + one example per structure.
+export const TEXT_TO_IR_SYSTEM = `You convert presentation ideas into Atlas IR JSON.
+
+Output ONLY JSON, no prose/fences: {"title": string, "slides": [IR, ...]}
+One slide per distinct point. 1-5 slides.
+
+IR = {"structure": S, "nodes": [names], "magnitude"?: [numbers, same length],
+      "relations"?: [[i,j],...], "emphasis"?: [index], "order"?: [indices], "title": string}
+
+Structures (pick per slide by the SHAPE of the point):
+- "sequence": ordered stages / conversion / pipeline. magnitude = per-stage size. emphasis = the outcome stage.
+- "hierarchy": tree (org / taxonomy / breakdown). relations = [parent,child] index pairs, exactly one root.
+- "network": web of relationships / ecosystem / dependencies. relations = undirected edges, no self-loops.
+- "magnitude": comparing quantities (revenue by X / market share). magnitude REQUIRED. emphasis = the winner or the point.
+
+Rules: indices are integers into nodes. Numbers real if given, plausible if not.
+emphasis = what the narrative punches. Node names <= 3 words.
+
+Example: "our funnel: 1200 leads to 45 closed, focus on the close"
+{"title":"Pipeline","slides":[{"structure":"sequence","nodes":["Leads","Qualified","Proposal","Closed"],"magnitude":[1200,400,150,45],"emphasis":[3],"title":"Sales Funnel"}]}`;
+
+/** Strip fences/prose and parse the model's reply into a validated deck. */
+export function parseIRResponse(text) {
+  let s = String(text).trim();
+  const fence = s.match(/```(?:json)?\s*([\s\S]*?)```/);
+  if (fence) s = fence[1].trim();
+  // tolerate leading prose before the JSON object
+  const start = s.indexOf('{');
+  if (start > 0) s = s.slice(start);
+  const end = s.lastIndexOf('}');
+  if (end >= 0) s = s.slice(0, end + 1);
+
+  let deck;
+  try {
+    deck = JSON.parse(s);
+  } catch (e) {
+    throw new Error(`text-to-ir: reply is not JSON (${e.message}): ${s.slice(0, 120)}…`);
+  }
+  if (!deck || !Array.isArray(deck.slides) || deck.slides.length === 0)
+    throw new Error('text-to-ir: reply must be {title, slides:[IR...]} with ≥1 slide');
+
+  const errors = [];
+  deck.slides.forEach((ir, i) => {
+    const v = validateIR(ir);
+    if (!v.ok) errors.push(`slide ${i} (${ir?.structure}): ${v.errors.join('; ')}`);
+    if (ir && !STRUCTURES.includes(ir.structure))
+      errors.push(`slide ${i}: unknown structure '${ir?.structure}'`);
+  });
+  if (errors.length) {
+    const err = new Error(`text-to-ir: invalid IR — ${errors.join(' | ')}`);
+    err.validationErrors = errors;
+    err.deck = deck;
+    throw err;
+  }
+  return deck;
+}
+
+async function callModel(messages, apiKey) {
+  const response = await fetch('https://api.anthropic.com/v1/messages', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'x-api-key': apiKey,
+      'anthropic-version': '2023-06-01',
+      'anthropic-dangerous-direct-browser-access': 'true',
+    },
+    body: JSON.stringify({
+      model: TEXT_TO_IR_MODEL,
+      max_tokens: 4096,
+      system: TEXT_TO_IR_SYSTEM,
+      messages,
+    }),
+  });
+  if (!response.ok) {
+    const errText = await response.text();
+    throw new Error(`Anthropic API ${response.status}: ${errText.slice(0, 300)}`);
+  }
+  const data = await response.json();
+  return data.content[0].text;
+}
+
+/**
+ * textToIR(text, apiKey) → {title, slides:[IR...]} (validated).
+ * One retry on validation failure, feeding the errors back to the model.
+ */
+export async function textToIR(text, apiKey) {
+  if (!apiKey) throw new Error('text-to-ir: Anthropic API key required (BYOK)');
+  const messages = [{ role: 'user', content: String(text) }];
+  const first = await callModel(messages, apiKey);
+  try {
+    return parseIRResponse(first);
+  } catch (e) {
+    if (!e.validationErrors) throw e; // not-JSON etc. — retrying rarely helps
+    messages.push({ role: 'assistant', content: first });
+    messages.push({
+      role: 'user',
+      content: `Your JSON failed validation:\n${e.validationErrors.join('\n')}\nReturn the corrected JSON only.`,
+    });
+    return parseIRResponse(await callModel(messages, apiKey));
+  }
+}


### PR DESCRIPTION
## What — the thesis loop closes

"你跟 AI 描述想讲什么，Atlas 生成沉浸式 3D 演示" — this PR makes that sentence literally true. `textToIR(text, apiKey)` turns natural language into a **validated deck of IRs**; `assembleDeck` builds the world; the camera flies it. The IR seam pays off exactly as designed: **zero renderer changes** — text is just another input adapter.

## Pieces

- **`src/scene/text-to-ir.js`** — browser-direct Anthropic call (BYOK, same localStorage key + header pattern as the compositor lift). System prompt kept SHORT per repo rule (**1232 chars**): IR schema + four structures + one worked example. Contract: the model always returns `{title, slides:[IR...]}` (single topic = one-slide deck) → the caller has exactly one path. Every slide validated with `validateIR`; **one retry** feeds validator errors back to the model.
- **`parseIRResponse`** — tolerates fences + leading prose (the lift's JSON-isms lesson), throws per-slide named errors with `.validationErrors`.
- **`apps/present/author.html`** — the one-input page: describe → Generate (Cmd/Ctrl+Enter) → status narrates `text → structures → stations` → the deck flies. BYOK field top-right; key never leaves the browser.
- **`figure-core.js`** extracted (createFigure/show, supports regeneration in place); `figure.js` now a thin viewer over the same core — behavior unchanged (verified: `?deck=deck-pitch` renders, replay hook intact).

## Verified

10/10 new tests (fence/prose parsing / clear failures / per-slide validation errors / **text→IR→deck→ONE compiled scene** / prompt-stays-short guard). Full suite **121/121**; lint clean. Author page verified headless: UI error paths + studio mount. The live LLM round-trip is BYOK — **the first real run is yours**:

```
apps/present/author.html
```

Paste your key (top right), then try: *“our Q3: revenue by region with Americas leading at 890, the funnel from 1200 leads to 45 closed, and the new org under the CEO”* → three stations, one world.

🤖 Generated with [Claude Code](https://claude.com/claude-code)