### PR TITLE
Sprint 40: ✋ 页锁定 — 重新 Generate 保留钉住页, 微调闭环收口

### DIFF
--- a/sdf-js/apps/present/author-2d.html
+++ b/sdf-js/apps/present/author-2d.html
@@ -147,6 +147,13 @@
       .slide-card {
         position: relative;
       }
+      .slide-card.locked {
+        outline: 2px solid #e0a33a;
+        outline-offset: -2px;
+      }
+      .slide-card.locked .slide-tools {
+        opacity: 1;
+      }
       .slide-tools {
         position: absolute;
         top: 8px;

--- a/sdf-js/apps/present/author-2d.js
+++ b/sdf-js/apps/present/author-2d.js
@@ -127,6 +127,16 @@ function attachSlideControls(card, canvas, deck, slot) {
   const bar = document.createElement('div');
   bar.className = 'slide-tools';
 
+  const lockBtn = document.createElement('button');
+  const syncLock = () => {
+    lockBtn.textContent = slot.locked ? '🔒' : '✋';
+    lockBtn.title = slot.locked
+      ? '已锁定 — 重新 Generate 时保留这一页 (点击解锁)'
+      : '锁定这一页 (重新 Generate 时保留, 不再重 lift)';
+    card.classList.toggle('locked', !!slot.locked);
+    rollBtn.disabled = editBtn.disabled = !!slot.locked;
+  };
+
   const rollBtn = document.createElement('button');
   rollBtn.textContent = '🎲';
   rollBtn.title = '重新生成这一页 (同素材, 新的排版/图表选择)';
@@ -169,6 +179,13 @@ function attachSlideControls(card, canvas, deck, slot) {
     }
   }
 
+  lockBtn.addEventListener('click', () => {
+    slot.locked = !slot.locked;
+    syncLock();
+    setStatus(
+      slot.locked ? `slide "${slot.slotTitle}" 已锁定` : `slide "${slot.slotTitle}" 已解锁`,
+    );
+  });
   rollBtn.addEventListener('click', () => relift(null));
   editBtn.addEventListener('click', () => {
     editRow.classList.toggle('open');
@@ -183,8 +200,10 @@ function attachSlideControls(card, canvas, deck, slot) {
     if (e.key === 'Enter') submitEdit();
   });
 
+  bar.appendChild(lockBtn);
   bar.appendChild(rollBtn);
   bar.appendChild(editBtn);
+  syncLock();
   card.appendChild(bar);
   card.appendChild(editRow);
   card.appendChild(busy);
@@ -205,8 +224,10 @@ async function generate() {
     if (!DEMO_MODE && modeEl.value === 'full') {
       // 整本模式 (Sprint 32): article → 10-20 page briefing via the SAME
       // pipeline modules the CLI bake uses (expand → map → per-slot lift).
+      const lockedSlots = (currentDeck?.slots || []).filter((s) => s.locked && s.liftParams);
       currentDeck = await newsToFullDeck(text, {
         apiKey,
+        lockedSlots,
         onProgress: (msg, pct) => setStatus(`${msg} (${Math.round(pct)}%)`),
       });
       window.__atlasDeck = currentDeck; // QA/debug handle

--- a/sdf-js/scripts/test-slide-reroll.mjs
+++ b/sdf-js/scripts/test-slide-reroll.mjs
@@ -98,5 +98,35 @@ const baseParams = {
   ok(/no slot/.test(threw || ''), 'unknown slotIdx throws');
 }
 
+// ── Sprint 40: mergeLockedSlots ──
+{
+  const { mergeLockedSlots } = await import('../src/present/news/full-deck.js');
+  const fresh = [
+    { slotIdx: 0, slotName: 'cover', sceneData: { v: 'new0' } },
+    { slotIdx: 3, slotName: 'lead', sceneData: { v: 'new3' } },
+    { slotIdx: 5, slotName: 'risk', sceneData: { v: 'new5' } },
+  ];
+  const locked = [
+    { slotIdx: 3, slotName: 'lead', sceneData: { v: 'PINNED3' } },
+    { slotIdx: 9, slotName: 'quote', sceneData: { v: 'PINNED9' } },
+  ];
+  const merged = mergeLockedSlots(fresh, locked);
+  ok(
+    merged.find((s) => s.slotIdx === 3).sceneData.v === 'PINNED3',
+    'pinned slot replaces the fresh one',
+  );
+  ok(merged.find((s) => s.slotIdx === 3).locked === true, 'merged slot carries locked flag');
+  ok(
+    merged.find((s) => s.slotIdx === 9)?.sceneData.v === 'PINNED9',
+    'pinned slot survives even when new run dropped its slotIdx',
+  );
+  ok(
+    merged.find((s) => s.slotIdx === 5).sceneData.v === 'new5',
+    'unlocked slots come from the new run',
+  );
+  ok(merged.map((s) => s.slotIdx).join(',') === '0,3,5,9', 'merged list sorted by slotIdx');
+  ok(mergeLockedSlots(fresh, []) === fresh, 'no locks → passthrough');
+}
+
 console.log(`\n${pass} passed, ${fail} failed`);
 process.exit(fail ? 1 : 0);

--- a/sdf-js/src/present/news/full-deck.js
+++ b/sdf-js/src/present/news/full-deck.js
@@ -31,7 +31,7 @@ async function getSystemPrompt() {
  */
 export async function newsToFullDeck(
   text,
-  { apiKey, minPages = 10, maxPages = 20, onProgress = () => {} } = {},
+  { apiKey, minPages = 10, maxPages = 20, onProgress = () => {}, lockedSlots = [] } = {},
 ) {
   if (!apiKey) throw new Error('newsToFullDeck: apiKey required');
 
@@ -95,7 +95,11 @@ export async function newsToFullDeck(
 
   // Parallel lift (Sprint 34): warmup + bounded pool via liftSlotsPool —
   // 14 serial calls (~95s) become 1 warmup + 13 over 5 workers (~30-40s).
-  const live = assignments.filter((a) => !a.empty);
+  // Locked slots (Sprint 40: user pinned these pages) are never re-lifted —
+  // their lift calls are skipped entirely and the pinned slot objects are
+  // merged back below.
+  const lockedIdx = new Set(lockedSlots.map((s) => s.slotIdx));
+  const live = assignments.filter((a) => !a.empty && !lockedIdx.has(a.slotIdx));
   let done = 0;
   const poolResults = await liftSlotsPool(
     live.map((a) => ({
@@ -151,9 +155,25 @@ export async function newsToFullDeck(
     title: slides[0]?.title || 'News Deck',
     theme,
     scaffold: { id: scaffold.id, label: scaffold.label },
-    slots,
+    slots: mergeLockedSlots(slots, lockedSlots),
     errors,
   };
+}
+
+/**
+ * mergeLockedSlots — splice pinned slot objects into a freshly generated
+ * slot list, in slotIdx order (Sprint 40). A locked slot ALWAYS survives:
+ * if the new run delivered a slide for the same slotIdx it is replaced by
+ * the pinned one; if the new run dropped that slotIdx the pinned slide is
+ * inserted anyway — the user chose to keep this page.
+ */
+export function mergeLockedSlots(newSlots, lockedSlots) {
+  if (!lockedSlots?.length) return newSlots;
+  const lockedIdx = new Set(lockedSlots.map((s) => s.slotIdx));
+  const merged = newSlots.filter((s) => !lockedIdx.has(s.slotIdx));
+  for (const locked of lockedSlots) merged.push({ ...locked, locked: true });
+  merged.sort((a, b) => a.slotIdx - b.slotIdx);
+  return merged;
 }
 
 /**


### PR DESCRIPTION
产品面自迭代第三步, 微调三件套后的闭环收口。

## 交互

每张卡新增 ✋/🔒 开关。锁定页:
- **整本重新 Generate 时字节级原样保留** — `newsToFullDeck` 新增 `lockedSlots` 参数, 锁定 slot 的 lift 调用**直接跳过** (更省钱更快), `mergeLockedSlots` 按 slotIdx 拼回; 即使新一轮 mapper 放弃了该 slot, 钉住的页也存活 (用户的选择优先)
- 锁定时 🎲/✏️ 禁用 (防误触), 但仍跟随 🎨 主题切换 (同一 deck 对象)

## 真机双轮验证

14 页生成 → 锁定 #2/#5 → 重新 Generate → 两页指纹字节级一致 + 锁定描边保留, 未锁页指纹全变 (确实重 lift 了), 两轮都是 14 页。

## 闭环全景

**🎲 重 roll / ✏️ 指令改写 / 🎨 换主题 / ✋ 锁定重生成** — 全部原地修改同一 deck 对象, 导出永远零记账跟随。"生成→微调→导出"完整闭环。

## Tests
130/130 (+6 mergeLockedSlots 断言: 替换/存活/排序/passthrough)

🤖 Generated with [Claude Code](https://claude.com/claude-code)