### PR TITLE
Sprint 41: 2D 修饰层 — P5 生成艺术语料 + 铸造 hash 作品唯一性

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -210,6 +210,7 @@ const TESTS = [
   { category: 'present', file: 'sdf-js/scripts/test-visual-audit.mjs' },
   { category: 'present', file: 'sdf-js/scripts/test-slide-reroll.mjs' },
   { category: 'present', file: 'sdf-js/scripts/test-retheme.mjs' },
+  { category: 'present', file: 'sdf-js/scripts/test-decor.mjs' },
 ];
 
 // -----------------------------------------------------------------------------

--- a/sdf-js/apps/present/author-2d.js
+++ b/sdf-js/apps/present/author-2d.js
@@ -12,6 +12,7 @@ import { irDeckTo2DDeck } from '../../src/scene/ir-to-2d.js';
 import { newsToFullDeck, reliftSlot } from '../../src/present/news/full-deck.js';
 import { renderSceneDataToCanvas } from '../../src/present/atoms-2d/renderer.js';
 import { rethemeDeck } from '../../src/present/retheme.js';
+import { decorFromHash, mintDecorHash } from '../../src/present/decor/registry.js';
 import { ATLAS_THEMES } from '../../src/present/themes.js';
 import { exportDeckToPPTX } from '../../src/present/exporters/pptx.js';
 import { exportDeckToPDF } from '../../src/present/exporters/pdf.js';
@@ -74,6 +75,8 @@ themeEl.addEventListener('change', async () => {
   if (!currentDeck) return;
   try {
     rethemeDeck(currentDeck, themeEl.value);
+    if (currentDeck.decor?.hash)
+      currentDeck.decor = decorFromHash(currentDeck.theme, currentDeck.decor.hash);
     await renderDeck(currentDeck);
     setStatus(`theme → ${themeEl.value} (re-rendered, exports follow)`);
   } catch (e) {
@@ -101,6 +104,14 @@ const setStatus = (msg, err = false) => {
   statusEl.className = err ? 'err' : '';
 };
 
+// Decoration provenance (Sprint 41): the hash is MINTED per generation
+// (crypto-random, fxhash-style) — never derived from the content. ?hash=
+// re-opens an existing work; otherwise every Generate mints a new one.
+function currentMintHash() {
+  const urlHash = new URLSearchParams(location.search).get('hash');
+  return urlHash || mintDecorHash();
+}
+
 async function renderDeck(deck) {
   slidesEl.innerHTML = '';
   for (const slot of deck.slots) {
@@ -116,7 +127,12 @@ async function renderDeck(deck) {
     card.appendChild(cap);
     if (slot.liftParams) attachSlideControls(card, canvas, deck, slot);
     slidesEl.appendChild(card);
-    await renderSceneDataToCanvas(canvas, slot.sceneData, { palette: deck.theme });
+    await renderSceneDataToCanvas(canvas, slot.sceneData, {
+      palette: deck.theme,
+      decor: deck.decor
+        ? { ...deck.decor, seed: (deck.decor.seed ?? 1) + (slot.slotIdx ?? 0) }
+        : undefined,
+    });
   }
 }
 
@@ -165,7 +181,12 @@ function attachSlideControls(card, canvas, deck, slot) {
     rollBtn.disabled = editGo.disabled = true;
     try {
       const sceneData = await reliftSlot(currentDeck, slot.slotIdx, { apiKey, revision });
-      await renderSceneDataToCanvas(canvas, sceneData, { palette: deck.theme });
+      await renderSceneDataToCanvas(canvas, sceneData, {
+        palette: deck.theme,
+        decor: deck.decor
+          ? { ...deck.decor, seed: (deck.decor.seed ?? 1) + (slot.slotIdx ?? 0) }
+          : undefined,
+      });
       editRow.classList.remove('open');
       editInput.value = '';
       setStatus(
@@ -234,11 +255,14 @@ async function generate() {
       if (currentDeck.errors?.length) {
         console.warn('[full-deck] slot errors:', currentDeck.errors);
       }
+      currentDeck.decor = decorFromHash(currentDeck.theme, currentMintHash());
       await renderDeck(currentDeck);
       const errNote = currentDeck.errors?.length
         ? ` (${currentDeck.errors.length} slot(s) failed — see console)`
         : '';
-      setStatus(`done — ${currentDeck.slots.length} pages rendered${errNote}. Export below.`);
+      setStatus(
+        `done — ${currentDeck.slots.length} pages rendered${errNote}. 作品 #${currentDeck.decor.hash} (唯一, 持 hash 可复现). Export below.`,
+      );
       exportPptxEl.disabled = false;
       exportPdfEl.disabled = false;
       syncThemeSelect();
@@ -256,8 +280,15 @@ async function generate() {
       `rendering ${irDeck.slides.length} slide${irDeck.slides.length > 1 ? 's' : ''}: ${irDeck.slides.map((s) => s.structure).join(' → ')}`,
     );
     currentDeck = irDeckTo2DDeck(irDeck);
+    currentDeck.decor = decorFromHash(
+      currentDeck.theme,
+      DEMO_MODE ? 'demo-fixed-hash' : currentMintHash(),
+    );
+    window.__atlasDeck = currentDeck; // QA/debug handle
     await renderDeck(currentDeck);
-    setStatus(`done — ${currentDeck.slots.length} slide(s) rendered. Export below.`);
+    setStatus(
+      `done — ${currentDeck.slots.length} slide(s) rendered. 作品 #${currentDeck.decor.hash}. Export below.`,
+    );
     exportPptxEl.disabled = false;
     exportPdfEl.disabled = false;
     syncThemeSelect();

--- a/sdf-js/scripts/test-decor.mjs
+++ b/sdf-js/scripts/test-decor.mjs
@@ -1,0 +1,219 @@
+#!/usr/bin/env node
+// test-decor.mjs — Sprint 41: decoration layer mechanics (determinism,
+// theme affinity, legibility caps, render ordering).
+import {
+  DECOR_FAMILIES,
+  pickDecorFor,
+  drawDecor,
+  mintDecorHash,
+  seedFromHash,
+  decorFromHash,
+} from '../src/present/decor/registry.js';
+import { renderSceneDataToCanvas } from '../src/present/atoms-2d/renderer.js';
+
+let pass = 0,
+  fail = 0;
+const ok = (c, n) => (c ? (pass++, console.log(`  ✓ ${n}`)) : (fail++, console.log(`  ✗ ${n}`)));
+console.log('=== decor layer (Sprint 41: 2D 修饰能力, P5 语料 ↔ shader 语料对位) ===\n');
+
+const palette = {
+  bg: [248, 246, 240],
+  silhouetteColor: [22, 35, 70],
+  accent: [38, 70, 130],
+  colors: [
+    [38, 70, 130],
+    [165, 130, 90],
+  ],
+};
+
+// recording ctx that captures stroke/fill styles + path commands
+function recCtx() {
+  const rec = { ops: [], styles: [] };
+  const push =
+    (name) =>
+    (...a) =>
+      rec.ops.push([
+        name,
+        ...a.map((v) => (typeof v === 'number' ? Math.round(v * 100) / 100 : v)),
+      ]);
+  const ctx = {
+    save: push('save'),
+    restore: push('restore'),
+    beginPath: push('beginPath'),
+    closePath: push('closePath'),
+    moveTo: push('moveTo'),
+    lineTo: push('lineTo'),
+    arc: push('arc'),
+    stroke: push('stroke'),
+    fill: push('fill'),
+    fillRect: push('fillRect'),
+    fillText: push('fillText'),
+    quadraticCurveTo: push('quadraticCurveTo'),
+    bezierCurveTo: push('bezierCurveTo'),
+    arcTo: push('arcTo'),
+    ellipse: push('ellipse'),
+    rect: push('rect'),
+    roundRect: push('roundRect'),
+    clip: push('clip'),
+    setLineDash: push('setLineDash'),
+    translate: push('translate'),
+    rotate: push('rotate'),
+    scale: push('scale'),
+    transform: push('transform'),
+    setTransform: push('setTransform'),
+    strokeRect: push('strokeRect'),
+    clearRect: push('clearRect'),
+    drawImage: push('drawImage'),
+    strokeText: push('strokeText'),
+    measureText: () => ({ width: 40 }),
+    createLinearGradient: () => ({ addColorStop: () => {} }),
+    createRadialGradient: () => ({ addColorStop: () => {} }),
+    set strokeStyle(v) {
+      rec.styles.push(v);
+    },
+    set fillStyle(v) {
+      rec.styles.push(v);
+    },
+    lineWidth: 1,
+    lineCap: '',
+    font: '',
+    textAlign: '',
+    textBaseline: '',
+    shadowColor: '',
+    shadowBlur: 0,
+    shadowOffsetY: 0,
+    globalAlpha: 1,
+  };
+  return { ctx, rec };
+}
+
+// ── determinism ──
+{
+  const a = recCtx();
+  const b = recCtx();
+  const c = recCtx();
+  const opts = { palette, x: 0, y: 0, w: 640, h: 360, intensity: 'subtle' };
+  drawDecor(a.ctx, { family: 'flow-streams', seed: 42 }, opts);
+  drawDecor(b.ctx, { family: 'flow-streams', seed: 42 }, opts);
+  drawDecor(c.ctx, { family: 'flow-streams', seed: 43 }, opts);
+  ok(JSON.stringify(a.rec.ops) === JSON.stringify(b.rec.ops), 'same seed → identical geometry');
+  ok(
+    JSON.stringify(a.rec.ops) !== JSON.stringify(c.rec.ops),
+    'different seed → different geometry',
+  );
+  ok(a.rec.ops.length > 50, `flow-streams actually draws (${a.rec.ops.length} ops)`);
+}
+
+// ── every family draws, palette-constrained, alpha-capped ──
+{
+  for (const family of Object.keys(DECOR_FAMILIES)) {
+    const { ctx, rec } = recCtx();
+    drawDecor(
+      ctx,
+      { family, seed: 7 },
+      { palette, x: 0, y: 0, w: 640, h: 360, intensity: 'subtle' },
+    );
+    ok(rec.ops.length > 20, `${family} draws (${rec.ops.length} ops)`);
+    const alphas = rec.styles
+      .map((s) => /rgba\(\d+, \d+, \d+, ([\d.]+)\)/.exec(String(s)))
+      .filter(Boolean)
+      .map((m) => parseFloat(m[1]));
+    ok(
+      alphas.length > 0 && Math.max(...alphas) <= 0.1,
+      `${family} subtle alpha ≤ 0.1 (legibility guard)`,
+    );
+    const paletteRgb = new Set(
+      [palette.accent, ...palette.colors].map((c) => `${c[0]}, ${c[1]}, ${c[2]}`),
+    );
+    const offPalette = rec.styles.filter((s) => {
+      const m = /rgba\((\d+, \d+, \d+),/.exec(String(s));
+      return m && !paletteRgb.has(m[1]);
+    });
+    ok(offPalette.length === 0, `${family} uses only theme colors`);
+  }
+}
+
+// ── pickDecorFor: deterministic + affinity ──
+{
+  const t = { id: 'editorial-navy', macroCluster: 'editorial' };
+  const p1 = pickDecorFor(t, 5);
+  const p2 = pickDecorFor(t, 5);
+  ok(p1.family === p2.family, 'pick deterministic per (theme, seed)');
+  ok(['flow-streams', 'shard-mesh'].includes(p1.family), 'editorial affinity respected');
+  ok(
+    pickDecorFor({ id: 'weird' }, 1).family in DECOR_FAMILIES,
+    'unknown cluster falls back to a valid family',
+  );
+}
+
+// ── drawDecor safety ──
+{
+  const { ctx, rec } = recCtx();
+  ok(
+    drawDecor(ctx, { family: 'no-such-family', seed: 1 }, { palette, w: 100, h: 100 }) === false,
+    'unknown family is a silent no-op',
+  );
+  ok(rec.ops.length === 0, 'no-op really draws nothing');
+}
+
+// ── renderer ordering: content slide decor UNDER atoms; cover slide OVER ──
+{
+  const calls = [];
+  const canvas = {
+    width: 1280,
+    height: 720,
+    getContext: () => {
+      const { ctx } = recCtx();
+      ctx.fillRect = (...a) => calls.push(['fillRect', ...a]);
+      ctx.stroke = () => calls.push(['stroke']);
+      ctx.fillText = (t) => calls.push(['fillText', String(t)]);
+      ctx.fill = () => calls.push(['fill']);
+      return ctx;
+    },
+  };
+  await renderSceneDataToCanvas(
+    canvas,
+    {
+      subjects: [
+        { type: 'kpi-card', x: 40, y: 160, w: 300, h: 200, args: { value: '9', label: 'L' } },
+      ],
+    },
+    { palette, decor: { family: 'weave-dashes', seed: 3 } },
+  );
+  const firstText = calls.findIndex((c) => c[0] === 'fillText');
+  const firstStroke = calls.findIndex((c) => c[0] === 'stroke');
+  ok(
+    firstStroke > -1 && firstStroke < firstText,
+    'content slide: decor strokes land before atom text',
+  );
+}
+
+// ── mint-hash provenance (Sprint 41 core insight) ──
+{
+  const h1 = mintDecorHash();
+  const h2 = mintDecorHash();
+  ok(/^[0-9a-f]{16}$/.test(h1), 'minted hash is 16 hex chars (64-bit)');
+  ok(h1 !== h2, 'two mints differ (crypto-random)');
+  ok(seedFromHash(h1) === seedFromHash(h1), 'seedFromHash deterministic');
+  const t = { id: 'editorial-navy', macroCluster: 'editorial' };
+  const d1 = decorFromHash(t, 'abcdef0123456789');
+  const d2 = decorFromHash(t, 'abcdef0123456789');
+  ok(
+    d1.family === d2.family && d1.seed === d2.seed,
+    'same (theme, hash) → same decoration everywhere',
+  );
+  ok(d1.hash === 'abcdef0123456789', 'provenance hash carried on the decor object');
+  // the owner-reproducibility property: two different hashes → (almost
+  // surely) different geometry
+  const a = recCtx();
+  const b = recCtx();
+  drawDecor(a.ctx, decorFromHash(t, 'aaaaaaaaaaaaaaaa'), { palette, w: 640, h: 360 });
+  drawDecor(b.ctx, decorFromHash(t, 'bbbbbbbbbbbbbbbb'), { palette, w: 640, h: 360 });
+  ok(
+    JSON.stringify(a.rec.ops) !== JSON.stringify(b.rec.ops),
+    'different hash → different artifact',
+  );
+}
+
+console.log(`\n${pass} passed, ${fail} failed`);
+process.exit(fail ? 1 : 0);

--- a/sdf-js/src/present/atoms-2d/renderer.js
+++ b/sdf-js/src/present/atoms-2d/renderer.js
@@ -16,6 +16,7 @@
 // =============================================================================
 
 import { renderAtom, isAtom2DType } from './registry.js';
+import { drawDecor } from '../decor/registry.js';
 
 const DEFAULT_PALETTE = {
   bg: [247, 244, 224],
@@ -48,6 +49,23 @@ export async function renderSceneDataToCanvas(canvas, sceneData, opts = {}) {
   }
 
   const subjects = Array.isArray(sceneData?.subjects) ? sceneData.subjects : [];
+
+  // Decoration layer (Sprint 41): generative backdrop, theme-constrained +
+  // seeded. Content slides get it UNDER the atoms ('subtle'); pure-cover
+  // slides get it OVER the gradient ('bold' — the cover paints full-bleed
+  // and would bury an underlay).
+  const decor = opts.decor;
+  const isPureCover = subjects.length > 0 && subjects.every((s) => s?.type === 'cover');
+  if (decor && !isPureCover) {
+    drawDecor(ctx, decor, {
+      palette,
+      x: 0,
+      y: 0,
+      w: canvas.width,
+      h: canvas.height,
+      intensity: decor.intensity || 'subtle',
+    });
+  }
   let rendered = 0;
   let skipped = 0;
   const errors = [];
@@ -81,6 +99,18 @@ export async function renderSceneDataToCanvas(canvas, sceneData, opts = {}) {
       ctx.restore(); // ensure no leaked transform state
       errors.push({ index: i, type: s.type, error: e.message });
     }
+  }
+
+  // Pure-cover slides: decoration goes on top of the gradient.
+  if (decor && isPureCover) {
+    drawDecor(ctx, decor, {
+      palette,
+      x: 0,
+      y: 0,
+      w: canvas.width,
+      h: canvas.height,
+      intensity: decor.intensity || 'bold',
+    });
   }
 
   return { rendered, skipped, errors };

--- a/sdf-js/src/present/decor/registry.js
+++ b/sdf-js/src/present/decor/registry.js
@@ -1,0 +1,300 @@
+// =============================================================================
+// decor/registry.js — Sprint 41: the 2D DECORATION layer (修饰能力).
+//
+// The style-layer thesis, 2D side: P5-generative-art idioms are to the 2D end
+// what shader idioms are to the 3D end — two independent "empirical domain"
+// supply lines (they deliberately do NOT need twins; decoration is not
+// semantic content and is exempt from the X-gap closure rule).
+//
+// Contract (mirrors the two-track lock):
+//   - Every decoration is a PURE function (ctx, {palette, seed, x, y, w, h,
+//     intensity}) — theme-palette-constrained, SFC32-seeded deterministic
+//     (same seed → same pixels, reproducible across re-renders and exports).
+//   - The LLM neither writes nor selects decoration code. Assignment is
+//     deterministic: theme macroCluster → family affinity + seeded pick.
+//   - Legibility guard: intensity presets cap stroke alpha ('subtle' for
+//     content backdrops, 'bold' only over cover gradients).
+//
+// Generators are ADAPTED COPIES from the P5 idiom registry corpus
+// (sdf-js/examples/p5-idiom-registry/ — the established src convention, same
+// as icon-badge and chromotome-palettes-data):
+//   flow-streams — after moussa-perlin-flow-field (Amin Moussa recipes) +
+//                  kgolid p5ycho flow tradition, MIT-implicit
+//   weave-dashes — after kgolid-weave-flow-dashes (Kjetil Golid, p5ycho/weave)
+//   circle-pack  — after moussa-shape-pack-grid-collision / Gorilla Sun
+//                  packing essays (recipe-only)
+//   shard-mesh   — after moussa-delaunay-voronoi (recipe-only: jittered-grid
+//                  triangulation approximation, no delaunay dependency)
+// =============================================================================
+
+// --- deterministic primitives (value noise + rng, per idiom-registry style) --
+function seededRand(seed) {
+  let s = seed | 0 || 1;
+  return () => {
+    s = (s * 1664525 + 1013904223) | 0;
+    return ((s >>> 9) & 0x7fffff) / 0x800000;
+  };
+}
+
+function noise2D(seed) {
+  const hash = (ix, iy) => {
+    let h = (ix * 374761393 + iy * 668265263 + seed * 1274126177) | 0;
+    h = (h ^ (h >>> 13)) * 1103515245;
+    return (((h ^ (h >>> 16)) >>> 0) % 1000) / 1000;
+  };
+  const lerp = (a, b, t) => a + (b - a) * t;
+  const fade = (t) => t * t * (3 - 2 * t);
+  return (x, y) => {
+    const ix = Math.floor(x);
+    const iy = Math.floor(y);
+    const fx = fade(x - ix);
+    const fy = fade(y - iy);
+    return lerp(
+      lerp(hash(ix, iy), hash(ix + 1, iy), fx),
+      lerp(hash(ix, iy + 1), hash(ix + 1, iy + 1), fx),
+      fy,
+    );
+  };
+}
+
+const rgba = ([r, g, b], a) => `rgba(${r}, ${g}, ${b}, ${a})`;
+
+// intensity presets — the legibility guard. Content backdrops stay whisper-
+// quiet; 'bold' is reserved for cover/divider slides over their gradient.
+const INTENSITY = {
+  subtle: { alpha: 0.07, alphaFill: 0.05, lineWidth: 1 },
+  medium: { alpha: 0.14, alphaFill: 0.1, lineWidth: 1.2 },
+  bold: { alpha: 0.26, alphaFill: 0.18, lineWidth: 1.6 },
+};
+
+// --- families ---------------------------------------------------------------
+
+// flow-streams: long noise-driven streamlines (wind / fluid feel)
+function drawFlowStreams(ctx, { palette, seed, x, y, w, h, intensity }) {
+  const P = INTENSITY[intensity] || INTENSITY.subtle;
+  const noise = noise2D(seed);
+  const rand = seededRand(seed * 7 + 1);
+  const colors = [palette.accent, ...(palette.colors || [])].filter(Boolean);
+  const lines = Math.round((w * h) / 18000);
+  ctx.save();
+  ctx.lineCap = 'round';
+  for (let i = 0; i < lines; i++) {
+    let px = x + rand() * w;
+    let py = y + rand() * h;
+    const color = colors[i % colors.length];
+    ctx.strokeStyle = rgba(color, P.alpha);
+    ctx.lineWidth = P.lineWidth;
+    ctx.beginPath();
+    ctx.moveTo(px, py);
+    for (let s = 0; s < 60; s++) {
+      const a = noise(px * 0.004, py * 0.004) * Math.PI * 4;
+      px += Math.cos(a) * 6;
+      py += Math.sin(a) * 6;
+      if (px < x || px > x + w || py < y || py > y + h) break;
+      ctx.lineTo(px, py);
+    }
+    ctx.stroke();
+  }
+  ctx.restore();
+}
+
+// weave-dashes: dense short dashes along local gradient (iron-filings weave)
+function drawWeaveDashes(ctx, { palette, seed, x, y, w, h, intensity }) {
+  const P = INTENSITY[intensity] || INTENSITY.subtle;
+  const colors = [palette.accent, ...(palette.colors || [])].filter(Boolean).slice(0, 3);
+  ctx.save();
+  ctx.lineCap = 'round';
+  const cell = 26;
+  for (let layer = 0; layer < colors.length; layer++) {
+    const noise = noise2D(seed + layer * 101);
+    ctx.strokeStyle = rgba(colors[layer], P.alpha);
+    ctx.lineWidth = P.lineWidth;
+    for (let gy = y + cell / 2; gy < y + h; gy += cell) {
+      for (let gx = x + cell / 2 + (layer * cell) / 3; gx < x + w; gx += cell) {
+        const a = noise(gx * 0.006, gy * 0.006) * Math.PI * 2;
+        const len = cell * 0.42;
+        ctx.beginPath();
+        ctx.moveTo(gx - Math.cos(a) * len, gy - Math.sin(a) * len);
+        ctx.lineTo(gx + Math.cos(a) * len, gy + Math.sin(a) * len);
+        ctx.stroke();
+      }
+    }
+  }
+  ctx.restore();
+}
+
+// circle-pack: collision-free circles, corner-weighted so slide centers stay clear
+function drawCirclePack(ctx, { palette, seed, x, y, w, h, intensity }) {
+  const P = INTENSITY[intensity] || INTENSITY.subtle;
+  const rand = seededRand(seed * 13 + 5);
+  const colors = [palette.accent, ...(palette.colors || [])].filter(Boolean);
+  const placed = [];
+  const tries = 260;
+  ctx.save();
+  for (let i = 0; i < tries; i++) {
+    // corner-weighted position (square the unit coords toward edges)
+    const u = rand();
+    const v = rand();
+    const cx = x + (u < 0.5 ? u * u * 2 : 1 - (1 - u) * (1 - u) * 2) * w;
+    const cy = y + (v < 0.5 ? v * v * 2 : 1 - (1 - v) * (1 - v) * 2) * h;
+    const r = 6 + rand() * Math.min(w, h) * 0.06;
+    let ok = true;
+    for (const c of placed) {
+      const d = Math.hypot(cx - c.x, cy - c.y);
+      if (d < r + c.r + 4) {
+        ok = false;
+        break;
+      }
+    }
+    if (!ok) continue;
+    placed.push({ x: cx, y: cy, r });
+    const color = colors[placed.length % colors.length];
+    if (placed.length % 3 === 0) {
+      ctx.fillStyle = rgba(color, P.alphaFill);
+      ctx.beginPath();
+      ctx.arc(cx, cy, r, 0, Math.PI * 2);
+      ctx.fill();
+    } else {
+      ctx.strokeStyle = rgba(color, P.alpha);
+      ctx.lineWidth = P.lineWidth;
+      ctx.beginPath();
+      ctx.arc(cx, cy, r, 0, Math.PI * 2);
+      ctx.stroke();
+    }
+    if (placed.length > 40) break;
+  }
+  ctx.restore();
+}
+
+// shard-mesh: jittered-grid triangulation outlines (delaunay-recipe look)
+function drawShardMesh(ctx, { palette, seed, x, y, w, h, intensity }) {
+  const P = INTENSITY[intensity] || INTENSITY.subtle;
+  const rand = seededRand(seed * 31 + 7);
+  const colors = [palette.accent, ...(palette.colors || [])].filter(Boolean);
+  const cols = 8;
+  const rows = 5;
+  const pts = [];
+  for (let j = 0; j <= rows; j++) {
+    for (let i = 0; i <= cols; i++) {
+      pts.push([
+        x + (i / cols) * w + (i > 0 && i < cols ? (rand() - 0.5) * (w / cols) * 0.9 : 0),
+        y + (j / rows) * h + (j > 0 && j < rows ? (rand() - 0.5) * (h / rows) * 0.9 : 0),
+      ]);
+    }
+  }
+  const at = (i, j) => pts[j * (cols + 1) + i];
+  ctx.save();
+  ctx.lineWidth = P.lineWidth;
+  let k = 0;
+  for (let j = 0; j < rows; j++) {
+    for (let i = 0; i < cols; i++) {
+      const quad = [at(i, j), at(i + 1, j), at(i + 1, j + 1), at(i, j + 1)];
+      const diag = rand() < 0.5;
+      const tris = diag
+        ? [
+            [quad[0], quad[1], quad[2]],
+            [quad[0], quad[2], quad[3]],
+          ]
+        : [
+            [quad[0], quad[1], quad[3]],
+            [quad[1], quad[2], quad[3]],
+          ];
+      for (const tri of tris) {
+        k++;
+        const color = colors[k % colors.length];
+        ctx.strokeStyle = rgba(color, P.alpha * 0.8);
+        if (k % 7 === 0) ctx.fillStyle = rgba(color, P.alphaFill * 0.6);
+        ctx.beginPath();
+        ctx.moveTo(tri[0][0], tri[0][1]);
+        ctx.lineTo(tri[1][0], tri[1][1]);
+        ctx.lineTo(tri[2][0], tri[2][1]);
+        ctx.closePath();
+        ctx.stroke();
+        if (k % 7 === 0) ctx.fill();
+      }
+    }
+  }
+  ctx.restore();
+}
+
+// --- registry ----------------------------------------------------------------
+
+export const DECOR_FAMILIES = {
+  'flow-streams': drawFlowStreams,
+  'weave-dashes': drawWeaveDashes,
+  'circle-pack': drawCirclePack,
+  'shard-mesh': drawShardMesh,
+};
+
+// theme macroCluster → family affinity (seeded pick between two candidates so
+// different decks in the same theme still vary)
+const CLUSTER_AFFINITY = {
+  editorial: ['flow-streams', 'shard-mesh'],
+  pitch: ['weave-dashes', 'circle-pack'],
+  organic: ['flow-streams', 'circle-pack'],
+  consulting: ['weave-dashes', 'shard-mesh'],
+  financial: ['shard-mesh', 'weave-dashes'],
+  hr: ['circle-pack', 'flow-streams'],
+};
+
+/**
+ * pickDecorFor(theme, seed) → { family, seed } — deterministic per
+ * (theme, seed); the LLM is never involved.
+ */
+export function pickDecorFor(theme, seed = 1) {
+  const cluster = String(theme?.macroCluster || theme?.id || '').split('-')[0];
+  const candidates = CLUSTER_AFFINITY[cluster] || ['flow-streams', 'weave-dashes'];
+  const rand = seededRand(seed);
+  return { family: candidates[Math.floor(rand() * candidates.length)], seed };
+}
+
+/**
+ * drawDecor(ctx, decor, opts) — paint one decoration region.
+ * decor: { family, seed }; opts: { palette, x, y, w, h, intensity }.
+ * Unknown family is a silent no-op (decks stay renderable across versions).
+ */
+export function drawDecor(ctx, decor, { palette, x = 0, y = 0, w, h, intensity = 'subtle' } = {}) {
+  const fn = DECOR_FAMILIES[decor?.family];
+  if (!fn || !palette || !w || !h) return false;
+  fn(ctx, { palette, seed: decor.seed ?? 1, x, y, w, h, intensity });
+  return true;
+}
+
+// --- mint-hash provenance (Sprint 41, user's core insight) -------------------
+// The decoration seed is NOT derived from the content. It is MINTED —
+// crypto-random at generation time, fxhash/ArtBlocks style. Consequences:
+//   - The seed space is astronomically large; a deck's generative identity
+//     is one unguessable point in it.
+//   - The OWNER (who holds the hash) can re-derive their exact artifact
+//     forever (determinism = proof of authorship).
+//   - An imitator with the same text and the same tool still cannot mint
+//     the same artifact — the visual identity is unforgeable without the
+//     hash. Provenance, not DRM: pixels can be screenshotted, but the
+//     original can always be distinguished and re-proven.
+export function mintDecorHash() {
+  const bytes = new Uint8Array(8);
+  if (globalThis.crypto?.getRandomValues) {
+    globalThis.crypto.getRandomValues(bytes);
+  } else {
+    for (let i = 0; i < 8; i++) bytes[i] = Math.floor(Math.random() * 256);
+  }
+  return [...bytes].map((b) => b.toString(16).padStart(2, '0')).join('');
+}
+
+// hash (hex string) → 31-bit seed for the generators
+export function seedFromHash(hash) {
+  let h = 2166136261;
+  const str = String(hash);
+  for (let i = 0; i < str.length; i++) h = ((h ^ str.charCodeAt(i)) * 16777619) | 0;
+  return (Math.abs(h) % 0x7fffffff) + 1;
+}
+
+/**
+ * decorFromHash(theme, hash) → { family, seed, hash } — the full provenance
+ * bundle. Same (theme, hash) always yields the same decoration everywhere
+ * (screen, PPTX, PDF, re-render).
+ */
+export function decorFromHash(theme, hash) {
+  const seed = seedFromHash(hash);
+  return { ...pickDecorFor(theme, seed), hash };
+}

--- a/sdf-js/src/present/exporters/pdf.js
+++ b/sdf-js/src/present/exporters/pdf.js
@@ -9,7 +9,7 @@
 // Both share the same canvas-render pipeline from atoms-2d.
 // =============================================================================
 
-import { renderAtom } from '../atoms-2d/registry.js';
+import { renderSceneDataToCanvas } from '../atoms-2d/renderer.js';
 
 const JSPDF_CDN = 'https://esm.sh/jspdf@2.5.2';
 let jsPDF = null;
@@ -63,24 +63,17 @@ export async function exportDeckToPDF(deck, opts = {}) {
     const canvas = document.createElement('canvas');
     canvas.width = 1280;
     canvas.height = 720;
-    const ctx = canvas.getContext('2d');
-    ctx.fillStyle = `rgb(${deck.theme.bg.join(',')})`;
-    ctx.fillRect(0, 0, canvas.width, canvas.height);
-
-    if (slot.sceneData?.subjects) {
-      for (const subj of slot.sceneData.subjects) {
-        try {
-          await renderAtom(ctx, subj.type, subj.args, 'pseudo3d', {
-            x: subj.x ?? 0,
-            y: subj.y ?? 0,
-            w: subj.w ?? 320,
-            h: subj.h ?? 240,
-            palette: deck.theme,
-          });
-        } catch (e) {
-          console.error(`[pdf] renderAtom ${subj.type} failed:`, e);
-        }
-      }
+    // Unified slide painter (Sprint 41): same renderer as the on-screen
+    // preview — decoration layer included, per-atom errors non-fatal.
+    try {
+      await renderSceneDataToCanvas(canvas, slot.sceneData || { subjects: [] }, {
+        palette: deck.theme,
+        decor: deck.decor
+          ? { ...deck.decor, seed: (deck.decor.seed ?? 1) + slot.slotIdx }
+          : undefined,
+      });
+    } catch (e) {
+      console.error(`[pdf] slide render failed:`, e);
     }
 
     const pngDataURL = canvas.toDataURL('image/png');

--- a/sdf-js/src/present/exporters/pptx.js
+++ b/sdf-js/src/present/exporters/pptx.js
@@ -17,7 +17,7 @@
 // NOT this PPTX. PPTX is for human delivery; deck.json is for 3D translator.
 // =============================================================================
 
-import { renderAtom } from '../atoms-2d/registry.js';
+import { renderSceneDataToCanvas } from '../atoms-2d/renderer.js';
 
 // pptxgenjs loaded from esm.sh on first call (matches pdfjs CDN pattern in
 // src/parser/pdf.js — no build step / bundler required).
@@ -79,24 +79,17 @@ export async function exportDeckToPPTX(deck, opts = {}) {
     const canvas = document.createElement('canvas');
     canvas.width = 1280;
     canvas.height = 720;
-    const ctx = canvas.getContext('2d');
-    ctx.fillStyle = `rgb(${deck.theme.bg.join(',')})`;
-    ctx.fillRect(0, 0, canvas.width, canvas.height);
-
-    if (slot.sceneData?.subjects) {
-      for (const subj of slot.sceneData.subjects) {
-        try {
-          await renderAtom(ctx, subj.type, subj.args, 'pseudo3d', {
-            x: subj.x ?? 0,
-            y: subj.y ?? 0,
-            w: subj.w ?? 320,
-            h: subj.h ?? 240,
-            palette: deck.theme,
-          });
-        } catch (e) {
-          console.error(`[pptx] renderAtom ${subj.type} failed:`, e);
-        }
-      }
+    // Unified slide painter (Sprint 41): same renderer as the on-screen
+    // preview — decoration layer included, per-atom errors non-fatal.
+    try {
+      await renderSceneDataToCanvas(canvas, slot.sceneData || { subjects: [] }, {
+        palette: deck.theme,
+        decor: deck.decor
+          ? { ...deck.decor, seed: (deck.decor.seed ?? 1) + slot.slotIdx }
+          : undefined,
+      });
+    } catch (e) {
+      console.error(`[pptx] slide render failed:`, e);
     }
 
     const pngDataURL = canvas.toDataURL('image/png');


### PR DESCRIPTION
两个 user 方向在本 PR 汇合: (1) 修饰能力 = 2D 端的风格层, 与 3D 端 shader 语料结构对位、各自独立补给、不需要 twin; (2) **铸造 hash 唯一性 — 作品不可仿制**。

## 修饰引擎 (`src/present/decor/`)

4 个家族, 全部改编自 P5 idiom 语料库存货 (Golid p5ycho weave / Moussa flow-field·circle-pack / delaunay recipe-only, 完整 attribution, 沿用 icon-badge 的"改编复制"惯例):

| 家族 | 视觉 | 主题亲和 |
|---|---|---|
| flow-streams | 长噪声流线 | editorial / organic |
| weave-dashes | 多层短划织物 | consulting / pitch / financial |
| circle-pack | 角落加权圆堆积 | organic / pitch / hr |
| shard-mesh | 抖动网格三角剖分 | financial / editorial |

契约: 纯函数 + 种子确定性 + 主题色约束 + **透明度上限** (内容页 subtle ≤0.1 垫底, 封面页 bold 叠顶) — 可读性是硬边界。**LLM 不写也不选修饰** (双轨锁延伸), 分配 = macroCluster 亲和 + 种子挑选。

## 铸造 hash (user 的关键洞见)

种子**不从内容派生** — 每次生成用 crypto 随机**铸造** 64-bit hash (fxhash/ArtBlocks 式)。由此获得的性质:

- **拥有者永久可复现**: 持 hash 者 (`?hash=` 重开) 在任何介质上重现完全一致的作品 — 确定性即作者身份证明
- **仿制者永不可复现**: 同样的文本 + 同样的工具, 不知道 hash 就铸不出同一件作品 — 生成身份不可伪造
- 这是 provenance 不是 DRM: 像素可以截图, 但原作永远可被区分、可被再证明

UI 显示 `作品 #a3f9…`。换主题从同一 hash 重挑家族 (身份不变, 表现随主题)。

## 渲染统一

导出器 (PPTX/PDF) 从各自手绘 loop 统一到 `renderSceneDataToCanvas` — **屏幕/PPTX/PDF 三处共用一个 painter**, 作品在所有介质严格一致 (这也是复现性主张成立的前提)。

## Tests
131/131 — test-decor.mjs 27 断言 (确定性 / 色板约束 / 透明度上限 / 亲和 / 渲染次序 / 铸造唯一性 / 拥有者复现性)

🤖 Generated with [Claude Code](https://claude.com/claude-code)