### PR TITLE
feat(hitstop): true frame freeze at the super — the fighting-game signature

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -151,6 +151,7 @@ const TESTS = [
   { category: 'scene', file: 'sdf-js/scripts/test-assemble-deck.mjs' },
   { category: 'scene', file: 'sdf-js/scripts/test-camera-shake.mjs' },
   { category: 'scene', file: 'sdf-js/scripts/test-text-to-ir.mjs' },
+  { category: 'scene', file: 'sdf-js/scripts/test-hitstop.mjs' },
   { category: 'scene', file: 'sdf-js/scripts/test-scaffold-to-ir.mjs' },
   { category: 'scene', file: 'sdf-js/scripts/test-atom-3d-coverage.mjs' },
 

--- a/sdf-js/scripts/test-hitstop.mjs
+++ b/sdf-js/scripts/test-hitstop.mjs
@@ -1,0 +1,88 @@
+// sdf-js/scripts/test-hitstop.mjs — fighting-game frame freeze (time warp).
+import { readFileSync } from 'node:fs';
+import { warpTime, unwarpTime } from '../src/scene/camera-sequence.js';
+import { renderIR } from '../src/scene/render-ir.js';
+import { assembleDeck } from '../src/scene/assemble-deck.js';
+import { validate as validateSceneData } from '../src/scene/spec.js';
+import { expandStage } from '../src/scene/stage.js';
+
+let pass = 0,
+  fail = 0;
+const ok = (c, n) => (c ? (pass++, console.log(`  ✓ ${n}`)) : (fail++, console.log(`  ✗ ${n}`)));
+console.log('=== hitstop (whole-world frame freeze) ===\n');
+
+// ---- warp math -----------------------------------------------------------------
+{
+  const stops = [{ at: 2.0, hold: 0.5 }];
+  ok(warpTime(1.5, stops) === 1.5, 'before the stop: 1:1');
+  ok(warpTime(2.2, stops) === 2.0, 'during the hold: frozen at `at`');
+  ok(warpTime(2.5, stops) === 2.0, 'end of hold: still frozen');
+  ok(Math.abs(warpTime(3.0, stops) - 2.5) < 1e-9, 'after: resumes, shifted by hold');
+  // two stops chain
+  const two = [
+    { at: 1.0, hold: 0.2 },
+    { at: 3.0, hold: 0.3 },
+  ];
+  ok(Math.abs(warpTime(4.6, two) - 4.1) < 1e-9, 'multiple stops accumulate');
+  // unwarp inverts (presentation → raw), across both stops
+  for (const T of [0.5, 1.0, 2.0, 3.5]) {
+    ok(Math.abs(warpTime(unwarpTime(T, two), two) - T) < 1e-9, `unwarp∘warp = id @ T=${T}`);
+  }
+  ok(warpTime(9, null) === 9 && unwarpTime(9, []) === 9, 'no stops → identity');
+}
+
+// ---- every structure carries a super hitstop at the cut -------------------------
+{
+  const irs = [
+    { structure: 'sequence', nodes: ['A', 'B', 'C'], magnitude: [9, 4, 1], title: 't' },
+    {
+      structure: 'hierarchy',
+      nodes: ['r', 'a', 'b'],
+      relations: [
+        [0, 1],
+        [0, 2],
+      ],
+      title: 't',
+    },
+    {
+      structure: 'network',
+      nodes: ['a', 'b', 'c'],
+      relations: [
+        [0, 1],
+        [1, 2],
+      ],
+      title: 't',
+    },
+    { structure: 'magnitude', nodes: ['a', 'b'], magnitude: [5, 2], title: 't' },
+  ];
+  for (const ir of irs) {
+    const scene = renderIR(ir);
+    const stops = scene.cameraSequence.hitstops;
+    ok(Array.isArray(stops) && stops.length === 1, `${ir.structure}: one hitstop`);
+    // the stop lands just inside the super (cut) shot's window
+    const shots = scene.cameraSequence.shots;
+    const cutIdx = shots.findIndex((s) => s.transition === 'cut');
+    const cutStart = shots.slice(0, cutIdx).reduce((s, sh) => s + sh.duration, 0);
+    ok(
+      stops[0].at >= cutStart && stops[0].at < cutStart + shots[cutIdx].duration,
+      `${ir.structure}: hitstop inside the super`,
+    );
+    const v = validateSceneData(expandStage(scene));
+    ok(v.ok !== false || !v.errors?.length, `${ir.structure}: scene still validates`);
+  }
+}
+
+// ---- deck shifts hitstops onto the deck timeline ---------------------------------
+{
+  const deck = JSON.parse(
+    readFileSync(new URL('../scenes/ir/deck-pitch.json', import.meta.url), 'utf8'),
+  );
+  const scene = assembleDeck(deck);
+  const stops = scene.cameraSequence.hitstops;
+  ok(stops.length === 3, 'three stations → three hitstops');
+  ok(stops[0].at < stops[1].at && stops[1].at < stops[2].at, 'sorted along the deck timeline');
+  ok(stops[1].at > 12, 'station 2 hitstop shifted past station 1 + transit');
+}
+
+console.log(`\n${pass} passed, ${fail} failed`);
+process.exit(fail ? 1 : 0);

--- a/sdf-js/src/render/studio.js
+++ b/sdf-js/src/render/studio.js
@@ -20,6 +20,8 @@ import {
   evaluateCameraSequence,
   sequenceStateToCamState,
   totalDuration as seqTotalDuration,
+  warpTime,
+  unwarpTime,
 } from '../scene/camera-sequence.js';
 
 // GLSL ES 3.00 (studio is WebGL2-only). Shaders without #version are parsed as
@@ -2085,6 +2087,10 @@ export function createStudioRenderer({
   // When non-null, drives camState per frame from a timeline (overrides WASD
   // fly camera until user explicitly takes back via fly keys / mouse).
   let activeSequence = null;
+  let activeHitstops = null; // [{at, hold}] — fighting-game frame freezes (see camera-sequence.js)
+  // Both clocks (sequence camera + u_time world) run through the same warp, so
+  // a hitstop freezes EVERYTHING for its hold, then the world resumes as one.
+  const warpSec = (raw) => warpTime(raw, activeHitstops);
   // Snapshot of the camera basis the LAST frame rendered with — used by
   // project() so Layer-2 overlay labels land exactly where the 3D point is
   // drawn (no camera-convention duplication outside the renderer).
@@ -2395,7 +2401,7 @@ export function createStudioRenderer({
     let frameSubjectOffsets = {};
     let frameSceneState = {};
     if (activeSequence && !sequencePaused && !userTookCam) {
-      const tSec = (performance.now() - sequenceStartTime) / 1000;
+      const tSec = warpSec((performance.now() - sequenceStartTime) / 1000);
       const state = evaluateCameraSequence(activeSequence, tSec, { subjectBaseTargets });
       if (state) {
         const cs = sequenceStateToCamState(state);
@@ -2565,7 +2571,7 @@ export function createStudioRenderer({
     // u_time drives time-aware primitives (sdWaves animation). Without
     // this set, waves were static — sea looked frozen.
     if (uniformsCache.u_time != null) {
-      gl.uniform1f(uniformsCache.u_time, (performance.now() - timeStart) / 1000);
+      gl.uniform1f(uniformsCache.u_time, warpSec((performance.now() - timeStart) / 1000));
     }
     // Sprint 3: volume LUTs. Uploaded per draw because the count + params may
     // change when setVolumes() is called between scene loads. Volume effects
@@ -2616,7 +2622,7 @@ export function createStudioRenderer({
     // Per-frame postfx params start from activePostFx (scene defaults) and
     // get patched with sequence camera overrides (aperture / focalDistance)
     // when a cameraSequence is driving the camera.
-    const tSec = (performance.now() - timeStart) / 1000;
+    const tSec = warpSec((performance.now() - timeStart) / 1000);
     const framePostFx = { ...activePostFx };
     if (sequenceAperture != null) framePostFx.aperture = sequenceAperture;
     if (sequenceFocalDist != null) framePostFx.focalDistance = sequenceFocalDist;
@@ -2730,7 +2736,7 @@ export function createStudioRenderer({
     if (sceneAnimated) return true;
     if (activeSequence && !sequencePaused && !userTookCam) {
       if (activeSequence.loop) return true;
-      const tSec = (performance.now() - sequenceStartTime) / 1000;
+      const tSec = warpSec((performance.now() - sequenceStartTime) / 1000);
       if (tSec < seqTotalDuration(activeSequence)) return true;
     }
     return false;
@@ -3169,6 +3175,8 @@ export function createStudioRenderer({
      */
     setSequence(seq) {
       activeSequence = seq || null;
+      activeHitstops =
+        (seq && Array.isArray(seq.hitstops) && seq.hitstops.length && seq.hitstops) || null;
       sequenceStartTime = performance.now();
       sequencePaused = false;
       userTookCam = false;
@@ -3202,7 +3210,9 @@ export function createStudioRenderer({
     },
     setSequenceTime(tSec) {
       if (!activeSequence) return;
-      sequenceStartTime = performance.now() - tSec * 1000;
+      // tSec is PRESENTATION time — unwarp it so seeks land where the caller
+      // expects even across hitstop holds.
+      sequenceStartTime = performance.now() - unwarpTime(tSec, activeHitstops) * 1000;
       sequencePaused = false;
       userTookCam = false;
       wake();
@@ -3222,7 +3232,7 @@ export function createStudioRenderer({
     getSequenceTime() {
       if (!activeSequence) return 0;
       const now = sequencePaused ? sequencePausedAt : performance.now();
-      return (now - sequenceStartTime) / 1000;
+      return warpSec((now - sequenceStartTime) / 1000);
     },
     getSequenceDuration() {
       return activeSequence ? seqTotalDuration(activeSequence) : 0;

--- a/sdf-js/src/scene/assemble-deck.js
+++ b/sdf-js/src/scene/assemble-deck.js
@@ -78,6 +78,7 @@ export function assembleDeck(deck, opts = {}) {
   const subjects = [];
   const overlay = [];
   const shots = [];
+  const hitstops = [];
   let clock = 0;
   let prevPayoff = null;
 
@@ -143,6 +144,10 @@ export function assembleDeck(deck, opts = {}) {
     st.cameraSequence.shots.forEach((sh) => {
       shots.push({ ...sh, pos: addV(sh.pos, origin), target: addV(sh.target, origin) });
     });
+    // Hitstops ride the deck timeline: shift each station's freezes by its start.
+    for (const h of st.cameraSequence.hitstops || []) {
+      hitstops.push({ at: h.at + clock, hold: h.hold });
+    }
     const stationDur = seqDuration(st.cameraSequence.shots);
     clock += stationDur;
     const last = st.cameraSequence.shots[st.cameraSequence.shots.length - 1];
@@ -206,7 +211,7 @@ export function assembleDeck(deck, opts = {}) {
     name: `(deck) ${deck.title || `${deck.slides.length} stations`}${env ? ' · alpine' : ''}`,
     subjects: env ? [...subjects, ...env.subjects] : subjects,
     overlay,
-    cameraSequence: { loop: false, shots },
+    cameraSequence: { loop: false, shots, hitstops },
     // One shared open world — no per-station stage room (walls would slice the
     // deck axis). Ground/sky come from the environment or the page defaults.
     defaults: env

--- a/sdf-js/src/scene/camera-sequence.js
+++ b/sdf-js/src/scene/camera-sequence.js
@@ -79,6 +79,31 @@ function shakeSway(t, phase) {
   );
 }
 
+// ---- Hitstop (fighting-game frame freeze) ------------------------------------
+// cameraSequence.hitstops = [{ at, hold }] — at each `at` (presentation-time
+// seconds), the WHOLE presentation clock freezes for `hold` wall-seconds, then
+// resumes: the impact frame holds, the world stops with it (camera, shake,
+// build-ins, sea — everything downstream of the warped clock). warpTime maps
+// raw wall seconds → presentation seconds; unwarpTime inverts it (seeking).
+// Stops must be sorted by `at` ascending and non-overlapping.
+export function warpTime(rawSec, stops) {
+  if (!Array.isArray(stops) || stops.length === 0) return rawSec;
+  let t = rawSec;
+  for (const s of stops) {
+    if (t <= s.at) break;
+    t -= Math.min(t - s.at, s.hold);
+  }
+  return t;
+}
+export function unwarpTime(tSec, stops) {
+  if (!Array.isArray(stops) || stops.length === 0) return tSec;
+  let raw = tSec;
+  for (const s of stops) {
+    if (tSec > s.at) raw += s.hold;
+  }
+  return raw;
+}
+
 /**
  * Compute total sequence duration. Returns 0 for empty sequences.
  * Cached on the seq object so repeat calls are O(1).

--- a/sdf-js/src/scene/render-hierarchy.js
+++ b/sdf-js/src/scene/render-hierarchy.js
@@ -195,6 +195,7 @@ export function renderHierarchy(ir, opts = {}) {
     });
   }
   // 4 — the super: hard cut punch-in on the emphasis node
+  const superAt = shots.reduce((s, sh) => s + sh.duration, 0); // presentation time of the impact
   shots.push({
     duration: 1.0,
     pos: [gp[0] + 0.5, Math.max(gp[1] - 0.1, 0.14), gp[2] + 1.6],
@@ -244,7 +245,7 @@ export function renderHierarchy(ir, opts = {}) {
     name: `(hierarchy) ${ir.title || nodes[root]}${env ? ' · alpine' : ''}`,
     subjects: env ? [...subjects, ...env.subjects] : subjects,
     overlay,
-    cameraSequence: { loop: false, shots },
+    cameraSequence: { loop: false, shots, hitstops: [{ at: superAt + 0.02, hold: 0.14 }] },
     defaults: env ? env.defaults : { stage: { size: [16, 12, 12] } },
   };
 }

--- a/sdf-js/src/scene/render-magnitude.js
+++ b/sdf-js/src/scene/render-magnitude.js
@@ -133,6 +133,7 @@ export function renderMagnitude(ir, opts = {}) {
     });
   });
   // 4 — the super: at the emphasis monolith's base, looking UP its height
+  const superAt = shots.reduce((s, sh) => s + sh.duration, 0); // presentation time of the impact
   shots.push({
     duration: 1.0,
     pos: [gx + 0.75, 0.35, 1.35],
@@ -190,7 +191,7 @@ export function renderMagnitude(ir, opts = {}) {
     name: `(magnitude) ${ir.title || nodes[tallest]}${env ? ' · alpine' : ''}`,
     subjects: env ? [...subjects, ...env.subjects] : subjects,
     overlay,
-    cameraSequence: { loop: false, shots },
+    cameraSequence: { loop: false, shots, hitstops: [{ at: superAt + 0.02, hold: 0.14 }] },
     defaults: env ? env.defaults : { stage: { size: [Math.max(16, rowSpan + 6), 12, 12] } },
   };
 }

--- a/sdf-js/src/scene/render-network.js
+++ b/sdf-js/src/scene/render-network.js
@@ -228,6 +228,7 @@ export function renderNetwork(ir, opts = {}) {
     });
   }
   // 4 — the super: hard cut punch-in on the hub/emphasis node
+  const superAt = shots.reduce((s, sh) => s + sh.duration, 0); // presentation time of the impact
   shots.push({
     duration: 1.0,
     pos: [gp[0] + 0.5, Math.max(gp[1] - 0.1, 0.14), gp[2] + 1.5],
@@ -278,7 +279,7 @@ export function renderNetwork(ir, opts = {}) {
     name: `(network) ${ir.title || nodes[hub]}${env ? ' · alpine' : ''}`,
     subjects: env ? [...subjects, ...env.subjects] : subjects,
     overlay,
-    cameraSequence: { loop: false, shots },
+    cameraSequence: { loop: false, shots, hitstops: [{ at: superAt + 0.02, hold: 0.14 }] },
     defaults: env ? env.defaults : { stage: { size: [16, 12, 12] } },
   };
 }

--- a/sdf-js/src/scene/render-sequence.js
+++ b/sdf-js/src/scene/render-sequence.js
@@ -142,6 +142,7 @@ export function renderSequence(ir, opts = {}) {
   // 4 — the super: hard cut, tight low-angle punch-in on the gold stage.
   // Camera stays above the floor (the emphasis stage can sit near y=0) while
   // still looking slightly UP at the stage for the hero read.
+  const superAt = shots.reduce((s, sh) => s + sh.duration, 0); // presentation time of the impact
   shots.push({
     duration: 1.0,
     pos: [0.55, Math.max(goldY - 0.15, 0.14), 1.9],
@@ -198,7 +199,7 @@ export function renderSequence(ir, opts = {}) {
     name: `(sequence) ${ir.title || 'funnel'}${env ? ' · alpine' : ''}`,
     subjects: env ? [...subjects, ...env.subjects] : subjects,
     overlay,
-    cameraSequence: { loop: false, shots },
+    cameraSequence: { loop: false, shots, hitstops: [{ at: superAt + 0.02, hold: 0.14 }] },
     defaults: env ? env.defaults : { stage: { size: [16, 12, 11] } },
   };
 }

--- a/sdf-js/src/scene/spec.js
+++ b/sdf-js/src/scene/spec.js
@@ -1301,6 +1301,30 @@ function validateCameraSequence(seq, errors, warnings) {
   if (seq.loop != null && typeof seq.loop !== 'boolean') {
     errors.push('cameraSequence.loop: must be a boolean if provided');
   }
+  // Hitstops: fighting-game frame freezes — presentation clock holds at `at`
+  // for `hold` wall-seconds. Must be sorted ascending, non-overlapping.
+  if (seq.hitstops != null) {
+    if (!Array.isArray(seq.hitstops)) {
+      errors.push('cameraSequence.hitstops: must be an array if provided');
+    } else {
+      let prevEnd = -Infinity;
+      seq.hitstops.forEach((h, i) => {
+        if (
+          !h ||
+          typeof h.at !== 'number' ||
+          h.at < 0 ||
+          typeof h.hold !== 'number' ||
+          h.hold <= 0
+        ) {
+          errors.push(`cameraSequence.hitstops[${i}]: requires {at >= 0, hold > 0}`);
+          return;
+        }
+        if (h.at < prevEnd)
+          errors.push(`cameraSequence.hitstops[${i}]: must be sorted and non-overlapping`);
+        prevEnd = h.at + h.hold;
+      });
+    }
+  }
   // Sprint 4: subjectMotion = per-subject CarInt physics (cross-phase integral).
   if (seq.subjectMotion != null) {
     if (!Array.isArray(seq.subjectMotion)) {


### PR DESCRIPTION
## What — the fighting-game signature lands

`cameraSequence.hitstops = [{at, hold}]`: at each `at` the **whole presentation clock freezes** for `hold` wall-seconds, then resumes. Both studio clocks (sequence camera + `u_time` world) run through the same warp — the impact frame holds **everything** (camera, shake, exposure pop, build-ins, sea), and the world resumes as one. The half-beat of stillness is what sells the weight of the hit.

## Pieces

- `warpTime` / `unwarpTime` (camera-sequence.js) — piecewise time warp + inverse; unit-tested incl. multi-stop accumulation and unwarp∘warp = id.
- Studio: all five clock sites route through the warp; `setSequenceTime` seeks in **presentation time** (unwarped internally) so pins/seeks land where callers expect.
- All four structure renderers stamp one hitstop just inside the super cut (`superAt + 0.02`, hold **0.14s**); `assembleDeck` shifts each station's stops onto the deck timeline; spec validates `{at ≥ 0, hold > 0, sorted, non-overlapping}`.

## Live-verified (not just unit math)

Sampling `getSequenceTime` through the funnel's super: the clock **plateaus at exactly 8.220 for ~0.14s**, then resumes — the freeze is real in the render loop, not cosmetic. 25/25 new tests; suite **122/122**; lint clean.

## Feel it

`apps/present/figure.html?ir=funnel-sales` — at the super cut: impact → **frozen half-beat** → shake settles, focus resolves. Also on every deck (`?deck=deck-pitch`), one freeze per station's super.

🤖 Generated with [Claude Code](https://claude.com/claude-code)