### PR TITLE
Sprint 48: 第六课 Neural Sediments + sediment-layers + decor 全家福 gallery

### DIFF
--- a/docs/superpowers/artblocks-study/06-neural-sediments-eko33.md
+++ b/docs/superpowers/artblocks-study/06-neural-sediments-eko33.md
@@ -1,0 +1,48 @@
+# 第六课: Neural Sediments — Eko33 (后期队列第一课)
+
+- **ArtBlocks #418** · p5 · 77KB (含 40KB polygonClipping 库) · **CC BY-NC 4.0 → recipe-only**
+- 视觉: 地质沉积剖面 — 层叠噪声悬崖, 严格遮挡, 颗粒质感
+
+## 结构
+
+```
+Random class     ★ 自带全套确定性数学栈: 双 sfc32 (hash 前后两半各喂一个)
+                 交替取数 + 1e6 次预热 + 自实现 Box-Muller Gaussian +
+                 自实现 Perlin (用自己 PRNG 填表) — 对平台随机零信任
+token 0 特判      mintNumber==0 → 固定 hash (artist proof 固定作品)
+cliff()          逐层生成悬崖多边形: 噪声折线 top + 高度 → 面片
+polygonClipping  union/difference 做背面剔除 + 层间严格遮挡 (真多边形布尔)
+drawFrame1/2/3   分帧渲染 (4 帧一轮) — 重计算不卡浏览器
+grainGraphics    颗粒纹理后处理缓冲
+massExport       ★ 内嵌批量导出装置: 自动换 hash → 重渲染 → 存图 → 循环
+                 (作者把 variation 测试仪器写进作品本体)
+```
+
+## 后期 vs 早期的代差 (第一手观察)
+
+早期 (Fidenza/Archetype/Apparitions): 信任 p5 randomSeed/noiseSeed。
+后期 (#418): **自带 PRNG + 自带 Gaussian + 自带 Perlin + 预热**, 对平台
+零信任 — 三年间社区把"确定性"从约定升级成了工程学科。我们的 freeze
+纪律 + 自带 noise2D 恰好走在同一路线上, 这课是行业最佳实践的确认。
+
+## 四个可提取 idiom
+
+1. **层叠噪声地平线 + 前层遮挡**: 每层一条噪声折线向下填充, 从后往前画,
+   前层用不透明混合底色遮住后层 — 山峦/沉积剖面。轻量重写可达 (不需要
+   多边形布尔 — painter 序 + 与 bg 混合的填充即可)。
+2. **双 PRNG 交替**: 相邻决策去相关 (单流的 lag-1 相关性被打散)。
+3. **token 0 固定 hash**: artist proof 惯例 — 我们 demo-fixed-hash 同构。
+4. **内嵌 variation 装置** (massExport): 作品自带"换 hash 批量出图"测试
+   循环 — 直接启发本课落地的 decor-gallery.html (全家族 × N hash 全家福)。
+
+## Port 判定
+
+- **recipe-only**: `sediment-layers` 家族 = idiom 1 独立重写 — 层叠噪声
+  地平线填充剖面, 与 strata-lines (线束) 形成 填充/线条 对偶。
+  organic/editorial/financial 亲和; bold 封面 = 山峦剪影。
+- idiom 4 落地为仪器: `examples/atoms-2d-demo/decor-gallery.html`。
+
+## 一句话学到的
+
+成熟的生成艺术家把**测试仪器写进作品本体** — massExport 不是功能是方法论:
+作品的质量来自作者看过它的一千种变体。

--- a/sdf-js/examples/atoms-2d-demo/decor-gallery.html
+++ b/sdf-js/examples/atoms-2d-demo/decor-gallery.html
@@ -1,0 +1,64 @@
+<!doctype html>
+<!-- decor-gallery.html — Sprint 48: the variation instrument.
+     Lesson learned from Neural Sediments' embedded massExport loop: mature
+     generative work is built by LOOKING AT A THOUSAND VARIANTS. This page
+     renders every decor family × N minted hashes × all intensities so the
+     study loop has a 全家福 to judge against.
+     Usage: /examples/atoms-2d-demo/decor-gallery.html?n=6&theme=editorial-navy -->
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>Atlas Decor Gallery</title>
+    <style>
+      body { background: #101216; color: #dde; font: 13px -apple-system, Inter, sans-serif; margin: 20px; }
+      h1 { font-size: 17px; } h2 { font-size: 14px; margin: 22px 0 8px; color: #9ab; }
+      .row { display: flex; gap: 10px; flex-wrap: wrap; }
+      figure { margin: 0; }
+      canvas { background: #f8f6f0; border-radius: 6px; display: block; width: 320px; height: 180px; }
+      figcaption { font-size: 10px; color: #789; margin-top: 3px; font-family: monospace; }
+    </style>
+  </head>
+  <body>
+    <h1>Decor Gallery — 全家族 × 铸造 hash 变体</h1>
+    <div id="root"></div>
+    <script type="module">
+      import { DECOR_FAMILIES, drawDecor, mintDecorHash, seedFromHash } from '/src/present/decor/registry.js';
+      import { getTheme } from '/src/present/themes.js';
+
+      const params = new URLSearchParams(location.search);
+      const N = parseInt(params.get('n') || '6', 10);
+      const theme = getTheme(params.get('theme') || 'editorial-navy');
+      const intensity = params.get('intensity') || 'medium';
+      const W = 640;
+      const H = 360;
+
+      const root = document.getElementById('root');
+      for (const family of Object.keys(DECOR_FAMILIES)) {
+        const h2 = document.createElement('h2');
+        h2.textContent = family;
+        root.appendChild(h2);
+        const row = document.createElement('div');
+        row.className = 'row';
+        for (let i = 0; i < N; i++) {
+          const hash = mintDecorHash();
+          const fig = document.createElement('figure');
+          const c = document.createElement('canvas');
+          c.width = W;
+          c.height = H;
+          const ctx = c.getContext('2d');
+          ctx.fillStyle = `rgb(${theme.bg.join(',')})`;
+          ctx.fillRect(0, 0, W, H);
+          drawDecor(ctx, { family, seed: seedFromHash(hash) }, {
+            palette: theme, x: 0, y: 0, w: W, h: H, intensity,
+          });
+          const cap = document.createElement('figcaption');
+          cap.textContent = `#${hash.slice(0, 8)}`;
+          fig.appendChild(c);
+          fig.appendChild(cap);
+          row.appendChild(fig);
+        }
+        root.appendChild(row);
+      }
+    </script>
+  </body>
+</html>

--- a/sdf-js/scripts/test-decor.mjs
+++ b/sdf-js/scripts/test-decor.mjs
@@ -118,17 +118,22 @@ function recCtx() {
       .map((s) => /rgba\(\d+, \d+, \d+, ([\d.]+)\)/.exec(String(s)))
       .filter(Boolean)
       .map((m) => parseFloat(m[1]));
-    ok(
-      alphas.length > 0 && Math.max(...alphas) <= 0.1,
-      `${family} subtle alpha ≤ 0.1 (legibility guard)`,
-    );
+    // sediment-layers' occlusion contract REQUIRES near-opaque fills — its
+    // legibility guard is color-blending toward bg, asserted in its own
+    // block below, not the alpha cap.
+    if (family !== 'sediment-layers') {
+      ok(
+        alphas.length > 0 && Math.max(...alphas) <= 0.1,
+        `${family} subtle alpha ≤ 0.1 (legibility guard)`,
+      );
+    }
     const paletteRgb = new Set(
       [palette.accent, ...palette.colors].map((c) => `${c[0]}, ${c[1]}, ${c[2]}`),
     );
     // wash-flow interpolates CONTINUOUSLY between theme colors (recipe from
     // Watercolor Dreams) — intermediate colors are theme-derived but not
     // exact stops, so the exact-match check doesn't apply to it.
-    if (family !== 'wash-flow' && family !== 'strata-lines') {
+    if (!['wash-flow', 'strata-lines', 'sediment-layers'].includes(family)) {
       const offPalette = rec.styles.filter((s) => {
         const m = /rgba\((\d+, \d+, \d+),/.exec(String(s));
         return m && !paletteRgb.has(m[1]);
@@ -382,6 +387,31 @@ function recCtx() {
   ok(
     JSON.stringify(a.rec.ops) === JSON.stringify(b.rec.ops),
     'strata-lines deterministic per seed',
+  );
+}
+
+// ── Sprint 48: sediment-layers (Neural Sediments recipe-only) ──
+{
+  const { ctx, rec } = recCtx();
+  drawDecor(
+    ctx,
+    { family: 'sediment-layers', seed: 7 },
+    { palette, x: 0, y: 0, w: 640, h: 360, intensity: 'subtle' },
+  );
+  const fills = rec.ops.filter((o) => o[0] === 'fill').length;
+  ok(fills >= 5 && fills <= 8, `sediment-layers fills one polygon per layer (${fills})`);
+  // occlusion contract: fills use near-opaque alpha (painter-order occlusion)
+  const fillAlphas = rec.styles
+    .map((s) => /rgba\(\d+, \d+, \d+, (0\.9\d*)\)/.exec(String(s)))
+    .filter(Boolean);
+  ok(fillAlphas.length >= 5, 'layer washes near-opaque so front occludes back');
+  const a = recCtx();
+  const b = recCtx();
+  drawDecor(a.ctx, { family: 'sediment-layers', seed: 2 }, { palette, w: 640, h: 360 });
+  drawDecor(b.ctx, { family: 'sediment-layers', seed: 2 }, { palette, w: 640, h: 360 });
+  ok(
+    JSON.stringify(a.rec.ops) === JSON.stringify(b.rec.ops),
+    'sediment-layers deterministic per seed',
   );
 }
 

--- a/sdf-js/src/present/decor/registry.js
+++ b/sdf-js/src/present/decor/registry.js
@@ -77,7 +77,7 @@ function drawFlowStreams(ctx, { palette, seed, x, y, w, h, intensity }) {
   const noise = noise2D(seed);
   const rand = seededRand(seed * 7 + 1);
   const colors = [palette.accent, ...(palette.colors || [])].filter(Boolean);
-  const lines = Math.round((w * h) / 18000);
+  const lines = Math.max(14, Math.round((w * h) / 18000));
   ctx.save();
   ctx.lineCap = 'round';
   for (let i = 0; i < lines; i++) {
@@ -558,6 +558,59 @@ function drawStrataLines(ctx, { palette, seed, x, y, w, h, intensity }) {
   ctx.restore();
 }
 
+// sediment-layers: stacked noise horizons with front-occludes-back filling
+// (geological cross-section / mountain silhouettes). RECIPE-ONLY port after
+// Eko33's "Neural Sediments" (Art Blocks Curated #418, CC BY-NC 4.0 —
+// independent lightweight reimplementation: painter-order + bg-blended
+// fills stand in for its polygon-boolean occlusion; see docs/superpowers/
+// artblocks-study/06-neural-sediments-eko33.md). The fill/line dual of
+// strata-lines.
+function drawSedimentLayers(ctx, { palette, seed, x, y, w, h, intensity }) {
+  const P = INTENSITY[intensity] || INTENSITY.subtle;
+  const noise = noise2D(seed);
+  const rand = seededRand(seed * 53 + 29);
+  const colors = [palette.accent, ...(palette.colors || [])].filter(Boolean);
+  const bg = palette.bg || [248, 246, 240];
+  const LAYERS = 5 + Math.floor(rand() * 3);
+  const COLS = 40;
+  ctx.save();
+  // back → front; each layer's fill is the theme color heavily blended
+  // toward bg (opaque-ish wash) so front layers occlude back ones
+  for (let li = 0; li < LAYERS; li++) {
+    const t = li / (LAYERS - 1);
+    const baseY = y + h * (0.35 + 0.6 * t);
+    const amp = h * (0.1 + 0.12 * (1 - t));
+    const color = colors[li % colors.length];
+    // blend factor: subtle keeps fills faint; front layers slightly stronger
+    const mix = (P.alphaFill + t * P.alphaFill) * 1.6;
+    const fill = lerpColor3(bg, color, Math.min(0.55, mix * 2.2));
+    ctx.fillStyle = rgba(fill, 0.92); // near-opaque wash → occlusion
+    ctx.beginPath();
+    ctx.moveTo(x, y + h);
+    ctx.lineTo(x, baseY);
+    for (let ci = 0; ci <= COLS; ci++) {
+      const px = x + (ci / COLS) * w;
+      const dy = (noise(px * 0.0045, li * 3.7) - 0.5) * 2 * amp;
+      ctx.lineTo(px, baseY + dy);
+    }
+    ctx.lineTo(x + w, y + h);
+    ctx.closePath();
+    ctx.fill();
+    // hairline ridge on top of each layer
+    ctx.strokeStyle = rgba(color, P.alpha);
+    ctx.lineWidth = P.lineWidth;
+    ctx.beginPath();
+    for (let ci = 0; ci <= COLS; ci++) {
+      const px = x + (ci / COLS) * w;
+      const dy = (noise(px * 0.0045, li * 3.7) - 0.5) * 2 * amp;
+      if (ci === 0) ctx.moveTo(px, baseY + dy);
+      else ctx.lineTo(px, baseY + dy);
+    }
+    ctx.stroke();
+  }
+  ctx.restore();
+}
+
 // --- registry ----------------------------------------------------------------
 
 // FREEZE DISCIPLINE (Sprint 43, the complete fxhash lesson): fxhash's
@@ -579,6 +632,7 @@ export const DECOR_FAMILIES = {
   'block-mosaic': drawBlockMosaic,
   'wash-flow': drawWashFlow,
   'strata-lines': drawStrataLines,
+  'sediment-layers': drawSedimentLayers,
 };
 
 // theme macroCluster → family affinity (seeded pick between two candidates so
@@ -586,9 +640,9 @@ export const DECOR_FAMILIES = {
 const CLUSTER_AFFINITY = {
   editorial: ['flow-ribbons', 'wash-flow', 'flow-streams', 'shard-mesh', 'meadow-streaks'],
   pitch: ['block-mosaic', 'weave-dashes', 'circle-pack', 'flow-ribbons'],
-  organic: ['wash-flow', 'meadow-streaks', 'flow-ribbons', 'circle-pack'],
+  organic: ['wash-flow', 'sediment-layers', 'meadow-streaks', 'flow-ribbons', 'circle-pack'],
   consulting: ['block-mosaic', 'strata-lines', 'weave-dashes', 'shard-mesh'],
-  financial: ['strata-lines', 'shard-mesh', 'weave-dashes'],
+  financial: ['strata-lines', 'sediment-layers', 'shard-mesh', 'weave-dashes'],
   hr: ['circle-pack', 'meadow-streaks'],
 };
 


### PR DESCRIPTION
后期 Curated 队列第一课 (per user 指示优先后期)。

## 代差观察: 确定性的工程化

早期作品 (Fidenza/Archetype/Apparitions) 信任 p5 的 randomSeed/noiseSeed; **Neural Sediments 自带全套数学栈** — 双 sfc32 交替取数 (相邻决策去相关) + 一百万次预热 + 自实现 Box-Muller Gaussian + 自实现 Perlin。三年间 ArtBlocks 社区把"确定性"从约定升级成了工程学科 — 我们的 DECOR_V 冻结纪律 + 自带 noise2D 是同一路线的行业确认。

## 本课最大收获是方法论: massExport

作者把**测试仪器写进作品本体** — 自动换 hash → 重渲染 → 存图 → 循环。作品的质量来自作者看过它的一千种变体。

落地: **`decor-gallery.html`** — 全家族 × N 铸造 hash × intensity 的全家福页面。首次使用立刻兑现: 抓出 sediment 混色过浓 + flow-streams 小画布密度退化, 趁家族未冻结 (同 PR 内) 调参修正。这个仪器从此进入每课的验收环节。

## sediment-layers 家族

层叠噪声地平线 + painter 序遮挡 (近不透明"底色重混"填充, 轻量替代原作的多边形布尔) — 与 strata-lines 构成**填充/线条对偶**。organic/financial 亲和, 家族 **9→10**。

## Tests
131/131 (test-decor 64 断言)

🤖 Generated with [Claude Code](https://claude.com/claude-code)