### PR TITLE
feat(assemble-deck): deck archetypes (line / radial / grid) + the deck finale

### DIFF
--- a/sdf-js/apps/present/figure.js
+++ b/sdf-js/apps/present/figure.js
@@ -12,6 +12,7 @@ const env = params.get('env') || 'studio';
 const { show } = createFigure({ outdoor: env !== 'studio' });
 
 const deckName = params.get('deck');
+const layout = params.get('layout') || undefined; // line | radial | grid
 const name = params.get('ir') || 'funnel-sales';
 const ir = await (await fetch(`../../scenes/ir/${deckName || name}.json`)).json();
-show(deckName ? assembleDeck(ir, { env }) : renderIR(ir, { env }));
+show(deckName ? assembleDeck(ir, { env, layout }) : renderIR(ir, { env }));

--- a/sdf-js/scripts/test-assemble-deck.mjs
+++ b/sdf-js/scripts/test-assemble-deck.mjs
@@ -59,10 +59,14 @@ const deck = JSON.parse(
     'stations spaced along the deck axis',
   );
 
-  // camera: all station shots + one transit between each pair
+  // camera: all station shots + one transit between each pair + the deck finale
   const shotCount =
-    stations.reduce((s, st) => s + st.cameraSequence.shots.length, 0) + (deck.slides.length - 1);
-  ok(scene.cameraSequence.shots.length === shotCount, 'shot count = stations + transits');
+    stations.reduce((s, st) => s + st.cameraSequence.shots.length, 0) +
+    (deck.slides.length - 1) +
+    1;
+  ok(scene.cameraSequence.shots.length === shotCount, 'shot count = stations + transits + finale');
+  const finale = scene.cameraSequence.shots[scene.cameraSequence.shots.length - 1];
+  ok(finale.pos[1] > 10 && (finale.focalDistance || 0) > 20, 'finale is high + wide (whole deck)');
   const transits = scene.cameraSequence.shots.filter(
     (s) => (Array.isArray(s.shake) ? s.shake[0] : s.shake || 0) > 0.1 && s.fov === 50,
   );
@@ -95,6 +99,42 @@ const deck = JSON.parse(
   // deterministic
   const again = assembleDeck(JSON.parse(JSON.stringify(deck)));
   ok(JSON.stringify(again) === JSON.stringify(scene), 'deterministic');
+}
+
+// ---- deck archetypes: radial ring + grid plaza ---------------------------------
+{
+  const radial = assembleDeck(JSON.parse(JSON.stringify(deck)), { layout: 'radial' });
+  const centers = ['s0-', 's1-', 's2-'].map((pfx) => {
+    const subs = radial.subjects.filter((s) => s.id.startsWith(pfx));
+    const cx = subs.reduce((a, s) => a + s.transform.translate[0], 0) / subs.length;
+    const cz = subs.reduce((a, s) => a + s.transform.translate[2], 0) / subs.length;
+    return [cx, cz];
+  });
+  const hubX = centers.reduce((a, c) => a + c[0], 0) / 3;
+  const hubZ = centers.reduce((a, c) => a + c[1], 0) / 3;
+  const radii = centers.map((c) => Math.hypot(c[0] - hubX, c[1] - hubZ));
+  ok(Math.max(...radii) - Math.min(...radii) < 2.5, 'radial: stations sit on a ring');
+  ok(
+    centers.some((c) => Math.abs(c[1] - hubZ) > 3),
+    'radial: ring uses the z axis',
+  );
+}
+{
+  const grid = assembleDeck(JSON.parse(JSON.stringify(deck)), { layout: 'grid' });
+  const zs = new Set(
+    grid.subjects
+      .filter((s) => /^s\d+-/.test(s.id))
+      .map((s) => Math.round(s.transform.translate[2] / 8)),
+  );
+  ok(zs.size >= 2, 'grid: stations occupy multiple rows');
+}
+{
+  // deck.layout field is honored; opts.layout overrides
+  const viaField = assembleDeck({ ...JSON.parse(JSON.stringify(deck)), layout: 'radial' });
+  ok(
+    viaField.subjects.some((s) => /^s\d+-/.test(s.id) && Math.abs(s.transform.translate[2]) > 5),
+    'deck.layout field honored',
+  );
 }
 
 console.log(`\n${pass} passed, ${fail} failed`);

--- a/sdf-js/src/scene/assemble-deck.js
+++ b/sdf-js/src/scene/assemble-deck.js
@@ -31,16 +31,49 @@ export function shiftBuildInExpr(expr, dy, dt) {
 const addV = (a, b) => [a[0] + b[0], a[1] + b[1], a[2] + b[2]];
 const seqDuration = (shots) => shots.reduce((s, sh) => s + (sh.duration || 0), 0);
 
+// ---- Deck archetypes ---------------------------------------------------------
+// The station LAYOUT is itself structure-aware (the deck-scale half of the
+// "geometric cores" thesis): a linear pitch is a corridor, an agenda-around-a-
+// theme is a ring, a portfolio is a plaza. Stations are never rotated — every
+// structure keeps facing +z so its own camera grammar stays valid; the layout
+// only chooses WHERE stations stand (and therefore how the transits sweep and
+// what the finale reveals).
+export const DECK_LAYOUTS = ['line', 'radial', 'grid'];
+
+function stationOrigins(n, stride, layout) {
+  if (layout === 'radial') {
+    // neighbor arc spacing ≈ stride; camera-side (+z) faces outward from the top
+    const R = Math.max(stride * 0.75, (stride * n) / (2 * Math.PI));
+    return Array.from({ length: n }, (_, k) => {
+      const th = (k * 2 * Math.PI) / n;
+      return [Math.sin(th) * R, 0, Math.cos(th) * R];
+    });
+  }
+  if (layout === 'grid') {
+    const cols = Math.ceil(Math.sqrt(n));
+    return Array.from({ length: n }, (_, k) => [
+      (k % cols) * stride,
+      0,
+      -Math.floor(k / cols) * stride, // rows recede — the city-of-data look
+    ]);
+  }
+  return Array.from({ length: n }, (_, k) => [k * stride, 0, 0]); // line
+}
+
 /**
  * assembleDeck(deck, opts) → SceneData
- * @param {object} deck  { title?, slides: IR[] }
- * @param {object} opts  { env?, stride?: station spacing (default 16) }
+ * @param {object} deck  { title?, layout?: 'line'|'radial'|'grid', slides: IR[] }
+ * @param {object} opts  { env?, stride? (default 16), layout? (overrides deck.layout) }
  */
 export function assembleDeck(deck, opts = {}) {
   if (!deck || !Array.isArray(deck.slides) || deck.slides.length === 0)
     throw new Error('assembleDeck: deck.slides must be a non-empty array of IRs');
   const env = getEnvironment(opts.env);
   const stride = opts.stride ?? 16;
+  const layout = DECK_LAYOUTS.includes(opts.layout ?? deck.layout)
+    ? (opts.layout ?? deck.layout)
+    : 'line';
+  const origins = stationOrigins(deck.slides.length, stride, layout);
 
   const subjects = [];
   const overlay = [];
@@ -51,7 +84,7 @@ export function assembleDeck(deck, opts = {}) {
   deck.slides.forEach((ir, k) => {
     // Render the station at the origin on its own clock, then transplant.
     const st = renderIR(ir); // no env here — the deck owns the world
-    const origin = [k * stride, 0, 0];
+    const origin = origins[k];
 
     // Transit shot: whip from the previous station's payoff toward this one's
     // hero position (fast lateral sling, a touch of shake — the stage change).
@@ -115,18 +148,26 @@ export function assembleDeck(deck, opts = {}) {
     const last = st.cameraSequence.shots[st.cameraSequence.shots.length - 1];
     prevPayoff = { pos: addV(last.pos, origin), target: addV(last.target, origin) };
 
-    // Breadcrumb path to the next station: a chain of low flat markers across
-    // the gap, so the transit flies over a PATH instead of empty floor (the
-    // world reads as connected, and the eye is led to the next arena).
+    // Breadcrumb path to the next station: a chain of low flat markers along
+    // the segment between the two origins (any layout), each oriented to face
+    // the walk direction — the transit flies over a PATH instead of empty
+    // floor, and the eye is led to the next arena.
     if (k < deck.slides.length - 1) {
+      const next = origins[k + 1];
+      const dx = next[0] - origin[0];
+      const dz = next[2] - origin[2];
+      const yaw = Math.atan2(dz, dx); // marker long axis along the segment
       const dots = 5;
       for (let d = 1; d <= dots; d++) {
-        const x = origin[0] + (stride * d) / (dots + 1);
+        const f = d / (dots + 1);
         subjects.push({
           id: `path-${k}-${d}`,
           type: 'box',
           args: { dims: [0.9, 0.06, 0.28] },
-          transform: { translate: [x, 0.03, 0] },
+          transform: {
+            translate: [origin[0] + dx * f, 0.03, origin[2] + dz * f],
+            rotate: [0, -yaw, 0],
+          },
           material: {
             hue: 0.58,
             sat: 0.25,
@@ -139,6 +180,26 @@ export function assembleDeck(deck, opts = {}) {
       }
     }
   });
+
+  // ---- Deck finale: one frame that holds the WHOLE presentation --------------
+  // After the last station's payoff, pull up and back until every station is in
+  // frame — the thesis money shot ("your entire deck is one world"). Framing
+  // scales with the layout's actual extent; deep focus so nothing blurs away.
+  {
+    const cx = origins.reduce((s, o) => s + o[0], 0) / origins.length;
+    const cz = origins.reduce((s, o) => s + o[2], 0) / origins.length;
+    const span = Math.max(1, ...origins.map((o) => Math.hypot(o[0] - cx, o[2] - cz))) * 2 + stride;
+    shots.push({
+      duration: 3.0,
+      pos: [cx + span * 0.25, span * 0.5 + 4.5, cz + span * 0.95],
+      target: [cx, 1.2, cz],
+      fov: 48,
+      transition: 'blend',
+      aperture: 0.08,
+      focalDistance: span * 1.05,
+      ease: 'out',
+    });
+  }
 
   return {
     v: 1,


### PR DESCRIPTION
## What — the deck-scale half of the geometric-cores thesis

The station **layout** is itself structure-aware. `deck.layout` (or `?layout=` on the figure page):

| layout | read | staging |
|---|---|---|
| **line** (default) | a corridor — the linear pitch | unchanged |
| **radial** | a RING — agenda around a theme | stations on a circle (neighbor spacing ≈ stride), transits arc around it |
| **grid** | a PLAZA — portfolio / city of data | rows recede in depth |

Stations are never rotated — every structure keeps facing +z so its own camera grammar stays valid; layout only chooses where stations stand, how transits sweep, and what the finale reveals. Breadcrumb paths generalized to run along any segment, yawed to the walk direction (radial decks get connecting arcs).

## THE DECK FINALE

After the last station's payoff: one 3-second pull-up until **every station is in frame** (framing scales with the layout's extent, deep focus). The radial capture is the thesis money shot — three structures on a ring, paths arcing between them, near titles crisp, far ones depth-faded: **"your entire presentation is one world."**

## Verified

20/20 deck tests (ring-radius invariant / z-axis usage / grid rows / `deck.layout` vs `opts.layout` precedence / finale high+wide / counts incl. finale). Full suite 121/121; lint clean.

## Try

- `apps/present/figure.html?deck=deck-pitch&layout=radial` — the ring + finale
- `…&layout=grid` — the plaza
- (no param) — the corridor, unchanged

## Note

`gh pr merge 217` switched this working copy to main again mid-work; the commit briefly landed on local main, the pre-push guard held the line, recovered here cleanly (routine now).

🤖 Generated with [Claude Code](https://claude.com/claude-code)