### PR TITLE
Sprint 38: 单页 ⚡ 编辑/重 roll — 生成→微调→导出 闭环

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -208,6 +208,7 @@ const TESTS = [
   { category: 'present', file: 'sdf-js/scripts/test-expand-news.mjs' },
   { category: 'present', file: 'sdf-js/scripts/test-lift-pool.mjs' },
   { category: 'present', file: 'sdf-js/scripts/test-visual-audit.mjs' },
+  { category: 'present', file: 'sdf-js/scripts/test-slide-reroll.mjs' },
 ];
 
 // -----------------------------------------------------------------------------

--- a/sdf-js/apps/present/author-2d.html
+++ b/sdf-js/apps/present/author-2d.html
@@ -131,6 +131,81 @@
       #status.err {
         color: #ff9a8a;
       }
+      .slide-card {
+        position: relative;
+      }
+      .slide-tools {
+        position: absolute;
+        top: 8px;
+        right: 8px;
+        display: flex;
+        gap: 6px;
+        opacity: 0;
+        transition: opacity 0.15s;
+        z-index: 5;
+      }
+      .slide-card:hover .slide-tools {
+        opacity: 1;
+      }
+      .slide-tools button {
+        border: none;
+        border-radius: 7px;
+        padding: 5px 9px;
+        background: rgba(20, 22, 28, 0.85);
+        color: #fff;
+        font-size: 14px;
+        cursor: pointer;
+      }
+      .slide-tools button:disabled {
+        opacity: 0.4;
+        cursor: wait;
+      }
+      .slide-edit-row {
+        display: none;
+        position: absolute;
+        top: 44px;
+        right: 8px;
+        left: 8px;
+        gap: 6px;
+        z-index: 5;
+      }
+      .slide-edit-row.open {
+        display: flex;
+      }
+      .slide-edit-row input {
+        flex: 1;
+        padding: 7px 10px;
+        border-radius: 7px;
+        border: 1px solid rgba(255, 255, 255, 0.2);
+        background: rgba(20, 22, 28, 0.92);
+        color: #fff;
+        font: 500 13px -apple-system, Inter, sans-serif;
+        outline: none;
+      }
+      .slide-edit-row button {
+        border: none;
+        border-radius: 7px;
+        padding: 5px 12px;
+        background: #2f6fd6;
+        color: #fff;
+        font-size: 14px;
+        cursor: pointer;
+      }
+      .slide-busy {
+        display: none;
+        position: absolute;
+        inset: 0;
+        background: rgba(10, 12, 16, 0.55);
+        color: #fff;
+        font: 600 14px -apple-system, Inter, sans-serif;
+        align-items: center;
+        justify-content: center;
+        z-index: 4;
+        border-radius: inherit;
+      }
+      .slide-card.busy .slide-busy {
+        display: flex;
+      }
       #keyrow {
         position: fixed;
         right: 14px;

--- a/sdf-js/apps/present/author-2d.js
+++ b/sdf-js/apps/present/author-2d.js
@@ -9,7 +9,7 @@
 // Used for headless verification where a real Anthropic call can't run.
 import { textToIR } from '../../src/scene/text-to-ir.js';
 import { irDeckTo2DDeck } from '../../src/scene/ir-to-2d.js';
-import { newsToFullDeck } from '../../src/present/news/full-deck.js';
+import { newsToFullDeck, reliftSlot } from '../../src/present/news/full-deck.js';
 import { renderSceneDataToCanvas } from '../../src/present/atoms-2d/renderer.js';
 import { exportDeckToPPTX } from '../../src/present/exporters/pptx.js';
 import { exportDeckToPDF } from '../../src/present/exporters/pdf.js';
@@ -87,9 +87,80 @@ async function renderDeck(deck) {
     cap.textContent = slot.slotTitle || slot.slotName || '';
     card.appendChild(canvas);
     card.appendChild(cap);
+    if (slot.liftParams) attachSlideControls(card, canvas, deck, slot);
     slidesEl.appendChild(card);
     await renderSceneDataToCanvas(canvas, slot.sceneData, { palette: deck.theme });
   }
+}
+
+// ── Sprint 38: per-slide ⚡ (Napkin-style) — 🎲 re-roll + ✏️ instruct ────────
+// Both re-lift THIS slot only (~6s, hits the prompt cache); the deck object
+// is mutated in place so PPTX/PDF exports automatically reflect edits.
+function attachSlideControls(card, canvas, deck, slot) {
+  const bar = document.createElement('div');
+  bar.className = 'slide-tools';
+
+  const rollBtn = document.createElement('button');
+  rollBtn.textContent = '🎲';
+  rollBtn.title = '重新生成这一页 (同素材, 新的排版/图表选择)';
+
+  const editBtn = document.createElement('button');
+  editBtn.textContent = '✏️';
+  editBtn.title = '用一句话修改这一页 (如: 换成柱状图 / 标题更简短)';
+
+  const editRow = document.createElement('div');
+  editRow.className = 'slide-edit-row';
+  const editInput = document.createElement('input');
+  editInput.placeholder = '想怎么改? 如: 换成柱状图 / 只保留三个要点';
+  const editGo = document.createElement('button');
+  editGo.textContent = '⚡';
+  editRow.appendChild(editInput);
+  editRow.appendChild(editGo);
+
+  const busy = document.createElement('div');
+  busy.className = 'slide-busy';
+  busy.textContent = 're-lifting…';
+
+  async function relift(revision) {
+    const apiKey = keyEl.value.trim();
+    if (!apiKey) return setStatus('paste your Anthropic API key first', true);
+    card.classList.add('busy');
+    rollBtn.disabled = editGo.disabled = true;
+    try {
+      const sceneData = await reliftSlot(currentDeck, slot.slotIdx, { apiKey, revision });
+      await renderSceneDataToCanvas(canvas, sceneData, { palette: deck.theme });
+      editRow.classList.remove('open');
+      editInput.value = '';
+      setStatus(
+        revision ? `slide "${slot.slotTitle}" revised.` : `slide "${slot.slotTitle}" re-rolled.`,
+      );
+    } catch (e) {
+      setStatus(`re-lift failed: ${e.message}`, true);
+    } finally {
+      card.classList.remove('busy');
+      rollBtn.disabled = editGo.disabled = false;
+    }
+  }
+
+  rollBtn.addEventListener('click', () => relift(null));
+  editBtn.addEventListener('click', () => {
+    editRow.classList.toggle('open');
+    if (editRow.classList.contains('open')) editInput.focus();
+  });
+  const submitEdit = () => {
+    const v = editInput.value.trim();
+    if (v) relift(v);
+  };
+  editGo.addEventListener('click', submitEdit);
+  editInput.addEventListener('keydown', (e) => {
+    if (e.key === 'Enter') submitEdit();
+  });
+
+  bar.appendChild(rollBtn);
+  bar.appendChild(editBtn);
+  card.appendChild(bar);
+  card.appendChild(editRow);
+  card.appendChild(busy);
 }
 
 async function generate() {
@@ -111,6 +182,7 @@ async function generate() {
         apiKey,
         onProgress: (msg, pct) => setStatus(`${msg} (${Math.round(pct)}%)`),
       });
+      window.__atlasDeck = currentDeck; // QA/debug handle
       if (currentDeck.errors?.length) {
         console.warn('[full-deck] slot errors:', currentDeck.errors);
       }

--- a/sdf-js/scripts/test-slide-reroll.mjs
+++ b/sdf-js/scripts/test-slide-reroll.mjs
@@ -1,0 +1,102 @@
+#!/usr/bin/env node
+// test-slide-reroll.mjs — Sprint 38: per-slide re-roll / revision mechanics
+// (no LLM — liftFn injection; the prompt-side revision block is asserted
+// as text).
+import { buildSlotUserMessage } from '../src/present/scaffolds/lift-slot-llm.js';
+import { reliftSlot } from '../src/present/news/full-deck.js';
+import { getScaffold, getThemeAffinity } from '../src/present/scaffolds/registry.js';
+
+let pass = 0,
+  fail = 0;
+const ok = (c, n) => (c ? (pass++, console.log(`  ✓ ${n}`)) : (fail++, console.log(`  ✗ ${n}`)));
+console.log('=== slide re-roll (Sprint 38: 生成→微调→导出 闭环) ===\n');
+
+const scaffold = getScaffold('news-briefing');
+const theme = getThemeAffinity(scaffold)[0];
+const slide = { title: '增长预测', body: ['IMF 3.3%', 'OECD 2.9%'] };
+const baseParams = {
+  scaffold,
+  slot: scaffold.slots[3],
+  slotIdx: 3,
+  slideIdx: 1,
+  theme,
+  slide,
+  slides: [slide],
+  extraSlides: [],
+};
+
+// ── revision block in the prompt ──
+{
+  const plain = buildSlotUserMessage(baseParams);
+  const revised = buildSlotUserMessage({ ...baseParams, revision: '换成柱状图' });
+  ok(!plain.includes('USER REVISION REQUEST'), 'no revision block without revision');
+  ok(revised.includes('USER REVISION REQUEST'), 'revision block present');
+  ok(revised.includes('换成柱状图'), 'revision text carried verbatim');
+  ok(
+    revised.includes('never the underlying facts'),
+    'revision constrained by fidelity rules (presentation-only)',
+  );
+  ok(
+    revised.indexOf('USER REVISION REQUEST') < revised.indexOf('## OUTPUT'),
+    'revision sits before the OUTPUT contract',
+  );
+  // quotes in the revision must not break the prompt quoting
+  const tricky = buildSlotUserMessage({ ...baseParams, revision: 'say "hello" twice' });
+  ok(tricky.includes("say 'hello' twice"), 'double quotes in revision are neutralized');
+}
+
+// ── reliftSlot mechanics (injected liftFn) ──
+{
+  const deck = {
+    title: 't',
+    theme,
+    scaffold: { id: scaffold.id },
+    slots: [
+      {
+        slotIdx: 3,
+        slotName: 'theme-1-lead',
+        slotTitle: 'Theme 1',
+        sceneData: { subjects: [{ type: 'pie', x: 0, y: 0, w: 100, h: 100, args: {} }] },
+        liftParams: baseParams,
+      },
+      { slotIdx: 4, slotName: 'x', sceneData: { subjects: [] } },
+    ],
+  };
+  const calls = [];
+  const fakeLift = async (params, opts) => {
+    calls.push({ revision: params.revision, hasSystem: !!opts.systemPrompt });
+    return { sceneData: { subjects: [{ type: 'bar', x: 0, y: 0, w: 100, h: 100, args: {} }] } };
+  };
+
+  const sceneData = await reliftSlot(deck, 3, {
+    apiKey: 'k',
+    revision: '换成柱状图',
+    liftFn: fakeLift,
+  });
+  ok(sceneData.subjects[0].type === 'bar', 'returns the new sceneData');
+  ok(deck.slots[0].sceneData.subjects[0].type === 'bar', 'deck mutated in place (exports follow)');
+  ok(calls[0].revision === '换成柱状图', 'revision forwarded to the lift');
+  ok(calls[0].hasSystem, 'system prompt supplied (cache-friendly)');
+
+  await reliftSlot(deck, 3, { apiKey: 'k', liftFn: fakeLift });
+  ok(calls[1].revision === null, 'plain re-roll sends no revision');
+
+  let threw = null;
+  try {
+    await reliftSlot(deck, 4, { apiKey: 'k', liftFn: fakeLift });
+  } catch (e) {
+    threw = e.message;
+  }
+  ok(/liftParams/.test(threw || ''), 'slot without liftParams throws a clear error');
+
+  threw = null;
+  try {
+    await reliftSlot(deck, 99, { apiKey: 'k', liftFn: fakeLift });
+  } catch (e) {
+    threw = e.message;
+  }
+  ok(/no slot/.test(threw || ''), 'unknown slotIdx throws');
+}
+
+console.log(`\n${pass} passed, ${fail} failed`);
+process.exit(fail ? 1 : 0);

--- a/sdf-js/src/present/news/full-deck.js
+++ b/sdf-js/src/present/news/full-deck.js
@@ -11,7 +11,16 @@
 import { expandNews } from './expand-core.js';
 import { getScaffold, getThemeAffinity } from '../scaffolds/registry.js';
 import { mapSlidesToSlotsLLM, scoreSlideForSlot } from '../scaffolds/mapper-llm.js';
-import { buildLiftSystemPrompt, liftSlotsPool } from '../scaffolds/lift-slot-llm.js';
+import { buildLiftSystemPrompt, liftSlotsPool, liftSlotLLM } from '../scaffolds/lift-slot-llm.js';
+
+// The lift system prompt is deterministic (atom+icon catalogs) — build once
+// per browser session so per-slide re-rolls (Sprint 38) skip the rebuild and
+// hit the Anthropic prompt cache from the original generation.
+let systemPromptCache = null;
+async function getSystemPrompt() {
+  if (!systemPromptCache) systemPromptCache = await buildLiftSystemPrompt();
+  return systemPromptCache;
+}
 
 /**
  * newsToFullDeck(text, opts) → exporter-ready deck
@@ -82,7 +91,7 @@ export async function newsToFullDeck(
   }
 
   onProgress('building lift prompt…', 12);
-  const systemPrompt = await buildLiftSystemPrompt();
+  const systemPrompt = await getSystemPrompt();
 
   // Parallel lift (Sprint 34): warmup + bounded pool via liftSlotsPool —
   // 14 serial calls (~95s) become 1 warmup + 13 over 5 workers (~30-40s).
@@ -119,6 +128,18 @@ export async function newsToFullDeck(
         slotName: a.slot.name,
         slotTitle: a.slot.title,
         sceneData: r.sceneData,
+        // Kept for per-slide re-roll / revision (Sprint 38): re-lifting a
+        // slot is just liftSlotLLM with these params again.
+        liftParams: {
+          scaffold,
+          slot: a.slot,
+          slotIdx: a.slotIdx,
+          slideIdx: a.slideIdx,
+          theme,
+          slide: slides[a.slideIdx],
+          slides,
+          extraSlides: a.extraSlides || [],
+        },
       });
     } else {
       errors.push({ slot: a.slot.name, message: r?.error || 'unknown' });
@@ -133,4 +154,31 @@ export async function newsToFullDeck(
     slots,
     errors,
   };
+}
+
+/**
+ * reliftSlot — Sprint 38 per-slide ⚡: re-run ONE slot's lift, optionally
+ * with a presenter revision request ("换成柱状图"). Mutates deck.slots[i]
+ * in place (sceneData swap) and returns the new sceneData, so exports and
+ * re-renders pick it up with no further bookkeeping.
+ *
+ * @param {object} deck — a newsToFullDeck result
+ * @param {number} slotIdx — the slot's slotIdx (not array index)
+ * @param {object} opts — { apiKey, revision?, liftFn? (test injection) }
+ */
+export async function reliftSlot(
+  deck,
+  slotIdx,
+  { apiKey, revision = null, liftFn = liftSlotLLM } = {},
+) {
+  const slot = deck.slots.find((s) => s.slotIdx === slotIdx);
+  if (!slot) throw new Error(`reliftSlot: no slot with slotIdx ${slotIdx}`);
+  if (!slot.liftParams)
+    throw new Error(
+      'reliftSlot: slot has no liftParams (quick-mode decks cannot re-roll per slide)',
+    );
+  const systemPrompt = await getSystemPrompt();
+  const { sceneData } = await liftFn({ ...slot.liftParams, revision }, { apiKey, systemPrompt });
+  slot.sceneData = sceneData;
+  return sceneData;
 }

--- a/sdf-js/src/present/scaffolds/lift-slot-llm.js
+++ b/sdf-js/src/present/scaffolds/lift-slot-llm.js
@@ -41,6 +41,7 @@ export function buildSlotUserMessage({
   slide,
   slides = [],
   extraSlides = [],
+  revision = null,
 }) {
   const bodyTexts = (slide.body || [])
     .map((b) => (typeof b === 'string' ? b : b.text || ''))
@@ -131,6 +132,15 @@ export function buildSlotUserMessage({
     bodyTexts.map((t) => `  - "${t}"`).join('\n') +
     '\n' +
     extraMaterial +
+    (revision
+      ? `\n## USER REVISION REQUEST (Sprint 38 — per-slide edit)\n\n` +
+        `The presenter reviewed this slide and asked: "${String(revision).replace(/"/g, "'")}"\n` +
+        `Apply this request while still obeying EVERY rule below — especially the\n` +
+        `fidelity rules (18-22): the revision changes PRESENTATION (atom choice,\n` +
+        `layout, emphasis, wording), never the underlying facts. If the request\n` +
+        `asks for data the source doesn't contain, satisfy the spirit of the\n` +
+        `request without inventing numbers or names.\n`
+      : '') +
     '\n' +
     `## OUTPUT\n\n` +
     `Canvas: **1280×720**. Emit SceneData JSON for ONE slot:\n\n` +


### PR DESCRIPTION
按 user 指令: 产品面, author-2d 生成后的单页编辑/重 roll (Napkin 式 ⚡)。

## 交互 (整本模式, 每张卡 hover)

- **🎲 重 roll**: 同素材重 lift 这一页 (新的排版/图表选择), ~8s, 走温 prompt cache (~$0.02)
- **✏️ 指令改写**: 一句话修改 ("换成柱状图 / 只保留三个要点") — 作为 USER REVISION REQUEST 块注入共享 slot prompt, 显式约束**只改呈现不改事实** (Rules 18-22 继续生效, 指令要不来源文没有的数据)

## 实现 (零平行管线)

- `newsToFullDeck` 每 slot 保留 `liftParams`; 新 `reliftSlot()` 原地替换 `deck.slots[i].sceneData` — **导出零记账自动跟随** (PPTX/PDF 读的就是这个对象)
- system prompt 模块级缓存 (重 roll 不重建, 且续用 Anthropic prompt cache)
- `buildSlotUserMessage` 加可选 `revision` 参数, CLI 路径不受影响

## 真机验证 (中文经济新闻)

42s 生成 14 页 → 🎲 "Key Figures" 重 roll (8s, kpi 卡重选) → ✏️ "把这些数字改用柱状图" → 8s 后 subjects 变为 `cover, bar`, 画布重渲染 (截图确认横向柱状图), 改后 PPTX 导出成功。

## Tests
129/129 — test-slide-reroll.mjs 13 断言 (revision 块位置/引号转义/保真约束、reliftSlot 原地修改语义、错误路径)

🤖 Generated with [Claude Code](https://claude.com/claude-code)