### PR TITLE
Study: ArtBlocks Curated 语料总览 + 第一课 Fragments (唯一 CC BY)

### DIFF
--- a/docs/superpowers/artblocks-study/00-corpus.md
+++ b/docs/superpowers/artblocks-study/00-corpus.md
@@ -1,0 +1,24 @@
+# ArtBlocks Curated 学习语料 — 总览 (2026-07-08)
+
+**语料位置 (repo 外, 不入 git)**: `~/Documents/artblocks/curated/` — 108 个 Curated 项目
+全量 (script.js + meta.json 逐字 license), 经 Hasura GraphQL 公开 API 抓取, 0 失败。
+索引与完整 Top-20: `~/Documents/artblocks/curated/STUDY-REPORT.md`。
+
+## License 地图 (决定 port 方式)
+
+| 类别 | 数量 | port 方式 |
+|---|---|---|
+| **CC BY** (仅 Fragments of an Infinite Field) | **1** | **code-port 可商用 (带 attribution)** |
+| CC BY-NC 系 | 56 | recipe-only (NC 禁商用代码) |
+| CC BY-NC-ND | 18 | recipe-only, 严格 (ND) |
+| CC BY-NC-SA | 9 | recipe-only (SA 传染) |
+| NFT/NIFTY License | 18 | 纯研究 |
+| 各式版权/无 license | 6 | 纯研究 |
+
+76% 是纯 2D (p5/js/svg/paper) — 与 deck 修饰层直接相关。
+
+## 学习节奏
+
+一课一项目, 每课产出: 本目录一份 recipe (结构分析 + 可提取 idiom + port 判定),
+可 port 的进 `src/present/decor/` 家族 (recipe-only 的只进 idiom 词表)。
+顺序按 STUDY-REPORT Top-20; 每个 port 遵守既有 5 步 recipe-only workflow 与 attribution 纪律。

--- a/docs/superpowers/artblocks-study/01-fragments-rizzolli.md
+++ b/docs/superpowers/artblocks-study/01-fragments-rizzolli.md
@@ -1,0 +1,45 @@
+# 第一课: Fragments of an Infinite Field — Monica Rizzolli
+
+- **ArtBlocks #159** · p5@1.0.0 · 738 行 · **CC BY (全语料唯一可商用 code-port, 需 attribution)**
+- 视觉: 四季花田 — 各向异性草叶场 + 程序化花朵 + 天气叠加 (雨/雪)
+- 语料: `~/Documents/artblocks/curated/159-fragments-of-an-infinite-field-by-monica-rizzolli/`
+
+## 结构 (自上而下)
+
+```
+semente()    hash → 32 个 0-9 决策位 (每 2 个 hex 字符 mod 10)
+variaveis()  决策位 → 参数: 网格 93-107×20-39 / 噪声系数 / 四季选择 /
+             每季 2 套手调 5 色板 (叶色 corFolhas × 花色 corFlor)
+folhas(chance)  草叶场: 密集网格逐格 → 噪声驱动旋转 + 各向异性椭圆 (fx=1, fy=10)
+flor()       花对象: petalaPlot/petalaOut/corona/stamen 四层构造
+chuva()/neve()  天气叠加: 夏雨 (斜线束) / 冬雪 (白点)
+play()       按季节决定花朵绘制顺序; 草叶场画两遍 (花前浓/花后疏) 制造纵深
+```
+
+## 六个可提取 idiom (按对 decor 层的价值排序)
+
+1. **hash → 32 决策位**: 每个美学决策一个独立 digit — 正交变化轴。我们的
+   `seedFromHash` 把 hash 坍缩成单个 int, 这是直接升级: 一个 hash 供给
+   家族选择/密度/方向/色板变体各自独立的 digit。
+2. **噪声索引色板** `fill(cor[floor(a * cor.length)])` — 颜色由**空间噪声**索引
+   而非独立随机 → 相邻元素同色成片, 有机色块而非均匀噪点。我们 weave-dashes
+   目前逐格独立取色, 该学这个。
+3. **噪声门控密度** `if (a2 < chance)` — 元素存在性也由噪声场决定 → 疏密成片。
+4. **各向异性椭圆场** (fx=1, fy=10 拉长 + 噪声旋转) = 草叶/织物质感 —
+   新家族候选 **meadow-streaks**, 低透明度下极适合 deck 背景。
+5. **季节色板系统**: 1 个 digit 选季节 + 每季 2 变体 — 结构化的"情绪"分层。
+   映射到 deck: theme 定大方向, hash 在 theme 内选变体。
+6. **双层场纵深**: 主体前画浓场、主体后画疏场 — 封面修饰可用 under+over 两遍。
+
+## Port 判定
+
+- **可 code-port (CC BY + attribution)**。第一优先: `meadow-streaks` 家族
+  (idiom 3+4+2 的组合, ~60 行), attribution 头注明 Rizzolli/#159/CC BY。
+- 决策位机制 (idiom 1) 升级 `decor/registry.js` 的 hash 消费方式, 全家族受益。
+- 花朵构造 (petala/corona/stamen) 对修饰层过于具象, 不 port; 天气叠加留作
+  accent 家族候选。
+
+## 一句话学到的
+
+把"一个 hash"当成 **32 个独立旋钮** 而不是一颗种子 — 变化空间从一维变成
+32 维正交格, 这是 fxhash 系作品"同一算法千姿百态"的核心机制。


### PR DESCRIPTION
按 user 指令: subagent 抓取全部 ArtBlocks Curated → 一一学习。

## 语料 (repo 外: ~/Documents/artblocks/curated/)

- **108 个 Curated 项目全量**, 0 失败, 每项带逐字 license 的 meta.json + index + STUDY-REPORT (Top-20 修饰学习候选)
- **License 地图是最重要发现**: 全语料**只有 1 个 CC BY** (可商用 code-port) — Rizzolli 的 Fragments of an Infinite Field; CC BY-NC 系 83 个 (recipe-only), NFT/NIFTY/版权 24 个 (纯研究)。语料本体永不入 repo, 只有 recipe 文档进来

## 第一课: Fragments (#159, 738 行 p5)

六个可提取 idiom, 最重要的一个: **hash → 32 个独立决策位** (每 2 hex 字符 mod 10, 每个美学决策一个正交旋钮) — 这是对我们刚上线的铸造 hash 机制的直接升级 (目前坍缩为单种子)。另有噪声索引色板 (空间成片而非均匀噪点)、噪声门控密度、各向异性椭圆场 (meadow-streaks 家族候选)、季节色板分层、双层场纵深。

Port 判定: meadow-streaks + 决策位机制列为下一步 code-port (CC BY + attribution); 花朵构造过于具象不 port。

🤖 Generated with [Claude Code](https://claude.com/claude-code)