### PR TITLE
Sprint 39: 一键换主题 — 12 主题零成本即时重渲染

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -209,6 +209,7 @@ const TESTS = [
   { category: 'present', file: 'sdf-js/scripts/test-lift-pool.mjs' },
   { category: 'present', file: 'sdf-js/scripts/test-visual-audit.mjs' },
   { category: 'present', file: 'sdf-js/scripts/test-slide-reroll.mjs' },
+  { category: 'present', file: 'sdf-js/scripts/test-retheme.mjs' },
 ];
 
 // -----------------------------------------------------------------------------

--- a/sdf-js/apps/present/author-2d.html
+++ b/sdf-js/apps/present/author-2d.html
@@ -113,6 +113,19 @@
         font: 600 13px -apple-system, Inter, sans-serif;
         cursor: pointer;
       }
+      #exportRow select {
+        border-radius: 9px;
+        border: 1px solid rgba(255, 255, 255, 0.18);
+        background: rgba(20, 22, 28, 0.9);
+        color: #fff;
+        font: 600 12px -apple-system, Inter, sans-serif;
+        padding: 0 6px;
+        cursor: pointer;
+      }
+      #exportRow select:disabled {
+        opacity: 0.35;
+        cursor: not-allowed;
+      }
       #exportRow button:disabled {
         opacity: 0.35;
         cursor: not-allowed;
@@ -245,6 +258,7 @@
       </select>
       <button id="go">Generate</button>
       <div id="exportRow">
+        <select id="theme" disabled title="换主题 (零成本, 即时重渲染)"></select>
         <button id="export-pptx" disabled>⬇ PPTX</button>
         <button id="export-pdf" disabled>⬇ PDF</button>
       </div>

--- a/sdf-js/apps/present/author-2d.js
+++ b/sdf-js/apps/present/author-2d.js
@@ -11,6 +11,8 @@ import { textToIR } from '../../src/scene/text-to-ir.js';
 import { irDeckTo2DDeck } from '../../src/scene/ir-to-2d.js';
 import { newsToFullDeck, reliftSlot } from '../../src/present/news/full-deck.js';
 import { renderSceneDataToCanvas } from '../../src/present/atoms-2d/renderer.js';
+import { rethemeDeck } from '../../src/present/retheme.js';
+import { ATLAS_THEMES } from '../../src/present/themes.js';
 import { exportDeckToPPTX } from '../../src/present/exporters/pptx.js';
 import { exportDeckToPDF } from '../../src/present/exporters/pdf.js';
 
@@ -58,6 +60,31 @@ const slidesEl = document.getElementById('slides');
 const exportPptxEl = document.getElementById('export-pptx');
 const exportPdfEl = document.getElementById('export-pdf');
 const modeEl = document.getElementById('mode');
+const themeEl = document.getElementById('theme');
+
+// Theme switcher (Sprint 39): zero-LLM-cost — palette swap + deterministic
+// remap of theme colors the lift baked into args, then full re-render.
+for (const t of ATLAS_THEMES) {
+  const opt = document.createElement('option');
+  opt.value = t.id;
+  opt.textContent = t.label || t.id;
+  themeEl.appendChild(opt);
+}
+themeEl.addEventListener('change', async () => {
+  if (!currentDeck) return;
+  try {
+    rethemeDeck(currentDeck, themeEl.value);
+    await renderDeck(currentDeck);
+    setStatus(`theme → ${themeEl.value} (re-rendered, exports follow)`);
+  } catch (e) {
+    setStatus(`theme switch failed: ${e.message}`, true);
+  }
+});
+
+function syncThemeSelect() {
+  if (currentDeck?.theme?.id) themeEl.value = currentDeck.theme.id;
+  themeEl.disabled = !currentDeck;
+}
 
 keyEl.value = localStorage.getItem(STORAGE_KEY) || '';
 keyEl.addEventListener('change', () => localStorage.setItem(STORAGE_KEY, keyEl.value.trim()));
@@ -193,6 +220,7 @@ async function generate() {
       setStatus(`done — ${currentDeck.slots.length} pages rendered${errNote}. Export below.`);
       exportPptxEl.disabled = false;
       exportPdfEl.disabled = false;
+      syncThemeSelect();
       return;
     }
     let irDeck;
@@ -211,6 +239,7 @@ async function generate() {
     setStatus(`done — ${currentDeck.slots.length} slide(s) rendered. Export below.`);
     exportPptxEl.disabled = false;
     exportPdfEl.disabled = false;
+    syncThemeSelect();
   } catch (e) {
     setStatus(e.message, true);
   } finally {

--- a/sdf-js/scripts/test-retheme.mjs
+++ b/sdf-js/scripts/test-retheme.mjs
@@ -1,0 +1,90 @@
+#!/usr/bin/env node
+// test-retheme.mjs — Sprint 39: zero-cost theme switching mechanics.
+import { rethemeDeck } from '../src/present/retheme.js';
+import { getTheme } from '../src/present/themes.js';
+
+let pass = 0,
+  fail = 0;
+const ok = (c, n) => (c ? (pass++, console.log(`  ✓ ${n}`)) : (fail++, console.log(`  ✗ ${n}`)));
+console.log('=== retheme (Sprint 39: 一键换主题, 零 LLM 成本) ===\n');
+
+const navy = getTheme('editorial-navy');
+const teal = getTheme('organic-teal');
+const [nr, ng, nb] = navy.accent;
+
+function makeDeck() {
+  return {
+    title: 't',
+    theme: navy,
+    slots: [
+      {
+        slotIdx: 0,
+        sceneData: {
+          subjects: [
+            {
+              type: 'icon-row',
+              x: 0,
+              y: 0,
+              w: 100,
+              h: 100,
+              args: {
+                items: [{ icon: 'shield', label: 'A', iconColor: `rgb(${nr}, ${ng}, ${nb})` }],
+                pillars: [{ accent: [...navy.accent] }],
+                note: `uses rgba(${nr}, ${ng}, ${nb}, 0.55) wash`,
+                custom: 'rgb(200, 10, 10)',
+                customArr: [200, 10, 10],
+              },
+            },
+          ],
+        },
+        liftParams: { theme: navy },
+      },
+    ],
+  };
+}
+
+{
+  const deck = makeDeck();
+  rethemeDeck(deck, 'organic-teal');
+  const args = deck.slots[0].sceneData.subjects[0].args;
+  const [tr, tg, tb] = teal.accent;
+  ok(deck.theme.id === 'organic-teal', 'deck.theme swapped');
+  ok(
+    args.items[0].iconColor === `rgb(${tr}, ${tg}, ${tb})`,
+    'rgb() string arg remapped to new accent',
+  );
+  ok(
+    args.pillars[0].accent[0] === tr && args.pillars[0].accent[2] === tb,
+    'numeric triple arg remapped',
+  );
+  ok(args.note.includes(`rgba(${tr}, ${tg}, ${tb}, 0.55)`), 'rgba keeps its alpha');
+  ok(args.custom === 'rgb(200, 10, 10)', 'non-theme string color untouched');
+  ok(args.customArr[0] === 200, 'non-theme triple untouched');
+  ok(
+    deck.slots[0].liftParams.theme.id === 'organic-teal',
+    'liftParams.theme follows (re-rolls use new theme)',
+  );
+}
+
+{
+  const deck = makeDeck();
+  rethemeDeck(deck, 'organic-teal');
+  rethemeDeck(deck, 'editorial-navy');
+  const args = deck.slots[0].sceneData.subjects[0].args;
+  ok(args.items[0].iconColor === `rgb(${nr}, ${ng}, ${nb})`, 'round-trip restores original colors');
+}
+
+{
+  const deck = makeDeck();
+  let threw = null;
+  try {
+    rethemeDeck(deck, 'nonexistent-theme');
+  } catch (e) {
+    threw = e.message;
+  }
+  ok(/unknown theme/.test(threw || ''), 'unknown theme id throws');
+  ok(deck.theme.id === 'editorial-navy', 'failed switch leaves deck untouched');
+}
+
+console.log(`\n${pass} passed, ${fail} failed`);
+process.exit(fail ? 1 : 0);

--- a/sdf-js/src/present/retheme.js
+++ b/sdf-js/src/present/retheme.js
@@ -1,0 +1,112 @@
+// =============================================================================
+// retheme.js — Sprint 39: switch a generated deck's theme with ZERO LLM cost.
+//
+// Atoms take their palette at render time, so most color comes free with a
+// re-render. But the lift prompt hands the LLM the theme's rgb values and
+// some land inside args (iconColor: "rgb(38, 70, 130)", pillars[].accent:
+// [38,70,130] — see the Sprint 33 color-leak audit). Left alone they'd
+// produce a mixed-theme deck. Deterministic remap: any arg color that
+// EXACTLY matches one of the old theme's colors is rewritten to the new
+// theme's counterpart (accent→accent, colors[i]→colors[i], bg→bg,
+// silhouette→silhouette). Colors the LLM invented (not from the theme
+// block) are left untouched — they were a deliberate choice.
+// =============================================================================
+import { getTheme } from './themes.js';
+
+const SLOT_KEYS = ['accent', 'bg', 'silhouetteColor'];
+
+function tripleOf(v) {
+  if (Array.isArray(v) && v.length === 3 && v.every((n) => typeof n === 'number')) return v;
+  return null;
+}
+
+// old-color → new-color pairs, position-aligned across the two themes
+function colorPairs(oldTheme, newTheme) {
+  const pairs = [];
+  for (const k of SLOT_KEYS) {
+    if (tripleOf(oldTheme[k]) && tripleOf(newTheme[k])) pairs.push([oldTheme[k], newTheme[k]]);
+  }
+  const oc = oldTheme.colors || [];
+  const nc = newTheme.colors || [];
+  for (let i = 0; i < oc.length; i++) {
+    if (tripleOf(oc[i]) && tripleOf(nc[i % Math.max(1, nc.length)]))
+      pairs.push([oc[i], nc[i % nc.length]]);
+  }
+  return pairs;
+}
+
+function sameTriple(a, b) {
+  return a[0] === b[0] && a[1] === b[1] && a[2] === b[2];
+}
+
+// every rgb()/rgba() spelling the lift is known to emit for a triple
+function stringForms([r, g, b]) {
+  return [
+    [`rgb(${r}, ${g}, ${b})`, (nr, ng, nb) => `rgb(${nr}, ${ng}, ${nb})`],
+    [`rgb(${r},${g},${b})`, (nr, ng, nb) => `rgb(${nr},${ng},${nb})`],
+  ];
+}
+
+function remapString(s, pairs) {
+  let out = s;
+  for (const [oldC, newC] of pairs) {
+    for (const [form, make] of stringForms(oldC)) {
+      if (out.includes(form)) out = out.split(form).join(make(...newC));
+    }
+    // rgba(r, g, b, a) — keep the alpha
+    out = out.replace(
+      new RegExp(
+        `rgba\\(\\s*${oldC[0]}\\s*,\\s*${oldC[1]}\\s*,\\s*${oldC[2]}\\s*,\\s*([\\d.]+)\\s*\\)`,
+        'g',
+      ),
+      (m, a) => `rgba(${newC[0]}, ${newC[1]}, ${newC[2]}, ${a})`,
+    );
+  }
+  return out;
+}
+
+function remapNode(node, pairs) {
+  if (node == null) return node;
+  if (typeof node === 'string') return remapString(node, pairs);
+  if (Array.isArray(node)) {
+    const t = tripleOf(node);
+    if (t) {
+      for (const [oldC, newC] of pairs) {
+        if (sameTriple(t, oldC)) return [...newC];
+      }
+      return node;
+    }
+    return node.map((el) => remapNode(el, pairs));
+  }
+  if (typeof node === 'object') {
+    const out = {};
+    for (const [k, v] of Object.entries(node)) out[k] = remapNode(v, pairs);
+    return out;
+  }
+  return node;
+}
+
+/**
+ * rethemeDeck(deck, newThemeId) — mutates the deck in place (same contract
+ * as reliftSlot: exports and re-renders follow with no bookkeeping).
+ * Returns the new theme. Works for quick-mode and full-deck decks alike.
+ */
+export function rethemeDeck(deck, newThemeId) {
+  const newTheme = getTheme(newThemeId);
+  if (!newTheme) throw new Error(`rethemeDeck: unknown theme "${newThemeId}"`);
+  const oldTheme = deck.theme;
+  if (oldTheme?.id === newTheme.id) return newTheme;
+  const pairs = colorPairs(oldTheme || {}, newTheme);
+
+  for (const slot of deck.slots || []) {
+    if (!slot.sceneData?.subjects) continue;
+    slot.sceneData.subjects = slot.sceneData.subjects.map((subj) => ({
+      ...subj,
+      args: remapNode(subj.args || {}, pairs),
+    }));
+    // future re-rolls should lift with the new theme
+    if (slot.liftParams) slot.liftParams.theme = newTheme;
+  }
+  deck.theme = newTheme;
+  return newTheme;
+}


### PR DESCRIPTION
产品面自迭代第二步 (接 #233 的单页 ⚡)。

## 交互

导出按钮旁新增主题下拉 (生成后可用): 选中即整本重渲染, **零 LLM 成本**, PPTX/PDF 导出自动跟随。快速/整本双模式通用。

## 微妙之处: lift 烤进 args 的主题色

atoms 的调色板是渲染时注入的, 但 lift 会把部分主题色写死进 args (`iconColor: "rgb(38,70,130)"`、`pillars[].accent` 三元组 — 正是 Sprint 33 视觉审计画出的泄漏地图)。`rethemeDeck()` 做确定性重映射: **精确匹配**旧主题色的 arg 一律改写为新主题对应位 (accent→accent, colors[i]→colors[i], rgba 保留透明度); LLM 自主选择的颜色不动。`liftParams.theme` 同步更新, 换主题后的重 roll 用新主题 lift。

原地修改同一 deck 对象 (与 reliftSlot 同契约) — 导出零记账跟随。

## 验证

浏览器 demo 模式: navy → pitch-cobalt-orange, donut/漏斗/org-chart 即时换装 (截图)。130/130 测试 (+10: 字符串/三元组/rgba 重映射、非主题色不动、往返还原、错误路径)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)