### PR TITLE
Sprint 36: 视觉对抗轴 — 插桩渲染六类判定 + cover 标题自适配, 117→84

### DIFF
--- a/docs/superpowers/sprint36-visual-adversarial.md
+++ b/docs/superpowers/sprint36-visual-adversarial.md
@@ -1,0 +1,39 @@
+# Sprint 36 — 视觉对抗轴 (2026-07-07)
+
+文本四轴 (facts/entities × recall/precision) 看不见"渲染坏了"的 slide。
+视觉轴 = **插桩渲染**: 真跑每个 atom 的绘制代码, 录制 fillText/fillRect +
+完整仿射变换 (旋转轴标签必须跟踪 transform, 否则假坐标), 确定性判六类:
+
+| 判定 | 含义 |
+|---|---|
+| RENDER_CRASH | atom 绘制抛异常 |
+| OUT_OF_BOUNDS | 墨水画出 1280×720 画布 (+8px 容差) |
+| TEXT_OVERFLOW | 字符串估宽 (CJK 1.0×fs / Latin 0.58×fs) 冲出右缘 |
+| TINY_FONT | < 9px 文字 (deck 尺度不可读) |
+| TEXT_COLLISION | 跨 subject 文字框重叠 > 40% |
+| SUBJECT_OVERLAP | 非 cover subject 声明框重叠 > 25% |
+| BLANK_SLOT | 全渲染 < 5 次落墨 (纯 cover 页豁免) |
+
+入口: `visual-audit.mjs` (auditSlotVisual/auditDeckVisual), 已接进
+eval scorer (VISUAL 块, report-only 不进 composite) + a16z 复验器 (visual 列)。
+
+## 首轮扫描 (39 decks) 与已修
+
+初扫 **117 issues** → 修复后 **84**:
+- **cover 标题无宽度自适应 (26 例, 最大真问题簇)**: titleSize=h*0.14 直画,
+  a16z 长英文标题冲出右缘 ~400px。修: shrink-to-fit (floor 20px), 副标题同。
+  浏览器截图交叉验证 raise-15b 首页 ✓
+- 指标噪音: 纯 cover 页误报 BLANK / 装饰性单字符引号误报 OOB / rotate 轴标签
+  假坐标 (transform 跟踪修复)
+
+## 剩余 84 = 下轮打磨排序清单
+
+- **TINY_FONT ×45** (最大簇): icon-grid ×9 / stat-with-icon ×7 / stat-banner ×7 /
+  dashboard ×4 …— fit-to-space 缩字无下限 (最恶劣 callout-banner 3px)。
+  修法样板 = stat-banner 的 fitLabelSize (floor + 换行)
+- TEXT_OVERFLOW ×20: isotype-stat-comparison ×11 领跑 (长 label 无适配)
+- SUBJECT_OVERLAP ×9 + TEXT_COLLISION ×5: LLM 排版错误 (100% 重叠框) —
+  候选修法: lift prompt 加排版规则 或 lift 后确定性推挤
+- OUT_OF_BOUNDS ×5
+
+方法论: 仪器先行 → 全量测量 → 修最大簇 → 复测。117→84 是第一轮, 清单已排序。

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -207,6 +207,7 @@ const TESTS = [
   { category: 'present', file: 'sdf-js/scripts/test-eval-harness.mjs' },
   { category: 'present', file: 'sdf-js/scripts/test-expand-news.mjs' },
   { category: 'present', file: 'sdf-js/scripts/test-lift-pool.mjs' },
+  { category: 'present', file: 'sdf-js/scripts/test-visual-audit.mjs' },
 ];
 
 // -----------------------------------------------------------------------------

--- a/sdf-js/examples/scaffold-pipeline/econ-news-2026/eval.json
+++ b/sdf-js/examples/scaffold-pipeline/econ-news-2026/eval.json
@@ -1,6 +1,6 @@
 {
-  "deckDir": "/Users/hexiaoyang/Documents/sdf-main/sdf-js/examples/scaffold-pipeline/eval-econ-news-2026",
-  "deckName": "eval-econ-news-2026",
+  "deckDir": "/Users/hexiaoyang/Documents/sdf-main/sdf-js/examples/scaffold-pipeline/econ-news-2026",
+  "deckName": "econ-news-2026",
   "structure": {
     "slots_total": 8,
     "slots_baked": 6,
@@ -12,9 +12,9 @@
     "theme_id": "editorial-navy"
   },
   "atomQuality": {
-    "atom_instances": 14,
-    "atom_types_distinct": 6,
-    "variety_ratio": 0.42857142857142855,
+    "atom_instances": 12,
+    "atom_types_distinct": 8,
+    "variety_ratio": 0.6666666666666666,
     "unknown_atom_count": 0,
     "unknown_atom_types": [],
     "arg_violations": 0,
@@ -28,30 +28,19 @@
     "lift_errors": [],
     "lifted_subject_rate": 1
   },
-  "visual": {
-    "total": 0,
-    "counts": {},
-    "slots_with_issues": []
-  },
   "textBudget": {
-    "chars_per_slot": 99.16666666666667,
-    "max_slot_chars": 128
+    "chars_per_slot": 207.83333333333334,
+    "max_slot_chars": 367
   },
   "fidelity": {
     "numbers_total": 11,
     "numbers_found": 11,
     "number_recall": 1,
     "missing_numbers": [],
-    "deck_numbers_total": 10,
-    "hallucinated_numbers": [],
-    "deck_entities_total": 8,
-    "hallucinated_entities": [],
-    "entity_precision": 1,
-    "number_precision": 1,
     "entities_total": 6,
-    "entities_found": 6,
-    "entity_recall": 1,
-    "missing_entities": []
+    "entities_found": 4,
+    "entity_recall": 0.6666666666666666,
+    "missing_entities": ["英国央行", "欧洲央行"]
   },
   "score": {
     "total": 93.8,
@@ -64,5 +53,5 @@
       "text": 10
     }
   },
-  "generatedAt": "2026-07-07T06:11:33.181Z"
+  "generatedAt": "2026-07-06T15:33:48.137Z"
 }

--- a/sdf-js/examples/scaffold-pipeline/eval-antfun-company/eval.json
+++ b/sdf-js/examples/scaffold-pipeline/eval-antfun-company/eval.json
@@ -28,6 +28,11 @@
     "lift_errors": [],
     "lifted_subject_rate": 1
   },
+  "visual": {
+    "total": 0,
+    "counts": {},
+    "slots_with_issues": []
+  },
   "textBudget": {
     "chars_per_slot": 303.14285714285717,
     "max_slot_chars": 477
@@ -61,5 +66,5 @@
       "text": 9.3
     }
   },
-  "generatedAt": "2026-07-07T05:17:25.045Z"
+  "generatedAt": "2026-07-07T06:11:33.127Z"
 }

--- a/sdf-js/examples/scaffold-pipeline/eval-edu-course-intro/eval.json
+++ b/sdf-js/examples/scaffold-pipeline/eval-edu-course-intro/eval.json
@@ -28,6 +28,11 @@
     "lift_errors": [],
     "lifted_subject_rate": 1
   },
+  "visual": {
+    "total": 0,
+    "counts": {},
+    "slots_with_issues": []
+  },
   "textBudget": {
     "chars_per_slot": 259.2857142857143,
     "max_slot_chars": 341
@@ -64,5 +69,5 @@
       "text": 10
     }
   },
-  "generatedAt": "2026-07-07T05:17:25.070Z"
+  "generatedAt": "2026-07-07T06:11:33.173Z"
 }

--- a/sdf-js/examples/scaffold-pipeline/eval-news-econ/eval.json
+++ b/sdf-js/examples/scaffold-pipeline/eval-news-econ/eval.json
@@ -28,6 +28,45 @@
     "lift_errors": [],
     "lifted_subject_rate": 1
   },
+  "visual": {
+    "total": 3,
+    "counts": {
+      "TINY_FONT": 2,
+      "OUT_OF_BOUNDS": 1
+    },
+    "slots_with_issues": [
+      {
+        "slotIdx": 4,
+        "slotName": "theme-1-detail",
+        "issues": [
+          {
+            "kind": "TINY_FONT",
+            "subject": 2,
+            "type": "stat-with-icon",
+            "detail": "\"增速排名\" at 8.0px"
+          },
+          {
+            "kind": "TINY_FONT",
+            "subject": 3,
+            "type": "stat-with-icon",
+            "detail": "\"贡献来源\" at 8.0px"
+          }
+        ]
+      },
+      {
+        "slotIdx": 11,
+        "slotName": "quote",
+        "issues": [
+          {
+            "kind": "OUT_OF_BOUNDS",
+            "subject": 1,
+            "type": "pull-quote-banner",
+            "detail": "\"新兴市场和发展中经济体将面临疫情以来最弱的人均收入增长\" at (-170,333)"
+          }
+        ]
+      }
+    ]
+  },
   "textBudget": {
     "chars_per_slot": 79,
     "max_slot_chars": 130
@@ -61,5 +100,5 @@
       "text": 10
     }
   },
-  "generatedAt": "2026-07-07T05:17:25.080Z"
+  "generatedAt": "2026-07-07T06:11:33.187Z"
 }

--- a/sdf-js/examples/scaffold-pipeline/eval-news-policy/eval.json
+++ b/sdf-js/examples/scaffold-pipeline/eval-news-policy/eval.json
@@ -28,6 +28,37 @@
     "lift_errors": [],
     "lifted_subject_rate": 1
   },
+  "visual": {
+    "total": 2,
+    "counts": {
+      "SUBJECT_OVERLAP": 1,
+      "OUT_OF_BOUNDS": 1
+    },
+    "slots_with_issues": [
+      {
+        "slotIdx": 3,
+        "slotName": "theme-1-lead",
+        "issues": [
+          {
+            "kind": "SUBJECT_OVERLAP",
+            "detail": "bar[1] × kpi-card[2] overlap 100%"
+          }
+        ]
+      },
+      {
+        "slotIdx": 11,
+        "slotName": "quote",
+        "issues": [
+          {
+            "kind": "OUT_OF_BOUNDS",
+            "subject": 1,
+            "type": "pull-quote-banner",
+            "detail": "\"中央财政安排专项补贴120亿元，地方配套资金约200亿元，合\" at (-731,350)"
+          }
+        ]
+      }
+    ]
+  },
   "textBudget": {
     "chars_per_slot": 74,
     "max_slot_chars": 128
@@ -64,5 +95,5 @@
       "text": 10
     }
   },
-  "generatedAt": "2026-07-07T05:17:25.087Z"
+  "generatedAt": "2026-07-07T06:11:33.190Z"
 }

--- a/sdf-js/examples/scaffold-pipeline/eval-nonprofit-annual-report/eval.json
+++ b/sdf-js/examples/scaffold-pipeline/eval-nonprofit-annual-report/eval.json
@@ -28,6 +28,51 @@
     "lift_errors": [],
     "lifted_subject_rate": 1
   },
+  "visual": {
+    "total": 4,
+    "counts": {
+      "TINY_FONT": 3,
+      "TEXT_OVERFLOW": 1
+    },
+    "slots_with_issues": [
+      {
+        "slotIdx": 2,
+        "slotName": "highlights-kpi",
+        "issues": [
+          {
+            "kind": "TINY_FONT",
+            "subject": 2,
+            "type": "testimonial-wall",
+            "detail": "\"Monthly donor since 2019\" at 6.0px"
+          },
+          {
+            "kind": "TINY_FONT",
+            "subject": 2,
+            "type": "testimonial-wall",
+            "detail": "\"Village Chief, Tanzania\" at 6.0px"
+          },
+          {
+            "kind": "TINY_FONT",
+            "subject": 2,
+            "type": "testimonial-wall",
+            "detail": "\"Foundation Program Officer\" at 6.0px"
+          }
+        ]
+      },
+      {
+        "slotIdx": 3,
+        "slotName": "income",
+        "issues": [
+          {
+            "kind": "TEXT_OVERFLOW",
+            "subject": 2,
+            "type": "pie",
+            "detail": "\"Individual Donors · 52%  52%\" ends at x=1379"
+          }
+        ]
+      }
+    ]
+  },
   "textBudget": {
     "chars_per_slot": 242,
     "max_slot_chars": 541
@@ -66,5 +111,5 @@
       "text": 10
     }
   },
-  "generatedAt": "2026-07-07T05:17:25.072Z"
+  "generatedAt": "2026-07-07T06:11:33.175Z"
 }

--- a/sdf-js/examples/scaffold-pipeline/eval-product-eng-retro/eval.json
+++ b/sdf-js/examples/scaffold-pipeline/eval-product-eng-retro/eval.json
@@ -34,6 +34,11 @@
     "lift_errors": [],
     "lifted_subject_rate": 1
   },
+  "visual": {
+    "total": 0,
+    "counts": {},
+    "slots_with_issues": []
+  },
   "textBudget": {
     "chars_per_slot": 229.33333333333334,
     "max_slot_chars": 442
@@ -81,5 +86,5 @@
       "text": 10
     }
   },
-  "generatedAt": "2026-07-07T05:17:25.074Z"
+  "generatedAt": "2026-07-07T06:11:33.178Z"
 }

--- a/sdf-js/examples/scaffold-pipeline/eval-qbr-q3-2026/eval.json
+++ b/sdf-js/examples/scaffold-pipeline/eval-qbr-q3-2026/eval.json
@@ -28,6 +28,11 @@
     "lift_errors": [],
     "lifted_subject_rate": 1
   },
+  "visual": {
+    "total": 0,
+    "counts": {},
+    "slots_with_issues": []
+  },
   "textBudget": {
     "chars_per_slot": 179.28571428571428,
     "max_slot_chars": 285
@@ -72,5 +77,5 @@
       "text": 10
     }
   },
-  "generatedAt": "2026-07-07T05:17:25.051Z"
+  "generatedAt": "2026-07-07T06:11:33.132Z"
 }

--- a/sdf-js/examples/scaffold-pipeline/eval-strategy-batch2-validation/eval.json
+++ b/sdf-js/examples/scaffold-pipeline/eval-strategy-batch2-validation/eval.json
@@ -28,6 +28,38 @@
     "lift_errors": [],
     "lifted_subject_rate": 1
   },
+  "visual": {
+    "total": 2,
+    "counts": {
+      "TINY_FONT": 2
+    },
+    "slots_with_issues": [
+      {
+        "slotIdx": 1,
+        "slotName": "case-for-change",
+        "issues": [
+          {
+            "kind": "TINY_FONT",
+            "subject": 1,
+            "type": "stat-banner",
+            "detail": "\"↑117% YoY\" at 7.0px"
+          }
+        ]
+      },
+      {
+        "slotIdx": 3,
+        "slotName": "target-state",
+        "issues": [
+          {
+            "kind": "TINY_FONT",
+            "subject": 3,
+            "type": "stat-banner",
+            "detail": "\"On Track\" at 7.0px"
+          }
+        ]
+      }
+    ]
+  },
   "textBudget": {
     "chars_per_slot": 312.375,
     "max_slot_chars": 489
@@ -76,5 +108,5 @@
       "text": 9
     }
   },
-  "generatedAt": "2026-07-07T05:17:25.056Z"
+  "generatedAt": "2026-07-07T06:11:33.139Z"
 }

--- a/sdf-js/examples/scaffold-pipeline/eval-strategy-swot-portfolio/eval.json
+++ b/sdf-js/examples/scaffold-pipeline/eval-strategy-swot-portfolio/eval.json
@@ -28,6 +28,31 @@
     "lift_errors": [],
     "lifted_subject_rate": 1
   },
+  "visual": {
+    "total": 2,
+    "counts": {
+      "TINY_FONT": 1,
+      "SUBJECT_OVERLAP": 1
+    },
+    "slots_with_issues": [
+      {
+        "slotIdx": 3,
+        "slotName": "data-findings",
+        "issues": [
+          {
+            "kind": "TINY_FONT",
+            "subject": 2,
+            "type": "callout-banner",
+            "detail": "\"Quote sourced from 32-customer\" at 5.0px"
+          },
+          {
+            "kind": "SUBJECT_OVERLAP",
+            "detail": "testimonial-wall[1] × callout-banner[2] overlap 100%"
+          }
+        ]
+      }
+    ]
+  },
   "textBudget": {
     "chars_per_slot": 287.625,
     "max_slot_chars": 525
@@ -71,5 +96,5 @@
       "text": 9.8
     }
   },
-  "generatedAt": "2026-07-07T05:17:25.059Z"
+  "generatedAt": "2026-07-07T06:11:33.146Z"
 }

--- a/sdf-js/examples/scaffold-pipeline/eval-swot-portfolio-2026/eval.json
+++ b/sdf-js/examples/scaffold-pipeline/eval-swot-portfolio-2026/eval.json
@@ -34,6 +34,45 @@
     "lift_errors": [],
     "lifted_subject_rate": 1
   },
+  "visual": {
+    "total": 3,
+    "counts": {
+      "TINY_FONT": 2,
+      "OUT_OF_BOUNDS": 1
+    },
+    "slots_with_issues": [
+      {
+        "slotIdx": 1,
+        "slotName": "tldr",
+        "issues": [
+          {
+            "kind": "TINY_FONT",
+            "subject": 1,
+            "type": "stat-banner",
+            "detail": "\"+62% ARR\" at 7.0px"
+          },
+          {
+            "kind": "TINY_FONT",
+            "subject": 5,
+            "type": "quote-pull",
+            "detail": "\"Investment Review 2026 · 47 ex\" at 6.0px"
+          }
+        ]
+      },
+      {
+        "slotIdx": 2,
+        "slotName": "metrics",
+        "issues": [
+          {
+            "kind": "OUT_OF_BOUNDS",
+            "subject": 2,
+            "type": "value-chain-diagram",
+            "detail": "\"Risk-Adjusted Returns\" at (1172,396)"
+          }
+        ]
+      }
+    ]
+  },
   "textBudget": {
     "chars_per_slot": 262.1666666666667,
     "max_slot_chars": 340
@@ -65,5 +104,5 @@
       "text": 10
     }
   },
-  "generatedAt": "2026-07-07T05:17:25.061Z"
+  "generatedAt": "2026-07-07T06:11:33.149Z"
 }

--- a/sdf-js/examples/scaffold-pipeline/eval-vc-pitch/eval.json
+++ b/sdf-js/examples/scaffold-pipeline/eval-vc-pitch/eval.json
@@ -34,6 +34,33 @@
     "lift_errors": [],
     "lifted_subject_rate": 1
   },
+  "visual": {
+    "total": 3,
+    "counts": {
+      "TEXT_COLLISION": 2,
+      "SUBJECT_OVERLAP": 1
+    },
+    "slots_with_issues": [
+      {
+        "slotIdx": 7,
+        "slotName": "business-model",
+        "issues": [
+          {
+            "kind": "TEXT_COLLISION",
+            "detail": "\"$2.7M\" (subj 2) × \"Projected Q3 2027\" (subj 3)"
+          },
+          {
+            "kind": "TEXT_COLLISION",
+            "detail": "\"$3.6M\" (subj 2) × \"$3M ARR\" (subj 3)"
+          },
+          {
+            "kind": "SUBJECT_OVERLAP",
+            "detail": "break-even[2] × kpi-card[3] overlap 100%"
+          }
+        ]
+      }
+    ]
+  },
   "textBudget": {
     "chars_per_slot": 196.22222222222223,
     "max_slot_chars": 264
@@ -77,5 +104,5 @@
       "text": 10
     }
   },
-  "generatedAt": "2026-07-07T05:17:25.065Z"
+  "generatedAt": "2026-07-07T06:11:33.163Z"
 }

--- a/sdf-js/examples/scaffold-pipeline/eval-yosemite-trip-2026/eval.json
+++ b/sdf-js/examples/scaffold-pipeline/eval-yosemite-trip-2026/eval.json
@@ -28,6 +28,11 @@
     "lift_errors": [],
     "lifted_subject_rate": 1
   },
+  "visual": {
+    "total": 0,
+    "counts": {},
+    "slots_with_issues": []
+  },
   "textBudget": {
     "chars_per_slot": 142.85714285714286,
     "max_slot_chars": 180
@@ -62,5 +67,5 @@
       "text": 10
     }
   },
-  "generatedAt": "2026-07-07T05:17:25.067Z"
+  "generatedAt": "2026-07-07T06:11:33.168Z"
 }

--- a/sdf-js/examples/scaffold-pipeline/news-econ-run1/eval.json
+++ b/sdf-js/examples/scaffold-pipeline/news-econ-run1/eval.json
@@ -39,8 +39,28 @@
     "lift_errors": [],
     "lifted_subject_rate": 1
   },
+  "visual": {
+    "total": 1,
+    "counts": {
+      "TINY_FONT": 1
+    },
+    "slots_with_issues": [
+      {
+        "slotIdx": 4,
+        "slotName": "theme-1-detail",
+        "issues": [
+          {
+            "kind": "TINY_FONT",
+            "subject": 2,
+            "type": "stat-with-icon",
+            "detail": "\"中国\" at 8.0px"
+          }
+        ]
+      }
+    ]
+  },
   "textBudget": {
-    "chars_per_slot": 95,
+    "chars_per_slot": 92.07142857142857,
     "max_slot_chars": 202
   },
   "fidelity": {
@@ -48,8 +68,14 @@
     "numbers_found": 11,
     "number_recall": 1,
     "missing_numbers": [],
-    "entities_total": 9,
-    "entities_found": 9,
+    "deck_numbers_total": 12,
+    "hallucinated_numbers": [],
+    "deck_entities_total": 8,
+    "hallucinated_entities": [],
+    "entity_precision": 1,
+    "number_precision": 1,
+    "entities_total": 8,
+    "entities_found": 8,
     "entity_recall": 1,
     "missing_entities": []
   },
@@ -64,5 +90,5 @@
       "text": 10
     }
   },
-  "generatedAt": "2026-07-06T16:50:56.213Z"
+  "generatedAt": "2026-07-07T06:09:09.961Z"
 }

--- a/sdf-js/examples/scaffold-pipeline/news-econ-run2/eval.json
+++ b/sdf-js/examples/scaffold-pipeline/news-econ-run2/eval.json
@@ -1,0 +1,63 @@
+{
+  "deckDir": "/Users/hexiaoyang/Documents/sdf-main/sdf-js/examples/scaffold-pipeline/news-econ-run2",
+  "deckName": "news-econ-run2",
+  "structure": {
+    "slots_total": 14,
+    "slots_baked": 14,
+    "slots_empty": 0,
+    "slots_errored": 0,
+    "fill_rate": 1,
+    "pick_method": "forced",
+    "scaffold_id": "news-briefing",
+    "theme_id": "editorial-navy"
+  },
+  "atomQuality": {
+    "atom_instances": 20,
+    "atom_types_distinct": 11,
+    "variety_ratio": 0.55,
+    "unknown_atom_count": 0,
+    "unknown_atom_types": [],
+    "arg_violations": 1,
+    "arg_violations_top_offenders": [
+      {
+        "type": "kpi-card",
+        "key": "trendDirection",
+        "count": 1
+      }
+    ]
+  },
+  "threeDReadiness": {
+    "twin_coverage": 1,
+    "untwinned_types": [],
+    "lift_success": 14,
+    "lift_attempted": 14,
+    "lift_errors": [],
+    "lifted_subject_rate": 1
+  },
+  "textBudget": {
+    "chars_per_slot": 72.35714285714286,
+    "max_slot_chars": 153
+  },
+  "fidelity": {
+    "numbers_total": 11,
+    "numbers_found": 11,
+    "number_recall": 1,
+    "missing_numbers": [],
+    "entities_total": 7,
+    "entities_found": 7,
+    "entity_recall": 1,
+    "missing_entities": []
+  },
+  "score": {
+    "total": 100,
+    "breakdown": {
+      "structure": 25,
+      "variety": 15,
+      "hallucination": 15,
+      "twin": 20,
+      "lift": 15,
+      "text": 10
+    }
+  },
+  "generatedAt": "2026-07-06T16:18:37.641Z"
+}

--- a/sdf-js/examples/scaffold-pipeline/news-policy-run1/eval.json
+++ b/sdf-js/examples/scaffold-pipeline/news-policy-run1/eval.json
@@ -1,0 +1,63 @@
+{
+  "deckDir": "/Users/hexiaoyang/Documents/sdf-main/sdf-js/examples/scaffold-pipeline/news-policy-run1",
+  "deckName": "news-policy-run1",
+  "structure": {
+    "slots_total": 14,
+    "slots_baked": 13,
+    "slots_empty": 1,
+    "slots_errored": 0,
+    "fill_rate": 0.9285714285714286,
+    "pick_method": "forced",
+    "scaffold_id": "news-briefing",
+    "theme_id": "editorial-navy"
+  },
+  "atomQuality": {
+    "atom_instances": 27,
+    "atom_types_distinct": 13,
+    "variety_ratio": 0.48148148148148145,
+    "unknown_atom_count": 0,
+    "unknown_atom_types": [],
+    "arg_violations": 2,
+    "arg_violations_top_offenders": [
+      {
+        "type": "kpi-card",
+        "key": "trendDirection",
+        "count": 2
+      }
+    ]
+  },
+  "threeDReadiness": {
+    "twin_coverage": 1,
+    "untwinned_types": [],
+    "lift_success": 13,
+    "lift_attempted": 13,
+    "lift_errors": [],
+    "lifted_subject_rate": 1
+  },
+  "textBudget": {
+    "chars_per_slot": 69.15384615384616,
+    "max_slot_chars": 111
+  },
+  "fidelity": {
+    "numbers_total": 21,
+    "numbers_found": 21,
+    "number_recall": 1,
+    "missing_numbers": [],
+    "entities_total": 0,
+    "entities_found": 0,
+    "entity_recall": 1,
+    "missing_entities": []
+  },
+  "score": {
+    "total": 98.2,
+    "breakdown": {
+      "structure": 23.2,
+      "variety": 15,
+      "hallucination": 15,
+      "twin": 20,
+      "lift": 15,
+      "text": 10
+    }
+  },
+  "generatedAt": "2026-07-06T16:55:11.573Z"
+}

--- a/sdf-js/examples/scaffold-pipeline/news-policy-run2/eval.json
+++ b/sdf-js/examples/scaffold-pipeline/news-policy-run2/eval.json
@@ -1,0 +1,63 @@
+{
+  "deckDir": "/Users/hexiaoyang/Documents/sdf-main/sdf-js/examples/scaffold-pipeline/news-policy-run2",
+  "deckName": "news-policy-run2",
+  "structure": {
+    "slots_total": 14,
+    "slots_baked": 13,
+    "slots_empty": 1,
+    "slots_errored": 0,
+    "fill_rate": 0.9285714285714286,
+    "pick_method": "forced",
+    "scaffold_id": "news-briefing",
+    "theme_id": "editorial-navy"
+  },
+  "atomQuality": {
+    "atom_instances": 24,
+    "atom_types_distinct": 12,
+    "variety_ratio": 0.5,
+    "unknown_atom_count": 0,
+    "unknown_atom_types": [],
+    "arg_violations": 1,
+    "arg_violations_top_offenders": [
+      {
+        "type": "kpi-card",
+        "key": "trendDirection",
+        "count": 1
+      }
+    ]
+  },
+  "threeDReadiness": {
+    "twin_coverage": 1,
+    "untwinned_types": [],
+    "lift_success": 13,
+    "lift_attempted": 13,
+    "lift_errors": [],
+    "lifted_subject_rate": 1
+  },
+  "textBudget": {
+    "chars_per_slot": 69.61538461538461,
+    "max_slot_chars": 140
+  },
+  "fidelity": {
+    "numbers_total": 20,
+    "numbers_found": 20,
+    "number_recall": 1,
+    "missing_numbers": [],
+    "entities_total": 0,
+    "entities_found": 0,
+    "entity_recall": 1,
+    "missing_entities": []
+  },
+  "score": {
+    "total": 98.2,
+    "breakdown": {
+      "structure": 23.2,
+      "variety": 15,
+      "hallucination": 15,
+      "twin": 20,
+      "lift": 15,
+      "text": 10
+    }
+  },
+  "generatedAt": "2026-07-06T16:27:24.782Z"
+}

--- a/sdf-js/examples/scaffold-pipeline/news-tech-run1/eval.json
+++ b/sdf-js/examples/scaffold-pipeline/news-tech-run1/eval.json
@@ -1,0 +1,60 @@
+{
+  "deckDir": "/Users/hexiaoyang/Documents/sdf-main/sdf-js/examples/scaffold-pipeline/news-tech-run1",
+  "deckName": "news-tech-run1",
+  "structure": {
+    "slots_total": 14,
+    "slots_baked": 13,
+    "slots_empty": 1,
+    "slots_errored": 0,
+    "fill_rate": 0.9285714285714286,
+    "pick_method": "forced",
+    "scaffold_id": "news-briefing",
+    "theme_id": "editorial-navy"
+  },
+  "atomQuality": {
+    "atom_instances": 22,
+    "atom_types_distinct": 14,
+    "variety_ratio": 0.6363636363636364,
+    "unknown_atom_count": 0,
+    "unknown_atom_types": [],
+    "arg_violations": 0,
+    "arg_violations_top_offenders": []
+  },
+  "threeDReadiness": {
+    "twin_coverage": 1,
+    "untwinned_types": [],
+    "lift_success": 13,
+    "lift_attempted": 13,
+    "lift_errors": [],
+    "lifted_subject_rate": 1
+  },
+  "textBudget": {
+    "chars_per_slot": 68.23076923076923,
+    "max_slot_chars": 141
+  },
+  "fidelity": {
+    "numbers_total": 14,
+    "numbers_found": 14,
+    "number_recall": 1,
+    "missing_numbers": [],
+    "deck_numbers_total": 20,
+    "hallucinated_numbers": ["0.5", "50%", "0.65"],
+    "number_precision": 0.85,
+    "entities_total": 0,
+    "entities_found": 0,
+    "entity_recall": 1,
+    "missing_entities": []
+  },
+  "score": {
+    "total": 98.2,
+    "breakdown": {
+      "structure": 23.2,
+      "variety": 15,
+      "hallucination": 15,
+      "twin": 20,
+      "lift": 15,
+      "text": 10
+    }
+  },
+  "generatedAt": "2026-07-07T05:02:01.146Z"
+}

--- a/sdf-js/examples/scaffold-pipeline/news-tech-run2/eval.json
+++ b/sdf-js/examples/scaffold-pipeline/news-tech-run2/eval.json
@@ -1,0 +1,63 @@
+{
+  "deckDir": "/Users/hexiaoyang/Documents/sdf-main/sdf-js/examples/scaffold-pipeline/news-tech-run2",
+  "deckName": "news-tech-run2",
+  "structure": {
+    "slots_total": 14,
+    "slots_baked": 12,
+    "slots_empty": 2,
+    "slots_errored": 0,
+    "fill_rate": 0.8571428571428571,
+    "pick_method": "forced",
+    "scaffold_id": "news-briefing",
+    "theme_id": "editorial-navy"
+  },
+  "atomQuality": {
+    "atom_instances": 20,
+    "atom_types_distinct": 9,
+    "variety_ratio": 0.45,
+    "unknown_atom_count": 0,
+    "unknown_atom_types": [],
+    "arg_violations": 2,
+    "arg_violations_top_offenders": [
+      {
+        "type": "kpi-card",
+        "key": "trendDirection",
+        "count": 2
+      }
+    ]
+  },
+  "threeDReadiness": {
+    "twin_coverage": 1,
+    "untwinned_types": [],
+    "lift_success": 12,
+    "lift_attempted": 12,
+    "lift_errors": [],
+    "lifted_subject_rate": 1
+  },
+  "textBudget": {
+    "chars_per_slot": 62,
+    "max_slot_chars": 123
+  },
+  "fidelity": {
+    "numbers_total": 14,
+    "numbers_found": 14,
+    "number_recall": 1,
+    "missing_numbers": [],
+    "entities_total": 0,
+    "entities_found": 0,
+    "entity_recall": 1,
+    "missing_entities": []
+  },
+  "score": {
+    "total": 96.4,
+    "breakdown": {
+      "structure": 21.4,
+      "variety": 15,
+      "hallucination": 15,
+      "twin": 20,
+      "lift": 15,
+      "text": 10
+    }
+  },
+  "generatedAt": "2026-07-06T16:22:54.525Z"
+}

--- a/sdf-js/scripts/a16z-adversarial-report.mjs
+++ b/sdf-js/scripts/a16z-adversarial-report.mjs
@@ -117,6 +117,8 @@ for (const id of ids) {
     entPrecision: f.entity_precision != null ? Math.round(f.entity_precision * 100) : null,
     inventedEntities: f.hallucinated_entities || [],
     hallucinated: f.hallucinated_numbers || [],
+    visualIssues: ev.visual?.total ?? 0,
+    visualCounts: ev.visual?.counts || {},
     missingNumbers: f.missing_numbers || [],
     missingEntities: f.missing_entities || [],
     renderFailures,
@@ -136,14 +138,16 @@ rows.sort((a, b) => {
   return (a.facts ?? 100) - (b.facts ?? 100);
 });
 
-console.log('\ndeck                      pages band score facts% ents% prec% entP%  renderFail');
+console.log(
+  '\ndeck                      pages band score facts% ents% prec% entP% visual  renderFail',
+);
 for (const r of rows) {
   if (r.missing) {
     console.log(`${r.id.padEnd(26)} MISSING (bake failed?)`);
     continue;
   }
   console.log(
-    `${r.id.padEnd(26)}${String(r.pages).padStart(4)}  ${r.inBand ? ' ✓  ' : ' ✗  '}${String(r.score).padStart(5)}${String(r.facts ?? '—').padStart(6)}${String(r.ents ?? '—').padStart(6)}${String(r.precision ?? '—').padStart(6)}${String(r.entPrecision ?? '—').padStart(6)}  ${r.renderFailures.length || ''}`,
+    `${r.id.padEnd(26)}${String(r.pages).padStart(4)}  ${r.inBand ? ' ✓  ' : ' ✗  '}${String(r.score).padStart(5)}${String(r.facts ?? '—').padStart(6)}${String(r.ents ?? '—').padStart(6)}${String(r.precision ?? '—').padStart(6)}${String(r.entPrecision ?? '—').padStart(6)}${String(r.visualIssues || 0).padStart(7)}  ${r.renderFailures.length || ''}`,
   );
   if (r.hallucinated.length) console.log(`    HALLUC#: ${r.hallucinated.join(', ')}`);
   if (r.inventedEntities.length) console.log(`    INVENTED-ENT: ${r.inventedEntities.join(', ')}`);

--- a/sdf-js/scripts/eval-deck-quality.mjs
+++ b/sdf-js/scripts/eval-deck-quality.mjs
@@ -22,6 +22,7 @@ import { readFileSync, writeFileSync, existsSync } from 'node:fs';
 import { resolve, join } from 'node:path';
 import { isAtom2DType, getAtomSpec } from '../src/present/atoms-2d/registry.js';
 import { hasTwin, liftScaffoldSlot } from '../src/scene/lift-scaffold.js';
+import { auditDeckVisual } from './visual-audit.mjs';
 
 // Arg keys that are style/enum/identifier controls, not user-visible prose.
 // Excluded (at any nesting depth, by key name) from the TEXT BUDGET char count.
@@ -767,6 +768,12 @@ export async function scoreDeckQuality(deckDir) {
     };
   }
 
+  // ── VISUAL (Sprint 36 — adversarial render audit, report-only) ──
+  // Instrumented render of every subject: off-canvas ink, text overflow,
+  // unreadable fonts, cross-subject collisions, blank slots, overlapping
+  // subject boxes. Not in the composite yet — counts are the worklist.
+  const visual = await auditDeckVisual(slotSceneDatas, { palette: manifest.theme });
+
   // ── SCORE ──
   const structureScore = fillRate * 25;
   const varietyScore = Math.min(1, atomTypesDistinct / 6) * 15;
@@ -806,6 +813,15 @@ export async function scoreDeckQuality(deckDir) {
       lift_attempted: slotSceneDatas.length,
       lift_errors: liftErrors,
       lifted_subject_rate: liftedSubjectRate,
+    },
+    visual: {
+      total: visual.total,
+      counts: visual.counts,
+      slots_with_issues: visual.bySlot.map((b) => ({
+        slotIdx: b.slotIdx,
+        slotName: b.slotName,
+        issues: b.issues.slice(0, 6),
+      })),
     },
     textBudget: {
       chars_per_slot: charsPerSlot,
@@ -874,6 +890,19 @@ function printHumanTable(result) {
       console.log(
         `  ent-precision: ${f.deck_entities_total - f.hallucinated_entities.length}/${f.deck_entities_total} deck entities grounded (${(f.entity_precision * 100).toFixed(0)}%)${f.hallucinated_entities.length ? '  INVENTED: ' + f.hallucinated_entities.join(', ') : ''}`,
       );
+    }
+  }
+  if (result.visual) {
+    console.log('\nVISUAL AUDIT');
+    console.log(
+      `  issues: ${result.visual.total}${result.visual.total ? '  ' + JSON.stringify(result.visual.counts) : ''}`,
+    );
+    for (const b of result.visual.slots_with_issues.slice(0, 5)) {
+      for (const i of b.issues.slice(0, 3)) {
+        console.log(
+          `    slot ${b.slotIdx} (${b.slotName}): ${i.kind} ${i.type || ''} — ${i.detail}`,
+        );
+      }
     }
   }
   console.log('\nTEXT BUDGET');

--- a/sdf-js/scripts/eval-results/summary.json
+++ b/sdf-js/scripts/eval-results/summary.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-07-07T05:17:25.087Z",
+  "generatedAt": "2026-07-07T06:11:33.190Z",
   "corpusSize": 13,
   "scored": 13,
   "skipped": [],

--- a/sdf-js/scripts/test-visual-audit.mjs
+++ b/sdf-js/scripts/test-visual-audit.mjs
@@ -1,0 +1,123 @@
+#!/usr/bin/env node
+// test-visual-audit.mjs — Sprint 36: the visual adversarial axis, tested
+// against synthetic scenes with DELIBERATE defects (and clean controls).
+import { auditSlotVisual, estimateTextWidth, makeAuditCtx } from './visual-audit.mjs';
+
+let pass = 0,
+  fail = 0;
+const ok = (c, n) => (c ? (pass++, console.log(`  ✓ ${n}`)) : (fail++, console.log(`  ✗ ${n}`)));
+console.log('=== visual-audit (Sprint 36: render-level adversarial checks) ===\n');
+
+const kindsOf = (issues) => new Set(issues.map((i) => i.kind));
+
+// ── clean control: a normal kpi slot produces zero issues ──
+{
+  const issues = await auditSlotVisual({
+    subjects: [
+      {
+        type: 'cover',
+        x: 0,
+        y: 0,
+        w: 1280,
+        h: 120,
+        args: { title: 'Quarterly', style: 'gradient' },
+      },
+      { type: 'kpi-card', x: 40, y: 160, w: 300, h: 200, args: { value: '$3.4M', label: 'ARR' } },
+      {
+        type: 'kpi-card',
+        x: 380,
+        y: 160,
+        w: 300,
+        h: 200,
+        args: { value: '92%', label: 'Retention' },
+      },
+    ],
+  });
+  ok(
+    issues.length === 0,
+    `clean slot has zero issues (got ${issues.length}: ${[...kindsOf(issues)]})`,
+  );
+}
+
+// ── SUBJECT_OVERLAP: two charts on the same box ──
+{
+  const issues = await auditSlotVisual({
+    subjects: [
+      { type: 'kpi-card', x: 40, y: 160, w: 400, h: 300, args: { value: '1', label: 'a' } },
+      { type: 'kpi-card', x: 60, y: 180, w: 400, h: 300, args: { value: '2', label: 'b' } },
+    ],
+  });
+  ok(kindsOf(issues).has('SUBJECT_OVERLAP'), 'overlapping subject boxes flagged');
+}
+
+// ── pure cover slot is NOT blank ──
+{
+  const issues = await auditSlotVisual({
+    subjects: [
+      {
+        type: 'cover',
+        x: 0,
+        y: 0,
+        w: 1280,
+        h: 720,
+        args: { title: 'Deck Title', style: 'gradient' },
+      },
+    ],
+  });
+  ok(!kindsOf(issues).has('BLANK_SLOT'), 'pure cover slot exempt from BLANK_SLOT');
+}
+
+// ── cover shrink-to-fit: a very long title no longer overflows ──
+{
+  const issues = await auditSlotVisual({
+    subjects: [
+      {
+        type: 'cover',
+        x: 0,
+        y: 0,
+        w: 1280,
+        h: 720,
+        args: {
+          title: 'Leaders, Gainers and Unexpected Winners in the Enterprise AI Arms Race of 2026',
+          style: 'gradient',
+        },
+      },
+    ],
+  });
+  ok(
+    !kindsOf(issues).has('TEXT_OVERFLOW'),
+    'cover shrink-to-fit: long title stays inside the canvas',
+  );
+}
+
+// ── instrumented ctx: transform tracking ──
+{
+  const record = { texts: [], rects: [], inkCalls: 0, currentSubject: 0 };
+  const ctx = makeAuditCtx(record);
+  ctx.save();
+  ctx.translate(100, 400);
+  ctx.rotate(-Math.PI / 2);
+  ctx.textAlign = 'center';
+  ctx.font = '700 12px Inter';
+  ctx.fillText('rotated label', 0, 0);
+  ctx.restore();
+  const t = record.texts[0];
+  ok(
+    t.x > 0 && t.y > 0 && t.y < 400,
+    `rotated text lands at real coords (${t.x.toFixed(0)},${t.y.toFixed(0)})`,
+  );
+  ok(t.h > t.w === false || t.h > 20, 'rotated bbox is tall not wide');
+  ctx.fillText('after restore', 10, 10);
+  ok(record.texts[1].x <= 10 + 1, 'restore pops the transform');
+}
+
+// ── width estimate: CJK wider than Latin ──
+{
+  ok(
+    estimateTextWidth('中文标题', 20) > estimateTextWidth('abcd', 20) * 1.5,
+    'CJK chars estimated wider than Latin',
+  );
+}
+
+console.log(`\n${pass} passed, ${fail} failed`);
+process.exit(fail ? 1 : 0);

--- a/sdf-js/scripts/visual-audit.mjs
+++ b/sdf-js/scripts/visual-audit.mjs
@@ -1,0 +1,320 @@
+#!/usr/bin/env node
+// =============================================================================
+// visual-audit.mjs — Sprint 36: the VISUAL adversarial axis.
+//
+// The text axes (facts/entities × recall/precision) can't see a slide that
+// RENDERS wrong: text drawn off-canvas, labels colliding across atoms,
+// unreadably small fonts, blank pages. Screenshot pixel-diffing would need a
+// browser per deck; instead this runs every atom's REAL drawing code against
+// an instrumented ctx that records each fillText/fillRect with the live font
+// size and position, then applies deterministic geometry judgments:
+//
+//   OUT_OF_BOUNDS    — ink drawn beyond the 1280×720 canvas (+8px tolerance)
+//   TEXT_OVERFLOW    — a string whose estimated width crosses the right edge
+//   TINY_FONT        — text at < 9px (unreadable at deck scale)
+//   TEXT_COLLISION   — text bboxes from DIFFERENT subjects overlapping >40%
+//                      of the smaller box (same-atom stacking is by design)
+//   BLANK_SLOT       — a slot whose full render produced < 5 ink calls
+//   SUBJECT_OVERLAP  — non-cover subject bboxes intersecting >25% of smaller
+//
+// Width estimate: CJK chars ≈ 1.0×fontSize, Latin ≈ 0.58×fontSize — the same
+// metric feeds the instrumented measureText so atoms' own fit logic
+// (fitLabelSize etc.) behaves realistically during the audit.
+// =============================================================================
+import { renderAtom } from '../src/present/atoms-2d/registry.js';
+
+const CANVAS_W = 1280;
+const CANVAS_H = 720;
+const EDGE_TOL = 8;
+
+export function estimateTextWidth(text, fontSize) {
+  let w = 0;
+  for (const ch of String(text)) {
+    w += /[ᄀ-ᇿ⺀-꓏가-힣豈-﫿︰-﹏＀-￯]/.test(ch) ? fontSize : fontSize * 0.58;
+  }
+  return w;
+}
+
+function parseFontPx(font) {
+  const m = String(font).match(/(\d+(?:\.\d+)?)px/);
+  return m ? parseFloat(m[1]) : 12;
+}
+
+// Instrumented ctx: tracks font/align/baseline AND the full affine transform
+// (atoms draw rotated axis labels via translate+rotate — a noop transform
+// would record false coordinates) through save/restore; records text and ink
+// calls tagged with the currently-rendering subject index.
+const IDENTITY = [1, 0, 0, 1, 0, 0];
+function matMul(m, n) {
+  return [
+    m[0] * n[0] + m[2] * n[1],
+    m[1] * n[0] + m[3] * n[1],
+    m[0] * n[2] + m[2] * n[3],
+    m[1] * n[2] + m[3] * n[3],
+    m[0] * n[4] + m[2] * n[5] + m[4],
+    m[1] * n[4] + m[3] * n[5] + m[5],
+  ];
+}
+function matApply(m, x, y) {
+  return [m[0] * x + m[2] * y + m[4], m[1] * x + m[3] * y + m[5]];
+}
+// axis-aligned bounding box of a local-space rect pushed through m
+function transformedAABB(m, x, y, w, h) {
+  const corners = [
+    matApply(m, x, y),
+    matApply(m, x + w, y),
+    matApply(m, x, y + h),
+    matApply(m, x + w, y + h),
+  ];
+  const xs = corners.map((c) => c[0]);
+  const ys = corners.map((c) => c[1]);
+  const minX = Math.min(...xs);
+  const minY = Math.min(...ys);
+  return { x: minX, y: minY, w: Math.max(...xs) - minX, h: Math.max(...ys) - minY };
+}
+
+export function makeAuditCtx(record) {
+  const state = {
+    font: '10px sans',
+    textAlign: 'left',
+    textBaseline: 'alphabetic',
+    m: [...IDENTITY],
+  };
+  const stack = [];
+  const noop = () => {};
+  const ink = () => record.inkCalls++;
+  return {
+    save: () => stack.push({ ...state, m: [...state.m] }),
+    restore: () => {
+      const prev = stack.pop();
+      if (prev) Object.assign(state, prev);
+    },
+    translate: (x, y) => {
+      state.m = matMul(state.m, [1, 0, 0, 1, x, y]);
+    },
+    rotate: (rad) => {
+      const c = Math.cos(rad);
+      const s = Math.sin(rad);
+      state.m = matMul(state.m, [c, s, -s, c, 0, 0]);
+    },
+    scale: (sx, sy) => {
+      state.m = matMul(state.m, [sx, 0, 0, sy ?? sx, 0, 0]);
+    },
+    transform: (a, b, c, d, e, f) => {
+      state.m = matMul(state.m, [a, b, c, d, e, f]);
+    },
+    setTransform: (a, b, c, d, e, f) => {
+      state.m = [a, b, c, d, e, f];
+    },
+    beginPath: noop,
+    closePath: noop,
+    moveTo: noop,
+    lineTo: noop,
+    quadraticCurveTo: noop,
+    bezierCurveTo: noop,
+    arc: ink,
+    arcTo: noop,
+    ellipse: ink,
+    rect: noop,
+    roundRect: noop,
+    clip: noop,
+    setLineDash: noop,
+    stroke: ink,
+    fill: ink,
+    strokeRect: ink,
+    clearRect: noop,
+    drawImage: ink,
+    strokeText: noop,
+    fillRect(x, y, w, h) {
+      record.inkCalls++;
+      record.rects.push({
+        subject: record.currentSubject,
+        ...transformedAABB(state.m, x, y, w, h),
+      });
+    },
+    fillText(text, x, y) {
+      if (!String(text).trim()) return;
+      record.inkCalls++;
+      const fs = parseFontPx(state.font);
+      const w = estimateTextWidth(text, fs);
+      let bx = x;
+      if (state.textAlign === 'center') bx = x - w / 2;
+      else if (state.textAlign === 'right' || state.textAlign === 'end') bx = x - w;
+      let by = y - fs; // approx top for alphabetic baseline
+      if (state.textBaseline === 'middle') by = y - fs / 2;
+      else if (state.textBaseline === 'top') by = y;
+      const box = transformedAABB(state.m, bx, by, w, fs);
+      record.texts.push({
+        subject: record.currentSubject,
+        text: String(text),
+        ...box,
+        fontSize: fs,
+      });
+    },
+    measureText: (t) => ({ width: estimateTextWidth(t, parseFontPx(state.font)) }),
+    createLinearGradient: () => ({ addColorStop: noop }),
+    createRadialGradient: () => ({ addColorStop: noop }),
+    set font(v) {
+      state.font = v;
+    },
+    get font() {
+      return state.font;
+    },
+    set textAlign(v) {
+      state.textAlign = v;
+    },
+    get textAlign() {
+      return state.textAlign;
+    },
+    set textBaseline(v) {
+      state.textBaseline = v;
+    },
+    get textBaseline() {
+      return state.textBaseline;
+    },
+    fillStyle: '',
+    strokeStyle: '',
+    lineWidth: 1,
+    lineCap: '',
+    lineJoin: '',
+    shadowColor: '',
+    shadowBlur: 0,
+    shadowOffsetX: 0,
+    shadowOffsetY: 0,
+    globalAlpha: 1,
+  };
+}
+
+function overlapArea(a, b) {
+  const w = Math.min(a.x + a.w, b.x + b.w) - Math.max(a.x, b.x);
+  const h = Math.min(a.y + a.h, b.y + b.h) - Math.max(a.y, b.y);
+  return w > 0 && h > 0 ? w * h : 0;
+}
+
+/**
+ * auditSlotVisual(sceneData, {palette}) → issues[]
+ * Each issue: { kind, subject?, type?, detail }
+ */
+export async function auditSlotVisual(sceneData, { palette } = {}) {
+  const record = { texts: [], rects: [], inkCalls: 0, currentSubject: -1 };
+  const ctx = makeAuditCtx(record);
+  const subjects = sceneData.subjects || [];
+  const issues = [];
+
+  for (let i = 0; i < subjects.length; i++) {
+    const s = subjects[i];
+    record.currentSubject = i;
+    try {
+      await renderAtom(ctx, s.type, s.args, 'pseudo3d', {
+        x: s.x ?? 0,
+        y: s.y ?? 0,
+        w: s.w ?? 320,
+        h: s.h ?? 240,
+        palette: palette || {
+          bg: [247, 244, 224],
+          silhouetteColor: [30, 27, 30],
+          accent: [38, 70, 130],
+          colors: [[38, 70, 130]],
+        },
+      });
+    } catch (e) {
+      issues.push({
+        kind: 'RENDER_CRASH',
+        subject: i,
+        type: s.type,
+        detail: e.message.slice(0, 100),
+      });
+    }
+  }
+
+  // BLANK_SLOT — a pure cover slot (deck/section cover) legitimately draws
+  // little (gradient + title); only flag content slots.
+  const isPureCover = subjects.length > 0 && subjects.every((s) => s.type === 'cover');
+  if (record.inkCalls < 5 && !isPureCover) {
+    issues.push({ kind: 'BLANK_SLOT', detail: `only ${record.inkCalls} ink calls` });
+  }
+
+  // OUT_OF_BOUNDS + TEXT_OVERFLOW + TINY_FONT
+  for (const t of record.texts) {
+    // single-char decorative glyphs (giant quote marks, arrows) hug or cross
+    // edges by design — not a layout defect
+    if (t.text.trim().length <= 1) continue;
+    if (t.fontSize < 9) {
+      issues.push({
+        kind: 'TINY_FONT',
+        subject: t.subject,
+        type: subjects[t.subject]?.type,
+        detail: `"${t.text.slice(0, 30)}" at ${t.fontSize.toFixed(1)}px`,
+      });
+    }
+    if (t.x < -EDGE_TOL || t.y < -EDGE_TOL || t.y + t.h > CANVAS_H + EDGE_TOL) {
+      issues.push({
+        kind: 'OUT_OF_BOUNDS',
+        subject: t.subject,
+        type: subjects[t.subject]?.type,
+        detail: `"${t.text.slice(0, 30)}" at (${t.x.toFixed(0)},${t.y.toFixed(0)})`,
+      });
+    } else if (t.x + t.w > CANVAS_W + EDGE_TOL) {
+      issues.push({
+        kind: 'TEXT_OVERFLOW',
+        subject: t.subject,
+        type: subjects[t.subject]?.type,
+        detail: `"${t.text.slice(0, 30)}" ends at x=${(t.x + t.w).toFixed(0)}`,
+      });
+    }
+  }
+
+  // TEXT_COLLISION across different subjects
+  for (let i = 0; i < record.texts.length; i++) {
+    for (let j = i + 1; j < record.texts.length; j++) {
+      const a = record.texts[i];
+      const b = record.texts[j];
+      if (a.subject === b.subject) continue;
+      const ov = overlapArea(a, b);
+      const smaller = Math.min(a.w * a.h, b.w * b.h);
+      if (smaller > 0 && ov / smaller > 0.4) {
+        issues.push({
+          kind: 'TEXT_COLLISION',
+          detail: `"${a.text.slice(0, 20)}" (subj ${a.subject}) × "${b.text.slice(0, 20)}" (subj ${b.subject})`,
+        });
+      }
+    }
+  }
+
+  // SUBJECT_OVERLAP (declared boxes, cover excluded — covers underlay by design)
+  for (let i = 0; i < subjects.length; i++) {
+    for (let j = i + 1; j < subjects.length; j++) {
+      const a = subjects[i];
+      const b = subjects[j];
+      if (a.type === 'cover' || b.type === 'cover') continue;
+      const ov = overlapArea(
+        { x: a.x ?? 0, y: a.y ?? 0, w: a.w ?? 0, h: a.h ?? 0 },
+        { x: b.x ?? 0, y: b.y ?? 0, w: b.w ?? 0, h: b.h ?? 0 },
+      );
+      const smaller = Math.min((a.w ?? 0) * (a.h ?? 0), (b.w ?? 0) * (b.h ?? 0));
+      if (smaller > 0 && ov / smaller > 0.25) {
+        issues.push({
+          kind: 'SUBJECT_OVERLAP',
+          detail: `${a.type}[${i}] × ${b.type}[${j}] overlap ${((ov / smaller) * 100).toFixed(0)}%`,
+        });
+      }
+    }
+  }
+
+  return issues;
+}
+
+/**
+ * auditDeckVisual(slotSceneDatas, {palette}) → { issues, bySlot, counts }
+ * slotSceneDatas: [{slotIdx, slotName, sceneData}]
+ */
+export async function auditDeckVisual(slotSceneDatas, opts = {}) {
+  const bySlot = [];
+  const counts = {};
+  for (const { slotIdx, slotName, sceneData } of slotSceneDatas) {
+    const issues = await auditSlotVisual(sceneData, opts);
+    for (const iss of issues) counts[iss.kind] = (counts[iss.kind] || 0) + 1;
+    if (issues.length) bySlot.push({ slotIdx, slotName, issues });
+  }
+  return { bySlot, counts, total: Object.values(counts).reduce((s, n) => s + n, 0) };
+}

--- a/sdf-js/src/present/atoms-2d/presentation/cover.js
+++ b/sdf-js/src/present/atoms-2d/presentation/cover.js
@@ -87,8 +87,30 @@ export function drawPseudo3D(ctx, args, opts = {}) {
 
   // ---- Title block — vertical center, left-aligned ----
   // Scale font relative to h but cap so short-strip (h≈100) stays readable.
-  const titleSize = Math.max(18, Math.min(Math.round(h * 0.14), 72));
-  const subtitleSize = Math.max(12, Math.min(Math.round(h * 0.065), 28));
+  // Then SHRINK-TO-FIT the width (Sprint 36 visual audit: long a16z-style
+  // titles at 72px ran ~400px past the right edge — cover had no width
+  // fitting at all). Floor 20px; at the floor a still-too-long title is the
+  // author's problem to shorten, not ours to clip.
+  let titleSize = Math.max(18, Math.min(Math.round(h * 0.14), 72));
+  {
+    const maxW = w - PAD * 2;
+    ctx.save();
+    for (; titleSize > 20; titleSize--) {
+      ctx.font = `900 ${titleSize}px "Inter Display", Inter, system-ui, sans-serif`;
+      if (ctx.measureText(String(title)).width <= maxW) break;
+    }
+    ctx.restore();
+  }
+  let subtitleSize = Math.max(12, Math.min(Math.round(h * 0.065), 28));
+  if (subtitle) {
+    const maxW = w - PAD * 2;
+    ctx.save();
+    for (; subtitleSize > 11; subtitleSize--) {
+      ctx.font = `500 ${subtitleSize}px Inter, system-ui, sans-serif`;
+      if (ctx.measureText(String(subtitle)).width <= maxW) break;
+    }
+    ctx.restore();
+  }
   const metaSize = Math.max(10, Math.min(Math.round(h * 0.038), 14));
 
   const titleX = x + PAD;


### PR DESCRIPTION
按 user 指令: 对抗验证从文本层扩展到截图级视觉层。

## 方案: 插桩渲染 (不是像素比对)

像素 diff 需要每 deck 开浏览器; 插桩渲染在 node 里**真跑每个 atom 的绘制代码**, 录制所有 fillText/fillRect + **完整仿射变换跟踪** (risk-heatmap 的旋转轴标签在 noop transform 下给假坐标 — 第一版就踩到, 已实现矩阵栈), 然后确定性判六类: RENDER_CRASH / OUT_OF_BOUNDS / TEXT_OVERFLOW (CJK 感知字宽估计) / TINY_FONT (<9px) / TEXT_COLLISION (跨 subject) / SUBJECT_OVERLAP / BLANK_SLOT (纯 cover 页豁免)。

已接进 eval scorer (VISUAL 块, report-only 不动 composite) + a16z 复验器 (visual 列)。

## 首轮扫描 (39 decks): 117 → 84

**修掉的最大真问题簇 — cover 标题完全没有宽度自适应 (26 例)**: `titleSize = h*0.14` 直接画, a16z 长英文标题在 72px 下冲出右缘 ~400px。修: shrink-to-fit (floor 20px) + 副标题同, 浏览器截图交叉验证 raise-15b 首页 ✓。中文 demo 标题短所以一直没暴露 — 又一次真实语料的价值。

指标噪音同轮清零: 纯 cover 页 BLANK 误报 / 装饰性大引号 OOB 误报 / 旋转标签假坐标。

## 剩余 84 = 排序过的下轮打磨清单 (`sprint36-visual-adversarial.md`)

- **TINY_FONT ×45** (icon-grid/stat-with-icon/stat-banner 领跑, 最恶劣 3px): fit-to-space 缩字无下限, 修法样板 = stat-banner 的 fitLabelSize
- TEXT_OVERFLOW ×20 (isotype ×11)
- LLM 排版重叠 ×14 (100% 重叠框 — 候选: lift 排版规则 或 lift 后确定性推挤)

## Tests
128/128 — test-visual-audit.mjs 8 断言 (故意缺陷合成场景 + 干净对照 + transform 跟踪 + cover 适配回归)

🤖 Generated with [Claude Code](https://claude.com/claude-code)