### PR TITLE
polish(cinematic): DoF story per beat + depth-faded labels + breadcrumb paths

### DIFF
--- a/sdf-js/apps/present/figure-core.js
+++ b/sdf-js/apps/present/figure-core.js
@@ -86,7 +86,13 @@ export function createFigure({ outdoor = false } = {}) {
       }
       el.style.left = `${p.x * canvas.clientWidth}px`;
       el.style.top = `${p.y * canvas.clientHeight}px`;
-      el.style.opacity = o.revealAt == null || t >= o.revealAt ? 1 : 0;
+      // Distance falloff: labels stay crisp near the camera, fade with depth so
+      // wide/deck shots don't pile every station's text on screen. Titles keep
+      // a longer reach (they ARE the far signpost).
+      const reach = o.role === 'title' ? 60 : 22;
+      const depthFade =
+        p.depth == null ? 1 : Math.max(0, Math.min(1, (reach - p.depth) / (reach * 0.45)));
+      el.style.opacity = (o.revealAt == null || t >= o.revealAt ? 1 : 0) * depthFade;
     }
     requestAnimationFrame(tick);
   }

--- a/sdf-js/scripts/test-assemble-deck.mjs
+++ b/sdf-js/scripts/test-assemble-deck.mjs
@@ -38,11 +38,14 @@ const deck = JSON.parse(
   const scene = assembleDeck(deck);
   const stations = deck.slides.map((ir) => renderIR(ir));
 
-  // subjects: sum of stations, prefixed, spatially separated by stride
+  // subjects: sum of stations (prefixed) + breadcrumb path markers between them
   const expected = stations.reduce((s, st) => s + st.subjects.length, 0);
-  ok(scene.subjects.length === expected, `all station subjects present (${expected})`);
+  const stationSubjects = scene.subjects.filter((s) => /^s\d+-/.test(s.id));
+  const pathMarkers = scene.subjects.filter((s) => /^path-/.test(s.id));
+  ok(stationSubjects.length === expected, `all station subjects present (${expected})`);
+  ok(pathMarkers.length === (deck.slides.length - 1) * 5, 'breadcrumb path markers span each gap');
   ok(
-    scene.subjects.every((s) => /^s\d+-/.test(s.id)),
+    scene.subjects.every((s) => /^s\d+-/.test(s.id) || /^path-/.test(s.id)),
     'ids prefixed per station (no collisions)',
   );
   const xOf = (pfx) => {

--- a/sdf-js/src/render/studio.js
+++ b/sdf-js/src/render/studio.js
@@ -3196,7 +3196,9 @@ export function createStudioRenderer({
       const uvy = (focal * b) / c;
       const x = (uvx / aspect + 1) / 2; // uv.x ∈ [-aspect,aspect] → [0,1]
       const y = 1 - (uvy + 1) / 2; // uv.y ∈ [-1,1] (bottom-up) → top-left [0,1]
-      return { x, y, visible: x >= -0.15 && x <= 1.15 && y >= -0.15 && y <= 1.15 };
+      // depth = forward distance (world units) — overlay layers use it to fade
+      // far labels so wide/deck shots don't pile every station's text on screen.
+      return { x, y, depth: c, visible: x >= -0.15 && x <= 1.15 && y >= -0.15 && y <= 1.15 };
     },
     setSequenceTime(tSec) {
       if (!activeSequence) return;

--- a/sdf-js/src/scene/assemble-deck.js
+++ b/sdf-js/src/scene/assemble-deck.js
@@ -114,6 +114,30 @@ export function assembleDeck(deck, opts = {}) {
     clock += stationDur;
     const last = st.cameraSequence.shots[st.cameraSequence.shots.length - 1];
     prevPayoff = { pos: addV(last.pos, origin), target: addV(last.target, origin) };
+
+    // Breadcrumb path to the next station: a chain of low flat markers across
+    // the gap, so the transit flies over a PATH instead of empty floor (the
+    // world reads as connected, and the eye is led to the next arena).
+    if (k < deck.slides.length - 1) {
+      const dots = 5;
+      for (let d = 1; d <= dots; d++) {
+        const x = origin[0] + (stride * d) / (dots + 1);
+        subjects.push({
+          id: `path-${k}-${d}`,
+          type: 'box',
+          args: { dims: [0.9, 0.06, 0.28] },
+          transform: { translate: [x, 0.03, 0] },
+          material: {
+            hue: 0.58,
+            sat: 0.25,
+            value: 0.75,
+            kind: 'normal',
+            roughness: 0.5,
+            clearcoat: 0.2,
+          },
+        });
+      }
+    }
   });
 
   return {

--- a/sdf-js/src/scene/render-hierarchy.js
+++ b/sdf-js/src/scene/render-hierarchy.js
@@ -161,7 +161,7 @@ export function renderHierarchy(ir, opts = {}) {
       pos: [2.1, Math.max(topY - 2.2, 0.5), 4.8],
       target: [0, topY, 0],
       fov: 52,
-      aperture: 0,
+      aperture: 0.55, // hero: shallow focus on the subject
       focalDistance: 5,
       ease: 'out',
     },
@@ -172,7 +172,7 @@ export function renderHierarchy(ir, opts = {}) {
       target: [0, topY - 0.4, 0],
       fov: 48,
       transition: 'blend',
-      aperture: 0,
+      aperture: 0.3,
       focalDistance: 4.4,
       ease: 'inout',
     },
@@ -188,7 +188,7 @@ export function renderHierarchy(ir, opts = {}) {
       target: [0, y, 0],
       fov: 46,
       transition: 'blend',
-      aperture: 0,
+      aperture: 0.25,
       focalDistance: dist,
       shake: 0.05,
       ease: 'smooth',
@@ -201,7 +201,7 @@ export function renderHierarchy(ir, opts = {}) {
     target: [gp[0], gp[1] + 0.08, gp[2]],
     fov: 40,
     transition: 'cut',
-    aperture: 0,
+    aperture: [0.9, 0.45], // rack focus: the world falls away, the subject stays
     focalDistance: 1.7,
     shake: [0.5, 0.06], // impact-then-settle
     exposure: [1.45, 1.0],
@@ -215,7 +215,7 @@ export function renderHierarchy(ir, opts = {}) {
     target: [0, midY, 0],
     fov: 44,
     transition: 'blend',
-    aperture: 0,
+    aperture: 0.12, // deep focus: the whole story stays sharp
     focalDistance: payoffDist,
     ease: 'out',
   });

--- a/sdf-js/src/scene/render-magnitude.js
+++ b/sdf-js/src/scene/render-magnitude.js
@@ -100,7 +100,7 @@ export function renderMagnitude(ir, opts = {}) {
       pos: [xOf(tallest) + 1.6, 0.5, 3.6],
       target: [xOf(tallest), tallH * 0.72, 0],
       fov: 54,
-      aperture: 0,
+      aperture: 0.55, // hero: shallow focus on the subject
       focalDistance: 4,
       ease: 'out',
     },
@@ -111,7 +111,7 @@ export function renderMagnitude(ir, opts = {}) {
       target: [0, tallH * 0.45, 0],
       fov: 48,
       transition: 'blend',
-      aperture: 0,
+      aperture: 0.3,
       focalDistance: rowSpan * 0.6 + 3,
       ease: 'inout',
     },
@@ -126,7 +126,7 @@ export function renderMagnitude(ir, opts = {}) {
       target: [x, Math.max(H * 0.55, 0.5), 0],
       fov: 46,
       transition: 'blend',
-      aperture: 0,
+      aperture: 0.25,
       focalDistance: 2.7,
       shake: 0.05,
       ease: 'smooth',
@@ -139,7 +139,7 @@ export function renderMagnitude(ir, opts = {}) {
     target: [gx, gH * 0.85, 0],
     fov: 44,
     transition: 'cut',
-    aperture: 0,
+    aperture: [0.9, 0.45], // rack focus: the world falls away, the subject stays
     focalDistance: 1.8,
     shake: [0.5, 0.06], // impact-then-settle
     exposure: [1.45, 1.0],
@@ -153,7 +153,7 @@ export function renderMagnitude(ir, opts = {}) {
     target: [0, tallH * 0.4, 0],
     fov: 44,
     transition: 'blend',
-    aperture: 0,
+    aperture: 0.12, // deep focus: the whole story stays sharp
     focalDistance: payoffDist,
     ease: 'out',
   });

--- a/sdf-js/src/scene/render-network.js
+++ b/sdf-js/src/scene/render-network.js
@@ -193,7 +193,7 @@ export function renderNetwork(ir, opts = {}) {
       pos: [hubP[0] + cloudR * 0.5, Math.max(hubP[1] - 0.6, 0.4), hubP[2] + cloudR * 0.55],
       target: [hubP[0], hubP[1], hubP[2]],
       fov: 56,
-      aperture: 0,
+      aperture: 0.55, // hero: shallow focus on the hub
       focalDistance: cloudR * 0.7,
       ease: 'out',
     },
@@ -204,7 +204,7 @@ export function renderNetwork(ir, opts = {}) {
       target: [0, midY, 0],
       fov: 48,
       transition: 'blend',
-      aperture: 0,
+      aperture: 0.3,
       focalDistance: cloudR * 1.9,
       ease: 'inout',
     },
@@ -221,7 +221,7 @@ export function renderNetwork(ir, opts = {}) {
       target: [0, midY, 0],
       fov: 46,
       transition: 'blend',
-      aperture: 0,
+      aperture: 0.25,
       focalDistance: dist,
       shake: 0.05,
       ease: 'smooth',
@@ -234,7 +234,7 @@ export function renderNetwork(ir, opts = {}) {
     target: [gp[0], gp[1] + 0.06, gp[2]],
     fov: 40,
     transition: 'cut',
-    aperture: 0,
+    aperture: [0.9, 0.45], // rack focus: the world falls away, the subject stays
     focalDistance: 1.6,
     shake: [0.5, 0.06], // impact-then-settle
     exposure: [1.45, 1.0],
@@ -248,7 +248,7 @@ export function renderNetwork(ir, opts = {}) {
     target: [0, midY, 0],
     fov: 44,
     transition: 'blend',
-    aperture: 0,
+    aperture: 0.12, // deep focus: the whole story stays sharp
     focalDistance: payoffDist,
     ease: 'out',
   });

--- a/sdf-js/src/scene/render-sequence.js
+++ b/sdf-js/src/scene/render-sequence.js
@@ -106,7 +106,7 @@ export function renderSequence(ir, opts = {}) {
       pos: [2.3, 0.55, 5.2],
       target: [0, topY - 0.2, 0],
       fov: 54,
-      aperture: 0,
+      aperture: 0.55, // hero: shallow focus on the subject
       focalDistance: 5.5,
       ease: 'out',
     },
@@ -117,7 +117,7 @@ export function renderSequence(ir, opts = {}) {
       target: [0, topY - 0.3, 0],
       fov: 50,
       transition: 'blend',
-      aperture: 0,
+      aperture: 0.3,
       focalDistance: 5,
       ease: 'inout',
     },
@@ -133,7 +133,7 @@ export function renderSequence(ir, opts = {}) {
       target: [0, y, 0],
       fov: 46,
       transition: 'blend',
-      aperture: 0,
+      aperture: 0.25,
       focalDistance: dist,
       shake: 0.05,
       ease: 'smooth',
@@ -148,7 +148,7 @@ export function renderSequence(ir, opts = {}) {
     target: [0, goldY + 0.12, 0],
     fov: 40,
     transition: 'cut',
-    aperture: 0,
+    aperture: [0.9, 0.45], // rack focus: the world falls away, the subject stays
     focalDistance: 2,
     shake: [0.5, 0.06], // impact-then-settle
     exposure: [1.45, 1.0],
@@ -163,7 +163,7 @@ export function renderSequence(ir, opts = {}) {
     target: [0, midY + 0.2, 0],
     fov: 44,
     transition: 'blend',
-    aperture: 0,
+    aperture: 0.12, // deep focus: the whole story stays sharp
     focalDistance: payoffDist,
     ease: 'out',
   });


### PR DESCRIPTION
## What — three cinematic upgrades, zero new machinery

1. **Depth-of-field story per beat.** Every shot had `aperture: 0` — all-sharp is the video-game default, not cinema. The five beats now carry a focal intention, uniform across all four structure renderers: **hero 0.55** (shallow — the subject pops) → crane/tour 0.3/0.25 → **the SUPER gets a rack-focus ramp `[0.9 → 0.45]`** (the world falls away on the cut, then the subject resolves — the SF6 punch-in focus snap) → **payoff 0.12** (deep focus — the whole closing frame stays sharp).

2. **Depth-faded labels.** `studio.project()` now returns forward distance; the overlay fades labels beyond ~22 world units (titles reach ~60 — they are the far signposts). Deck/wide shots stop piling every station's text on screen; the cone tree's crowded lower level declutters with distance.

3. **Breadcrumb paths.** `assembleDeck` lays low flat markers across each station gap — the transit flies over a **path**, the world reads as connected, the eye is led to the next arena.

## Verified

121/121 (deck test updated for the path markers); lint clean. Transit frame captured: path leading to the next station, far labels gone, motion blur + DoF natural.

## Try

`apps/present/figure.html?deck=deck-pitch` — watch the super's focus snap and the transit path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)