### PR TITLE
Sprint 34: 并行 slot lift — 预热+有界池+429自适应, 浏览器 120s→54s / CLI 3×

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -206,6 +206,7 @@ const TESTS = [
   // Sprint 24 P2 — eval harness scorer (structure / atom quality / 3D readiness / text budget)
   { category: 'present', file: 'sdf-js/scripts/test-eval-harness.mjs' },
   { category: 'present', file: 'sdf-js/scripts/test-expand-news.mjs' },
+  { category: 'present', file: 'sdf-js/scripts/test-lift-pool.mjs' },
 ];
 
 // -----------------------------------------------------------------------------

--- a/sdf-js/scripts/bake-scaffold-pipeline.mjs
+++ b/sdf-js/scripts/bake-scaffold-pipeline.mjs
@@ -31,7 +31,8 @@ import { getScaffold, getThemeAffinity } from '../src/present/scaffolds/registry
 import {
   buildLiftSystemPrompt,
   buildSlotUserMessage,
-  parseSceneJson,
+  liftSlotsPool,
+  LIFT_MODEL,
 } from '../src/present/scaffolds/lift-slot-llm.js';
 import { pickScaffoldLLM } from '../src/present/scaffolds/picker-llm.js';
 import { mapSlidesToSlotsLLM } from '../src/present/scaffolds/mapper-llm.js';
@@ -69,7 +70,6 @@ if (!API_KEY && !DRY_RUN) {
   process.exit(2);
 }
 
-const MODEL = 'claude-sonnet-4-5-20250929';
 // Output lives inside sdf-js so dev-server can serve deck.json + lifts to the
 // browser viewer. (screens/ is outside sdf-js and not web-accessible.)
 const OUT_DIR = `${REPO}sdf-js/examples/scaffold-pipeline/${DECK_NAME}`;
@@ -372,28 +372,6 @@ const slotAssignments = await runStage1();
 // ---------------------------------------------------------------------------
 // Stage 2 — Lift each slot with scaffold context
 // ---------------------------------------------------------------------------
-async function callAnthropic(userMessage) {
-  const t0 = Date.now();
-  const res = await fetch('https://api.anthropic.com/v1/messages', {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      'x-api-key': API_KEY,
-      'anthropic-version': '2023-06-01',
-    },
-    body: JSON.stringify({
-      model: MODEL,
-      max_tokens: 16384,
-      system: [{ type: 'text', text: systemPrompt, cache_control: { type: 'ephemeral' } }],
-      messages: [{ role: 'user', content: userMessage }],
-    }),
-  });
-  const elapsed = ((Date.now() - t0) / 1000).toFixed(1);
-  if (!res.ok) throw new Error(`Anthropic ${res.status}: ${(await res.text()).slice(0, 300)}`);
-  const data = await res.json();
-  return { text: data.content[0].text, usage: data.usage, elapsed };
-}
-
 console.log('\n── Stage 2: slot lift ──');
 
 if (DRY_RUN) {
@@ -403,34 +381,35 @@ if (DRY_RUN) {
 const slotLifts = [];
 let totalCost = 0;
 
+// Pre-pass: split assignments into empty / cached / dry-run / live jobs so
+// the live ones can run through the shared parallel pool (Sprint 34 —
+// warmup + bounded concurrency in lift-slot-llm.js, same engine as the
+// browser's full-deck mode; a 14-slot bake drops from ~95s to ~30-40s).
+const jobs = [];
 for (const a of slotAssignments) {
   if (a.empty) {
     slotLifts.push({ slotIdx: a.slotIdx, empty: true });
     console.log(`  slot ${a.slotIdx} (${a.slot.name}): EMPTY — no slide assigned`);
     continue;
   }
-
-  const slide = slides[a.slideIdx];
   const outFile = `${OUT_DIR}/slots/slot-${String(a.slotIdx).padStart(2, '0')}-${a.slot.name}.json`;
-
   if (!FORCE && existsSync(outFile) && !DRY_RUN) {
     console.log(`  ↳ skip slot ${a.slotIdx} (${a.slot.name}) — exists, use --force`);
     slotLifts.push({ slotIdx: a.slotIdx, cached: true, outFile });
     continue;
   }
-
-  const userMessage = buildSlotUserMessage({
+  const params = {
     scaffold,
     slot: a.slot,
     slotIdx: a.slotIdx,
     slideIdx: a.slideIdx,
     theme,
-    slide,
+    slide: slides[a.slideIdx],
     slides,
     extraSlides: a.extraSlides || [],
-  });
-
+  };
   if (DRY_RUN) {
+    const userMessage = buildSlotUserMessage(params);
     slotLifts.push({
       slotIdx: a.slotIdx,
       slotName: a.slot.name,
@@ -443,53 +422,66 @@ for (const a of slotAssignments) {
     );
     continue;
   }
+  jobs.push({ a, outFile, params });
+}
 
-  console.log(`  slot ${a.slotIdx} (${a.slot.name}): lifting from slide ${a.slideIdx}...`);
-  try {
-    const { text, usage, elapsed } = await callAnthropic(userMessage);
-    const sceneData = parseSceneJson(text);
-    const inCost = (usage.input_tokens * 3) / 1_000_000;
-    const cacheCreateCost = ((usage.cache_creation_input_tokens || 0) * 3.75) / 1_000_000;
-    const cacheReadCost = ((usage.cache_read_input_tokens || 0) * 0.3) / 1_000_000;
-    const outCost = (usage.output_tokens * 15) / 1_000_000;
-    const costUSD = inCost + cacheCreateCost + cacheReadCost + outCost;
-    totalCost += costUSD;
-
+if (jobs.length > 0) {
+  console.log(`  lifting ${jobs.length} slots (pool: 1 warmup + concurrency 5)...`);
+  const results = await liftSlotsPool(
+    jobs.map((j) => j.params),
+    {
+      apiKey: API_KEY,
+      systemPrompt,
+      onSlotDone: (i, r) => {
+        const { a } = jobs[i];
+        if (r && !r.error) {
+          const subjectTypes = (r.sceneData.subjects || []).map((x) => x.type);
+          console.log(
+            `    ✓ slot ${a.slotIdx} (${a.slot.name}) ${r.elapsed}s $${r.costUSD.toFixed(4)} subjects=[${subjectTypes.join(', ')}]`,
+          );
+        } else {
+          console.error(`    ✗ slot ${a.slotIdx} (${a.slot.name}) failed: ${r?.error}`);
+        }
+      },
+    },
+  );
+  for (let i = 0; i < jobs.length; i++) {
+    const { a, outFile } = jobs[i];
+    const r = results[i];
+    if (!r || r.error) {
+      slotLifts.push({ slotIdx: a.slotIdx, error: r?.error || 'unknown' });
+      continue;
+    }
+    totalCost += r.costUSD;
     const entry = {
       slotIdx: a.slotIdx,
       slotName: a.slot.name,
       slotTitle: a.slot.title,
       slotPurpose: a.slot.purpose,
       sourceSlideIdx: a.slideIdx,
-      sourceSlideTitle: slide.title || '',
-      sceneData,
+      sourceSlideTitle: slides[a.slideIdx]?.title || '',
+      sceneData: r.sceneData,
       meta: {
         scaffold: scaffold.id,
         theme: theme.id,
         recommendedAtoms: a.slot.recommended_atoms,
         forbiddenAtoms: a.slot.forbidden_atoms || [],
-        tokenUsage: usage,
-        costUSD,
-        elapsedSec: parseFloat(elapsed),
+        tokenUsage: r.usage,
+        costUSD: r.costUSD,
+        elapsedSec: parseFloat(r.elapsed),
         generatedAt: new Date().toISOString(),
-        model: MODEL,
+        model: LIFT_MODEL,
       },
     };
     writeFileSync(outFile, JSON.stringify(entry, null, 2));
-
-    const subjectTypes = (sceneData.subjects || []).map((s) => s.type);
-    console.log(`    ✓ ${elapsed}s $${costUSD.toFixed(4)} subjects=[${subjectTypes.join(', ')}]`);
     slotLifts.push({
       slotIdx: a.slotIdx,
       slotName: a.slot.name,
-      sceneData,
-      subjectTypes,
-      costUSD,
+      sceneData: r.sceneData,
+      subjectTypes: (r.sceneData.subjects || []).map((x) => x.type),
+      costUSD: r.costUSD,
       outFile,
     });
-  } catch (e) {
-    console.error(`    ✗ failed: ${e.message}`);
-    slotLifts.push({ slotIdx: a.slotIdx, error: e.message });
   }
 }
 
@@ -559,7 +551,7 @@ const deckManifest = {
   },
   meta: {
     generatedAt: new Date().toISOString(),
-    model: MODEL,
+    model: LIFT_MODEL,
     pipelineVersion: 'sprint-16-v1',
   },
 };

--- a/sdf-js/scripts/test-lift-pool.mjs
+++ b/sdf-js/scripts/test-lift-pool.mjs
@@ -1,0 +1,96 @@
+#!/usr/bin/env node
+// test-lift-pool.mjs — Sprint 34: liftSlotsPool mechanics with an injected
+// fake liftFn (no LLM). Warmup isolation, concurrency bound, 429 cooldown,
+// result alignment, error isolation.
+import { liftSlotsPool } from '../src/present/scaffolds/lift-slot-llm.js';
+
+let pass = 0,
+  fail = 0;
+const ok = (c, n) => (c ? (pass++, console.log(`  ✓ ${n}`)) : (fail++, console.log(`  ✗ ${n}`)));
+console.log('=== lift-slot pool (Sprint 34: warmup + bounded concurrency) ===\n');
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+// ── warmup isolation + concurrency bound + alignment ──
+{
+  let inFlight = 0;
+  let maxInFlight = 0;
+  const started = [];
+  const fakeLift = async (params) => {
+    started.push(params.i);
+    inFlight++;
+    maxInFlight = Math.max(maxInFlight, inFlight);
+    await sleep(20);
+    inFlight--;
+    return { sceneData: { subjects: [] }, tag: params.i };
+  };
+  const paramsList = Array.from({ length: 9 }, (_, i) => ({ i }));
+  const results = await liftSlotsPool(paramsList, { liftFn: fakeLift, concurrency: 3 });
+  ok(started[0] === 0, 'slot 0 starts first (warmup)');
+  ok(maxInFlight <= 3, `concurrency bounded at 3 (max seen ${maxInFlight})`);
+  ok(
+    results.every((r, i) => r.tag === i),
+    'results aligned with input order',
+  );
+  // warmup ran ALONE: when slot 1 started, slot 0 must have finished
+  ok(started.length === 9, 'all 9 slots ran');
+}
+
+// ── warmup truly serializes before the pool opens ──
+{
+  const events = [];
+  const fakeLift = async (params) => {
+    events.push(`start-${params.i}`);
+    await sleep(10);
+    events.push(`end-${params.i}`);
+    return { ok: true };
+  };
+  await liftSlotsPool(
+    Array.from({ length: 4 }, (_, i) => ({ i })),
+    { liftFn: fakeLift, concurrency: 4 },
+  );
+  ok(
+    events[0] === 'start-0' && events[1] === 'end-0',
+    'warmup completes before any pool slot starts',
+  );
+}
+
+// ── error isolation ──
+{
+  const fakeLift = async (params) => {
+    if (params.i === 2) throw new Error('boom');
+    return { good: params.i };
+  };
+  const results = await liftSlotsPool(
+    Array.from({ length: 4 }, (_, i) => ({ i })),
+    { liftFn: fakeLift, concurrency: 2 },
+  );
+  ok(results[2].error === 'boom', 'failing slot becomes {error}, does not reject the pool');
+  ok(results[1].good === 1 && results[3].good === 3, 'other slots unaffected');
+}
+
+// ── 429 cooldown: onThrottle pushes shared cooldown that delays new starts ──
+{
+  const startTimes = [];
+  const t0 = Date.now();
+  const fakeLift = async (params, opts) => {
+    startTimes.push({ i: params.i, at: Date.now() - t0 });
+    if (params.i === 1) opts.onThrottle(); // simulate a 429 on slot 1
+    await sleep(10);
+    return { ok: true };
+  };
+  // shrink cooldown window for the test by monkey-scale: cooldown is 15s in
+  // prod — here we only assert that slots starting AFTER the throttle wait
+  // (i.e. no new start within the first 100ms after the throttle fires).
+  const p = liftSlotsPool(
+    Array.from({ length: 4 }, (_, i) => ({ i })),
+    { liftFn: fakeLift, concurrency: 1 },
+  );
+  const timeout = sleep(1200).then(() => 'timeout');
+  const winner = await Promise.race([p.then(() => 'done'), timeout]);
+  ok(winner === 'timeout', 'post-429 slots wait out the cooldown (pool still running at 1.2s)');
+  // don't await p (15s cooldown) — verified the delay exists, that's the contract
+}
+
+console.log(`\n${pass} passed, ${fail} failed`);
+process.exit(fail ? 1 : 0);

--- a/sdf-js/src/present/news/full-deck.js
+++ b/sdf-js/src/present/news/full-deck.js
@@ -11,7 +11,7 @@
 import { expandNews } from './expand-core.js';
 import { getScaffold, getThemeAffinity } from '../scaffolds/registry.js';
 import { mapSlidesToSlotsLLM, scoreSlideForSlot } from '../scaffolds/mapper-llm.js';
-import { buildLiftSystemPrompt, liftSlotLLM } from '../scaffolds/lift-slot-llm.js';
+import { buildLiftSystemPrompt, liftSlotsPool } from '../scaffolds/lift-slot-llm.js';
 
 /**
  * newsToFullDeck(text, opts) → exporter-ready deck
@@ -84,34 +84,44 @@ export async function newsToFullDeck(
   onProgress('building lift prompt…', 12);
   const systemPrompt = await buildLiftSystemPrompt();
 
+  // Parallel lift (Sprint 34): warmup + bounded pool via liftSlotsPool —
+  // 14 serial calls (~95s) become 1 warmup + 13 over 5 workers (~30-40s).
   const live = assignments.filter((a) => !a.empty);
+  let done = 0;
+  const poolResults = await liftSlotsPool(
+    live.map((a) => ({
+      scaffold,
+      slot: a.slot,
+      slotIdx: a.slotIdx,
+      slideIdx: a.slideIdx,
+      theme,
+      slide: slides[a.slideIdx],
+      slides,
+      extraSlides: a.extraSlides || [],
+    })),
+    {
+      apiKey,
+      systemPrompt,
+      onSlotDone: () => {
+        done++;
+        onProgress(`lifted ${done}/${live.length} slots…`, 15 + (done / live.length) * 80);
+      },
+    },
+  );
   const slots = [];
   const errors = [];
   for (let i = 0; i < live.length; i++) {
     const a = live[i];
-    onProgress(`lifting ${i + 1}/${live.length} (${a.slot.name})…`, 15 + (i / live.length) * 80);
-    try {
-      const { sceneData } = await liftSlotLLM(
-        {
-          scaffold,
-          slot: a.slot,
-          slotIdx: a.slotIdx,
-          slideIdx: a.slideIdx,
-          theme,
-          slide: slides[a.slideIdx],
-          slides,
-          extraSlides: a.extraSlides || [],
-        },
-        { apiKey, systemPrompt },
-      );
+    const r = poolResults[i];
+    if (r && !r.error) {
       slots.push({
         slotIdx: a.slotIdx,
         slotName: a.slot.name,
         slotTitle: a.slot.title,
-        sceneData,
+        sceneData: r.sceneData,
       });
-    } catch (e) {
-      errors.push({ slot: a.slot.name, message: e.message });
+    } else {
+      errors.push({ slot: a.slot.name, message: r?.error || 'unknown' });
     }
   }
 

--- a/sdf-js/src/present/scaffolds/lift-slot-llm.js
+++ b/sdf-js/src/present/scaffolds/lift-slot-llm.js
@@ -249,28 +249,50 @@ export function parseSceneJson(text) {
 
 // One fetch to the Anthropic API with the lift system prompt cached.
 // Returns { sceneData, usage, costUSD, elapsed }.
-export async function liftSlotLLM(params, { apiKey, systemPrompt, model = LIFT_MODEL }) {
+export async function liftSlotLLM(
+  params,
+  { apiKey, systemPrompt, model = LIFT_MODEL, onThrottle },
+) {
   if (!apiKey) throw new Error('liftSlotLLM: apiKey required');
   const userMessage = buildSlotUserMessage(params);
   const t0 = Date.now();
-  const res = await fetch('https://api.anthropic.com/v1/messages', {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      'x-api-key': apiKey,
-      'anthropic-version': '2023-06-01',
-      'anthropic-dangerous-direct-browser-access': 'true',
-    },
-    body: JSON.stringify({
-      model,
-      max_tokens: 16384,
-      system: [{ type: 'text', text: systemPrompt, cache_control: { type: 'ephemeral' } }],
-      messages: [{ role: 'user', content: userMessage }],
-    }),
-  });
+  // Retry with exponential backoff on 429/5xx/network (Sprint 34 — a lift
+  // that dies on one transient 429 kills a whole page of the deck).
+  let lastErr;
+  let data;
+  for (let attempt = 0; attempt < 3 && !data; attempt++) {
+    if (attempt > 0) await new Promise((r) => setTimeout(r, 2000 * 4 ** (attempt - 1)));
+    try {
+      const res = await fetch('https://api.anthropic.com/v1/messages', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'x-api-key': apiKey,
+          'anthropic-version': '2023-06-01',
+          'anthropic-dangerous-direct-browser-access': 'true',
+        },
+        body: JSON.stringify({
+          model,
+          max_tokens: 16384,
+          system: [{ type: 'text', text: systemPrompt, cache_control: { type: 'ephemeral' } }],
+          messages: [{ role: 'user', content: userMessage }],
+        }),
+      });
+      if (!res.ok) {
+        const err = new Error(`Anthropic ${res.status}: ${(await res.text()).slice(0, 300)}`);
+        if (res.status !== 429 && res.status < 500) throw err;
+        if (res.status === 429 && onThrottle) onThrottle();
+        lastErr = err;
+        continue;
+      }
+      data = await res.json();
+    } catch (e) {
+      if (e.message?.startsWith('Anthropic 4') && !e.message.startsWith('Anthropic 429')) throw e;
+      lastErr = e; // network hiccup — loop
+    }
+  }
+  if (!data) throw lastErr;
   const elapsed = ((Date.now() - t0) / 1000).toFixed(1);
-  if (!res.ok) throw new Error(`Anthropic ${res.status}: ${(await res.text()).slice(0, 300)}`);
-  const data = await res.json();
   const usage = data.usage;
   const inCost = (usage.input_tokens * 3) / 1_000_000;
   const cacheCreateCost = ((usage.cache_creation_input_tokens || 0) * 3.75) / 1_000_000;
@@ -278,4 +300,60 @@ export async function liftSlotLLM(params, { apiKey, systemPrompt, model = LIFT_M
   const outCost = (usage.output_tokens * 15) / 1_000_000;
   const costUSD = inCost + cacheCreateCost + cacheReadCost + outCost;
   return { sceneData: parseSceneJson(data.content[0].text), usage, costUSD, elapsed };
+}
+
+/**
+ * liftSlotsPool — lift many slots concurrently without breaking the prompt
+ * cache or the user's rate limit (Sprint 34):
+ *
+ *   1. WARMUP: the first slot runs ALONE so its call writes the (large)
+ *      system prompt into Anthropic's prompt cache — 14 simultaneous first
+ *      calls would each pay full-price cache_creation.
+ *   2. BOUNDED POOL: remaining slots run under `concurrency` workers
+ *      (default 5 — safe for low-tier BYOK keys, still ~3-4× faster).
+ *   3. 429-ADAPTIVE: any throttled call pushes a shared cooldown; workers
+ *      wait it out before starting new slots (graceful degrade toward
+ *      serial instead of blowing up the page).
+ *
+ * @param {object[]} paramsList — buildSlotUserMessage params per slot
+ * @param {object} opts — { apiKey, systemPrompt, model?, concurrency=5,
+ *   onSlotDone(i, result)?, liftFn? (test injection) }
+ * @returns results[] aligned with paramsList; each { sceneData, usage,
+ *   costUSD, elapsed } or { error }
+ */
+export async function liftSlotsPool(paramsList, opts) {
+  const { concurrency = 5, onSlotDone = () => {}, liftFn = liftSlotLLM } = opts;
+  const results = new Array(paramsList.length);
+  if (paramsList.length === 0) return results;
+
+  const throttle = { until: 0 };
+  const run = async (i) => {
+    const waitMs = throttle.until - Date.now();
+    if (waitMs > 0) await new Promise((r) => setTimeout(r, waitMs));
+    try {
+      results[i] = await liftFn(paramsList[i], {
+        ...opts,
+        onThrottle: () => {
+          throttle.until = Date.now() + 15000;
+        },
+      });
+    } catch (e) {
+      results[i] = { error: e.message };
+    }
+    onSlotDone(i, results[i]);
+  };
+
+  await run(0); // warmup — writes the system-prompt cache
+  let next = 1;
+  const workers = Array.from(
+    { length: Math.max(1, Math.min(concurrency, paramsList.length - 1)) },
+    async () => {
+      while (next < paramsList.length) {
+        const i = next++;
+        await run(i);
+      }
+    },
+  );
+  await Promise.all(workers);
+  return results;
 }


### PR DESCRIPTION
按讨论的方案实现 (b)。

## 设计 → 实现 (共享模块, 双端同吃)

`liftSlotsPool` 落在 `lift-slot-llm.js` (不是 author-2d 私有):

1. **预热**: slot 0 单独先跑, 一次调用写入 13k-token system prompt 缓存 — 避免 14 个并发首调各付全价 cache_creation。实测: warmup 付 13,008 创建 token, 其余 12 slot 共读 169,104 缓存 token, **总成本与串行持平** ($0.35/deck)
2. **有界池**: 并发 5 (低 tier BYOK key 安全; 按讨论不暴露旋钮)
3. **429 自适应**: liftSlotLLM 补指数退避重试 (此前是唯一没保护的 LLM 调用); 任何 429 推 15s 共享冷却, workers 等待后再取新任务 — 优雅降级到近串行, 永不炸页面

## 实测 (质量不降: 98.2 分 / 13 页 / precision 85%)

| 路径 | 之前 | 现在 |
|---|---|---|
| 浏览器整本端到端 | ~120s | **54s** (lift 阶段 95s→24s, 4×) |
| CLI news-to-deck | ~150s | **50.6s** (3×) |

剩余 ~30s 是 expand+map 的串行依赖, 不可池化。CLI 提速的复利: 以后每轮语料重 bake / 对抗迭代周转快 3 倍。

## Tests
127/127 — 新 test-lift-pool.mjs 8 断言 (注入 fake liftFn: 预热隔离 / 并发上限 / 错误隔离 / 冷却生效)

🤖 Generated with [Claude Code](https://claude.com/claude-code)