### PR TITLE
Sprint 27: atoms→IR bridge — the 2D pipeline feeds the cinematic renderer

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -28,6 +28,7 @@ sdf-js/scenes/deck-*.json
 sdf-js/scenes/sphere-fill-*.json
 sdf-js/scenes/shape-*.json
 sdf-js/scenes/lifted-*.json
+sdf-js/scenes/ir-from-*.json
 sdf-js/scenes/rec-*.json
 sdf-js/scenes/deck-rec-*.json
 sdf-js/scenes/deck-charts-*.json

--- a/docs/superpowers/atoms-to-ir-coverage.md
+++ b/docs/superpowers/atoms-to-ir-coverage.md
@@ -1,0 +1,59 @@
+# atoms → IR 覆盖表 — Sprint 27 (2026-07-06)
+
+`sdf-js/src/scene/scaffold-to-ir.js` 的 `atomToIR()` 把 2D atom SceneData 映射到
+IR 4 结构 (sequence / hierarchy / network / magnitude), 让 3-stage scaffold 管线
+的输出直接喂 `assembleDeck` (格斗游戏 cinematic 渲染)。只读 DATA args, 不读 x/y/w/h。
+
+## 已映射 (34)
+
+**sequence (12)**: change-curve-chart · circle-process-cycle · flow-chart · funnel ·
+funnel-with-conversion · journey-flow-curve · kanban-board · maturity-model ·
+process-arrows · progression · timeline · vertical-timeline
+
+**hierarchy (6)**: decision-tree-3-arm · mindmap · okr-tree · org-chart ·
+sphere-tree · tree-diagram
+
+**network (4)**: circle-image-hub-spoke · radial-wheel-segmented ·
+relationship-graph · sphere-network
+
+**magnitude (12)**: bar · column · dashboard-multi-kpi-composite · donut-with-center ·
+histogram · isotype-stat-comparison · pie · pyramid · radar-chart · segmented-bar ·
+stat-grid-large · waterfall
+
+## 无结构内容, 设计上不映射 (~40)
+
+装饰/文字/单值/形状类 — IR 表达的是"结构", 这些没有:
+cover · quote-pull · pull-quote-banner · callout-banner · call-to-action ·
+section-number-divider · stat-banner · stat-with-icon · kpi-card · kpi-water-drop ·
+testimonial-wall · pillar-3up · feature-card-grid · image · image-split ·
+icon-badge · icon-row · icon-grid · bullet-list · agenda-list · number-list ·
+numbered-grid · magazine-column-grid · arrow · diamond · cube · gear · circle-frame ·
+circle-loop · circle-stack · circle-segmented · cube-grid · cube-segmented ·
+gear-cluster · puzzle-pieces · sphere-fill · sphere-segmented · device-mockup-frame ·
+device-mockup-row · isotype-people-grid · isotype-prop-row
+
+## TODO (真有结构但 v1 未映射, ~13)
+
+| atom | 候选结构 | 备注 |
+|---|---|---|
+| fishbone | hierarchy | effect 为根, branches 为子 |
+| swot / cost-benefit-matrix / risk-heatmap / nine-field-matrix / matrix-grid / org-vs-org-matrix | — | 2 维分类, IR 没有 matrix 结构; 等 3D 端加或降维为 magnitude |
+| gantt | sequence | tasks 有起止 — 需要时间轴语义, v2 |
+| line / stacked-area / scatter / bubble / break-even | magnitude/sequence | 连续序列数据, magnitude 语义勉强; 等 IR 加 series 结构 |
+| value-chain-diagram | sequence | primary 链条可映射, v2 |
+| strategy-map / layer-stack / seven-s-model | hierarchy? | 层带模型, 无单根; v2 |
+| balance-scale / venn / comparison-table | — | 对比语义, IR 无对应 |
+| mountain-path / multiple-arrows / infinity-loop-flow / traffic-light / gauge | sequence/单值 | 边角, 按需 |
+
+## 入口 API
+
+- `atomToIR(subject) → IR | null` — 单 subject
+- `slotToIR(sceneData) → IR | null` — 一个 slot 选最富结构的 subject
+- `deckToIR(deckDir) → {title, slides: IR[]}` — 整个 baked deck, assembleDeck-ready
+- `parseMagnitude(v)` — "$3.4M"→3400000, "92%"→92, "12,450"→12450
+
+## 证明产物
+
+- `sdf-js/scenes/ir-from-qbr-q3-2026.json` (2 slides: hierarchy + sequence)
+- `sdf-js/scenes/ir-from-vc-pitch.json` (5 slides: magnitude×3 + sequence + network)
+- 3D 机器打开: `?scene=ir-from-vc-pitch`

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -153,6 +153,7 @@ const TESTS = [
   { category: 'scene', file: 'sdf-js/scripts/test-text-to-ir.mjs' },
   { category: 'scene', file: 'sdf-js/scripts/test-hitstop.mjs' },
   { category: 'scene', file: 'sdf-js/scripts/test-scaffold-to-ir.mjs' },
+  { category: 'scene', file: 'sdf-js/scripts/test-atoms-to-ir.mjs' },
   { category: 'scene', file: 'sdf-js/scripts/test-atom-3d-coverage.mjs' },
 
   // Sprint 5 Wave C: fishbone / traffic-light / radial-spoke + puzzle-piece.

--- a/sdf-js/scenes/ir-from-qbr-q3-2026.json
+++ b/sdf-js/scenes/ir-from-qbr-q3-2026.json
@@ -1,0 +1,1501 @@
+{
+  "v": 1,
+  "name": "(deck) Quarterly Business Review",
+  "subjects": [
+    {
+      "id": "s0-node-0",
+      "type": "union",
+      "children": [
+        {
+          "id": "node-ball-0",
+          "type": "sphere",
+          "args": {
+            "radius": 0.42000000000000004
+          },
+          "transform": {
+            "translate": [
+              0,
+              0,
+              0
+            ]
+          }
+        }
+      ],
+      "transform": {
+        "translate": [
+          0,
+          2.5749999999999997,
+          0
+        ]
+      },
+      "material": {
+        "hue": 0.55,
+        "sat": 0.62,
+        "value": 0.85,
+        "kind": "normal",
+        "roughness": 0.3,
+        "clearcoat": 0.45
+      },
+      "animation": [
+        {
+          "channel": "transform.translate.y",
+          "expr": "3.575 - 1 * smoothstep(1.55, 2.10, t)"
+        }
+      ]
+    },
+    {
+      "id": "s0-node-1",
+      "type": "union",
+      "children": [
+        {
+          "id": "node-ball-1",
+          "type": "sphere",
+          "args": {
+            "radius": 0.42000000000000004
+          },
+          "transform": {
+            "translate": [
+              0,
+              0,
+              0
+            ]
+          }
+        },
+        {
+          "id": "node-link-1",
+          "type": "capsule",
+          "args": {
+            "a": [
+              0,
+              0,
+              0
+            ],
+            "b": [
+              -1.1634144591899854e-16,
+              1.15,
+              1.9
+            ],
+            "radius": 0.045
+          },
+          "transform": {
+            "translate": [
+              0,
+              0,
+              0
+            ]
+          }
+        }
+      ],
+      "transform": {
+        "translate": [
+          1.1634144591899854e-16,
+          1.4249999999999998,
+          -1.9
+        ]
+      },
+      "material": {
+        "hue": 0.64,
+        "sat": 0.78,
+        "value": 0.57,
+        "kind": "normal",
+        "roughness": 0.3,
+        "clearcoat": 0.45
+      },
+      "animation": [
+        {
+          "channel": "transform.translate.y",
+          "expr": "2.425 - 1 * smoothstep(3.05, 3.60, t)"
+        }
+      ]
+    },
+    {
+      "id": "s0-node-2",
+      "type": "union",
+      "children": [
+        {
+          "id": "node-ball-2",
+          "type": "sphere",
+          "args": {
+            "radius": 0.42000000000000004
+          },
+          "transform": {
+            "translate": [
+              0,
+              0,
+              0
+            ]
+          }
+        },
+        {
+          "id": "node-link-2",
+          "type": "capsule",
+          "args": {
+            "a": [
+              0,
+              0,
+              0
+            ],
+            "b": [
+              -1.9,
+              1.15,
+              0
+            ],
+            "radius": 0.045
+          },
+          "transform": {
+            "translate": [
+              0,
+              0,
+              0
+            ]
+          }
+        }
+      ],
+      "transform": {
+        "translate": [
+          1.9,
+          1.4249999999999998,
+          0
+        ]
+      },
+      "material": {
+        "hue": 0.64,
+        "sat": 0.78,
+        "value": 0.57,
+        "kind": "normal",
+        "roughness": 0.3,
+        "clearcoat": 0.45
+      },
+      "animation": [
+        {
+          "channel": "transform.translate.y",
+          "expr": "2.425 - 1 * smoothstep(3.05, 3.60, t)"
+        }
+      ]
+    },
+    {
+      "id": "s0-node-3",
+      "type": "union",
+      "children": [
+        {
+          "id": "node-ball-3",
+          "type": "sphere",
+          "args": {
+            "radius": 0.42000000000000004
+          },
+          "transform": {
+            "translate": [
+              0,
+              0,
+              0
+            ]
+          }
+        },
+        {
+          "id": "node-link-3",
+          "type": "capsule",
+          "args": {
+            "a": [
+              0,
+              0,
+              0
+            ],
+            "b": [
+              -1.1634144591899854e-16,
+              1.15,
+              -1.9
+            ],
+            "radius": 0.045
+          },
+          "transform": {
+            "translate": [
+              0,
+              0,
+              0
+            ]
+          }
+        }
+      ],
+      "transform": {
+        "translate": [
+          1.1634144591899854e-16,
+          1.4249999999999998,
+          1.9
+        ]
+      },
+      "material": {
+        "hue": 0.64,
+        "sat": 0.78,
+        "value": 0.57,
+        "kind": "normal",
+        "roughness": 0.3,
+        "clearcoat": 0.45
+      },
+      "animation": [
+        {
+          "channel": "transform.translate.y",
+          "expr": "2.425 - 1 * smoothstep(3.05, 3.60, t)"
+        }
+      ]
+    },
+    {
+      "id": "s0-node-4",
+      "type": "union",
+      "children": [
+        {
+          "id": "node-ball-4",
+          "type": "sphere",
+          "args": {
+            "radius": 0.42000000000000004
+          },
+          "transform": {
+            "translate": [
+              0,
+              0,
+              0
+            ]
+          }
+        },
+        {
+          "id": "node-link-4",
+          "type": "capsule",
+          "args": {
+            "a": [
+              0,
+              0,
+              0
+            ],
+            "b": [
+              1.9,
+              1.15,
+              -2.326828918379971e-16
+            ],
+            "radius": 0.045
+          },
+          "transform": {
+            "translate": [
+              0,
+              0,
+              0
+            ]
+          }
+        }
+      ],
+      "transform": {
+        "translate": [
+          -1.9,
+          1.4249999999999998,
+          2.326828918379971e-16
+        ]
+      },
+      "material": {
+        "hue": 0.64,
+        "sat": 0.78,
+        "value": 0.57,
+        "kind": "normal",
+        "roughness": 0.3,
+        "clearcoat": 0.45
+      },
+      "animation": [
+        {
+          "channel": "transform.translate.y",
+          "expr": "2.425 - 1 * smoothstep(3.05, 3.60, t)"
+        }
+      ]
+    },
+    {
+      "id": "path-0-1",
+      "type": "box",
+      "args": {
+        "dims": [
+          0.9,
+          0.06,
+          0.28
+        ]
+      },
+      "transform": {
+        "translate": [
+          2.6666666666666665,
+          0.03,
+          0
+        ],
+        "rotate": [
+          0,
+          0,
+          0
+        ]
+      },
+      "material": {
+        "hue": 0.58,
+        "sat": 0.25,
+        "value": 0.75,
+        "kind": "normal",
+        "roughness": 0.5,
+        "clearcoat": 0.2
+      }
+    },
+    {
+      "id": "path-0-2",
+      "type": "box",
+      "args": {
+        "dims": [
+          0.9,
+          0.06,
+          0.28
+        ]
+      },
+      "transform": {
+        "translate": [
+          5.333333333333333,
+          0.03,
+          0
+        ],
+        "rotate": [
+          0,
+          0,
+          0
+        ]
+      },
+      "material": {
+        "hue": 0.58,
+        "sat": 0.25,
+        "value": 0.75,
+        "kind": "normal",
+        "roughness": 0.5,
+        "clearcoat": 0.2
+      }
+    },
+    {
+      "id": "path-0-3",
+      "type": "box",
+      "args": {
+        "dims": [
+          0.9,
+          0.06,
+          0.28
+        ]
+      },
+      "transform": {
+        "translate": [
+          8,
+          0.03,
+          0
+        ],
+        "rotate": [
+          0,
+          0,
+          0
+        ]
+      },
+      "material": {
+        "hue": 0.58,
+        "sat": 0.25,
+        "value": 0.75,
+        "kind": "normal",
+        "roughness": 0.5,
+        "clearcoat": 0.2
+      }
+    },
+    {
+      "id": "path-0-4",
+      "type": "box",
+      "args": {
+        "dims": [
+          0.9,
+          0.06,
+          0.28
+        ]
+      },
+      "transform": {
+        "translate": [
+          10.666666666666666,
+          0.03,
+          0
+        ],
+        "rotate": [
+          0,
+          0,
+          0
+        ]
+      },
+      "material": {
+        "hue": 0.58,
+        "sat": 0.25,
+        "value": 0.75,
+        "kind": "normal",
+        "roughness": 0.5,
+        "clearcoat": 0.2
+      }
+    },
+    {
+      "id": "path-0-5",
+      "type": "box",
+      "args": {
+        "dims": [
+          0.9,
+          0.06,
+          0.28
+        ]
+      },
+      "transform": {
+        "translate": [
+          13.333333333333334,
+          0.03,
+          0
+        ],
+        "rotate": [
+          0,
+          0,
+          0
+        ]
+      },
+      "material": {
+        "hue": 0.58,
+        "sat": 0.25,
+        "value": 0.75,
+        "kind": "normal",
+        "roughness": 0.5,
+        "clearcoat": 0.2
+      }
+    },
+    {
+      "id": "s1-stage-0",
+      "type": "funnel-3d",
+      "args": {
+        "stages": 1,
+        "radii": [
+          1.4,
+          1.4
+        ],
+        "stageHeight": 0.55,
+        "gap": 0
+      },
+      "transform": {
+        "translate": [
+          16,
+          2.605,
+          0
+        ]
+      },
+      "material": {
+        "hue": 0.55,
+        "sat": 0.62,
+        "value": 0.85,
+        "kind": "normal",
+        "roughness": 0.3,
+        "clearcoat": 0.45
+      },
+      "animation": [
+        {
+          "channel": "transform.translate.y",
+          "expr": "3.505 - 0.9 * smoothstep(9.95, 10.55, t)"
+        }
+      ]
+    },
+    {
+      "id": "s1-stage-1",
+      "type": "funnel-3d",
+      "args": {
+        "stages": 1,
+        "radii": [
+          1.4,
+          1.4
+        ],
+        "stageHeight": 0.55,
+        "gap": 0
+      },
+      "transform": {
+        "translate": [
+          16,
+          1.935,
+          0
+        ]
+      },
+      "material": {
+        "hue": 0.5800000000000001,
+        "sat": 0.6733333333333333,
+        "value": 0.75,
+        "kind": "normal",
+        "roughness": 0.3,
+        "clearcoat": 0.45
+      },
+      "animation": [
+        {
+          "channel": "transform.translate.y",
+          "expr": "2.835 - 0.9 * smoothstep(10.30, 10.90, t)"
+        }
+      ]
+    },
+    {
+      "id": "s1-stage-2",
+      "type": "funnel-3d",
+      "args": {
+        "stages": 1,
+        "radii": [
+          1.4,
+          1.4
+        ],
+        "stageHeight": 0.55,
+        "gap": 0
+      },
+      "transform": {
+        "translate": [
+          16,
+          1.265,
+          0
+        ]
+      },
+      "material": {
+        "hue": 0.6100000000000001,
+        "sat": 0.7266666666666667,
+        "value": 0.65,
+        "kind": "normal",
+        "roughness": 0.3,
+        "clearcoat": 0.45
+      },
+      "animation": [
+        {
+          "channel": "transform.translate.y",
+          "expr": "2.165 - 0.9 * smoothstep(10.65, 11.25, t)"
+        }
+      ]
+    },
+    {
+      "id": "s1-stage-3",
+      "type": "funnel-3d",
+      "args": {
+        "stages": 1,
+        "radii": [
+          1.4,
+          0.12
+        ],
+        "stageHeight": 0.55,
+        "gap": 0
+      },
+      "transform": {
+        "translate": [
+          16,
+          0.5949999999999998,
+          0
+        ]
+      },
+      "material": {
+        "hue": 0.11,
+        "sat": 0.78,
+        "value": 0.95,
+        "metal": 0,
+        "glow": 0.22,
+        "kind": "normal",
+        "roughness": 0.22,
+        "clearcoat": 0.6
+      },
+      "animation": [
+        {
+          "channel": "transform.translate.y",
+          "expr": "1.495 - 0.9 * smoothstep(11.00, 11.60, t)"
+        }
+      ]
+    },
+    {
+      "id": "horizon-0",
+      "type": "ellipsoid",
+      "args": {
+        "dims": [
+          38.13727924718674,
+          13.215912874692448,
+          26.696095473030717
+        ]
+      },
+      "transform": {
+        "translate": [
+          8,
+          -7.268752081080847,
+          149.4873849663741
+        ]
+      },
+      "material": {
+        "hue": 0.62,
+        "sat": 0.3,
+        "value": 0.3,
+        "metal": 0,
+        "glow": 0,
+        "kind": "normal",
+        "roughness": 0.85
+      }
+    },
+    {
+      "id": "horizon-1",
+      "type": "ellipsoid",
+      "args": {
+        "dims": [
+          37.52483816920971,
+          14.338825549215796,
+          26.267386718446794
+        ]
+      },
+      "transform": {
+        "translate": [
+          79.56684028028803,
+          -7.886354052068689,
+          104.97304017873017
+        ]
+      },
+      "material": {
+        "hue": 0.62,
+        "sat": 0.3,
+        "value": 0.3,
+        "metal": 0,
+        "glow": 0,
+        "kind": "normal",
+        "roughness": 0.85
+      }
+    },
+    {
+      "id": "horizon-2",
+      "type": "ellipsoid",
+      "args": {
+        "dims": [
+          36.95026224801879,
+          9.147324207562857,
+          25.86518357361315
+        ]
+      },
+      "transform": {
+        "translate": [
+          67.75924111207317,
+          -5.031028314159571,
+          82.4573973625209
+        ]
+      },
+      "material": {
+        "hue": 0.62,
+        "sat": 0.3,
+        "value": 0.3,
+        "metal": 0,
+        "glow": 0,
+        "kind": "normal",
+        "roughness": 0.85
+      }
+    },
+    {
+      "id": "horizon-3",
+      "type": "ellipsoid",
+      "args": {
+        "dims": [
+          36.41752513919053,
+          9.18889152114572,
+          25.49226759743337
+        ]
+      },
+      "transform": {
+        "translate": [
+          147.64714305397118,
+          -5.053890336630147,
+          -16.13936109603344
+        ]
+      },
+      "material": {
+        "hue": 0.62,
+        "sat": 0.3,
+        "value": 0.3,
+        "metal": 0,
+        "glow": 0,
+        "kind": "normal",
+        "roughness": 0.85
+      }
+    },
+    {
+      "id": "horizon-4",
+      "type": "ellipsoid",
+      "args": {
+        "dims": [
+          35.93031114919384,
+          14.371069104286219,
+          25.15121780443569
+        ]
+      },
+      "transform": {
+        "translate": [
+          147.7457789393791,
+          -7.904088007357421,
+          16.69851650009929
+        ]
+      },
+      "material": {
+        "hue": 0.62,
+        "sat": 0.3,
+        "value": 0.3,
+        "metal": 0,
+        "glow": 0,
+        "kind": "normal",
+        "roughness": 0.85
+      }
+    },
+    {
+      "id": "horizon-5",
+      "type": "ellipsoid",
+      "args": {
+        "dims": [
+          35.49198975544141,
+          13.167113168752554,
+          24.844392828808985
+        ]
+      },
+      "transform": {
+        "translate": [
+          66.89384281368567,
+          -7.241912242813905,
+          -83.14840635485335
+        ]
+      },
+      "material": {
+        "hue": 0.62,
+        "sat": 0.3,
+        "value": 0.3,
+        "metal": 0,
+        "glow": 0,
+        "kind": "normal",
+        "roughness": 0.85
+      }
+    },
+    {
+      "id": "horizon-6",
+      "type": "ellipsoid",
+      "args": {
+        "dims": [
+          35.105592303637735,
+          8.254988986589172,
+          24.573914612546414
+        ]
+      },
+      "transform": {
+        "translate": [
+          81.0971923834581,
+          -4.540243942624045,
+          -103.66792263452328
+        ]
+      },
+      "material": {
+        "hue": 0.62,
+        "sat": 0.3,
+        "value": 0.3,
+        "metal": 0,
+        "glow": 0,
+        "kind": "normal",
+        "roughness": 0.85
+      }
+    },
+    {
+      "id": "horizon-7",
+      "type": "ellipsoid",
+      "args": {
+        "dims": [
+          34.77379104358041,
+          10.56075920141966,
+          24.341653730506284
+        ]
+      },
+      "transform": {
+        "translate": [
+          5.360722365339581,
+          -5.808417560780814,
+          -149.536065887123
+        ]
+      },
+      "material": {
+        "hue": 0.62,
+        "sat": 0.3,
+        "value": 0.3,
+        "metal": 0,
+        "glow": 0,
+        "kind": "normal",
+        "roughness": 0.85
+      }
+    },
+    {
+      "id": "horizon-8",
+      "type": "ellipsoid",
+      "args": {
+        "dims": [
+          34.49888064839919,
+          14.955687471333393,
+          24.14921645387943
+        ]
+      },
+      "transform": {
+        "translate": [
+          -52.44412567299632,
+          -8.225628109233368,
+          -91.80877229827446
+        ]
+      },
+      "material": {
+        "hue": 0.62,
+        "sat": 0.3,
+        "value": 0.3,
+        "metal": 0,
+        "glow": 0,
+        "kind": "normal",
+        "roughness": 0.85
+      }
+    },
+    {
+      "id": "horizon-9",
+      "type": "ellipsoid",
+      "args": {
+        "dims": [
+          34.282762345041725,
+          11.66411263416465,
+          23.997933641529205
+        ]
+      },
+      "transform": {
+        "translate": [
+          -59.26628918333596,
+          -6.415261948790558,
+          -90.59592022307277
+        ]
+      },
+      "material": {
+        "hue": 0.62,
+        "sat": 0.3,
+        "value": 0.3,
+        "metal": 0,
+        "glow": 0,
+        "kind": "normal",
+        "roughness": 0.85
+      }
+    },
+    {
+      "id": "horizon-10",
+      "type": "ellipsoid",
+      "args": {
+        "dims": [
+          34.12693076575705,
+          8.007501235419541,
+          23.888851536029936
+        ]
+      },
+      "transform": {
+        "translate": [
+          -141.6750233575849,
+          -4.404125679480748,
+          16.581296589816493
+        ]
+      },
+      "material": {
+        "hue": 0.62,
+        "sat": 0.3,
+        "value": 0.3,
+        "metal": 0,
+        "glow": 0,
+        "kind": "normal",
+        "roughness": 0.85
+      }
+    },
+    {
+      "id": "horizon-11",
+      "type": "ellipsoid",
+      "args": {
+        "dims": [
+          34.032463611508966,
+          12.119272489365873,
+          23.822724528056273
+        ]
+      },
+      "transform": {
+        "translate": [
+          -114.34736116270167,
+          -6.66559986915123,
+          -14.991066199015563
+        ]
+      },
+      "material": {
+        "hue": 0.62,
+        "sat": 0.3,
+        "value": 0.3,
+        "metal": 0,
+        "glow": 0,
+        "kind": "normal",
+        "roughness": 0.85
+      }
+    },
+    {
+      "id": "horizon-12",
+      "type": "ellipsoid",
+      "args": {
+        "dims": [
+          34.00001419880521,
+          14.853592815492972,
+          23.800009939163647
+        ]
+      },
+      "transform": {
+        "translate": [
+          -50.7805809230263,
+          -8.169476048521135,
+          84.79880368810014
+        ]
+      },
+      "material": {
+        "hue": 0.62,
+        "sat": 0.3,
+        "value": 0.3,
+        "metal": 0,
+        "glow": 0,
+        "kind": "normal",
+        "roughness": 0.85
+      }
+    },
+    {
+      "id": "horizon-13",
+      "type": "ellipsoid",
+      "args": {
+        "dims": [
+          34.02980694148735,
+          10.128499693496575,
+          23.820864859041144
+        ]
+      },
+      "transform": {
+        "translate": [
+          -76.47905988961341,
+          -5.570674831423117,
+          115.98928845605614
+        ]
+      },
+      "material": {
+        "hue": 0.62,
+        "sat": 0.3,
+        "value": 0.3,
+        "metal": 0,
+        "glow": 0,
+        "kind": "normal",
+        "roughness": 0.85
+      }
+    }
+  ],
+  "overlay": [
+    {
+      "text": "SCALE TO $2.4M ARR · Q4 2024",
+      "anchor": [
+        0,
+        3.875,
+        0
+      ],
+      "role": "title",
+      "revealAt": 0
+    },
+    {
+      "text": "Scale to $2.4M ARR",
+      "anchor": [
+        0.74,
+        2.5749999999999997,
+        0
+      ],
+      "role": "card",
+      "align": "left",
+      "revealAt": 2.45
+    },
+    {
+      "text": "Launch Perp DEX",
+      "anchor": [
+        0.7400000000000002,
+        1.4249999999999998,
+        -1.9
+      ],
+      "role": "card",
+      "align": "left",
+      "revealAt": 3.95
+    },
+    {
+      "text": "Insurance expansion",
+      "anchor": [
+        2.6399999999999997,
+        1.4249999999999998,
+        0
+      ],
+      "role": "card",
+      "align": "left",
+      "revealAt": 3.95
+    },
+    {
+      "text": "Asia regulatory clearance",
+      "anchor": [
+        0.7400000000000002,
+        1.4249999999999998,
+        1.9
+      ],
+      "role": "card",
+      "align": "left",
+      "revealAt": 3.95
+    },
+    {
+      "text": "Series B exploration",
+      "anchor": [
+        -1.16,
+        1.4249999999999998,
+        2.326828918379971e-16
+      ],
+      "role": "card",
+      "align": "left",
+      "revealAt": 3.95
+    },
+    {
+      "text": "ENGINEERING",
+      "anchor": [
+        16,
+        4.279999999999999,
+        0
+      ],
+      "role": "title",
+      "revealAt": 9.7
+    },
+    {
+      "text": "Engineering",
+      "anchor": [
+        17.9,
+        2.605,
+        0
+      ],
+      "role": "card",
+      "align": "left",
+      "revealAt": 12.35
+    },
+    {
+      "text": "1",
+      "anchor": [
+        16,
+        2.605,
+        1.5999999999999999
+      ],
+      "role": "value",
+      "radius": 0.36,
+      "revealAt": 12.35
+    },
+    {
+      "text": "Product",
+      "anchor": [
+        17.9,
+        1.935,
+        0
+      ],
+      "role": "card",
+      "align": "left",
+      "revealAt": 13.55
+    },
+    {
+      "text": "1",
+      "anchor": [
+        16,
+        1.935,
+        1.5999999999999999
+      ],
+      "role": "value",
+      "radius": 0.36,
+      "revealAt": 13.55
+    },
+    {
+      "text": "Legal",
+      "anchor": [
+        17.9,
+        1.265,
+        0
+      ],
+      "role": "card",
+      "align": "left",
+      "revealAt": 14.75
+    },
+    {
+      "text": "1",
+      "anchor": [
+        16,
+        1.265,
+        1.5999999999999999
+      ],
+      "role": "value",
+      "radius": 0.36,
+      "revealAt": 14.75
+    },
+    {
+      "text": "CEO",
+      "anchor": [
+        17.9,
+        0.5949999999999998,
+        0
+      ],
+      "role": "card",
+      "align": "left",
+      "revealAt": 15.95
+    },
+    {
+      "text": "1",
+      "anchor": [
+        16,
+        0.5949999999999998,
+        1.5999999999999999
+      ],
+      "role": "value",
+      "radius": 0.5,
+      "revealAt": 15.95
+    }
+  ],
+  "cameraSequence": {
+    "loop": false,
+    "shots": [
+      {
+        "duration": 0.9,
+        "pos": [
+          2.1,
+          0.5,
+          4.8
+        ],
+        "target": [
+          0,
+          2.5749999999999997,
+          0
+        ],
+        "fov": 52,
+        "aperture": 0.55,
+        "focalDistance": 5,
+        "ease": "out"
+      },
+      {
+        "duration": 1.2,
+        "pos": [
+          0.8,
+          4.975,
+          3.8
+        ],
+        "target": [
+          0,
+          2.175,
+          0
+        ],
+        "fov": 48,
+        "transition": "blend",
+        "aperture": 0.3,
+        "focalDistance": 4.4,
+        "ease": "inout"
+      },
+      {
+        "duration": 1.5,
+        "pos": [
+          2.8518635521965936,
+          3.4749999999999996,
+          1.4515075885618476
+        ],
+        "target": [
+          0,
+          2.5749999999999997,
+          0
+        ],
+        "fov": 46,
+        "transition": "blend",
+        "aperture": 0.25,
+        "focalDistance": 3.2,
+        "shake": 0.05,
+        "ease": "smooth"
+      },
+      {
+        "duration": 1.5,
+        "pos": [
+          3.476534536424238,
+          2.3249999999999997,
+          -2.5305548041979873
+        ],
+        "target": [
+          0,
+          1.4249999999999998,
+          0
+        ],
+        "fov": 46,
+        "transition": "blend",
+        "aperture": 0.25,
+        "focalDistance": 4.300000000000001,
+        "shake": 0.05,
+        "ease": "smooth"
+      },
+      {
+        "duration": 1,
+        "pos": [
+          0.5,
+          2.4749999999999996,
+          1.6
+        ],
+        "target": [
+          0,
+          2.655,
+          0
+        ],
+        "fov": 40,
+        "transition": "cut",
+        "aperture": [
+          0.9,
+          0.45
+        ],
+        "focalDistance": 1.7,
+        "shake": [
+          0.5,
+          0.06
+        ],
+        "ambient": [
+          0.15,
+          1
+        ],
+        "exposure": [
+          1.45,
+          1
+        ],
+        "ease": "out"
+      },
+      {
+        "duration": 2.4,
+        "pos": [
+          1.6,
+          3.3999999999999995,
+          9.56
+        ],
+        "target": [
+          0,
+          1.9999999999999998,
+          0
+        ],
+        "fov": 44,
+        "transition": "blend",
+        "aperture": 0.12,
+        "focalDistance": 9.56,
+        "ease": "out"
+      },
+      {
+        "duration": 1.2,
+        "pos": [
+          9.950000000000001,
+          5,
+          11.56
+        ],
+        "target": [
+          8,
+          2.6799999999999997,
+          0
+        ],
+        "fov": 50,
+        "transition": "blend",
+        "aperture": 0,
+        "focalDistance": 12.8,
+        "shake": [
+          0.14,
+          0.05
+        ],
+        "ease": "whip"
+      },
+      {
+        "duration": 0.9,
+        "pos": [
+          18.3,
+          0.55,
+          5.2
+        ],
+        "target": [
+          16,
+          2.6799999999999997,
+          0
+        ],
+        "fov": 54,
+        "aperture": 0.55,
+        "focalDistance": 5.5,
+        "ease": "out"
+      },
+      {
+        "duration": 1.3,
+        "pos": [
+          16.9,
+          5.38,
+          4.4
+        ],
+        "target": [
+          16,
+          2.58,
+          0
+        ],
+        "fov": 50,
+        "transition": "blend",
+        "aperture": 0.3,
+        "focalDistance": 5,
+        "ease": "inout"
+      },
+      {
+        "duration": 1.2,
+        "pos": [
+          21.23262375631159,
+          3.455,
+          4.152354588048038
+        ],
+        "target": [
+          16,
+          2.605,
+          0
+        ],
+        "fov": 46,
+        "transition": "blend",
+        "aperture": 0.25,
+        "focalDistance": 6.68,
+        "shake": 0.05,
+        "ease": "smooth"
+      },
+      {
+        "duration": 1.2,
+        "pos": [
+          22.505302174266344,
+          2.785,
+          -1.5177099925498219
+        ],
+        "target": [
+          16,
+          1.935,
+          0
+        ],
+        "fov": 46,
+        "transition": "blend",
+        "aperture": 0.25,
+        "focalDistance": 6.68,
+        "shake": 0.05,
+        "ease": "smooth"
+      },
+      {
+        "duration": 1.2,
+        "pos": [
+          18.854897599961983,
+          2.1149999999999998,
+          -6.039201908673968
+        ],
+        "target": [
+          16,
+          1.265,
+          0
+        ],
+        "fov": 46,
+        "transition": "blend",
+        "aperture": 0.25,
+        "focalDistance": 6.68,
+        "shake": 0.05,
+        "ease": "smooth"
+      },
+      {
+        "duration": 1.2,
+        "pos": [
+          13.043963438790385,
+          1.4449999999999998,
+          -5.990346221112102
+        ],
+        "target": [
+          16,
+          0.5949999999999998,
+          0
+        ],
+        "fov": 46,
+        "transition": "blend",
+        "aperture": 0.25,
+        "focalDistance": 6.68,
+        "shake": 0.05,
+        "ease": "smooth"
+      },
+      {
+        "duration": 1,
+        "pos": [
+          16.55,
+          0.44499999999999973,
+          1.9
+        ],
+        "target": [
+          16,
+          0.7149999999999997,
+          0
+        ],
+        "fov": 40,
+        "transition": "cut",
+        "aperture": [
+          0.9,
+          0.45
+        ],
+        "focalDistance": 2,
+        "shake": [
+          0.5,
+          0.06
+        ],
+        "ambient": [
+          0.15,
+          1
+        ],
+        "exposure": [
+          1.45,
+          1
+        ],
+        "ease": "out"
+      },
+      {
+        "duration": 2.4,
+        "pos": [
+          17.4,
+          2.7,
+          7.992
+        ],
+        "target": [
+          16,
+          1.7999999999999998,
+          0
+        ],
+        "fov": 44,
+        "transition": "blend",
+        "aperture": 0.12,
+        "focalDistance": 7.992,
+        "ease": "out"
+      },
+      {
+        "duration": 3,
+        "pos": [
+          16,
+          20.5,
+          30.4
+        ],
+        "target": [
+          8,
+          1.2,
+          0
+        ],
+        "fov": 48,
+        "transition": "blend",
+        "aperture": 0.08,
+        "focalDistance": 33.6,
+        "ease": "out"
+      }
+    ],
+    "hitstops": [
+      {
+        "at": 5.119999999999999,
+        "hold": 0.14
+      },
+      {
+        "at": 16.72,
+        "hold": 0.14
+      }
+    ]
+  },
+  "defaults": {
+    "camera": {
+      "yaw": 0,
+      "pitch": -0.1,
+      "distance": 12,
+      "focal": 1.2,
+      "targetX": 0,
+      "targetY": 2,
+      "targetZ": 0
+    },
+    "light": {
+      "azimuth": 0.5,
+      "altitude": 0.7,
+      "distance": 40,
+      "intensity": 1.1
+    }
+  }
+}

--- a/sdf-js/scenes/ir-from-vc-pitch.json
+++ b/sdf-js/scenes/ir-from-vc-pitch.json
@@ -1,0 +1,3173 @@
+{
+  "v": 1,
+  "name": "(deck) VC Pitch Deck",
+  "subjects": [
+    {
+      "id": "s0-plinth-0",
+      "type": "box",
+      "args": {
+        "dims": [
+          1.06,
+          0.12,
+          1.06
+        ]
+      },
+      "transform": {
+        "translate": [
+          -1.27,
+          0.06,
+          0
+        ]
+      },
+      "material": {
+        "hue": 0.58,
+        "sat": 0.1,
+        "value": 0.55,
+        "kind": "normal",
+        "roughness": 0.6,
+        "clearcoat": 0.1
+      }
+    },
+    {
+      "id": "s0-mono-0",
+      "type": "rounded_box",
+      "args": {
+        "dims": [
+          0.72,
+          3.4,
+          0.72
+        ],
+        "cornerR": 0.045
+      },
+      "transform": {
+        "translate": [
+          -1.27,
+          1.7,
+          0
+        ]
+      },
+      "material": {
+        "hue": 0.11,
+        "sat": 0.78,
+        "value": 0.95,
+        "metal": 0,
+        "glow": 0.22,
+        "kind": "normal",
+        "roughness": 0.22,
+        "clearcoat": 0.6
+      },
+      "animation": [
+        {
+          "channel": "transform.translate.y",
+          "expr": "-2.000 + 3.700 * smoothstep(1.65, 2.25, t)"
+        }
+      ]
+    },
+    {
+      "id": "s0-plinth-1",
+      "type": "box",
+      "args": {
+        "dims": [
+          1.06,
+          0.12,
+          1.06
+        ]
+      },
+      "transform": {
+        "translate": [
+          0,
+          0.06,
+          0
+        ]
+      },
+      "material": {
+        "hue": 0.58,
+        "sat": 0.1,
+        "value": 0.55,
+        "kind": "normal",
+        "roughness": 0.6,
+        "clearcoat": 0.1
+      }
+    },
+    {
+      "id": "s0-mono-1",
+      "type": "rounded_box",
+      "args": {
+        "dims": [
+          0.72,
+          0.33999999999999997,
+          0.72
+        ],
+        "cornerR": 0.045
+      },
+      "transform": {
+        "translate": [
+          0,
+          0.16999999999999998,
+          0
+        ]
+      },
+      "material": {
+        "hue": 0.5950000000000001,
+        "sat": 0.69,
+        "value": 0.71,
+        "kind": "normal",
+        "roughness": 0.3,
+        "clearcoat": 0.45
+      },
+      "animation": [
+        {
+          "channel": "transform.translate.y",
+          "expr": "-0.470 + 0.640 * smoothstep(2.75, 3.35, t)"
+        }
+      ],
+      "pattern": "cracked"
+    },
+    {
+      "id": "s0-plinth-2",
+      "type": "box",
+      "args": {
+        "dims": [
+          1.06,
+          0.12,
+          1.06
+        ]
+      },
+      "transform": {
+        "translate": [
+          1.27,
+          0.06,
+          0
+        ]
+      },
+      "material": {
+        "hue": 0.58,
+        "sat": 0.1,
+        "value": 0.55,
+        "kind": "normal",
+        "roughness": 0.6,
+        "clearcoat": 0.1
+      }
+    },
+    {
+      "id": "s0-mono-2",
+      "type": "rounded_box",
+      "args": {
+        "dims": [
+          0.72,
+          0.14875000000000002,
+          0.72
+        ],
+        "cornerR": 0.045
+      },
+      "transform": {
+        "translate": [
+          1.27,
+          0.07437500000000001,
+          0
+        ]
+      },
+      "material": {
+        "hue": 0.64,
+        "sat": 0.76,
+        "value": 0.6,
+        "kind": "normal",
+        "roughness": 0.3,
+        "clearcoat": 0.45
+      },
+      "animation": [
+        {
+          "channel": "transform.translate.y",
+          "expr": "-0.374 + 0.449 * smoothstep(3.85, 4.45, t)"
+        }
+      ],
+      "pattern": "cracked"
+    },
+    {
+      "id": "path-0-1",
+      "type": "box",
+      "args": {
+        "dims": [
+          0.9,
+          0.06,
+          0.28
+        ]
+      },
+      "transform": {
+        "translate": [
+          2.6666666666666665,
+          0.03,
+          0
+        ],
+        "rotate": [
+          0,
+          0,
+          0
+        ]
+      },
+      "material": {
+        "hue": 0.58,
+        "sat": 0.25,
+        "value": 0.75,
+        "kind": "normal",
+        "roughness": 0.5,
+        "clearcoat": 0.2
+      }
+    },
+    {
+      "id": "path-0-2",
+      "type": "box",
+      "args": {
+        "dims": [
+          0.9,
+          0.06,
+          0.28
+        ]
+      },
+      "transform": {
+        "translate": [
+          5.333333333333333,
+          0.03,
+          0
+        ],
+        "rotate": [
+          0,
+          0,
+          0
+        ]
+      },
+      "material": {
+        "hue": 0.58,
+        "sat": 0.25,
+        "value": 0.75,
+        "kind": "normal",
+        "roughness": 0.5,
+        "clearcoat": 0.2
+      }
+    },
+    {
+      "id": "path-0-3",
+      "type": "box",
+      "args": {
+        "dims": [
+          0.9,
+          0.06,
+          0.28
+        ]
+      },
+      "transform": {
+        "translate": [
+          8,
+          0.03,
+          0
+        ],
+        "rotate": [
+          0,
+          0,
+          0
+        ]
+      },
+      "material": {
+        "hue": 0.58,
+        "sat": 0.25,
+        "value": 0.75,
+        "kind": "normal",
+        "roughness": 0.5,
+        "clearcoat": 0.2
+      }
+    },
+    {
+      "id": "path-0-4",
+      "type": "box",
+      "args": {
+        "dims": [
+          0.9,
+          0.06,
+          0.28
+        ]
+      },
+      "transform": {
+        "translate": [
+          10.666666666666666,
+          0.03,
+          0
+        ],
+        "rotate": [
+          0,
+          0,
+          0
+        ]
+      },
+      "material": {
+        "hue": 0.58,
+        "sat": 0.25,
+        "value": 0.75,
+        "kind": "normal",
+        "roughness": 0.5,
+        "clearcoat": 0.2
+      }
+    },
+    {
+      "id": "path-0-5",
+      "type": "box",
+      "args": {
+        "dims": [
+          0.9,
+          0.06,
+          0.28
+        ]
+      },
+      "transform": {
+        "translate": [
+          13.333333333333334,
+          0.03,
+          0
+        ],
+        "rotate": [
+          0,
+          0,
+          0
+        ]
+      },
+      "material": {
+        "hue": 0.58,
+        "sat": 0.25,
+        "value": 0.75,
+        "kind": "normal",
+        "roughness": 0.5,
+        "clearcoat": 0.2
+      }
+    },
+    {
+      "id": "s1-stage-0",
+      "type": "funnel-3d",
+      "args": {
+        "stages": 1,
+        "radii": [
+          1.4,
+          1.4
+        ],
+        "stageHeight": 0.55,
+        "gap": 0
+      },
+      "transform": {
+        "translate": [
+          16,
+          2.605,
+          0
+        ]
+      },
+      "material": {
+        "hue": 0.55,
+        "sat": 0.62,
+        "value": 0.85,
+        "kind": "normal",
+        "roughness": 0.3,
+        "clearcoat": 0.45
+      },
+      "animation": [
+        {
+          "channel": "transform.translate.y",
+          "expr": "3.505 - 0.9 * smoothstep(10.25, 10.85, t)"
+        }
+      ]
+    },
+    {
+      "id": "s1-stage-1",
+      "type": "funnel-3d",
+      "args": {
+        "stages": 1,
+        "radii": [
+          1.4,
+          1.4
+        ],
+        "stageHeight": 0.55,
+        "gap": 0
+      },
+      "transform": {
+        "translate": [
+          16,
+          1.935,
+          0
+        ]
+      },
+      "material": {
+        "hue": 0.5800000000000001,
+        "sat": 0.6733333333333333,
+        "value": 0.75,
+        "kind": "normal",
+        "roughness": 0.3,
+        "clearcoat": 0.45
+      },
+      "animation": [
+        {
+          "channel": "transform.translate.y",
+          "expr": "2.835 - 0.9 * smoothstep(10.60, 11.20, t)"
+        }
+      ]
+    },
+    {
+      "id": "s1-stage-2",
+      "type": "funnel-3d",
+      "args": {
+        "stages": 1,
+        "radii": [
+          1.4,
+          1.4
+        ],
+        "stageHeight": 0.55,
+        "gap": 0
+      },
+      "transform": {
+        "translate": [
+          16,
+          1.265,
+          0
+        ]
+      },
+      "material": {
+        "hue": 0.6100000000000001,
+        "sat": 0.7266666666666667,
+        "value": 0.65,
+        "kind": "normal",
+        "roughness": 0.3,
+        "clearcoat": 0.45
+      },
+      "animation": [
+        {
+          "channel": "transform.translate.y",
+          "expr": "2.165 - 0.9 * smoothstep(10.95, 11.55, t)"
+        }
+      ]
+    },
+    {
+      "id": "s1-stage-3",
+      "type": "funnel-3d",
+      "args": {
+        "stages": 1,
+        "radii": [
+          1.4,
+          0.12
+        ],
+        "stageHeight": 0.55,
+        "gap": 0
+      },
+      "transform": {
+        "translate": [
+          16,
+          0.5949999999999998,
+          0
+        ]
+      },
+      "material": {
+        "hue": 0.11,
+        "sat": 0.78,
+        "value": 0.95,
+        "metal": 0,
+        "glow": 0.22,
+        "kind": "normal",
+        "roughness": 0.22,
+        "clearcoat": 0.6
+      },
+      "animation": [
+        {
+          "channel": "transform.translate.y",
+          "expr": "1.495 - 0.9 * smoothstep(11.30, 11.90, t)"
+        }
+      ]
+    },
+    {
+      "id": "path-1-1",
+      "type": "box",
+      "args": {
+        "dims": [
+          0.9,
+          0.06,
+          0.28
+        ]
+      },
+      "transform": {
+        "translate": [
+          18.666666666666668,
+          0.03,
+          0
+        ],
+        "rotate": [
+          0,
+          0,
+          0
+        ]
+      },
+      "material": {
+        "hue": 0.58,
+        "sat": 0.25,
+        "value": 0.75,
+        "kind": "normal",
+        "roughness": 0.5,
+        "clearcoat": 0.2
+      }
+    },
+    {
+      "id": "path-1-2",
+      "type": "box",
+      "args": {
+        "dims": [
+          0.9,
+          0.06,
+          0.28
+        ]
+      },
+      "transform": {
+        "translate": [
+          21.333333333333332,
+          0.03,
+          0
+        ],
+        "rotate": [
+          0,
+          0,
+          0
+        ]
+      },
+      "material": {
+        "hue": 0.58,
+        "sat": 0.25,
+        "value": 0.75,
+        "kind": "normal",
+        "roughness": 0.5,
+        "clearcoat": 0.2
+      }
+    },
+    {
+      "id": "path-1-3",
+      "type": "box",
+      "args": {
+        "dims": [
+          0.9,
+          0.06,
+          0.28
+        ]
+      },
+      "transform": {
+        "translate": [
+          24,
+          0.03,
+          0
+        ],
+        "rotate": [
+          0,
+          0,
+          0
+        ]
+      },
+      "material": {
+        "hue": 0.58,
+        "sat": 0.25,
+        "value": 0.75,
+        "kind": "normal",
+        "roughness": 0.5,
+        "clearcoat": 0.2
+      }
+    },
+    {
+      "id": "path-1-4",
+      "type": "box",
+      "args": {
+        "dims": [
+          0.9,
+          0.06,
+          0.28
+        ]
+      },
+      "transform": {
+        "translate": [
+          26.666666666666664,
+          0.03,
+          0
+        ],
+        "rotate": [
+          0,
+          0,
+          0
+        ]
+      },
+      "material": {
+        "hue": 0.58,
+        "sat": 0.25,
+        "value": 0.75,
+        "kind": "normal",
+        "roughness": 0.5,
+        "clearcoat": 0.2
+      }
+    },
+    {
+      "id": "path-1-5",
+      "type": "box",
+      "args": {
+        "dims": [
+          0.9,
+          0.06,
+          0.28
+        ]
+      },
+      "transform": {
+        "translate": [
+          29.333333333333336,
+          0.03,
+          0
+        ],
+        "rotate": [
+          0,
+          0,
+          0
+        ]
+      },
+      "material": {
+        "hue": 0.58,
+        "sat": 0.25,
+        "value": 0.75,
+        "kind": "normal",
+        "roughness": 0.5,
+        "clearcoat": 0.2
+      }
+    },
+    {
+      "id": "s2-plinth-0",
+      "type": "box",
+      "args": {
+        "dims": [
+          1.06,
+          0.12,
+          1.06
+        ]
+      },
+      "transform": {
+        "translate": [
+          30.73,
+          0.06,
+          0
+        ]
+      },
+      "material": {
+        "hue": 0.58,
+        "sat": 0.1,
+        "value": 0.55,
+        "kind": "normal",
+        "roughness": 0.6,
+        "clearcoat": 0.1
+      }
+    },
+    {
+      "id": "s2-mono-0",
+      "type": "rounded_box",
+      "args": {
+        "dims": [
+          0.72,
+          0.12,
+          0.72
+        ],
+        "cornerR": 0.045
+      },
+      "transform": {
+        "translate": [
+          30.73,
+          0.06,
+          0
+        ]
+      },
+      "material": {
+        "hue": 0.55,
+        "sat": 0.62,
+        "value": 0.82,
+        "kind": "normal",
+        "roughness": 0.3,
+        "clearcoat": 0.45
+      },
+      "animation": [
+        {
+          "channel": "transform.translate.y",
+          "expr": "-0.360 + 0.420 * smoothstep(23.25, 23.85, t)"
+        }
+      ],
+      "pattern": "cracked"
+    },
+    {
+      "id": "s2-plinth-1",
+      "type": "box",
+      "args": {
+        "dims": [
+          1.06,
+          0.12,
+          1.06
+        ]
+      },
+      "transform": {
+        "translate": [
+          32,
+          0.06,
+          0
+        ]
+      },
+      "material": {
+        "hue": 0.58,
+        "sat": 0.1,
+        "value": 0.55,
+        "kind": "normal",
+        "roughness": 0.6,
+        "clearcoat": 0.1
+      }
+    },
+    {
+      "id": "s2-mono-1",
+      "type": "rounded_box",
+      "args": {
+        "dims": [
+          0.72,
+          0.12,
+          0.72
+        ],
+        "cornerR": 0.045
+      },
+      "transform": {
+        "translate": [
+          32,
+          0.06,
+          0
+        ]
+      },
+      "material": {
+        "hue": 0.5950000000000001,
+        "sat": 0.69,
+        "value": 0.71,
+        "kind": "normal",
+        "roughness": 0.3,
+        "clearcoat": 0.45
+      },
+      "animation": [
+        {
+          "channel": "transform.translate.y",
+          "expr": "-0.360 + 0.420 * smoothstep(24.35, 24.95, t)"
+        }
+      ],
+      "pattern": "cracked"
+    },
+    {
+      "id": "s2-plinth-2",
+      "type": "box",
+      "args": {
+        "dims": [
+          1.06,
+          0.12,
+          1.06
+        ]
+      },
+      "transform": {
+        "translate": [
+          33.27,
+          0.06,
+          0
+        ]
+      },
+      "material": {
+        "hue": 0.58,
+        "sat": 0.1,
+        "value": 0.55,
+        "kind": "normal",
+        "roughness": 0.6,
+        "clearcoat": 0.1
+      }
+    },
+    {
+      "id": "s2-mono-2",
+      "type": "rounded_box",
+      "args": {
+        "dims": [
+          0.72,
+          3.4,
+          0.72
+        ],
+        "cornerR": 0.045
+      },
+      "transform": {
+        "translate": [
+          33.27,
+          1.7,
+          0
+        ]
+      },
+      "material": {
+        "hue": 0.11,
+        "sat": 0.78,
+        "value": 0.95,
+        "metal": 0,
+        "glow": 0.22,
+        "kind": "normal",
+        "roughness": 0.22,
+        "clearcoat": 0.6
+      },
+      "animation": [
+        {
+          "channel": "transform.translate.y",
+          "expr": "-2.000 + 3.700 * smoothstep(25.45, 26.05, t)"
+        }
+      ]
+    },
+    {
+      "id": "path-2-1",
+      "type": "box",
+      "args": {
+        "dims": [
+          0.9,
+          0.06,
+          0.28
+        ]
+      },
+      "transform": {
+        "translate": [
+          34.666666666666664,
+          0.03,
+          0
+        ],
+        "rotate": [
+          0,
+          0,
+          0
+        ]
+      },
+      "material": {
+        "hue": 0.58,
+        "sat": 0.25,
+        "value": 0.75,
+        "kind": "normal",
+        "roughness": 0.5,
+        "clearcoat": 0.2
+      }
+    },
+    {
+      "id": "path-2-2",
+      "type": "box",
+      "args": {
+        "dims": [
+          0.9,
+          0.06,
+          0.28
+        ]
+      },
+      "transform": {
+        "translate": [
+          37.333333333333336,
+          0.03,
+          0
+        ],
+        "rotate": [
+          0,
+          0,
+          0
+        ]
+      },
+      "material": {
+        "hue": 0.58,
+        "sat": 0.25,
+        "value": 0.75,
+        "kind": "normal",
+        "roughness": 0.5,
+        "clearcoat": 0.2
+      }
+    },
+    {
+      "id": "path-2-3",
+      "type": "box",
+      "args": {
+        "dims": [
+          0.9,
+          0.06,
+          0.28
+        ]
+      },
+      "transform": {
+        "translate": [
+          40,
+          0.03,
+          0
+        ],
+        "rotate": [
+          0,
+          0,
+          0
+        ]
+      },
+      "material": {
+        "hue": 0.58,
+        "sat": 0.25,
+        "value": 0.75,
+        "kind": "normal",
+        "roughness": 0.5,
+        "clearcoat": 0.2
+      }
+    },
+    {
+      "id": "path-2-4",
+      "type": "box",
+      "args": {
+        "dims": [
+          0.9,
+          0.06,
+          0.28
+        ]
+      },
+      "transform": {
+        "translate": [
+          42.666666666666664,
+          0.03,
+          0
+        ],
+        "rotate": [
+          0,
+          0,
+          0
+        ]
+      },
+      "material": {
+        "hue": 0.58,
+        "sat": 0.25,
+        "value": 0.75,
+        "kind": "normal",
+        "roughness": 0.5,
+        "clearcoat": 0.2
+      }
+    },
+    {
+      "id": "path-2-5",
+      "type": "box",
+      "args": {
+        "dims": [
+          0.9,
+          0.06,
+          0.28
+        ]
+      },
+      "transform": {
+        "translate": [
+          45.333333333333336,
+          0.03,
+          0
+        ],
+        "rotate": [
+          0,
+          0,
+          0
+        ]
+      },
+      "material": {
+        "hue": 0.58,
+        "sat": 0.25,
+        "value": 0.75,
+        "kind": "normal",
+        "roughness": 0.5,
+        "clearcoat": 0.2
+      }
+    },
+    {
+      "id": "s3-net-node-0",
+      "type": "sphere",
+      "args": {
+        "radius": 0.33999999999999997
+      },
+      "transform": {
+        "translate": [
+          48,
+          3.31378414901835,
+          0
+        ]
+      },
+      "material": {
+        "hue": 0.11,
+        "sat": 0.78,
+        "value": 0.95,
+        "metal": 0,
+        "glow": 0.22,
+        "kind": "normal",
+        "roughness": 0.22,
+        "clearcoat": 0.6
+      },
+      "animation": [
+        {
+          "channel": "transform.translate.y",
+          "expr": "4.414 - 1.1 * smoothstep(31.85, 32.35, t) + 0.018 * sin(1.3 * t + -41.08)"
+        }
+      ]
+    },
+    {
+      "id": "s3-net-node-1",
+      "type": "sphere",
+      "args": {
+        "radius": 0.33999999999999997
+      },
+      "transform": {
+        "translate": [
+          45.9967389213689,
+          3.610442324700232,
+          1.8899991526810829
+        ]
+      },
+      "material": {
+        "hue": 0.61,
+        "sat": 0.7266666666666667,
+        "value": 0.65,
+        "kind": "normal",
+        "roughness": 0.3,
+        "clearcoat": 0.45
+      },
+      "animation": [
+        {
+          "channel": "transform.translate.y",
+          "expr": "4.710 - 1.1 * smoothstep(31.97, 32.47, t) + 0.018 * sin(1.3 * t + -38.98)"
+        }
+      ]
+    },
+    {
+      "id": "s3-net-node-2",
+      "type": "sphere",
+      "args": {
+        "radius": 0.33999999999999997
+      },
+      "transform": {
+        "translate": [
+          48.188889482343214,
+          2.474812722873115,
+          -2.6298275902042088
+        ]
+      },
+      "material": {
+        "hue": 0.61,
+        "sat": 0.7266666666666667,
+        "value": 0.65,
+        "kind": "normal",
+        "roughness": 0.3,
+        "clearcoat": 0.45
+      },
+      "animation": [
+        {
+          "channel": "transform.translate.y",
+          "expr": "3.575 - 1.1 * smoothstep(32.09, 32.59, t) + 0.018 * sin(1.3 * t + -36.88)"
+        }
+      ]
+    },
+    {
+      "id": "s3-net-node-3",
+      "type": "sphere",
+      "args": {
+        "radius": 0.33999999999999997
+      },
+      "transform": {
+        "translate": [
+          48.15554283760545,
+          0.6000000000000001,
+          0.5294788816155364
+        ]
+      },
+      "material": {
+        "hue": 0.61,
+        "sat": 0.7266666666666667,
+        "value": 0.65,
+        "kind": "normal",
+        "roughness": 0.3,
+        "clearcoat": 0.45
+      },
+      "animation": [
+        {
+          "channel": "transform.translate.y",
+          "expr": "1.700 - 1.1 * smoothstep(32.21, 32.71, t) + 0.018 * sin(1.3 * t + -34.78)"
+        }
+      ]
+    },
+    {
+      "id": "s3-net-edge-0",
+      "type": "capsule",
+      "args": {
+        "a": [
+          0,
+          0,
+          0
+        ],
+        "b": [
+          -2.0032610786310996,
+          0.2966581756818818,
+          1.8899991526810829
+        ],
+        "radius": 0.035
+      },
+      "transform": {
+        "translate": [
+          48,
+          3.31378414901835,
+          0
+        ]
+      },
+      "material": {
+        "hue": 0.58,
+        "sat": 0.25,
+        "value": 0.8,
+        "glow": 0.08,
+        "kind": "normal",
+        "roughness": 0.35,
+        "clearcoat": 0.3
+      },
+      "animation": [
+        {
+          "channel": "transform.translate.y",
+          "expr": "4.414 - 1.1 * smoothstep(32.53, 32.98, t)"
+        }
+      ]
+    },
+    {
+      "id": "s3-net-edge-1",
+      "type": "capsule",
+      "args": {
+        "a": [
+          0,
+          0,
+          0
+        ],
+        "b": [
+          0.18888948234321554,
+          -0.838971426145235,
+          -2.6298275902042088
+        ],
+        "radius": 0.035
+      },
+      "transform": {
+        "translate": [
+          48,
+          3.31378414901835,
+          0
+        ]
+      },
+      "material": {
+        "hue": 0.58,
+        "sat": 0.25,
+        "value": 0.8,
+        "glow": 0.08,
+        "kind": "normal",
+        "roughness": 0.35,
+        "clearcoat": 0.3
+      },
+      "animation": [
+        {
+          "channel": "transform.translate.y",
+          "expr": "4.414 - 1.1 * smoothstep(32.67, 33.12, t)"
+        }
+      ]
+    },
+    {
+      "id": "s3-net-edge-2",
+      "type": "capsule",
+      "args": {
+        "a": [
+          0,
+          0,
+          0
+        ],
+        "b": [
+          0.15554283760545182,
+          -2.71378414901835,
+          0.5294788816155364
+        ],
+        "radius": 0.035
+      },
+      "transform": {
+        "translate": [
+          48,
+          3.31378414901835,
+          0
+        ]
+      },
+      "material": {
+        "hue": 0.58,
+        "sat": 0.25,
+        "value": 0.8,
+        "glow": 0.08,
+        "kind": "normal",
+        "roughness": 0.35,
+        "clearcoat": 0.3
+      },
+      "animation": [
+        {
+          "channel": "transform.translate.y",
+          "expr": "4.414 - 1.1 * smoothstep(32.81, 33.26, t)"
+        }
+      ]
+    },
+    {
+      "id": "path-3-1",
+      "type": "box",
+      "args": {
+        "dims": [
+          0.9,
+          0.06,
+          0.28
+        ]
+      },
+      "transform": {
+        "translate": [
+          50.666666666666664,
+          0.03,
+          0
+        ],
+        "rotate": [
+          0,
+          0,
+          0
+        ]
+      },
+      "material": {
+        "hue": 0.58,
+        "sat": 0.25,
+        "value": 0.75,
+        "kind": "normal",
+        "roughness": 0.5,
+        "clearcoat": 0.2
+      }
+    },
+    {
+      "id": "path-3-2",
+      "type": "box",
+      "args": {
+        "dims": [
+          0.9,
+          0.06,
+          0.28
+        ]
+      },
+      "transform": {
+        "translate": [
+          53.333333333333336,
+          0.03,
+          0
+        ],
+        "rotate": [
+          0,
+          0,
+          0
+        ]
+      },
+      "material": {
+        "hue": 0.58,
+        "sat": 0.25,
+        "value": 0.75,
+        "kind": "normal",
+        "roughness": 0.5,
+        "clearcoat": 0.2
+      }
+    },
+    {
+      "id": "path-3-3",
+      "type": "box",
+      "args": {
+        "dims": [
+          0.9,
+          0.06,
+          0.28
+        ]
+      },
+      "transform": {
+        "translate": [
+          56,
+          0.03,
+          0
+        ],
+        "rotate": [
+          0,
+          0,
+          0
+        ]
+      },
+      "material": {
+        "hue": 0.58,
+        "sat": 0.25,
+        "value": 0.75,
+        "kind": "normal",
+        "roughness": 0.5,
+        "clearcoat": 0.2
+      }
+    },
+    {
+      "id": "path-3-4",
+      "type": "box",
+      "args": {
+        "dims": [
+          0.9,
+          0.06,
+          0.28
+        ]
+      },
+      "transform": {
+        "translate": [
+          58.666666666666664,
+          0.03,
+          0
+        ],
+        "rotate": [
+          0,
+          0,
+          0
+        ]
+      },
+      "material": {
+        "hue": 0.58,
+        "sat": 0.25,
+        "value": 0.75,
+        "kind": "normal",
+        "roughness": 0.5,
+        "clearcoat": 0.2
+      }
+    },
+    {
+      "id": "path-3-5",
+      "type": "box",
+      "args": {
+        "dims": [
+          0.9,
+          0.06,
+          0.28
+        ]
+      },
+      "transform": {
+        "translate": [
+          61.333333333333336,
+          0.03,
+          0
+        ],
+        "rotate": [
+          0,
+          0,
+          0
+        ]
+      },
+      "material": {
+        "hue": 0.58,
+        "sat": 0.25,
+        "value": 0.75,
+        "kind": "normal",
+        "roughness": 0.5,
+        "clearcoat": 0.2
+      }
+    },
+    {
+      "id": "s4-plinth-0",
+      "type": "box",
+      "args": {
+        "dims": [
+          1.06,
+          0.12,
+          1.06
+        ]
+      },
+      "transform": {
+        "translate": [
+          62.73,
+          0.06,
+          0
+        ]
+      },
+      "material": {
+        "hue": 0.58,
+        "sat": 0.1,
+        "value": 0.55,
+        "kind": "normal",
+        "roughness": 0.6,
+        "clearcoat": 0.1
+      }
+    },
+    {
+      "id": "s4-mono-0",
+      "type": "rounded_box",
+      "args": {
+        "dims": [
+          0.72,
+          3.4,
+          0.72
+        ],
+        "cornerR": 0.045
+      },
+      "transform": {
+        "translate": [
+          62.73,
+          1.7,
+          0
+        ]
+      },
+      "material": {
+        "hue": 0.11,
+        "sat": 0.78,
+        "value": 0.95,
+        "metal": 0,
+        "glow": 0.22,
+        "kind": "normal",
+        "roughness": 0.22,
+        "clearcoat": 0.6
+      },
+      "animation": [
+        {
+          "channel": "transform.translate.y",
+          "expr": "-2.000 + 3.700 * smoothstep(43.75, 44.35, t)"
+        }
+      ]
+    },
+    {
+      "id": "s4-plinth-1",
+      "type": "box",
+      "args": {
+        "dims": [
+          1.06,
+          0.12,
+          1.06
+        ]
+      },
+      "transform": {
+        "translate": [
+          64,
+          0.06,
+          0
+        ]
+      },
+      "material": {
+        "hue": 0.58,
+        "sat": 0.1,
+        "value": 0.55,
+        "kind": "normal",
+        "roughness": 0.6,
+        "clearcoat": 0.1
+      }
+    },
+    {
+      "id": "s4-mono-1",
+      "type": "rounded_box",
+      "args": {
+        "dims": [
+          0.72,
+          1.4166666666666667,
+          0.72
+        ],
+        "cornerR": 0.045
+      },
+      "transform": {
+        "translate": [
+          64,
+          0.7083333333333334,
+          0
+        ]
+      },
+      "material": {
+        "hue": 0.5950000000000001,
+        "sat": 0.69,
+        "value": 0.71,
+        "kind": "normal",
+        "roughness": 0.3,
+        "clearcoat": 0.45
+      },
+      "animation": [
+        {
+          "channel": "transform.translate.y",
+          "expr": "-1.008 + 1.717 * smoothstep(44.85, 45.45, t)"
+        }
+      ],
+      "pattern": "cracked"
+    },
+    {
+      "id": "s4-plinth-2",
+      "type": "box",
+      "args": {
+        "dims": [
+          1.06,
+          0.12,
+          1.06
+        ]
+      },
+      "transform": {
+        "translate": [
+          65.27,
+          0.06,
+          0
+        ]
+      },
+      "material": {
+        "hue": 0.58,
+        "sat": 0.1,
+        "value": 0.55,
+        "kind": "normal",
+        "roughness": 0.6,
+        "clearcoat": 0.1
+      }
+    },
+    {
+      "id": "s4-mono-2",
+      "type": "rounded_box",
+      "args": {
+        "dims": [
+          0.72,
+          0.85,
+          0.72
+        ],
+        "cornerR": 0.045
+      },
+      "transform": {
+        "translate": [
+          65.27,
+          0.425,
+          0
+        ]
+      },
+      "material": {
+        "hue": 0.64,
+        "sat": 0.76,
+        "value": 0.6,
+        "kind": "normal",
+        "roughness": 0.3,
+        "clearcoat": 0.45
+      },
+      "animation": [
+        {
+          "channel": "transform.translate.y",
+          "expr": "-0.725 + 1.150 * smoothstep(45.95, 46.55, t)"
+        }
+      ],
+      "pattern": "cracked"
+    },
+    {
+      "id": "horizon-0",
+      "type": "ellipsoid",
+      "args": {
+        "dims": [
+          38.13727924718674,
+          13.215912874692448,
+          26.696095473030717
+        ]
+      },
+      "transform": {
+        "translate": [
+          32,
+          -7.268752081080847,
+          149.4873849663741
+        ]
+      },
+      "material": {
+        "hue": 0.62,
+        "sat": 0.3,
+        "value": 0.3,
+        "metal": 0,
+        "glow": 0,
+        "kind": "normal",
+        "roughness": 0.85
+      }
+    },
+    {
+      "id": "horizon-1",
+      "type": "ellipsoid",
+      "args": {
+        "dims": [
+          37.52483816920971,
+          14.338825549215796,
+          26.267386718446794
+        ]
+      },
+      "transform": {
+        "translate": [
+          103.56684028028803,
+          -7.886354052068689,
+          104.97304017873017
+        ]
+      },
+      "material": {
+        "hue": 0.62,
+        "sat": 0.3,
+        "value": 0.3,
+        "metal": 0,
+        "glow": 0,
+        "kind": "normal",
+        "roughness": 0.85
+      }
+    },
+    {
+      "id": "horizon-2",
+      "type": "ellipsoid",
+      "args": {
+        "dims": [
+          36.95026224801879,
+          9.147324207562857,
+          25.86518357361315
+        ]
+      },
+      "transform": {
+        "translate": [
+          91.75924111207317,
+          -5.031028314159571,
+          82.4573973625209
+        ]
+      },
+      "material": {
+        "hue": 0.62,
+        "sat": 0.3,
+        "value": 0.3,
+        "metal": 0,
+        "glow": 0,
+        "kind": "normal",
+        "roughness": 0.85
+      }
+    },
+    {
+      "id": "horizon-3",
+      "type": "ellipsoid",
+      "args": {
+        "dims": [
+          36.41752513919053,
+          9.18889152114572,
+          25.49226759743337
+        ]
+      },
+      "transform": {
+        "translate": [
+          171.64714305397118,
+          -5.053890336630147,
+          -16.13936109603344
+        ]
+      },
+      "material": {
+        "hue": 0.62,
+        "sat": 0.3,
+        "value": 0.3,
+        "metal": 0,
+        "glow": 0,
+        "kind": "normal",
+        "roughness": 0.85
+      }
+    },
+    {
+      "id": "horizon-4",
+      "type": "ellipsoid",
+      "args": {
+        "dims": [
+          35.93031114919384,
+          14.371069104286219,
+          25.15121780443569
+        ]
+      },
+      "transform": {
+        "translate": [
+          171.7457789393791,
+          -7.904088007357421,
+          16.69851650009929
+        ]
+      },
+      "material": {
+        "hue": 0.62,
+        "sat": 0.3,
+        "value": 0.3,
+        "metal": 0,
+        "glow": 0,
+        "kind": "normal",
+        "roughness": 0.85
+      }
+    },
+    {
+      "id": "horizon-5",
+      "type": "ellipsoid",
+      "args": {
+        "dims": [
+          35.49198975544141,
+          13.167113168752554,
+          24.844392828808985
+        ]
+      },
+      "transform": {
+        "translate": [
+          90.89384281368567,
+          -7.241912242813905,
+          -83.14840635485335
+        ]
+      },
+      "material": {
+        "hue": 0.62,
+        "sat": 0.3,
+        "value": 0.3,
+        "metal": 0,
+        "glow": 0,
+        "kind": "normal",
+        "roughness": 0.85
+      }
+    },
+    {
+      "id": "horizon-6",
+      "type": "ellipsoid",
+      "args": {
+        "dims": [
+          35.105592303637735,
+          8.254988986589172,
+          24.573914612546414
+        ]
+      },
+      "transform": {
+        "translate": [
+          105.0971923834581,
+          -4.540243942624045,
+          -103.66792263452328
+        ]
+      },
+      "material": {
+        "hue": 0.62,
+        "sat": 0.3,
+        "value": 0.3,
+        "metal": 0,
+        "glow": 0,
+        "kind": "normal",
+        "roughness": 0.85
+      }
+    },
+    {
+      "id": "horizon-7",
+      "type": "ellipsoid",
+      "args": {
+        "dims": [
+          34.77379104358041,
+          10.56075920141966,
+          24.341653730506284
+        ]
+      },
+      "transform": {
+        "translate": [
+          29.36072236533958,
+          -5.808417560780814,
+          -149.536065887123
+        ]
+      },
+      "material": {
+        "hue": 0.62,
+        "sat": 0.3,
+        "value": 0.3,
+        "metal": 0,
+        "glow": 0,
+        "kind": "normal",
+        "roughness": 0.85
+      }
+    },
+    {
+      "id": "horizon-8",
+      "type": "ellipsoid",
+      "args": {
+        "dims": [
+          34.49888064839919,
+          14.955687471333393,
+          24.14921645387943
+        ]
+      },
+      "transform": {
+        "translate": [
+          -28.44412567299632,
+          -8.225628109233368,
+          -91.80877229827446
+        ]
+      },
+      "material": {
+        "hue": 0.62,
+        "sat": 0.3,
+        "value": 0.3,
+        "metal": 0,
+        "glow": 0,
+        "kind": "normal",
+        "roughness": 0.85
+      }
+    },
+    {
+      "id": "horizon-9",
+      "type": "ellipsoid",
+      "args": {
+        "dims": [
+          34.282762345041725,
+          11.66411263416465,
+          23.997933641529205
+        ]
+      },
+      "transform": {
+        "translate": [
+          -35.26628918333596,
+          -6.415261948790558,
+          -90.59592022307277
+        ]
+      },
+      "material": {
+        "hue": 0.62,
+        "sat": 0.3,
+        "value": 0.3,
+        "metal": 0,
+        "glow": 0,
+        "kind": "normal",
+        "roughness": 0.85
+      }
+    },
+    {
+      "id": "horizon-10",
+      "type": "ellipsoid",
+      "args": {
+        "dims": [
+          34.12693076575705,
+          8.007501235419541,
+          23.888851536029936
+        ]
+      },
+      "transform": {
+        "translate": [
+          -117.6750233575849,
+          -4.404125679480748,
+          16.581296589816493
+        ]
+      },
+      "material": {
+        "hue": 0.62,
+        "sat": 0.3,
+        "value": 0.3,
+        "metal": 0,
+        "glow": 0,
+        "kind": "normal",
+        "roughness": 0.85
+      }
+    },
+    {
+      "id": "horizon-11",
+      "type": "ellipsoid",
+      "args": {
+        "dims": [
+          34.032463611508966,
+          12.119272489365873,
+          23.822724528056273
+        ]
+      },
+      "transform": {
+        "translate": [
+          -90.34736116270167,
+          -6.66559986915123,
+          -14.991066199015563
+        ]
+      },
+      "material": {
+        "hue": 0.62,
+        "sat": 0.3,
+        "value": 0.3,
+        "metal": 0,
+        "glow": 0,
+        "kind": "normal",
+        "roughness": 0.85
+      }
+    },
+    {
+      "id": "horizon-12",
+      "type": "ellipsoid",
+      "args": {
+        "dims": [
+          34.00001419880521,
+          14.853592815492972,
+          23.800009939163647
+        ]
+      },
+      "transform": {
+        "translate": [
+          -26.7805809230263,
+          -8.169476048521135,
+          84.79880368810014
+        ]
+      },
+      "material": {
+        "hue": 0.62,
+        "sat": 0.3,
+        "value": 0.3,
+        "metal": 0,
+        "glow": 0,
+        "kind": "normal",
+        "roughness": 0.85
+      }
+    },
+    {
+      "id": "horizon-13",
+      "type": "ellipsoid",
+      "args": {
+        "dims": [
+          34.02980694148735,
+          10.128499693496575,
+          23.820864859041144
+        ]
+      },
+      "transform": {
+        "translate": [
+          -52.47905988961341,
+          -5.570674831423117,
+          115.98928845605614
+        ]
+      },
+      "material": {
+        "hue": 0.62,
+        "sat": 0.3,
+        "value": 0.3,
+        "metal": 0,
+        "glow": 0,
+        "kind": "normal",
+        "roughness": 0.85
+      }
+    }
+  ],
+  "overlay": [
+    {
+      "text": "TAM / SAM / SOM",
+      "anchor": [
+        0,
+        4.7,
+        0
+      ],
+      "role": "title",
+      "revealAt": 0
+    },
+    {
+      "text": "AI Productivity",
+      "anchor": [
+        -1.27,
+        -0.02,
+        0.71
+      ],
+      "role": "card",
+      "revealAt": 2.45
+    },
+    {
+      "text": "48",
+      "anchor": [
+        -1.27,
+        3.7199999999999998,
+        0
+      ],
+      "role": "value",
+      "radius": 0.5,
+      "revealAt": 2.45
+    },
+    {
+      "text": "Presentation Software",
+      "anchor": [
+        0,
+        -0.02,
+        0.71
+      ],
+      "role": "card",
+      "revealAt": 3.5500000000000003
+    },
+    {
+      "text": "4.8",
+      "anchor": [
+        0,
+        0.6599999999999999,
+        0
+      ],
+      "role": "value",
+      "radius": 0.36,
+      "revealAt": 3.5500000000000003
+    },
+    {
+      "text": "Editorial + Infographic",
+      "anchor": [
+        1.27,
+        -0.02,
+        0.71
+      ],
+      "role": "card",
+      "revealAt": 4.65
+    },
+    {
+      "text": "2.1",
+      "anchor": [
+        1.27,
+        0.46875,
+        0
+      ],
+      "role": "value",
+      "radius": 0.36,
+      "revealAt": 4.65
+    },
+    {
+      "text": "LLM WRITES INTENT",
+      "anchor": [
+        16,
+        4.279999999999999,
+        0
+      ],
+      "role": "title",
+      "revealAt": 10
+    },
+    {
+      "text": "LLM writes intent",
+      "anchor": [
+        17.9,
+        2.605,
+        0
+      ],
+      "role": "card",
+      "align": "left",
+      "revealAt": 12.65
+    },
+    {
+      "text": "1",
+      "anchor": [
+        16,
+        2.605,
+        1.5999999999999999
+      ],
+      "role": "value",
+      "radius": 0.36,
+      "revealAt": 12.65
+    },
+    {
+      "text": "Atlas renders",
+      "anchor": [
+        17.9,
+        1.935,
+        0
+      ],
+      "role": "card",
+      "align": "left",
+      "revealAt": 13.850000000000001
+    },
+    {
+      "text": "1",
+      "anchor": [
+        16,
+        1.935,
+        1.5999999999999999
+      ],
+      "role": "value",
+      "radius": 0.36,
+      "revealAt": 13.850000000000001
+    },
+    {
+      "text": "Choose renderer",
+      "anchor": [
+        17.9,
+        1.265,
+        0
+      ],
+      "role": "card",
+      "align": "left",
+      "revealAt": 15.05
+    },
+    {
+      "text": "1",
+      "anchor": [
+        16,
+        1.265,
+        1.5999999999999999
+      ],
+      "role": "value",
+      "radius": 0.36,
+      "revealAt": 15.05
+    },
+    {
+      "text": "Edit & regenerate",
+      "anchor": [
+        17.9,
+        0.5949999999999998,
+        0
+      ],
+      "role": "card",
+      "align": "left",
+      "revealAt": 16.25
+    },
+    {
+      "text": "1",
+      "anchor": [
+        16,
+        0.5949999999999998,
+        1.5999999999999999
+      ],
+      "role": "value",
+      "radius": 0.5,
+      "revealAt": 16.25
+    },
+    {
+      "text": "UNIT ECONOMICS",
+      "anchor": [
+        32,
+        4.7,
+        0
+      ],
+      "role": "title",
+      "revealAt": 21.599999999999998
+    },
+    {
+      "text": "Pro",
+      "anchor": [
+        30.73,
+        -0.02,
+        0.71
+      ],
+      "role": "card",
+      "revealAt": 24.049999999999997
+    },
+    {
+      "text": "30",
+      "anchor": [
+        30.73,
+        0.44,
+        0
+      ],
+      "role": "value",
+      "radius": 0.36,
+      "revealAt": 24.049999999999997
+    },
+    {
+      "text": "Team",
+      "anchor": [
+        32,
+        -0.02,
+        0.71
+      ],
+      "role": "card",
+      "revealAt": 25.15
+    },
+    {
+      "text": "200",
+      "anchor": [
+        32,
+        0.44,
+        0
+      ],
+      "role": "value",
+      "radius": 0.36,
+      "revealAt": 25.15
+    },
+    {
+      "text": "Studio",
+      "anchor": [
+        33.27,
+        -0.02,
+        0.71
+      ],
+      "role": "card",
+      "revealAt": 26.25
+    },
+    {
+      "text": "50000",
+      "anchor": [
+        33.27,
+        3.7199999999999998,
+        0
+      ],
+      "role": "value",
+      "radius": 0.5,
+      "revealAt": 26.25
+    },
+    {
+      "text": "LEADERSHIP",
+      "anchor": [
+        48,
+        4.810442324700232,
+        0
+      ],
+      "role": "title",
+      "revealAt": 31.599999999999998
+    },
+    {
+      "text": "Leadership",
+      "anchor": [
+        48.64,
+        3.31378414901835,
+        0
+      ],
+      "role": "card",
+      "align": "left",
+      "revealAt": 32.449999999999996
+    },
+    {
+      "text": "Sarah Chen · CEO",
+      "anchor": [
+        46.6367389213689,
+        3.610442324700232,
+        1.8899991526810829
+      ],
+      "role": "card",
+      "align": "left",
+      "revealAt": 32.57
+    },
+    {
+      "text": "Alex Wu · CTO",
+      "anchor": [
+        48.828889482343214,
+        2.474812722873115,
+        -2.6298275902042088
+      ],
+      "role": "card",
+      "align": "left",
+      "revealAt": 32.69
+    },
+    {
+      "text": "Diana Liu · Design",
+      "anchor": [
+        48.79554283760545,
+        0.6000000000000001,
+        0.5294788816155364
+      ],
+      "role": "card",
+      "align": "left",
+      "revealAt": 32.809999999999995
+    },
+    {
+      "text": "USE OF FUNDS",
+      "anchor": [
+        64,
+        4.7,
+        0
+      ],
+      "role": "title",
+      "revealAt": 42.1
+    },
+    {
+      "text": "Engineering · 60%",
+      "anchor": [
+        62.73,
+        -0.02,
+        0.71
+      ],
+      "role": "card",
+      "revealAt": 44.550000000000004
+    },
+    {
+      "text": "60",
+      "anchor": [
+        62.73,
+        3.7199999999999998,
+        0
+      ],
+      "role": "value",
+      "radius": 0.5,
+      "revealAt": 44.550000000000004
+    },
+    {
+      "text": "Sales + Community · 25%",
+      "anchor": [
+        64,
+        -0.02,
+        0.71
+      ],
+      "role": "card",
+      "revealAt": 45.65
+    },
+    {
+      "text": "25",
+      "anchor": [
+        64,
+        1.7366666666666668,
+        0
+      ],
+      "role": "value",
+      "radius": 0.36,
+      "revealAt": 45.65
+    },
+    {
+      "text": "Reserve · 15%",
+      "anchor": [
+        65.27,
+        -0.02,
+        0.71
+      ],
+      "role": "card",
+      "revealAt": 46.75
+    },
+    {
+      "text": "15",
+      "anchor": [
+        65.27,
+        1.17,
+        0
+      ],
+      "role": "value",
+      "radius": 0.36,
+      "revealAt": 46.75
+    }
+  ],
+  "cameraSequence": {
+    "loop": false,
+    "shots": [
+      {
+        "duration": 0.9,
+        "pos": [
+          0.33000000000000007,
+          0.5,
+          3.6
+        ],
+        "target": [
+          -1.27,
+          2.448,
+          0
+        ],
+        "fov": 54,
+        "aperture": 0.55,
+        "focalDistance": 4,
+        "ease": "out"
+      },
+      {
+        "duration": 1.2,
+        "pos": [
+          0.6,
+          5.6,
+          4.23
+        ],
+        "target": [
+          0,
+          1.53,
+          0
+        ],
+        "fov": 48,
+        "transition": "blend",
+        "aperture": 0.3,
+        "focalDistance": 4.9559999999999995,
+        "ease": "inout"
+      },
+      {
+        "duration": 1.1,
+        "pos": [
+          -0.37,
+          1.1,
+          2.5
+        ],
+        "target": [
+          -1.27,
+          1.87,
+          0
+        ],
+        "fov": 46,
+        "transition": "blend",
+        "aperture": 0.25,
+        "focalDistance": 2.7,
+        "shake": 0.05,
+        "ease": "smooth"
+      },
+      {
+        "duration": 1.1,
+        "pos": [
+          0.9,
+          0.5369999999999999,
+          2.5
+        ],
+        "target": [
+          0,
+          0.5,
+          0
+        ],
+        "fov": 46,
+        "transition": "blend",
+        "aperture": 0.25,
+        "focalDistance": 2.7,
+        "shake": 0.05,
+        "ease": "smooth"
+      },
+      {
+        "duration": 1.1,
+        "pos": [
+          2.17,
+          0.4318125,
+          2.5
+        ],
+        "target": [
+          1.27,
+          0.5,
+          0
+        ],
+        "fov": 46,
+        "transition": "blend",
+        "aperture": 0.25,
+        "focalDistance": 2.7,
+        "shake": 0.05,
+        "ease": "smooth"
+      },
+      {
+        "duration": 1,
+        "pos": [
+          -0.52,
+          0.35,
+          1.35
+        ],
+        "target": [
+          -1.27,
+          2.8899999999999997,
+          0
+        ],
+        "fov": 44,
+        "transition": "cut",
+        "aperture": [
+          0.9,
+          0.45
+        ],
+        "focalDistance": 1.8,
+        "shake": [
+          0.5,
+          0.06
+        ],
+        "ambient": [
+          0.15,
+          1
+        ],
+        "exposure": [
+          1.45,
+          1
+        ],
+        "ease": "out"
+      },
+      {
+        "duration": 2.4,
+        "pos": [
+          1.2,
+          2.87,
+          5.971
+        ],
+        "target": [
+          0,
+          1.36,
+          0
+        ],
+        "fov": 44,
+        "transition": "blend",
+        "aperture": 0.12,
+        "focalDistance": 5.971,
+        "ease": "out"
+      },
+      {
+        "duration": 1.2,
+        "pos": [
+          9.75,
+          4.470000000000001,
+          7.971
+        ],
+        "target": [
+          8,
+          2.6799999999999997,
+          0
+        ],
+        "fov": 50,
+        "transition": "blend",
+        "aperture": 0,
+        "focalDistance": 12.8,
+        "shake": [
+          0.14,
+          0.05
+        ],
+        "ease": "whip"
+      },
+      {
+        "duration": 0.9,
+        "pos": [
+          18.3,
+          0.55,
+          5.2
+        ],
+        "target": [
+          16,
+          2.6799999999999997,
+          0
+        ],
+        "fov": 54,
+        "aperture": 0.55,
+        "focalDistance": 5.5,
+        "ease": "out"
+      },
+      {
+        "duration": 1.3,
+        "pos": [
+          16.9,
+          5.38,
+          4.4
+        ],
+        "target": [
+          16,
+          2.58,
+          0
+        ],
+        "fov": 50,
+        "transition": "blend",
+        "aperture": 0.3,
+        "focalDistance": 5,
+        "ease": "inout"
+      },
+      {
+        "duration": 1.2,
+        "pos": [
+          21.23262375631159,
+          3.455,
+          4.152354588048038
+        ],
+        "target": [
+          16,
+          2.605,
+          0
+        ],
+        "fov": 46,
+        "transition": "blend",
+        "aperture": 0.25,
+        "focalDistance": 6.68,
+        "shake": 0.05,
+        "ease": "smooth"
+      },
+      {
+        "duration": 1.2,
+        "pos": [
+          22.505302174266344,
+          2.785,
+          -1.5177099925498219
+        ],
+        "target": [
+          16,
+          1.935,
+          0
+        ],
+        "fov": 46,
+        "transition": "blend",
+        "aperture": 0.25,
+        "focalDistance": 6.68,
+        "shake": 0.05,
+        "ease": "smooth"
+      },
+      {
+        "duration": 1.2,
+        "pos": [
+          18.854897599961983,
+          2.1149999999999998,
+          -6.039201908673968
+        ],
+        "target": [
+          16,
+          1.265,
+          0
+        ],
+        "fov": 46,
+        "transition": "blend",
+        "aperture": 0.25,
+        "focalDistance": 6.68,
+        "shake": 0.05,
+        "ease": "smooth"
+      },
+      {
+        "duration": 1.2,
+        "pos": [
+          13.043963438790385,
+          1.4449999999999998,
+          -5.990346221112102
+        ],
+        "target": [
+          16,
+          0.5949999999999998,
+          0
+        ],
+        "fov": 46,
+        "transition": "blend",
+        "aperture": 0.25,
+        "focalDistance": 6.68,
+        "shake": 0.05,
+        "ease": "smooth"
+      },
+      {
+        "duration": 1,
+        "pos": [
+          16.55,
+          0.44499999999999973,
+          1.9
+        ],
+        "target": [
+          16,
+          0.7149999999999997,
+          0
+        ],
+        "fov": 40,
+        "transition": "cut",
+        "aperture": [
+          0.9,
+          0.45
+        ],
+        "focalDistance": 2,
+        "shake": [
+          0.5,
+          0.06
+        ],
+        "ambient": [
+          0.15,
+          1
+        ],
+        "exposure": [
+          1.45,
+          1
+        ],
+        "ease": "out"
+      },
+      {
+        "duration": 2.4,
+        "pos": [
+          17.4,
+          2.7,
+          7.992
+        ],
+        "target": [
+          16,
+          1.7999999999999998,
+          0
+        ],
+        "fov": 44,
+        "transition": "blend",
+        "aperture": 0.12,
+        "focalDistance": 7.992,
+        "ease": "out"
+      },
+      {
+        "duration": 1.2,
+        "pos": [
+          26.134999999999998,
+          4.300000000000001,
+          9.992
+        ],
+        "target": [
+          24.635,
+          2.448,
+          0
+        ],
+        "fov": 50,
+        "transition": "blend",
+        "aperture": 0,
+        "focalDistance": 12.8,
+        "shake": [
+          0.14,
+          0.05
+        ],
+        "ease": "whip"
+      },
+      {
+        "duration": 0.9,
+        "pos": [
+          34.87,
+          0.5,
+          3.6
+        ],
+        "target": [
+          33.27,
+          2.448,
+          0
+        ],
+        "fov": 54,
+        "aperture": 0.55,
+        "focalDistance": 4,
+        "ease": "out"
+      },
+      {
+        "duration": 1.2,
+        "pos": [
+          32.6,
+          5.6,
+          4.23
+        ],
+        "target": [
+          32,
+          1.53,
+          0
+        ],
+        "fov": 48,
+        "transition": "blend",
+        "aperture": 0.3,
+        "focalDistance": 4.9559999999999995,
+        "ease": "inout"
+      },
+      {
+        "duration": 1.1,
+        "pos": [
+          31.63,
+          0.416,
+          2.5
+        ],
+        "target": [
+          30.73,
+          0.5,
+          0
+        ],
+        "fov": 46,
+        "transition": "blend",
+        "aperture": 0.25,
+        "focalDistance": 2.7,
+        "shake": 0.05,
+        "ease": "smooth"
+      },
+      {
+        "duration": 1.1,
+        "pos": [
+          32.9,
+          0.416,
+          2.5
+        ],
+        "target": [
+          32,
+          0.5,
+          0
+        ],
+        "fov": 46,
+        "transition": "blend",
+        "aperture": 0.25,
+        "focalDistance": 2.7,
+        "shake": 0.05,
+        "ease": "smooth"
+      },
+      {
+        "duration": 1.1,
+        "pos": [
+          34.17,
+          1.1,
+          2.5
+        ],
+        "target": [
+          33.27,
+          1.87,
+          0
+        ],
+        "fov": 46,
+        "transition": "blend",
+        "aperture": 0.25,
+        "focalDistance": 2.7,
+        "shake": 0.05,
+        "ease": "smooth"
+      },
+      {
+        "duration": 1,
+        "pos": [
+          34.02,
+          0.35,
+          1.35
+        ],
+        "target": [
+          33.27,
+          2.8899999999999997,
+          0
+        ],
+        "fov": 44,
+        "transition": "cut",
+        "aperture": [
+          0.9,
+          0.45
+        ],
+        "focalDistance": 1.8,
+        "shake": [
+          0.5,
+          0.06
+        ],
+        "ambient": [
+          0.15,
+          1
+        ],
+        "exposure": [
+          1.45,
+          1
+        ],
+        "ease": "out"
+      },
+      {
+        "duration": 2.4,
+        "pos": [
+          33.2,
+          2.87,
+          5.971
+        ],
+        "target": [
+          32,
+          1.36,
+          0
+        ],
+        "fov": 44,
+        "transition": "blend",
+        "aperture": 0.12,
+        "focalDistance": 5.971,
+        "ease": "out"
+      },
+      {
+        "duration": 1.2,
+        "pos": [
+          41.43852885498238,
+          4.470000000000001,
+          7.971
+        ],
+        "target": [
+          40,
+          3.31378414901835,
+          0
+        ],
+        "fov": 50,
+        "transition": "blend",
+        "aperture": 0,
+        "focalDistance": 12.8,
+        "shake": [
+          0.14,
+          0.05
+        ],
+        "ease": "whip"
+      },
+      {
+        "duration": 1,
+        "pos": [
+          49.67705770996475,
+          2.71378414901835,
+          1.8447634809612252
+        ],
+        "target": [
+          48,
+          3.31378414901835,
+          0
+        ],
+        "fov": 56,
+        "aperture": 0.55,
+        "focalDistance": 2.34788079395065,
+        "ease": "out"
+      },
+      {
+        "duration": 1.3,
+        "pos": [
+          49,
+          6.5246983030633245,
+          5.70199621388015
+        ],
+        "target": [
+          48,
+          2.4997597991479243,
+          0
+        ],
+        "fov": 48,
+        "transition": "blend",
+        "aperture": 0.3,
+        "focalDistance": 6.37281929786605,
+        "ease": "inout"
+      },
+      {
+        "duration": 1.2,
+        "pos": [
+          54.356855300154955,
+          3.3997597991479243,
+          0.4507954038649796
+        ],
+        "target": [
+          48,
+          2.4997597991479243,
+          0
+        ],
+        "fov": 46,
+        "transition": "blend",
+        "aperture": 0.25,
+        "focalDistance": 6.37281929786605,
+        "shake": 0.05,
+        "ease": "smooth"
+      },
+      {
+        "duration": 1.2,
+        "pos": [
+          49.524692742216374,
+          3.1497597991479243,
+          -6.187740932285922
+        ],
+        "target": [
+          48,
+          2.4997597991479243,
+          0
+        ],
+        "fov": 46,
+        "transition": "blend",
+        "aperture": 0.25,
+        "focalDistance": 6.37281929786605,
+        "shake": 0.05,
+        "ease": "smooth"
+      },
+      {
+        "duration": 1.2,
+        "pos": [
+          42.16144003823555,
+          2.8997597991479243,
+          -2.554220698400003
+        ],
+        "target": [
+          48,
+          2.4997597991479243,
+          0
+        ],
+        "fov": 46,
+        "transition": "blend",
+        "aperture": 0.25,
+        "focalDistance": 6.37281929786605,
+        "shake": 0.05,
+        "ease": "smooth"
+      },
+      {
+        "duration": 1,
+        "pos": [
+          48.5,
+          3.21378414901835,
+          1.5
+        ],
+        "target": [
+          48,
+          3.37378414901835,
+          0
+        ],
+        "fov": 40,
+        "transition": "cut",
+        "aperture": [
+          0.9,
+          0.45
+        ],
+        "focalDistance": 1.6,
+        "shake": [
+          0.5,
+          0.06
+        ],
+        "ambient": [
+          0.15,
+          1
+        ],
+        "exposure": [
+          1.45,
+          1
+        ],
+        "ease": "out"
+      },
+      {
+        "duration": 2.4,
+        "pos": [
+          49.4,
+          3.699759799147924,
+          10.2207000918167
+        ],
+        "target": [
+          48,
+          2.4997597991479243,
+          0
+        ],
+        "fov": 44,
+        "transition": "blend",
+        "aperture": 0.12,
+        "focalDistance": 10.2207000918167,
+        "ease": "out"
+      },
+      {
+        "duration": 1.2,
+        "pos": [
+          56.864999999999995,
+          5.299759799147925,
+          12.2207000918167
+        ],
+        "target": [
+          55.364999999999995,
+          2.448,
+          0
+        ],
+        "fov": 50,
+        "transition": "blend",
+        "aperture": 0,
+        "focalDistance": 12.8,
+        "shake": [
+          0.14,
+          0.05
+        ],
+        "ease": "whip"
+      },
+      {
+        "duration": 0.9,
+        "pos": [
+          64.33,
+          0.5,
+          3.6
+        ],
+        "target": [
+          62.73,
+          2.448,
+          0
+        ],
+        "fov": 54,
+        "aperture": 0.55,
+        "focalDistance": 4,
+        "ease": "out"
+      },
+      {
+        "duration": 1.2,
+        "pos": [
+          64.6,
+          5.6,
+          4.23
+        ],
+        "target": [
+          64,
+          1.53,
+          0
+        ],
+        "fov": 48,
+        "transition": "blend",
+        "aperture": 0.3,
+        "focalDistance": 4.9559999999999995,
+        "ease": "inout"
+      },
+      {
+        "duration": 1.1,
+        "pos": [
+          63.63,
+          1.1,
+          2.5
+        ],
+        "target": [
+          62.73,
+          1.87,
+          0
+        ],
+        "fov": 46,
+        "transition": "blend",
+        "aperture": 0.25,
+        "focalDistance": 2.7,
+        "shake": 0.05,
+        "ease": "smooth"
+      },
+      {
+        "duration": 1.1,
+        "pos": [
+          64.9,
+          1.1,
+          2.5
+        ],
+        "target": [
+          64,
+          0.7791666666666668,
+          0
+        ],
+        "fov": 46,
+        "transition": "blend",
+        "aperture": 0.25,
+        "focalDistance": 2.7,
+        "shake": 0.05,
+        "ease": "smooth"
+      },
+      {
+        "duration": 1.1,
+        "pos": [
+          66.17,
+          0.8175,
+          2.5
+        ],
+        "target": [
+          65.27,
+          0.5,
+          0
+        ],
+        "fov": 46,
+        "transition": "blend",
+        "aperture": 0.25,
+        "focalDistance": 2.7,
+        "shake": 0.05,
+        "ease": "smooth"
+      },
+      {
+        "duration": 1,
+        "pos": [
+          63.48,
+          0.35,
+          1.35
+        ],
+        "target": [
+          62.73,
+          2.8899999999999997,
+          0
+        ],
+        "fov": 44,
+        "transition": "cut",
+        "aperture": [
+          0.9,
+          0.45
+        ],
+        "focalDistance": 1.8,
+        "shake": [
+          0.5,
+          0.06
+        ],
+        "ambient": [
+          0.15,
+          1
+        ],
+        "exposure": [
+          1.45,
+          1
+        ],
+        "ease": "out"
+      },
+      {
+        "duration": 2.4,
+        "pos": [
+          65.2,
+          2.87,
+          5.971
+        ],
+        "target": [
+          64,
+          1.36,
+          0
+        ],
+        "fov": 44,
+        "transition": "blend",
+        "aperture": 0.12,
+        "focalDistance": 5.971,
+        "ease": "out"
+      },
+      {
+        "duration": 3,
+        "pos": [
+          52,
+          44.5,
+          76
+        ],
+        "target": [
+          32,
+          1.2,
+          0
+        ],
+        "fov": 48,
+        "transition": "blend",
+        "aperture": 0.08,
+        "focalDistance": 84,
+        "ease": "out"
+      }
+    ],
+    "hitstops": [
+      {
+        "at": 5.42,
+        "hold": 0.14
+      },
+      {
+        "at": 17.02,
+        "hold": 0.14
+      },
+      {
+        "at": 27.019999999999996,
+        "hold": 0.14
+      },
+      {
+        "at": 37.519999999999996,
+        "hold": 0.14
+      },
+      {
+        "at": 47.52,
+        "hold": 0.14
+      }
+    ]
+  },
+  "defaults": {
+    "camera": {
+      "yaw": 0,
+      "pitch": -0.1,
+      "distance": 12,
+      "focal": 1.2,
+      "targetX": 0,
+      "targetY": 2,
+      "targetZ": 0
+    },
+    "light": {
+      "azimuth": 0.5,
+      "altitude": 0.7,
+      "distance": 40,
+      "intensity": 1.1
+    }
+  }
+}

--- a/sdf-js/scripts/atoms-to-ir-demo.mjs
+++ b/sdf-js/scripts/atoms-to-ir-demo.mjs
@@ -1,0 +1,38 @@
+#!/usr/bin/env node
+// atoms-to-ir-demo.mjs — Sprint 27 proof CLI: baked scaffold deck → IR deck →
+// assembleDeck → compiled-ready scene JSON. The 2D pipeline's rich output
+// (101 atoms, facts recall 95.8%) feeding the cinematic IR renderer.
+//
+// Usage: node sdf-js/scripts/atoms-to-ir-demo.mjs <deck-dir> [--env alpine]
+// Writes sdf-js/scenes/ir-from-<deckname>.json (open on the 3D machine via
+// ?scene=ir-from-<deckname>).
+import { writeFileSync } from 'node:fs';
+import { basename, resolve } from 'node:path';
+import { deckToIR } from '../src/scene/scaffold-to-ir.js';
+import { assembleDeck } from '../src/scene/assemble-deck.js';
+
+const args = process.argv.slice(2);
+const deckDir = args.find((a) => !a.startsWith('--'));
+if (!deckDir) {
+  console.error('usage: node sdf-js/scripts/atoms-to-ir-demo.mjs <deck-dir> [--env alpine]');
+  process.exit(2);
+}
+const envIdx = args.indexOf('--env');
+const env = envIdx > -1 ? args[envIdx + 1] : undefined;
+
+const irDeck = deckToIR(resolve(deckDir));
+console.log(`\n══ ${irDeck.title} — ${irDeck.slides.length} structural slides ══`);
+for (const ir of irDeck.slides) {
+  console.log(
+    `  ${(ir.title || '(untitled)').padEnd(34)} ${ir.structure.padEnd(10)} nodes=${ir.nodes.length}${ir.magnitude ? ' +magnitude' : ''}${ir.relations ? ` +relations(${ir.relations.length})` : ''}`,
+  );
+}
+
+const scene = assembleDeck(irDeck, env ? { env } : {});
+const name = `ir-from-${basename(resolve(deckDir)).replace(/^eval-/, '')}`;
+scene.name = scene.name || name;
+const out = new URL(`../scenes/${name}.json`, import.meta.url).pathname;
+writeFileSync(out, JSON.stringify(scene, null, 2));
+console.log(
+  `\nWrote ${out.replace(/^.*sdf-js\//, 'sdf-js/')} (subjects: ${scene.subjects.length}, overlay: ${(scene.overlay || []).length})`,
+);

--- a/sdf-js/scripts/test-atoms-to-ir.mjs
+++ b/sdf-js/scripts/test-atoms-to-ir.mjs
@@ -1,0 +1,372 @@
+// sdf-js/scripts/test-atoms-to-ir.mjs — atoms→IR bridge (Sprint 27)
+// Per-structure atom mappings, parseMagnitude numeric parsing, slotToIR
+// richest-subject selection, and deckToIR on a REAL baked eval deck, closed
+// with the full loop: deckToIR → assembleDeck → compile.
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  atomToIR,
+  slotToIR,
+  deckToIR,
+  parseMagnitude,
+  funnelSlotToIR,
+} from '../src/scene/scaffold-to-ir.js';
+import { validateIR } from '../src/scene/ir.js';
+import { assembleDeck } from '../src/scene/assemble-deck.js';
+import { compile } from '../src/scene/index.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+let pass = 0,
+  fail = 0;
+const ok = (c, n) => (c ? (pass++, console.log(`  ✓ ${n}`)) : (fail++, console.log(`  ✗ ${n}`)));
+console.log('=== atoms-to-ir (Sprint 27 bridge) ===\n');
+
+// ---- parseMagnitude ----------------------------------------------------------
+ok(parseMagnitude('$3.4M') === 3400000, 'parseMagnitude: "$3.4M" → 3400000');
+ok(parseMagnitude('12,450') === 12450, 'parseMagnitude: "12,450" → 12450');
+ok(parseMagnitude('92%') === 92, 'parseMagnitude: "92%" → 92');
+ok(parseMagnitude('abc') === null, 'parseMagnitude: "abc" → null');
+ok(parseMagnitude(42) === 42, 'parseMagnitude: passthrough number');
+ok(parseMagnitude('-8') === -8, 'parseMagnitude: negative string');
+
+// ---- sequence family ----------------------------------------------------------
+{
+  const ir = atomToIR({
+    type: 'funnel',
+    args: {
+      title: 'F',
+      stages: [
+        { label: 'A', value: 100 },
+        { label: 'B', value: 40 },
+      ],
+    },
+  });
+  ok(ir && ir.structure === 'sequence', 'funnel → sequence');
+  ok(validateIR(ir).ok, 'funnel IR validates');
+}
+{
+  const ir = atomToIR({
+    type: 'process-arrows',
+    args: { steps: [{ label: 'Discover' }, { label: 'Design' }, { label: 'Deploy' }] },
+  });
+  ok(ir && ir.structure === 'sequence' && ir.nodes.length === 3, 'process-arrows → sequence (3)');
+  ok(validateIR(ir).ok, 'process-arrows IR validates');
+}
+{
+  const ir = atomToIR({
+    type: 'timeline',
+    args: {
+      events: [
+        { date: 'Q1', label: 'Seed' },
+        { date: 'Q4', label: 'Launch' },
+      ],
+    },
+  });
+  ok(ir && ir.structure === 'sequence', 'timeline → sequence');
+}
+{
+  const ir = atomToIR({
+    type: 'vertical-timeline',
+    args: {
+      events: [
+        { date: 'Q1', label: 'Seed' },
+        { date: 'Q4', label: 'Launch' },
+      ],
+    },
+  });
+  ok(ir && ir.structure === 'sequence', 'vertical-timeline → sequence');
+}
+{
+  const ir = atomToIR({
+    type: 'kanban-board',
+    args: {
+      columns: [
+        { label: 'Backlog', cards: [{ label: 'a' }] },
+        { label: 'Done', cards: [{ label: 'b' }, { label: 'c' }] },
+      ],
+    },
+  });
+  ok(
+    ir && ir.structure === 'sequence' && JSON.stringify(ir.magnitude) === JSON.stringify([1, 2]),
+    'kanban-board → sequence, magnitude = card counts',
+  );
+}
+{
+  const ir = atomToIR({
+    type: 'maturity-model',
+    args: { stages: [{ label: 'A' }, { label: 'B' }, { label: 'C' }], currentLevel: 2 },
+  });
+  ok(ir && ir.emphasis && ir.emphasis[0] === 1, 'maturity-model emphasis = currentLevel-1');
+}
+
+// ---- hierarchy family -----------------------------------------------------
+{
+  const ir = atomToIR({
+    type: 'org-chart',
+    args: {
+      root: {
+        name: 'CEO',
+        children: [{ name: 'CTO', children: [{ name: 'Eng' }] }, { name: 'CFO' }],
+      },
+    },
+  });
+  ok(ir && ir.structure === 'hierarchy', 'org-chart → hierarchy');
+  const v = validateIR(ir);
+  ok(v.ok, `org-chart IR validates (${v.errors.join(';')})`);
+  ok(ir.nodes.length === 4 && ir.relations.length === 3, 'org-chart flattens 4 nodes / 3 edges');
+  const hasParent = new Set(ir.relations.map((r) => r[1]));
+  const roots = ir.nodes.map((_, i) => i).filter((i) => !hasParent.has(i));
+  ok(roots.length === 1, 'org-chart has exactly one root');
+}
+{
+  const ir = atomToIR({
+    type: 'okr-tree',
+    args: {
+      objective: 'Grow ARR',
+      keyResults: [
+        { label: 'KR1', progress: 0.5 },
+        { label: 'KR2', progress: 0.2 },
+      ],
+    },
+  });
+  ok(
+    ir && ir.structure === 'hierarchy' && ir.nodes[0] === 'Grow ARR',
+    'okr-tree → hierarchy, objective = root',
+  );
+}
+{
+  const ir = atomToIR({
+    type: 'decision-tree-3-arm',
+    args: { question: 'Which path?', arms: [{ label: 'A' }, { label: 'B' }, { label: 'C' }] },
+  });
+  ok(ir && ir.structure === 'hierarchy', 'decision-tree-3-arm → hierarchy');
+}
+{
+  const ir = atomToIR({
+    type: 'pyramid',
+    args: {
+      layers: [
+        { label: 'Base', value: 48 },
+        { label: 'Mid', value: 4.8 },
+        { label: 'Apex', value: 2.1 },
+      ],
+    },
+  });
+  ok(ir && ir.structure === 'magnitude', 'pyramid with values → magnitude');
+}
+{
+  const ir = atomToIR({
+    type: 'pyramid',
+    args: { layers: [{ label: 'Base' }, { label: 'Mid' }, { label: 'Apex' }] },
+  });
+  ok(ir && ir.structure === 'sequence', 'pyramid without values → sequence');
+}
+
+// ---- network family -------------------------------------------------------
+{
+  const ir = atomToIR({
+    type: 'relationship-graph',
+    args: {
+      nodes: [
+        { id: 'a', label: 'Team A' },
+        { id: 'b', label: 'Team B' },
+        { id: 'c', label: 'Tool X' },
+      ],
+      edges: [
+        { from: 'a', to: 'c' },
+        { from: 'b', to: 'c' },
+      ],
+    },
+  });
+  ok(ir && ir.structure === 'network', 'relationship-graph → network');
+  ok(validateIR(ir).ok, 'relationship-graph IR validates');
+  ok(!ir.relations.some((r) => r[0] === r[1]), 'network has no self-loops');
+}
+{
+  const ir = atomToIR({
+    type: 'sphere-network',
+    args: {
+      hub: { label: 'Platform' },
+      satellites: [{ label: 'API' }, { label: 'Web' }, { label: 'CLI' }],
+    },
+  });
+  ok(
+    ir && ir.structure === 'network' && ir.nodes[0] === 'Platform',
+    'sphere-network → network, hub = root node',
+  );
+}
+{
+  const ir = atomToIR({
+    type: 'circle-image-hub-spoke',
+    args: { center: { label: 'Atlas' }, satellites: [{ label: 'Sketch' }, { label: 'Figma' }] },
+  });
+  ok(ir && ir.structure === 'network', 'circle-image-hub-spoke → network');
+}
+{
+  const ir = atomToIR({
+    type: 'radial-wheel-segmented',
+    args: {
+      hub: 'HR Core',
+      segments: [{ label: 'Recruit' }, { label: 'Retain' }, { label: 'Reward' }],
+    },
+  });
+  ok(ir && ir.structure === 'network', 'radial-wheel-segmented → network');
+}
+
+// ---- magnitude family -------------------------------------------------------
+{
+  const ir = atomToIR({
+    type: 'bar',
+    args: { values: [1.2, 1.8, 2.4], labels: ['Q1', 'Q2', 'Q3'] },
+  });
+  ok(
+    ir && ir.structure === 'magnitude' && ir.emphasis[0] === 2,
+    'bar → magnitude, emphasis = max index',
+  );
+}
+{
+  const ir = atomToIR({ type: 'pie', args: { values: [32, 23, 45], labels: ['A', 'B', 'C'] } });
+  ok(ir && ir.structure === 'magnitude', 'pie → magnitude');
+}
+{
+  const ir = atomToIR({
+    type: 'dashboard-multi-kpi-composite',
+    args: {
+      kpis: [
+        { value: '$3.4M', label: 'Revenue' },
+        { value: '12,450', label: 'MAU' },
+      ],
+    },
+  });
+  ok(
+    ir &&
+      ir.structure === 'magnitude' &&
+      JSON.stringify(ir.magnitude) === JSON.stringify([3400000, 12450]),
+    'dashboard-multi-kpi-composite → magnitude, values parsed',
+  );
+}
+{
+  const ir = atomToIR({
+    type: 'dashboard-multi-kpi-composite',
+    args: {
+      kpis: [
+        { value: 'Week 8', label: 'Unparseable' },
+        { value: '10', label: 'OK' },
+      ],
+    },
+  });
+  ok(ir === null, 'dashboard-multi-kpi-composite skips atom on unparseable value');
+}
+{
+  const ir = atomToIR({
+    type: 'stat-grid-large',
+    args: {
+      stats: [
+        { value: '$24M', label: 'ARR' },
+        { value: '92%', label: 'Retention' },
+      ],
+    },
+  });
+  ok(ir && ir.structure === 'magnitude', 'stat-grid-large → magnitude');
+}
+{
+  const ir = atomToIR({
+    type: 'waterfall',
+    args: {
+      bars: [
+        { label: 'Q1', value: 100, kind: 'start' },
+        { label: 'New', value: 30, kind: 'positive' },
+        { label: 'Q2', value: 130, kind: 'end' },
+      ],
+    },
+  });
+  ok(
+    ir && ir.structure === 'magnitude' && ir.emphasis[0] === 2,
+    'waterfall → magnitude, emphasis = end bar',
+  );
+}
+{
+  const ir = atomToIR({
+    type: 'radar-chart',
+    args: {
+      axes: ['Speed', 'Quality', 'Cost'],
+      series: [{ label: 'Current', values: [0.7, 0.4, 0.6] }],
+    },
+  });
+  ok(
+    ir && ir.structure === 'magnitude' && ir.nodes.length === 3,
+    'radar-chart → magnitude, nodes = axes',
+  );
+}
+
+// ---- no structural content / null cases -------------------------------------
+ok(atomToIR({ type: 'cover', args: { title: 'Deck' } }) === null, 'cover → null (no structure)');
+ok(atomToIR({ type: 'not-a-real-atom', args: {} }) === null, 'unknown atom type → null');
+ok(atomToIR(null) === null, 'null subject → null');
+ok(atomToIR({ type: 'org-chart', args: {} }) === null, 'org-chart with no root → null');
+
+// ---- slotToIR: richest-subject selection ------------------------------------
+{
+  const ir = slotToIR({
+    subjects: [
+      { type: 'cover', args: { title: 'x' } },
+      { type: 'bar', args: { values: [1, 2], labels: ['A', 'B'] } },
+      {
+        type: 'org-chart',
+        args: { root: { name: 'CEO', children: [{ name: 'A' }, { name: 'B' }, { name: 'C' }] } },
+      },
+    ],
+  });
+  ok(
+    ir && ir.structure === 'hierarchy' && ir.nodes.length === 4,
+    'slotToIR picks richest (4 nodes > 2)',
+  );
+}
+ok(
+  slotToIR({ subjects: [{ type: 'cover', args: { title: 'x' } }] }) === null,
+  'slotToIR: cover-only slot → null',
+);
+ok(slotToIR({ subjects: [] }) === null, 'slotToIR: no subjects → null');
+
+// ---- funnelSlotToIR back-compat ---------------------------------------------
+{
+  const ir = funnelSlotToIR({
+    subjects: [{ type: 'funnel', args: { title: 'F', stages: [{ label: 'A', value: 10 }] } }],
+  });
+  ok(ir.structure === 'sequence', 'funnelSlotToIR back-compat still works');
+}
+
+// ---- deckToIR on a REAL baked eval deck -------------------------------------
+const QBR_DIR = resolve(__dirname, '../examples/scaffold-pipeline/eval-qbr-q3-2026');
+{
+  const deck = deckToIR(QBR_DIR);
+  ok(
+    deck.slides.length > 0,
+    `deckToIR(eval-qbr-q3-2026) → non-empty slides (${deck.slides.length})`,
+  );
+  ok(
+    deck.slides.every((ir) => validateIR(ir).ok),
+    'every slide from deckToIR passes validateIR',
+  );
+  ok(typeof deck.title === 'string' && deck.title.length > 0, 'deckToIR carries a title');
+}
+
+// ---- end-to-end: deckToIR → assembleDeck → compile ---------------------------
+{
+  const deck = deckToIR(QBR_DIR);
+  const scene = assembleDeck(deck);
+  ok(
+    scene.subjects.length > 0 && scene.cameraSequence.shots.length > 0,
+    'assembleDeck assembles the IR deck',
+  );
+  try {
+    compile(scene, {});
+    ok(true, 'scaffold deck → IR → assembled world → COMPILES (thesis loop closes)');
+  } catch (e) {
+    ok(false, `compile failed: ${e.message}`);
+  }
+}
+
+console.log(`\n${pass} passed, ${fail} failed`);
+process.exit(fail ? 1 : 0);

--- a/sdf-js/src/scene/scaffold-to-ir.js
+++ b/sdf-js/src/scene/scaffold-to-ir.js
@@ -1,6 +1,598 @@
 // sdf-js/src/scene/scaffold-to-ir.js
-// Input adapter: a 2D scaffold slot with a funnel → sequence IR. Reads data only,
-// never x/y/w/h — that's what lets a text→IR adapter slot in later unchanged.
+// Input adapter: the 2D scaffold pipeline's baked output (deck.json + slot
+// sceneData, 101 atoms) → IR. Reads data (args) only, never x/y/w/h — that's
+// what lets a text→IR adapter slot in later unchanged, and lets a scaffold
+// deck feed the SAME cinematic renderer (assembleDeck) as text-to-ir.
+//
+// Layers, thin → thick:
+//   atomToIR(subject)   — one atom's args → one IR, or null (no/invalid structure)
+//   slotToIR(sceneData) — a slot's several subjects → the ONE richest IR
+//   deckToIR(deckDir)   — a baked deck directory → {title, slides: IR[]}
+//
+// Every IR this file emits is run through validateIR before being returned;
+// on failure we console.warn and return null rather than hand the renderer
+// garbage (per the IR contract's own rule: the validator is the gate).
+import { readFileSync, existsSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import { validateIR } from './ir.js';
+
+// ---- numeric parsing --------------------------------------------------------
+// Atom args are prose-formatted for human legibility ("$3.4M", "12,450",
+// "92%") but IR magnitude must be real numbers. Leading-numeric parse with
+// K/M/B multiplier support; anything that doesn't look like a number → null
+// so the caller can skip the atom rather than emit a fake zero.
+export function parseMagnitude(v) {
+  if (typeof v === 'number') return Number.isFinite(v) ? v : null;
+  if (typeof v !== 'string') return null;
+  const m = v.trim().match(/^([+-])?\$?([\d,]+(?:\.\d+)?)\s*([KMBkmb])?%?$/);
+  if (!m) return null;
+  const [, sign, numStr, suffix] = m;
+  let num = parseFloat(numStr.replace(/,/g, ''));
+  if (!Number.isFinite(num)) return null;
+  if (suffix) num *= { k: 1e3, m: 1e6, b: 1e9 }[suffix.toLowerCase()];
+  if (sign === '-') num = -num;
+  return num;
+}
+
+// argmax helper — index of the largest value (ties → first).
+function argmax(values) {
+  let best = 0;
+  for (let i = 1; i < values.length; i++) if (values[i] > values[best]) best = i;
+  return best;
+}
+
+// Validate + warn-and-drop-on-failure, so a mapping bug never emits garbage
+// IR into the renderer — it just silently loses that one atom.
+function finish(ir, atomType) {
+  const v = validateIR(ir);
+  if (!v.ok) {
+    console.warn(`scaffold-to-ir: ${atomType} produced invalid IR — ${v.errors.join('; ')}`);
+    return null;
+  }
+  return ir;
+}
+
+// Flatten a recursive { [labelKey], children? } tree into IR nodes + relations
+// (parent→child index pairs). Root is always index 0 and — by construction —
+// the only node with no incoming relation, so validateIR's "exactly one root"
+// check always passes for a genuine tree input.
+function flattenTree(root, labelKey) {
+  const nodes = [];
+  const relations = [];
+  (function visit(node, parentIdx) {
+    const idx = nodes.length;
+    nodes.push(node?.[labelKey] || '');
+    if (parentIdx != null) relations.push([parentIdx, idx]);
+    const children = Array.isArray(node?.children) ? node.children : [];
+    for (const c of children) visit(c, idx);
+  })(root, null);
+  return { nodes, relations };
+}
+
+function treeToIR(a, atomType, labelKey) {
+  if (!a?.root) return null;
+  const { nodes, relations } = flattenTree(a.root, labelKey);
+  if (nodes.length < 2) return null; // no children — nothing structural to show
+  return finish(
+    {
+      structure: 'hierarchy',
+      nodes,
+      relations,
+      order: nodes.map((_, i) => i),
+      title: a.title || '',
+    },
+    atomType,
+  );
+}
+
+// ---- sequence family (ordered stages) ---------------------------------------
+
+function funnelToIR(a) {
+  const stages = Array.isArray(a?.stages) ? a.stages : [];
+  if (!stages.length) return null;
+  const nodes = stages.map((s) => (typeof s === 'string' ? s : s?.label || ''));
+  return finish(
+    {
+      structure: 'sequence',
+      nodes,
+      magnitude: stages.map((s) => Number(s?.value) || 0),
+      emphasis: [Math.max(0, stages.length - 1)],
+      order: nodes.map((_, i) => i),
+      title: a.title || '',
+    },
+    'funnel',
+  );
+}
+
+function funnelWithConversionToIR(a) {
+  const stages = Array.isArray(a?.stages) ? a.stages : [];
+  if (!stages.length) return null;
+  const nodes = stages.map((s) => s?.label || '');
+  return finish(
+    {
+      structure: 'sequence',
+      nodes,
+      magnitude: stages.map((s) => Number(s?.value) || 0),
+      emphasis: [Math.max(0, stages.length - 1)],
+      order: nodes.map((_, i) => i),
+      title: a.title || '',
+    },
+    'funnel-with-conversion',
+  );
+}
+
+function processArrowsToIR(a) {
+  const steps = Array.isArray(a?.steps) ? a.steps : [];
+  if (!steps.length) return null;
+  const nodes = steps.map((s) => (typeof s === 'string' ? s : s?.label || ''));
+  return finish(
+    { structure: 'sequence', nodes, order: nodes.map((_, i) => i), title: a.title || '' },
+    'process-arrows',
+  );
+}
+
+function progressionToIR(a) {
+  const steps = Array.isArray(a?.steps) ? a.steps : [];
+  if (!steps.length) return null;
+  const nodes = steps.map((s) => (typeof s === 'string' ? s : s?.label || ''));
+  const currentIdx = steps.findIndex((s) => s?.status === 'current');
+  const ir = { structure: 'sequence', nodes, order: nodes.map((_, i) => i), title: a.title || '' };
+  if (currentIdx >= 0) ir.emphasis = [currentIdx];
+  return finish(ir, 'progression');
+}
+
+function flowChartToIR(a) {
+  const steps = Array.isArray(a?.steps) ? a.steps : [];
+  if (!steps.length) return null;
+  const nodes = steps.map((s) => String(s));
+  const ir = { structure: 'sequence', nodes, order: nodes.map((_, i) => i), title: a.title || '' };
+  if (Number.isInteger(a.highlight)) ir.emphasis = [a.highlight];
+  return finish(ir, 'flow-chart');
+}
+
+function timelineToIR(a, atomType) {
+  const events = Array.isArray(a?.events) ? a.events : [];
+  if (!events.length) return null;
+  const nodes = events.map((e) => e?.label || e?.date || '');
+  return finish(
+    { structure: 'sequence', nodes, order: nodes.map((_, i) => i), title: a.title || '' },
+    atomType,
+  );
+}
+
+function journeyFlowCurveToIR(a) {
+  const tps = Array.isArray(a?.touchpoints) ? a.touchpoints : [];
+  if (!tps.length) return null;
+  const nodes = tps.map((t) => t?.label || '');
+  // emotion is -1..+1; remap to a positive 0..100 magnitude scale.
+  const magnitude = tps.map((t) => (Number.isFinite(t?.emotion) ? (t.emotion + 1) * 50 : 50));
+  return finish(
+    {
+      structure: 'sequence',
+      nodes,
+      magnitude,
+      order: nodes.map((_, i) => i),
+      emphasis: [argmax(magnitude)],
+      title: a.title || '',
+    },
+    'journey-flow-curve',
+  );
+}
+
+function changeCurveChartToIR(a) {
+  const phases = Array.isArray(a?.phases) ? a.phases : [];
+  if (!phases.length) return null;
+  const nodes = phases.map((p) => (typeof p === 'string' ? p : p?.label || ''));
+  return finish(
+    { structure: 'sequence', nodes, order: nodes.map((_, i) => i), title: a.title || '' },
+    'change-curve-chart',
+  );
+}
+
+function circleProcessCycleToIR(a) {
+  const steps = Array.isArray(a?.steps) ? a.steps : [];
+  if (!steps.length) return null;
+  const nodes = steps.map((s) => (typeof s === 'string' ? s : s?.label || ''));
+  return finish(
+    {
+      structure: 'sequence',
+      nodes,
+      order: nodes.map((_, i) => i),
+      title: a.title || a.centerLabel || '',
+    },
+    'circle-process-cycle',
+  );
+}
+
+function maturityModelToIR(a) {
+  const stages = Array.isArray(a?.stages) ? a.stages : [];
+  if (!stages.length) return null;
+  const nodes = stages.map((s) => (typeof s === 'string' ? s : s?.label || ''));
+  const ir = { structure: 'sequence', nodes, order: nodes.map((_, i) => i), title: a.title || '' };
+  if (Number.isInteger(a.currentLevel)) ir.emphasis = [Math.max(0, a.currentLevel - 1)];
+  return finish(ir, 'maturity-model');
+}
+
+function kanbanBoardToIR(a) {
+  const columns = Array.isArray(a?.columns) ? a.columns : [];
+  if (!columns.length) return null;
+  const nodes = columns.map((c) => c?.label || '');
+  const magnitude = columns.map((c) => (Array.isArray(c?.cards) ? c.cards.length : 0));
+  return finish(
+    {
+      structure: 'sequence',
+      nodes,
+      magnitude,
+      order: nodes.map((_, i) => i),
+      title: a.title || '',
+    },
+    'kanban-board',
+  );
+}
+
+// ---- hierarchy family (parent→child, one root) ------------------------------
+
+function okrTreeToIR(a) {
+  const krs = Array.isArray(a?.keyResults) ? a.keyResults : [];
+  if (!a?.objective || !krs.length) return null;
+  const nodes = [a.objective, ...krs.map((k) => (typeof k === 'string' ? k : k?.label || ''))];
+  const relations = krs.map((_, i) => [0, i + 1]);
+  return finish(
+    {
+      structure: 'hierarchy',
+      nodes,
+      relations,
+      order: nodes.map((_, i) => i),
+      title: a.quarter ? `${a.objective} · ${a.quarter}` : a.objective,
+    },
+    'okr-tree',
+  );
+}
+
+function decisionTree3ArmToIR(a) {
+  const arms = Array.isArray(a?.arms) ? a.arms : [];
+  if (!a?.question || !arms.length) return null;
+  const nodes = [a.question, ...arms.map((ar) => (typeof ar === 'string' ? ar : ar?.label || ''))];
+  const relations = arms.map((_, i) => [0, i + 1]);
+  return finish(
+    {
+      structure: 'hierarchy',
+      nodes,
+      relations,
+      order: nodes.map((_, i) => i),
+      title: a.title || a.question,
+    },
+    'decision-tree-3-arm',
+  );
+}
+
+// pyramid is levels, not strictly parent→child — but its layers are ordered
+// broad-to-narrow, so it fits sequence naturally; when layers carry values it
+// is better read as a magnitude comparison (base vs apex size).
+function pyramidToIR(a) {
+  const layers = Array.isArray(a?.layers) ? a.layers : [];
+  if (!layers.length) return null;
+  const nodes = layers.map((l) => (typeof l === 'string' ? l : l?.label || ''));
+  const parsedValues = layers.map((l) => (l && l.value != null ? parseMagnitude(l.value) : null));
+  const hasAllValues = parsedValues.every((v) => v != null);
+  if (hasAllValues) {
+    return finish(
+      {
+        structure: 'magnitude',
+        nodes,
+        magnitude: parsedValues,
+        emphasis: [argmax(parsedValues)],
+        title: a.title || '',
+      },
+      'pyramid',
+    );
+  }
+  return finish(
+    {
+      structure: 'sequence',
+      nodes,
+      order: nodes.map((_, i) => i),
+      emphasis: [a.inverted ? 0 : nodes.length - 1],
+      title: a.title || '',
+    },
+    'pyramid',
+  );
+}
+
+// ---- network family (undirected edges) --------------------------------------
+
+function relationshipGraphToIR(a) {
+  const nodesArr = Array.isArray(a?.nodes) ? a.nodes : [];
+  const edgesArr = Array.isArray(a?.edges) ? a.edges : [];
+  if (nodesArr.length < 2 || !edgesArr.length) return null;
+  const idIndex = new Map(nodesArr.map((n, i) => [n.id, i]));
+  const relations = [];
+  for (const e of edgesArr) {
+    const from = idIndex.get(e.from);
+    const to = idIndex.get(e.to);
+    if (from == null || to == null || from === to) continue;
+    relations.push([from, to]);
+  }
+  if (!relations.length) return null;
+  return finish(
+    {
+      structure: 'network',
+      nodes: nodesArr.map((n) => n.label || n.id || ''),
+      relations,
+      title: a.title || '',
+    },
+    'relationship-graph',
+  );
+}
+
+// Star-topology helper: one hub + N satellites, all satellites edged to hub.
+function hubSpokeToIR(hubLabel, satellites, satLabelFn, atomType, title) {
+  if (!satellites || satellites.length < 2) return null;
+  const nodes = [hubLabel || 'Hub', ...satellites.map(satLabelFn)];
+  const relations = satellites.map((_, i) => [0, i + 1]);
+  return finish({ structure: 'network', nodes, relations, title: title || '' }, atomType);
+}
+
+function sphereNetworkToIR(a) {
+  const sats = Array.isArray(a?.satellites) ? a.satellites : [];
+  return hubSpokeToIR(a?.hub?.label, sats, (s) => s?.label || '', 'sphere-network', a.title);
+}
+
+function circleImageHubSpokeToIR(a) {
+  const sats = Array.isArray(a?.satellites) ? a.satellites : [];
+  if (!a?.center) return null;
+  return hubSpokeToIR(
+    a.center.label,
+    sats,
+    (s) => s?.label || '',
+    'circle-image-hub-spoke',
+    a.title,
+  );
+}
+
+function radialWheelSegmentedToIR(a) {
+  const segs = Array.isArray(a?.segments) ? a.segments : [];
+  if (!a?.hub) return null;
+  return hubSpokeToIR(
+    a.hub,
+    segs,
+    (s) => (typeof s === 'string' ? s : s?.label || ''),
+    'radial-wheel-segmented',
+    a.title,
+  );
+}
+
+// ---- magnitude family (quantities compared) ---------------------------------
+
+function valuesLabelsToIR(a, atomType) {
+  const values = Array.isArray(a?.values) ? a.values : [];
+  const labels = Array.isArray(a?.labels) ? a.labels : [];
+  if (!values.length || values.length !== labels.length) return null;
+  return finish(
+    {
+      structure: 'magnitude',
+      nodes: labels,
+      magnitude: values,
+      emphasis: [argmax(values)],
+      title: a.title || '',
+    },
+    atomType,
+  );
+}
+
+// Shared shape for "array of { label, <valueKey> }" → magnitude, parsing
+// prose-formatted values; skips the whole atom (returns null) if ANY value
+// fails to parse rather than emit a partial/garbage magnitude array.
+function labeledValuesToIR(items, valueKey, atomType, title) {
+  if (!items || !items.length) return null;
+  const nodes = items.map((it) => it?.label || '');
+  const magnitude = items.map((it) => parseMagnitude(it?.[valueKey]));
+  if (magnitude.some((v) => v == null)) return null;
+  return finish(
+    { structure: 'magnitude', nodes, magnitude, emphasis: [argmax(magnitude)], title: title || '' },
+    atomType,
+  );
+}
+
+function donutWithCenterToIR(a) {
+  return labeledValuesToIR(a?.segments, 'value', 'donut-with-center', a?.title || a?.centerLabel);
+}
+
+function segmentedBarToIR(a) {
+  return labeledValuesToIR(a?.segments, 'value', 'segmented-bar', a?.title);
+}
+
+function statGridLargeToIR(a) {
+  return labeledValuesToIR(a?.stats, 'value', 'stat-grid-large', a?.title);
+}
+
+function dashboardMultiKpiToIR(a) {
+  return labeledValuesToIR(a?.kpis, 'value', 'dashboard-multi-kpi-composite', a?.title);
+}
+
+function isotypeStatComparisonToIR(a) {
+  return labeledValuesToIR(a?.stats, 'count', 'isotype-stat-comparison', a?.title);
+}
+
+function histogramToIR(a) {
+  const bins = Array.isArray(a?.bins) ? a.bins : [];
+  if (!bins.length) return null;
+  const nodes = bins.map((b) => (Array.isArray(b?.range) ? `${b.range[0]}-${b.range[1]}` : ''));
+  const magnitude = bins.map((b) => (typeof b?.count === 'number' ? b.count : null));
+  if (magnitude.some((v) => v == null)) return null;
+  return finish(
+    {
+      structure: 'magnitude',
+      nodes,
+      magnitude,
+      emphasis: [argmax(magnitude)],
+      title: a.title || '',
+    },
+    'histogram',
+  );
+}
+
+function waterfallToIR(a) {
+  const bars = Array.isArray(a?.bars) ? a.bars : [];
+  if (!bars.length) return null;
+  const nodes = bars.map((b) => b?.label || '');
+  const magnitude = bars.map((b) =>
+    typeof b?.value === 'number' ? b.value : parseMagnitude(b?.value),
+  );
+  if (magnitude.some((v) => v == null)) return null;
+  const endIdx = bars.findIndex((b) => b?.kind === 'end');
+  return finish(
+    {
+      structure: 'magnitude',
+      nodes,
+      magnitude,
+      emphasis: [endIdx >= 0 ? endIdx : nodes.length - 1],
+      title: a.title || '',
+    },
+    'waterfall',
+  );
+}
+
+function radarChartToIR(a) {
+  const axes = Array.isArray(a?.axes) ? a.axes : [];
+  const series = Array.isArray(a?.series) ? a.series : [];
+  if (!axes.length || !series.length) return null;
+  const first = series[0];
+  const values = Array.isArray(first?.values) ? first.values : [];
+  if (values.length !== axes.length) return null;
+  const magnitude = values.map((v) => (Number.isFinite(v) ? v * 100 : null));
+  if (magnitude.some((v) => v == null)) return null;
+  return finish(
+    {
+      structure: 'magnitude',
+      nodes: axes,
+      magnitude,
+      emphasis: [argmax(magnitude)],
+      title: a.title || first.label || '',
+    },
+    'radar-chart',
+  );
+}
+
+// ---- registry ----------------------------------------------------------------
+// type → (args) => IR|null. ~30 high-value atoms with real structural content;
+// everything else (cover / quote-pull / image / single-value stat cards /
+// pure shapes / icons…) has no entry and atomToIR returns null for it — by
+// design, not oversight. See docs/superpowers/atoms-to-ir-coverage.md.
+const ATOM_IR_MAP = {
+  // sequence
+  funnel: funnelToIR,
+  'funnel-with-conversion': funnelWithConversionToIR,
+  'process-arrows': processArrowsToIR,
+  progression: progressionToIR,
+  'flow-chart': flowChartToIR,
+  timeline: (a) => timelineToIR(a, 'timeline'),
+  'vertical-timeline': (a) => timelineToIR(a, 'vertical-timeline'),
+  'journey-flow-curve': journeyFlowCurveToIR,
+  'change-curve-chart': changeCurveChartToIR,
+  'circle-process-cycle': circleProcessCycleToIR,
+  'maturity-model': maturityModelToIR,
+  'kanban-board': kanbanBoardToIR,
+
+  // hierarchy
+  'org-chart': (a) => treeToIR(a, 'org-chart', 'name'),
+  'tree-diagram': (a) => treeToIR(a, 'tree-diagram', 'label'),
+  mindmap: (a) => treeToIR(a, 'mindmap', 'label'),
+  'sphere-tree': (a) => treeToIR(a, 'sphere-tree', 'label'),
+  'okr-tree': okrTreeToIR,
+  'decision-tree-3-arm': decisionTree3ArmToIR,
+  pyramid: pyramidToIR, // conditional: magnitude (has values) or sequence
+
+  // network
+  'relationship-graph': relationshipGraphToIR,
+  'sphere-network': sphereNetworkToIR,
+  'circle-image-hub-spoke': circleImageHubSpokeToIR,
+  'radial-wheel-segmented': radialWheelSegmentedToIR,
+
+  // magnitude
+  bar: (a) => valuesLabelsToIR(a, 'bar'),
+  column: (a) => valuesLabelsToIR(a, 'column'),
+  pie: (a) => valuesLabelsToIR(a, 'pie'),
+  'donut-with-center': donutWithCenterToIR,
+  'segmented-bar': segmentedBarToIR,
+  'stat-grid-large': statGridLargeToIR,
+  'dashboard-multi-kpi-composite': dashboardMultiKpiToIR,
+  'isotype-stat-comparison': isotypeStatComparisonToIR,
+  histogram: histogramToIR,
+  waterfall: waterfallToIR,
+  'radar-chart': radarChartToIR,
+};
+
+/**
+ * atomToIR(subject) → IR | null
+ * One 2D atom subject ({ type, args }) → its best-fit IR, or null if the atom
+ * has no structural content mapped (by design) or its args don't shape into
+ * a valid IR (e.g. missing required fields, unparseable magnitude values).
+ */
+export function atomToIR(subject) {
+  if (!subject || typeof subject.type !== 'string') return null;
+  const fn = ATOM_IR_MAP[subject.type];
+  if (!fn) return null;
+  try {
+    return fn(subject.args || {});
+  } catch (e) {
+    console.warn(`scaffold-to-ir: ${subject.type} threw — ${e.message}`);
+    return null;
+  }
+}
+
+/**
+ * slotToIR(sceneData) → IR | null
+ * A slot carries several atom subjects (a cover + N content atoms); pick the
+ * single richest structural one — most nodes wins, first wins ties. Returns
+ * null when no subject in the slot has structural content (e.g. a cover-only
+ * slot, or a slot of icon-grid/kpi-card atoms with no mapped structure).
+ */
+export function slotToIR(sceneData) {
+  const subjects = Array.isArray(sceneData?.subjects) ? sceneData.subjects : [];
+  let best = null;
+  for (const s of subjects) {
+    const ir = atomToIR(s);
+    if (!ir) continue;
+    if (!best || ir.nodes.length > best.nodes.length) best = ir;
+  }
+  return best;
+}
+
+/**
+ * deckToIR(deckDir) → { title, slides: IR[] }
+ * Reads a baked scaffold deck directory (deck.json manifest + slots/*.json,
+ * the shape bake-scaffold-pipeline.mjs produces and eval-deck-quality.mjs
+ * reads) and returns an assembleDeck-ready deck. Skips slots that errored,
+ * mapped empty, or have no structural subject.
+ */
+export function deckToIR(deckDir) {
+  const dir = resolve(deckDir);
+  const manifestPath = join(dir, 'deck.json');
+  if (!existsSync(manifestPath)) throw new Error(`deckToIR: no deck.json in ${dir}`);
+  const manifest = JSON.parse(readFileSync(manifestPath, 'utf8'));
+
+  const slides = [];
+  for (const slot of manifest.slots || []) {
+    if (!slot.liftFile || slot.error || slot.mappingEmpty) continue;
+    const slotPath = join(dir, slot.liftFile);
+    if (!existsSync(slotPath)) continue;
+    const slotEntry = JSON.parse(readFileSync(slotPath, 'utf8'));
+    const sceneData = slotEntry.sceneData;
+    if (!sceneData) continue;
+    const ir = slotToIR(sceneData);
+    if (ir) slides.push(ir);
+  }
+
+  const title = manifest.scaffold?.label || manifest.deckName || 'Deck';
+  return { title, slides };
+}
+
+/**
+ * funnelSlotToIR(sceneData) — kept for back-compat with existing callers/tests.
+ * Throws (rather than returning null) if the slot has no funnel subject —
+ * this is the ORIGINAL narrow adapter; new code should use slotToIR/atomToIR.
+ */
 export function funnelSlotToIR(sceneData) {
   const f = (sceneData.subjects || []).find((s) => s.type === 'funnel');
   if (!f) throw new Error('funnelSlotToIR: no funnel subject in slot');


### PR DESCRIPTION
## Summary

3D 端过去 2 天 ship 了新 IR 架构线 (text-to-ir / assembleDeck / 格斗游戏摄像机, #201-#221), 但 `scaffold-to-ir.js` 只是 1-atom (funnel) stub — 我们打磨 3 个 Sprint 的重管线 (101 atoms, facts recall 95.8%) 接不进新的 cinematic 渲染路径。本 PR 从 2D 侧闭合这个洞。

## The bridge

```
文本 → 3-stage scaffold 管线 (质量 97.0 / 保真 95.8%) → deck.json
                                                      ↓ deckToIR (NEW)
                          assembleDeck → 格斗游戏 cinematic 3D 世界
```

- **`atomToIR(subject)`**: 34 个结构性 atom → IR 4 结构
  - sequence×12: funnel / funnel-with-conversion / process-arrows / progression / flow-chart / timeline / vertical-timeline / journey-flow-curve / change-curve-chart / circle-process-cycle / maturity-model / kanban-board
  - hierarchy×6: org-chart / tree-diagram / mindmap / okr-tree / decision-tree-3-arm / sphere-tree
  - network×4: relationship-graph / sphere-network / circle-image-hub-spoke / radial-wheel-segmented
  - magnitude×12: bar / column / pie / donut-with-center / segmented-bar / stat-grid-large / dashboard-multi-kpi-composite / isotype-stat-comparison / histogram / waterfall / radar-chart / pyramid
  - 只读 DATA args (不读 x/y/w/h); 全部输出过 validateIR 闸门 (invalid → null + warn)
- **`parseMagnitude`**: "$3.4M"→3400000 / "92%"→92 / "12,450"→12450
- **`slotToIR`**: 每 slot 选最富结构的 subject
- **`deckToIR(deckDir)`**: 整个 baked deck → `{title, slides}` assembleDeck-ready
- funnelSlotToIR 保留向后兼容

## 证明 (真 deck, 真编译)

```
══ VC Pitch Deck — 5 structural slides ══
  TAM / SAM / SOM        magnitude  nodes=3 +magnitude
  (funnel)               sequence   nodes=4
  Unit Economics         magnitude  nodes=3 +magnitude
  (team network)         network    nodes=4 +relations(3)
  Use of Funds           magnitude  nodes=3 +magnitude
```

- e2e 测试: **eval-qbr 真 deck → IR → assembleDeck → COMPILES** ✅
- 证明场景已提交 (本机显示弱, 3D 机器直接开): `?scene=ir-from-vc-pitch` / `?scene=ir-from-qbr-q3-2026`

## 覆盖 (诚实账)

[atoms-to-ir-coverage.md](docs/superpowers/atoms-to-ir-coverage.md): 34 mapped / ~40 无结构内容 (设计上不映射: cover/quote/kpi 单值/icon/形状) / ~13 TODO — **matrix 家族 (swot/risk-heatmap/matrix-grid...) 需要 IR 增加 matrix 结构** (现有 4 结构表达不了 2 维分类), 已在文档中留给 3D 端。

## Tests

- test-atoms-to-ir.mjs: **48 assertions**
- npm test: **123/123**

Per CLAUDE.md: DO NOT merge. Awaiting user review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)