### PR TITLE
Sprint 45: 第三课 Archetype + block-mosaic (recipe-only 细胞生长矩形)

### DIFF
--- a/docs/superpowers/artblocks-study/03-archetype-golid.md
+++ b/docs/superpowers/artblocks-study/03-archetype-golid.md
@@ -1,0 +1,51 @@
+# 第三课: Archetype — Kjetil Golid
+
+- **ArtBlocks #23** · p5 · 13.9KB minified · **CC BY-NC 4.0 → recipe-only**
+- 视觉: 等轴测块体构成 — 嵌套网格里的彩色矩形块, 三面受光, 42 套手调色板
+- 更正: 前两课记录的"语料空文件"是误诊 (`wc -l` 对单行 minified 返回 0),
+  语料 108 项 100% 完整
+
+## 结构
+
+```
+rnd()          xorshift32 (seed^=seed<<13 / >>17 / <<5) — 最小可用 PRNG
+w_pick(arr,w)  加权选择 (累计和数组) — Golid 全部决策的基本算子
+布局人格        chaos/balance/pattern 三套参数包, w_pick([1,4,2]) 加权抽取
+Apparatus      ★ 他的招牌开源生成器: 细胞生长状态机长出紧密矩形填充
+               next_block: 延伸水平块/延伸垂直块/开新块 (概率驱动),
+               linegrid → NW 角点 → 矩形
+颜色模式        group/main/single/random + group_size —
+               "group": 新块以概率继承邻块颜色 → 颜色连片成组
+嵌套网格        外层 Apparatus 分区 → 每区内层 Apparatus 原子块 (+量化深度 z1)
+等轴测投影      xu/yu/zu 三单位向量, 每块画三面, 面透明度组合 = 明暗人格
+painter 排序   块重叠图 toposort — 严格正确的遮挡顺序
+42 套色板      手调 {c[], s 描边, b 底色, w 权重}, w_pick 按权重抽
+```
+
+## 五个可提取 idiom
+
+1. **Apparatus 矩形填充** (最重要): 细胞生长状态机产出的"紧密但不规则"
+   面板布局 — 视觉上是 Mondrian 有机版。decor 之外, 这个生成器对
+   **slide 面板布局本身**都有启发 (未来 layout 引擎候选)。
+2. **邻块颜色继承** (group 模式 + group_size): 颜色分组不靠噪声索引
+   (Rizzolli 式) 而靠**结构继承** — 新块以概率继承邻块色。块状构图里
+   这是正确的形态: 色块连片、边界清晰。
+3. **人格 = 加权参数包**: chaos/balance/pattern 整包抽取, 而非逐参数
+   独立随机 — 保证参数间协调, 人格分明。我们 decor 家族的 intensity
+   只有一维, 该学: 每家族定义 2-3 个"人格包"由 hash lane 抽取。
+4. **w_pick 累计和加权** — 与我们 lane 引擎的 weighted() 相同, 互证。
+5. **量化深度 + 三面受光**: depthSteps=8 的 z 量化 + 面透明度组合 —
+   留作未来 pseudo-3D 块修饰参考, v1 不做 (平面块更安全)。
+
+## Port 判定
+
+- **recipe-only** (CC BY-NC): 新家族 `block-mosaic` = idiom 1+2 独立重写
+  (细胞生长矩形填充 + 邻块颜色继承), 平面、低透明度、subtle 全幅 /
+  bold 封面。pitch/consulting 亲和 (面板感与商务 deck 天然契合)。
+- idiom 3 (人格包) 记为 decor 引擎 v2 的候选升级 (需要新 lane, 加而不改,
+  冻结纪律兼容)。
+
+## 一句话学到的
+
+Golid 的构成感来自**生长而非切分** — 矩形不是把画布递归切出来的,
+是从细胞状态机里长出来的; "有机的秩序"与"规则的秩序"的差异正在于此。

--- a/sdf-js/scripts/test-decor.mjs
+++ b/sdf-js/scripts/test-decor.mjs
@@ -312,5 +312,29 @@ function recCtx() {
   );
 }
 
+// ── Sprint 45: block-mosaic (Archetype recipe-only) ──
+{
+  const { ctx, rec } = recCtx();
+  drawDecor(
+    ctx,
+    { family: 'block-mosaic', seed: 9 },
+    { palette, x: 0, y: 0, w: 640, h: 360, intensity: 'subtle' },
+  );
+  ok(
+    rec.ops.filter((o) => o[0] === 'strokeRect').length === 16 * 9,
+    'block-mosaic strokes every cell',
+  );
+  const fills = rec.ops.filter((o) => o[0] === 'fillRect').length;
+  ok(fills > 10 && fills < 16 * 9 * 0.6, `sparse fill gate working (${fills} of 144 cells filled)`);
+  const a = recCtx();
+  const b = recCtx();
+  drawDecor(a.ctx, { family: 'block-mosaic', seed: 4 }, { palette, w: 640, h: 360 });
+  drawDecor(b.ctx, { family: 'block-mosaic', seed: 4 }, { palette, w: 640, h: 360 });
+  ok(
+    JSON.stringify(a.rec.ops) === JSON.stringify(b.rec.ops),
+    'block-mosaic deterministic per seed',
+  );
+}
+
 console.log(`\n${pass} passed, ${fail} failed`);
 process.exit(fail ? 1 : 0);

--- a/sdf-js/src/present/decor/registry.js
+++ b/sdf-js/src/present/decor/registry.js
@@ -374,6 +374,69 @@ function drawFlowRibbons(ctx, { palette, seed, x, y, w, h, intensity }) {
   ctx.restore();
 }
 
+// block-mosaic: cellular-growth rectangle packing with neighbor-inherited
+// color groups. RECIPE-ONLY port after Kjetil Golid's "Archetype" (Art
+// Blocks Curated #23, CC BY-NC 4.0 — independent reimplementation of the
+// published ideas; see docs/superpowers/artblocks-study/03-archetype-golid.md).
+// Two idioms, rewritten from the recipe:
+//   - apparatus-style growth: blocks EXTEND horizontally/vertically or
+//     start fresh, probability-driven — packed-but-irregular panels grown
+//     from a state machine, not sliced from the canvas
+//   - group color mode: a new block inherits its neighbor's color with
+//     probability → contiguous color patches with crisp borders
+function drawBlockMosaic(ctx, { palette, seed, x, y, w, h, intensity }) {
+  const P = INTENSITY[intensity] || INTENSITY.subtle;
+  const rand = seededRand(seed * 23 + 11);
+  const colors = [palette.accent, ...(palette.colors || [])].filter(Boolean);
+  const COLS = 16;
+  const ROWS = 9;
+  const cw = w / COLS;
+  const chh = h / ROWS;
+  // cell ownership grid: growth state machine
+  const owner = Array.from({ length: ROWS }, () => new Array(COLS).fill(-1));
+  const blockColor = [];
+  let nextId = 0;
+  for (let r = 0; r < ROWS; r++) {
+    for (let c = 0; c < COLS; c++) {
+      if (owner[r][c] !== -1) continue;
+      const left = c > 0 ? owner[r][c - 1] : -1;
+      const up = r > 0 ? owner[r - 1][c] : -1;
+      const t = rand();
+      if (left !== -1 && t < 0.42) {
+        owner[r][c] = left; // extend horizontally
+      } else if (up !== -1 && t < 0.72) {
+        owner[r][c] = up; // extend vertically
+      } else {
+        const id = nextId++;
+        owner[r][c] = id;
+        // group color mode: inherit a neighbor's color with probability
+        const inheritFrom = rand() < 0.55 ? (left !== -1 ? left : up) : -1;
+        blockColor[id] =
+          inheritFrom !== -1 ? blockColor[inheritFrom] : colors[Math.floor(rand() * colors.length)];
+      }
+    }
+  }
+  // draw per-cell (merged visually by shared color + hairline borders)
+  ctx.save();
+  for (let r = 0; r < ROWS; r++) {
+    for (let c = 0; c < COLS; c++) {
+      const id = owner[r][c];
+      const color = blockColor[id];
+      // sparse fill: only a fraction of blocks get filled, id-hashed so a
+      // whole block fills or not together
+      const fillGate = (id * 2654435761) % 100;
+      if (fillGate < 34) {
+        ctx.fillStyle = rgba(color, P.alphaFill);
+        ctx.fillRect(x + c * cw, y + r * chh, cw + 0.5, chh + 0.5);
+      }
+      ctx.strokeStyle = rgba(color, P.alpha * 0.9);
+      ctx.lineWidth = P.lineWidth * 0.8;
+      ctx.strokeRect(x + c * cw, y + r * chh, cw, chh);
+    }
+  }
+  ctx.restore();
+}
+
 // --- registry ----------------------------------------------------------------
 
 // FREEZE DISCIPLINE (Sprint 43, the complete fxhash lesson): fxhash's
@@ -392,15 +455,16 @@ export const DECOR_FAMILIES = {
   'shard-mesh': drawShardMesh,
   'meadow-streaks': drawMeadowStreaks,
   'flow-ribbons': drawFlowRibbons,
+  'block-mosaic': drawBlockMosaic,
 };
 
 // theme macroCluster → family affinity (seeded pick between two candidates so
 // different decks in the same theme still vary)
 const CLUSTER_AFFINITY = {
   editorial: ['flow-ribbons', 'flow-streams', 'shard-mesh', 'meadow-streaks'],
-  pitch: ['weave-dashes', 'circle-pack', 'flow-ribbons'],
+  pitch: ['block-mosaic', 'weave-dashes', 'circle-pack', 'flow-ribbons'],
   organic: ['meadow-streaks', 'flow-ribbons', 'circle-pack'],
-  consulting: ['weave-dashes', 'shard-mesh'],
+  consulting: ['block-mosaic', 'weave-dashes', 'shard-mesh'],
   financial: ['shard-mesh', 'weave-dashes'],
   hr: ['circle-pack', 'meadow-streaks'],
 };


### PR DESCRIPTION
ArtBlocks 学习第三课。

## 先更正一个误诊

前两课记录的"语料空文件"是我的检查方法错误 — `wc -l` 对无换行的 minified 单行返回 0。全量复核: **108 项语料 100% 完整** (Fidenza 14.5KB / Archetype 13.9KB 都在), subagent 的"0 空文件"报告无误, 补洞待办撤销。

## Archetype 读透

**核心洞见: Golid 的构成感来自生长而非切分** — 矩形不是递归切出来的, 是细胞状态机长出来的 (延伸水平/延伸垂直/开新块, 概率驱动), "有机的秩序"由此而来。颜色分组是**结构继承** (新块以概率继承邻块色 → 色块连片、边界干脆) — 与 Rizzolli 噪声索引恰成对照: 场类构图用噪声索引, 块类构图用邻居继承。另收获: **人格 = 加权参数包** (chaos/balance/pattern 整包抽取, 参数间自洽) — 记为 decor 引擎升级候选; 他的 w_pick 与我们 lane 的 weighted() 完全同构, 互证。

Recipe: `docs/superpowers/artblocks-study/03-archetype-golid.md`

## block-mosaic 家族 (recipe-only)

生长填充 + 邻块继承色 + id 哈希稀疏填充的独立重写, pitch/consulting 亲和 (面板感 × 商务 deck)。增量加入 DECOR_V=1, 家族 6→7。浏览器视觉验证 (截图)。

## Tests
131/131 (test-decor 51 断言)

🤖 Generated with [Claude Code](https://claude.com/claude-code)