### PR TITLE
Sprint 49: 人格包机制 — decor 引擎升级第一件 (四课设计输入落地)

### DIFF
--- a/sdf-js/examples/atoms-2d-demo/decor-gallery.html
+++ b/sdf-js/examples/atoms-2d-demo/decor-gallery.html
@@ -22,7 +22,7 @@
     <h1>Decor Gallery — 全家族 × 铸造 hash 变体</h1>
     <div id="root"></div>
     <script type="module">
-      import { DECOR_FAMILIES, drawDecor, mintDecorHash, seedFromHash } from '/src/present/decor/registry.js';
+      import { DECOR_FAMILIES, drawDecor, mintDecorHash, seedFromHash, decorFromHash } from '/src/present/decor/registry.js';
       import { getTheme } from '/src/present/themes.js';
 
       const params = new URLSearchParams(location.search);
@@ -41,6 +41,7 @@
         row.className = 'row';
         for (let i = 0; i < N; i++) {
           const hash = mintDecorHash();
+          const minted = decorFromHash(theme, hash);
           const fig = document.createElement('figure');
           const c = document.createElement('canvas');
           c.width = W;
@@ -48,11 +49,11 @@
           const ctx = c.getContext('2d');
           ctx.fillStyle = `rgb(${theme.bg.join(',')})`;
           ctx.fillRect(0, 0, W, H);
-          drawDecor(ctx, { family, seed: seedFromHash(hash) }, {
+          drawDecor(ctx, { family, seed: minted.seed, personality: minted.personality }, {
             palette: theme, x: 0, y: 0, w: W, h: H, intensity,
           });
           const cap = document.createElement('figcaption');
-          cap.textContent = `#${hash.slice(0, 8)}`;
+          cap.textContent = `#${hash.slice(0, 8)} · ${minted.personality}`;
           fig.appendChild(c);
           fig.appendChild(cap);
           row.appendChild(fig);

--- a/sdf-js/scripts/test-decor.mjs
+++ b/sdf-js/scripts/test-decor.mjs
@@ -415,5 +415,46 @@ function recCtx() {
   );
 }
 
+// ── Sprint 49: personality bundles (Golid lesson) ──
+{
+  // FREEZE regression: absent personality === 'balanced', pixel-identical —
+  // every pre-personality mint keeps its artwork.
+  for (const family of ['flow-ribbons', 'wash-flow', 'sediment-layers']) {
+    const a = recCtx();
+    const b = recCtx();
+    drawDecor(a.ctx, { family, seed: 6 }, { palette, w: 640, h: 360 });
+    drawDecor(b.ctx, { family, seed: 6, personality: 'balanced' }, { palette, w: 640, h: 360 });
+    ok(
+      JSON.stringify(a.rec.ops) === JSON.stringify(b.rec.ops),
+      `${family}: absent personality renders identical to 'balanced' (freeze)`,
+    );
+    const c = recCtx();
+    drawDecor(c.ctx, { family, seed: 6, personality: 'wild' }, { palette, w: 640, h: 360 });
+    ok(
+      JSON.stringify(a.rec.ops) !== JSON.stringify(c.rec.ops),
+      `${family}: 'wild' personality differs`,
+    );
+  }
+  // minted decor carries a deterministic personality from its own lane
+  const t = { id: 'organic-teal', macroCluster: 'organic' };
+  const d1 = decorFromHash(t, 'a1b2c3d4e5f60718');
+  const d2 = decorFromHash(t, 'a1b2c3d4e5f60718');
+  ok(d1.personality === d2.personality, 'personality deterministic per hash');
+  const seen = new Set();
+  for (const h of [
+    '1111111111111111',
+    '2222222222222222',
+    '3333333333333333',
+    '4444444444444444',
+    '5555555555555555',
+    '6666666666666666',
+    '7777777777777777',
+    '8888888888888888',
+  ]) {
+    seen.add(decorFromHash(t, h).personality);
+  }
+  ok(seen.size >= 2, `personalities vary across hashes (${[...seen].join(',')})`);
+}
+
 console.log(`\n${pass} passed, ${fail} failed`);
 process.exit(fail ? 1 : 0);

--- a/sdf-js/src/present/decor/registry.js
+++ b/sdf-js/src/present/decor/registry.js
@@ -267,7 +267,45 @@ function drawMeadowStreaks(ctx, { palette, seed, x, y, w, h, intensity }) {
 //   - sector-grid collision with curve-id exemption (self never collides)
 //   - look-ahead minimum-segment precheck (no stubby fragments)
 // plus a probability-weighted width spectrum (rare-thick, common-thin).
-function drawFlowRibbons(ctx, { palette, seed, x, y, w, h, intensity }) {
+// Personality bundles (Sprint 49, the Golid lesson): parameters are picked
+// as COHERENT SETS, not independently — calm/balanced/wild per family.
+// FREEZE CONTRACT: 'balanced' is verbatim the pre-personality constants, and
+// an absent personality resolves to 'balanced', so every existing mint
+// renders pixel-identical.
+const RIBBON_PERSONALITIES = {
+  calm: {
+    rows: 7,
+    cols: 20,
+    steps: 34,
+    widths: [
+      [8, 0.05],
+      [5, 0.25],
+      [3, 0.7],
+    ],
+  },
+  balanced: {
+    rows: 9,
+    cols: 26,
+    steps: 42,
+    widths: [
+      [10, 0.08],
+      [6, 0.22],
+      [3, 0.7],
+    ],
+  },
+  wild: {
+    rows: 12,
+    cols: 34,
+    steps: 56,
+    widths: [
+      [14, 0.12],
+      [7, 0.3],
+      [2, 0.58],
+    ],
+  },
+};
+
+function drawFlowRibbons(ctx, { palette, seed, x, y, w, h, intensity, personality }) {
   const P = INTENSITY[intensity] || INTENSITY.subtle;
   const noise = noise2D(seed);
   const rand = seededRand(seed * 17 + 3);
@@ -295,18 +333,22 @@ function drawFlowRibbons(ctx, { palette, seed, x, y, w, h, intensity }) {
 
   // gaussian-ish jitter via sum of uniforms
   const jitter = (amp) => (rand() + rand() - 1) * amp;
+  const B = RIBBON_PERSONALITIES[personality] || RIBBON_PERSONALITIES.balanced;
   // probability-weighted width spectrum: rare thick, common thin
   const widthOf = () => {
     const t = rand();
-    if (t < 0.08) return 10;
-    if (t < 0.3) return 6;
-    return 3;
+    let acc = 0;
+    for (const [width, p] of B.widths) {
+      acc += p;
+      if (t < acc) return width;
+    }
+    return B.widths[B.widths.length - 1][0];
   };
 
   // start points: rows + jitter, then shuffle
   const starts = [];
-  for (let ry = y; ry <= y + h; ry += h / 9) {
-    for (let rx = x - w * 0.1; rx <= x + w * 1.1; rx += w / 26) {
+  for (let ry = y; ry <= y + h; ry += h / B.rows) {
+    for (let rx = x - w * 0.1; rx <= x + w * 1.1; rx += w / B.cols) {
       starts.push([rx + jitter(w / 40), ry + jitter(h / 14)]);
     }
   }
@@ -336,7 +378,7 @@ function drawFlowRibbons(ctx, { palette, seed, x, y, w, h, intensity }) {
       }
       segment = [];
     };
-    for (let step = 0; step < 42; step++) {
+    for (let step = 0; step < B.steps; step++) {
       const ok = inBounds(px, py) && !collides(px, py, width, id);
       if (ok) {
         if (segment.length === 0) {
@@ -461,7 +503,13 @@ function continuousPalette(colors, t) {
   return lerpColor3(colors[i], colors[i + 1], x - i);
 }
 
-function drawWashFlow(ctx, { palette, seed, x, y, w, h, intensity }) {
+const WASH_PERSONALITIES = {
+  calm: { nodes: 70, steps: 20, step: 5 },
+  balanced: { nodes: 90, steps: 26, step: 6 },
+  wild: { nodes: 130, steps: 36, step: 7 },
+};
+
+function drawWashFlow(ctx, { palette, seed, x, y, w, h, intensity, personality }) {
   const P = INTENSITY[intensity] || INTENSITY.subtle;
   const noise = noise2D(seed);
   const rand = seededRand(seed * 29 + 13);
@@ -469,9 +517,10 @@ function drawWashFlow(ctx, { palette, seed, x, y, w, h, intensity }) {
   // source shape: a gently sloped band across the slide (seeded position)
   const bandY = y + h * (0.25 + rand() * 0.5);
   const slope = (rand() - 0.5) * h * 0.4;
-  const NODES = 90;
-  const STEPS = 26;
-  const STEP = 6;
+  const B = WASH_PERSONALITIES[personality] || WASH_PERSONALITIES.balanced;
+  const NODES = B.nodes;
+  const STEPS = B.steps;
+  const STEP = B.step;
   ctx.save();
   ctx.lineCap = 'round';
   const nodes = [];
@@ -565,13 +614,20 @@ function drawStrataLines(ctx, { palette, seed, x, y, w, h, intensity }) {
 // fills stand in for its polygon-boolean occlusion; see docs/superpowers/
 // artblocks-study/06-neural-sediments-eko33.md). The fill/line dual of
 // strata-lines.
-function drawSedimentLayers(ctx, { palette, seed, x, y, w, h, intensity }) {
+const SEDIMENT_PERSONALITIES = {
+  calm: { minLayers: 4, layerSpan: 2 },
+  balanced: { minLayers: 5, layerSpan: 3 },
+  wild: { minLayers: 7, layerSpan: 3 },
+};
+
+function drawSedimentLayers(ctx, { palette, seed, x, y, w, h, intensity, personality }) {
   const P = INTENSITY[intensity] || INTENSITY.subtle;
   const noise = noise2D(seed);
   const rand = seededRand(seed * 53 + 29);
   const colors = [palette.accent, ...(palette.colors || [])].filter(Boolean);
   const bg = palette.bg || [248, 246, 240];
-  const LAYERS = 5 + Math.floor(rand() * 3);
+  const SB = SEDIMENT_PERSONALITIES[personality] || SEDIMENT_PERSONALITIES.balanced;
+  const LAYERS = SB.minLayers + Math.floor(rand() * SB.layerSpan);
   const COLS = 40;
   ctx.save();
   // back → front; each layer's fill is the theme color heavily blended
@@ -665,7 +721,16 @@ export function pickDecorFor(theme, seed = 1) {
 export function drawDecor(ctx, decor, { palette, x = 0, y = 0, w, h, intensity = 'subtle' } = {}) {
   const fn = DECOR_FAMILIES[decor?.family];
   if (!fn || !palette || !w || !h) return false;
-  fn(ctx, { palette, seed: decor.seed ?? 1, x, y, w, h, intensity });
+  fn(ctx, {
+    palette,
+    seed: decor.seed ?? 1,
+    x,
+    y,
+    w,
+    h,
+    intensity,
+    personality: decor.personality,
+  });
   return true;
 }
 
@@ -715,6 +780,15 @@ export function decorFromHash(theme, hash) {
   return {
     family: R.pick('family', candidates),
     seed: R.int('seed', 1, 0x7ffffffe),
+    // Sprint 49 (Golid personality bundles + Watercolor rarity ladder):
+    // most mints are 'balanced', a weighted minority carry a distinct
+    // temperament. New lane — old mints (no personality field) resolve to
+    // 'balanced' in the families, keeping their pixels frozen.
+    personality: R.weighted('personality', [
+      ['calm', 2],
+      ['balanced', 5],
+      ['wild', 2],
+    ]),
     hash,
     v: DECOR_V,
   };


### PR DESCRIPTION
六课攒下的四件设计输入 (Golid 人格包 / 稀有度阶梯 ×2 / Eko33 双 PRNG) 落地第一件。

## 人格包 (the Golid lesson)

参数以**整包**铸造而非逐个随机 — calm / balanced / wild 三种气质, 专属 hash lane 按 2/5/2 加权抽取。逐参数随机给的是糊, 整包随机给的是性格。示范三家族: flow-ribbons (密度/步数/粗细谱)、wash-flow (节点/步数/步长)、sediment-layers (层数)。

## 冻结契约双重兑现

1. **'balanced' 逐字等于升级前常量**, personality 缺省解析为 balanced — 回归断言逐字节一致: 所有已铸作品像素不变
2. personality 是**新 lane** — 既有 hash 的 family/seed lane 分毫不动 (lane 独立性是机制而非承诺, Sprint 43 的承重测试仍在)

gallery caption 现在显示 `hash · personality`, 变体仪器一眼可见气质分布 (实测 6 hash × 10 家族: balanced 主导, calm/wild 少数点缀, 符合权重)。

## Tests
131/131 (test-decor 72 断言, 冻结回归 ×3 + 气质分化 ×3 + 分布确定性)

🤖 Generated with [Claude Code](https://claude.com/claude-code)