### PR TITLE
polish(tier1): material presence + narrative light + idle life + count-up values

### DIFF
--- a/sdf-js/apps/present/figure-core.js
+++ b/sdf-js/apps/present/figure-core.js
@@ -54,6 +54,11 @@ export function createFigure({ outdoor = false } = {}) {
     els = items.map((o) => {
       const d = document.createElement('div');
       d.className = 'lbl' + (o.role === 'value' ? ' value' : '');
+      // Numeric value chips COUNT UP over ~0.8s after their reveal — numbers
+      // that arrive read as data landing, not captions appearing.
+      if (o.role === 'value' && /^[\d,]+$/.test(o.text)) {
+        o._countTarget = Number(o.text.replace(/,/g, ''));
+      }
       d.textContent = o.text;
       if (o.role === 'title') {
         d.style.fontSize = '20px';
@@ -93,6 +98,13 @@ export function createFigure({ outdoor = false } = {}) {
       const depthFade =
         p.depth == null ? 1 : Math.max(0, Math.min(1, (reach - p.depth) / (reach * 0.45)));
       el.style.opacity = (o.revealAt == null || t >= o.revealAt ? 1 : 0) * depthFade;
+      if (o._countTarget != null && o.revealAt != null) {
+        const k = Math.max(0, Math.min(1, (t - o.revealAt) / 0.8));
+        const eased = 1 - (1 - k) * (1 - k); // ease-out: fast start, settle on the number
+        const v = Math.round(o._countTarget * eased);
+        const shown = k >= 1 ? o.text : v.toLocaleString('en-US');
+        if (el.textContent !== shown) el.textContent = shown;
+      }
     }
     requestAnimationFrame(tick);
   }

--- a/sdf-js/scripts/test-assemble-deck.mjs
+++ b/sdf-js/scripts/test-assemble-deck.mjs
@@ -28,6 +28,16 @@ console.log('=== assemble-deck (N IRs → one continuous world) ===\n');
     threw = true;
   }
   ok(threw, 'unknown expr shape throws (fail loud)');
+  // idle-breathing tail: amplitude/freq preserved, PHASE rewinds by F*dt so the
+  // bob is continuous across the station's shifted clock
+  ok(
+    shiftBuildInExpr(
+      '2.500 - 1.1 * smoothstep(0.25, 0.75, t) + 0.018 * sin(1.3 * t + 4.20)',
+      0,
+      10,
+    ) === '2.500 - 1.1 * smoothstep(10.25, 10.75, t) + 0.018 * sin(1.3 * t + -8.80)',
+    'idle tail shifts phase (−F·dt), keeps amplitude/freq',
+  );
 }
 
 const deck = JSON.parse(

--- a/sdf-js/scripts/test-render-magnitude.mjs
+++ b/sdf-js/scripts/test-render-magnitude.mjs
@@ -25,6 +25,14 @@ ok(
   const scene = renderMagnitude(ir);
   const monos = scene.subjects.filter((s) => s.id.startsWith('mono-'));
   ok(monos.length === 5, 'one monolith per category');
+  ok(
+    monos.every((s) => s.type === 'rounded_box'),
+    'monoliths are beveled (hewn stone)',
+  );
+  ok(
+    scene.subjects.filter((s) => s.id.startsWith('plinth-')).length === 5,
+    'each monolith has a plinth',
+  );
   // honest encoding: height linear in magnitude, equal footprints
   const h = Object.fromEntries(monos.map((s) => [s.id, s.args.dims[1]]));
   ok(Math.abs(h['mono-2'] / h['mono-1'] - 890 / 620) < 0.01, 'heights linear in magnitude');
@@ -56,6 +64,10 @@ ok(
     'super punch-in (cut + shake + exposure pop)',
   );
   ok(superShot.target[1] > superShot.pos[1], 'super looks UP the emphasis monolith');
+  ok(
+    Array.isArray(superShot.ambient) && superShot.ambient[0] < 0.5,
+    'super crashes the ambient (spotlight moment)',
+  );
   ok((shots[shots.length - 1].focalDistance || 0) > 5, 'ends on a wide payoff frame');
 
   // labels: 5 name cards + 5 value chips, reveal-tagged

--- a/sdf-js/scripts/test-render-network.mjs
+++ b/sdf-js/scripts/test-render-network.mjs
@@ -60,6 +60,10 @@ ok(
   // wiring order: all nodes land before the first edge starts
   const t0 = (s) => Number(s.animation[0].expr.match(/smoothstep\(([\d.]+)/)[1]);
   ok(Math.max(...nodesS.map(t0)) < Math.min(...edgesS.map(t0)), 'edges wire AFTER nodes land');
+  ok(
+    nodesS.every((s) => /sin\(/.test(s.animation[0].expr)),
+    'nodes idle-breathe after landing',
+  );
 
   // fighting-game grammar
   const shots = scene.cameraSequence.shots;

--- a/sdf-js/src/render/studio.js
+++ b/sdf-js/src/render/studio.js
@@ -2393,6 +2393,7 @@ export function createStudioRenderer({
     let sequenceFocalDist = null;
     // Sprint 8: per-shot exposure override + renderer override (Blueprint-as-shot).
     let sequenceExposure = null;
+    let sequenceAmbient = null; // shot-level sky-ambient override (the spotlight crash)
     let sequenceShotRenderer = null;
     // Sprint 4: per-frame subject motion offsets + scene-state. Both are
     // produced by the sequence evaluator and feed: (a) subject SDF translate
@@ -2414,6 +2415,7 @@ export function createStudioRenderer({
         sequenceAperture = cs.aperture;
         sequenceFocalDist = cs.focalDistance;
         if (typeof state.exposure === 'number') sequenceExposure = state.exposure;
+        if (typeof state.ambient === 'number') sequenceAmbient = state.ambient;
         if (state.shotRenderer) sequenceShotRenderer = state.shotRenderer;
         frameSubjectOffsets = state.subjectOffsets || {};
         frameSceneState = state.sceneState || {};
@@ -2602,7 +2604,11 @@ export function createStudioRenderer({
       gl.uniform1i(uniformsCache['u_numExtraLights'], numExtraLights);
     }
     if (uniformsCache['u_ambientScale'] != null) {
-      gl.uniform1f(uniformsCache['u_ambientScale'], ambientScale);
+      // Shot-level ambient (spotlight crash) scales the scene's baseline.
+      gl.uniform1f(
+        uniformsCache['u_ambientScale'],
+        sequenceAmbient != null ? ambientScale * sequenceAmbient : ambientScale,
+      );
     }
     if (numExtraLights > 0) {
       if (uniformsCache['u_extraLightPos[0]'] != null)

--- a/sdf-js/src/scene/assemble-deck.js
+++ b/sdf-js/src/scene/assemble-deck.js
@@ -17,15 +17,24 @@ import { renderIR } from './render-ir.js';
 import { getEnvironment } from './environments.js';
 
 // Every structure renderer emits build-ins of exactly this shape:
-//   "<A> - <D> * smoothstep(<t0>, <t1>, t)"   (drop from above)
-//   "<A> + <D> * smoothstep(<t0>, <t1>, t)"   (erupt from below)
-// Shift: A += dy (the y-channel constant), t0/t1 += dt.
-const EXPR_RE = /^(-?[\d.]+) (\+|-) ([\d.]+) \* smoothstep\((-?[\d.]+), (-?[\d.]+), t\)$/;
+//   "<A> - <D> * smoothstep(<t0>, <t1>, t)"            (drop from above)
+//   "<A> + <D> * smoothstep(<t0>, <t1>, t)"            (erupt from below)
+//   … + optional " + <I> * sin(<F> * t + <P>)" idle tail (breathing)
+// Shift: A += dy (the y-channel constant), t0/t1 += dt; the idle tail is
+// time-invariant in amplitude but its PHASE must rewind by F*dt so the motion
+// is continuous across the station's shifted clock.
+const EXPR_RE =
+  /^(-?[\d.]+) (\+|-) ([\d.]+) \* smoothstep\((-?[\d.]+), (-?[\d.]+), t\)(?: \+ ([\d.]+) \* sin\(([\d.]+) \* t \+ (-?[\d.]+)\))?$/;
 export function shiftBuildInExpr(expr, dy, dt) {
   const m = String(expr).match(EXPR_RE);
   if (!m) throw new Error(`assemble-deck: unrecognized build-in expr shape: "${expr}"`);
-  const [, A, sign, D, t0, t1] = m;
-  return `${(Number(A) + dy).toFixed(3)} ${sign} ${D} * smoothstep(${(Number(t0) + dt).toFixed(2)}, ${(Number(t1) + dt).toFixed(2)}, t)`;
+  const [, A, sign, D, t0, t1, idleAmp, idleFreq, idlePhase] = m;
+  let out = `${(Number(A) + dy).toFixed(3)} ${sign} ${D} * smoothstep(${(Number(t0) + dt).toFixed(2)}, ${(Number(t1) + dt).toFixed(2)}, t)`;
+  if (idleAmp != null) {
+    const p = Number(idlePhase) - Number(idleFreq) * dt;
+    out += ` + ${idleAmp} * sin(${idleFreq} * t + ${p.toFixed(2)})`;
+  }
+  return out;
 }
 
 const addV = (a, b) => [a[0] + b[0], a[1] + b[1], a[2] + b[2]];

--- a/sdf-js/src/scene/camera-sequence.js
+++ b/sdf-js/src/scene/camera-sequence.js
@@ -244,6 +244,16 @@ export function evaluateCameraSequence(seq, tSec, ctx) {
   out.aperture = dofValue(shot.aperture, blend, out.aperture);
   out.focalDistance = dofValue(shot.focalDistance, blend, out.focalDistance);
 
+  // Shot-level ambient: light participates in the narrative. number OR
+  // [from, to] intra-shot ramp scaling the scene's sky-ambient (u_ambientScale)
+  // — the super's [dip → 1.0] is the "spotlight crash" (surroundings collapse
+  // on the impact, then the room comes back). null → scene default untouched.
+  if (shot.ambient != null) {
+    out.ambient = Array.isArray(shot.ambient)
+      ? lerp(Number(shot.ambient[0]) || 0, Number(shot.ambient[1]) || 0, clamp01(shotT))
+      : Number(shot.ambient);
+  }
+
   // Shake: number (constant) OR [from, to] intra-shot ramp (the super's
   // impact-then-settle) OR legacy {amount, ...}. An edge ENVELOPE fades shake
   // in/out near shot boundaries so it never pops on when a calm shot blends

--- a/sdf-js/src/scene/render-hierarchy.js
+++ b/sdf-js/src/scene/render-hierarchy.js
@@ -72,7 +72,16 @@ export function coneTreeLayout(ir, opts = {}) {
 // Cool cyan→indigo by depth (matches the funnel family), emphasis in warm gold.
 const nodeMat = (lvl, maxLvl, emphasized) => {
   if (emphasized)
-    return { hue: 0.11, sat: 0.78, value: 0.95, kind: 'normal', roughness: 0.22, clearcoat: 0.6 };
+    return {
+      hue: 0.11,
+      sat: 0.78,
+      value: 0.95,
+      metal: 0,
+      glow: 0.22,
+      kind: 'normal',
+      roughness: 0.22,
+      clearcoat: 0.6,
+    };
   const k = maxLvl > 0 ? lvl / maxLvl : 0;
   return {
     hue: 0.55 + 0.09 * k,
@@ -205,6 +214,7 @@ export function renderHierarchy(ir, opts = {}) {
     aperture: [0.9, 0.45], // rack focus: the world falls away, the subject stays
     focalDistance: 1.7,
     shake: [0.5, 0.06], // impact-then-settle
+    ambient: [0.15, 1.0], // spotlight crash: surroundings collapse on the hit, then recover
     exposure: [1.45, 1.0],
     ease: 'out',
   });

--- a/sdf-js/src/scene/render-magnitude.js
+++ b/sdf-js/src/scene/render-magnitude.js
@@ -24,7 +24,16 @@ const label = (n) => (typeof n === 'string' ? n : (n && (n.label ?? n.name)) || 
 
 const monoMat = (i, N, emphasized) => {
   if (emphasized)
-    return { hue: 0.11, sat: 0.78, value: 0.95, kind: 'normal', roughness: 0.22, clearcoat: 0.6 };
+    return {
+      hue: 0.11,
+      sat: 0.78,
+      value: 0.95,
+      metal: 0,
+      glow: 0.22,
+      kind: 'normal',
+      roughness: 0.22,
+      clearcoat: 0.6,
+    };
   const k = N > 1 ? i / (N - 1) : 0;
   return {
     hue: 0.55 + 0.09 * k,
@@ -73,10 +82,26 @@ export function renderMagnitude(ir, opts = {}) {
     const buried = H + 0.3; // start fully underground, then erupt
     const t0 = Math.max(0.2, riseStart(k));
     const t1 = t0 + 0.6;
+    // Plinth first: a static base slab each monolith erupts THROUGH — turns a
+    // floating box into a mounted monument (and grounds the eruption).
     subjects.push({
-      id: `mono-${i}`,
+      id: `plinth-${i}`,
       type: 'box',
-      args: { dims: [W, H, W] },
+      args: { dims: [W + 0.34, 0.12, W + 0.34] },
+      transform: { translate: [xOf(i), 0.06, 0] },
+      material: {
+        hue: 0.58,
+        sat: 0.1,
+        value: 0.55,
+        kind: 'normal',
+        roughness: 0.6,
+        clearcoat: 0.1,
+      },
+    });
+    const craft = {
+      id: `mono-${i}`,
+      type: 'rounded_box', // beveled edges — a hewn stone, not a raw prim
+      args: { dims: [W, H, W], cornerR: 0.045 },
       transform: { translate: [xOf(i), yFinal, 0] },
       material: monoMat(i, N, emphasis.has(i)),
       animation: [
@@ -85,7 +110,9 @@ export function renderMagnitude(ir, opts = {}) {
           expr: `${(yFinal - buried).toFixed(3)} + ${buried.toFixed(3)} * smoothstep(${t0.toFixed(2)}, ${t1.toFixed(2)}, t)`,
         },
       ],
-    });
+    };
+    if (!emphasis.has(i)) craft.pattern = 'cracked'; // stone grain; the gold champion stays polished
+    subjects.push(craft);
   });
 
   // ---- camera: five beats, magnitude variation --------------------------------
@@ -143,6 +170,7 @@ export function renderMagnitude(ir, opts = {}) {
     aperture: [0.9, 0.45], // rack focus: the world falls away, the subject stays
     focalDistance: 1.8,
     shake: [0.5, 0.06], // impact-then-settle
+    ambient: [0.15, 1.0], // spotlight crash: surroundings collapse on the hit, then recover
     exposure: [1.45, 1.0],
     ease: 'out',
   });

--- a/sdf-js/src/scene/render-network.js
+++ b/sdf-js/src/scene/render-network.js
@@ -96,7 +96,16 @@ export function constellationLayout(ir, opts = {}) {
 
 const nodeMatN = (deg, maxDeg, emphasized) => {
   if (emphasized)
-    return { hue: 0.11, sat: 0.78, value: 0.95, kind: 'normal', roughness: 0.22, clearcoat: 0.6 };
+    return {
+      hue: 0.11,
+      sat: 0.78,
+      value: 0.95,
+      metal: 0,
+      glow: 0.22,
+      kind: 'normal',
+      roughness: 0.22,
+      clearcoat: 0.6,
+    };
   const k = maxDeg > 0 ? deg / maxDeg : 0; // hubs lighter, leaves deeper
   return {
     hue: 0.64 - 0.09 * k,
@@ -112,6 +121,7 @@ const EDGE_MAT = {
   hue: 0.58,
   sat: 0.25,
   value: 0.8,
+  glow: 0.08, // faint circuit glow — the wiring reads as live
   kind: 'normal',
   roughness: 0.35,
   clearcoat: 0.3,
@@ -153,7 +163,7 @@ export function renderNetwork(ir, opts = {}) {
       animation: [
         {
           channel: 'transform.translate.y',
-          expr: `${(p[1] + drop).toFixed(3)} - ${drop} * smoothstep(${t0.toFixed(2)}, ${(t0 + 0.5).toFixed(2)}, t)`,
+          expr: `${(p[1] + drop).toFixed(3)} - ${drop} * smoothstep(${t0.toFixed(2)}, ${(t0 + 0.5).toFixed(2)}, t) + 0.018 * sin(1.3 * t + ${(i * 2.1).toFixed(2)})`, // + idle breathing: a living constellation, not statues
         },
       ],
     });
@@ -238,6 +248,7 @@ export function renderNetwork(ir, opts = {}) {
     aperture: [0.9, 0.45], // rack focus: the world falls away, the subject stays
     focalDistance: 1.6,
     shake: [0.5, 0.06], // impact-then-settle
+    ambient: [0.15, 1.0], // spotlight crash: surroundings collapse on the hit, then recover
     exposure: [1.45, 1.0],
     ease: 'out',
   });

--- a/sdf-js/src/scene/render-sequence.js
+++ b/sdf-js/src/scene/render-sequence.js
@@ -24,7 +24,16 @@ export function magnitudeToRadii(magnitude, maxR = 1.4, tipR = 0.12) {
 // is proven legible there (sphere-fill gauge).
 const stageMat = (i, N, emphasized) => {
   if (emphasized)
-    return { hue: 0.11, sat: 0.78, value: 0.95, kind: 'normal', roughness: 0.22, clearcoat: 0.6 };
+    return {
+      hue: 0.11,
+      sat: 0.78,
+      value: 0.95,
+      metal: 0,
+      glow: 0.22,
+      kind: 'normal',
+      roughness: 0.22,
+      clearcoat: 0.6,
+    };
   const k = N > 1 ? i / (N - 1) : 0;
   return {
     hue: 0.55 + 0.09 * k, // cyan-blue → indigo
@@ -152,6 +161,7 @@ export function renderSequence(ir, opts = {}) {
     aperture: [0.9, 0.45], // rack focus: the world falls away, the subject stays
     focalDistance: 2,
     shake: [0.5, 0.06], // impact-then-settle
+    ambient: [0.15, 1.0], // spotlight crash: surroundings collapse on the hit, then recover
     exposure: [1.45, 1.0],
     ease: 'out',
   });

--- a/sdf-js/src/scene/spec.js
+++ b/sdf-js/src/scene/spec.js
@@ -1419,6 +1419,15 @@ function validateCameraSequence(seq, errors, warnings) {
     if (shot.transition != null && !SHOT_TRANSITIONS.has(shot.transition)) {
       errors.push(`${tag}.transition: must be one of ${[...SHOT_TRANSITIONS].join(' | ')}`);
     }
+    // ambient: number OR [from, to] intra-shot ramp scaling sky-ambient - the
+    // super's "spotlight crash". 0..2 sensible range.
+    if (shot.ambient != null) {
+      const okNum = (x) => typeof x === 'number' && x >= 0 && x <= 2;
+      const valid =
+        okNum(shot.ambient) ||
+        (Array.isArray(shot.ambient) && shot.ambient.length === 2 && shot.ambient.every(okNum));
+      if (!valid) errors.push(`${tag}.ambient: must be a number 0..2 or [from, to] pair`);
+    }
     // shake: number (legacy) OR [from, to] intra-shot ramp (impact-then-settle)
     // OR { amount, velocityScale, scaleWith }
     if (shot.shake != null) {


### PR DESCRIPTION
## What — Tier 1: the "same geometry, instantly more premium" batch

Four upgrades using **only existing engine capability** (glow field, pattern presets, `u_ambientScale`, expr sines, DOM overlay) — none of it was reaching the structure renderers until now.

1. **Material presence.** Emphasis objects gain emissive glow (0.22) — the gold champion *luminates* instead of just being yellow. Network edges carry a faint circuit glow (the wiring reads as live). Monoliths get the full craft pass: `rounded_box` bevels (hewn stone, edges catch light), **'cracked' stone grain** on the non-emphasis pillars (the champion stays polished), and a dark **plinth** under each — a mounted monument the eruption bursts through, not a floating box.
2. **Narrative light.** New `shot.ambient` (number or `[from,to]` ramp, validated): the super carries `[0.15, 1.0]` — the surroundings **crash to near-black on the cut** (a spotlight moment), then the room comes back through the shot.
3. **Idle life.** Network nodes breathe (±0.018 sine bob, per-node phase) after landing — a living constellation, not a museum of statues. The deck expr-shifter's strict parser extended for the idle tail (phase rewinds by F·dt so the bob is continuous across a station's shifted clock; unit-tested).
4. **Count-up values.** Numeric chips animate 0 → value over 0.8s after reveal (ease-out, locale separators) — numbers that *arrive* read as data landing, not captions appearing.

## Verified

The monolith **super frame is transformed**: glowing gold champion, ambient crashed to black, rack-focus mid-pull. The payoff shows plinths + bevels + visible stone grain (screenshots in session). Suite **122/122**; lint clean.

## Try

- `figure.html?ir=revenue-regions` — the crafted monoliths + spotlight super + counting numbers
- `figure.html?ir=ecosystem` — the breathing constellation with live wiring
- any deck — everything inherits

🤖 Generated with [Claude Code](https://claude.com/claude-code)