### PR TITLE
Sprint 50: 第七课 INK + ink-scribble (误差统计的手绘感)

### DIFF
--- a/docs/superpowers/artblocks-study/07-ink-velitchkova.md
+++ b/docs/superpowers/artblocks-study/07-ink-velitchkova.md
@@ -1,0 +1,45 @@
+# 第七课: INK — Iskra Velitchkova (后期队列)
+
+- **ArtBlocks #497** · p5@1.9 · 45KB · **CC BY-NC-SA 4.0 → recipe-only (SA 传染, 严格)**
+- 视觉: 手绘墨迹/炭笔涂鸦 — 密集噪声闭环 + 复笔抖动, 15 种西语命名"笔法"
+
+## 结构
+
+```
+Random class     后期标配: 自带 sfc32 (与 Eko33 同代差特征)
+笔法目录          drawMacarra / drawCarboncillo / drawGridSuave /
+                 drawRamonycajal / drawDomingoMercado / drawDelicado /
+                 drawNovia / drawPelo … ~15 种命名笔法, hash 选用 —
+                 人格包思想的极端形态: 一件作品 = 家族中的家族
+噪声-利萨茹涂鸦   ★ 核心笔画: for e in [0,2π) step 0.001:
+                   vertex(cx + noise(cy + sin(e)·freq)·ampX,
+                          cy + noise(cy + cos(e)·freq)·ampY)
+                 — 闭环参数曲线, 半径被噪声调制 → 手绘涂鸦轮廓
+三遍复笔          同一曲线画 3 遍, 每顶点独立随机偏移 (R.r(4)~R.r(44)) —
+                 墨迹的"毛边"= 顶点级抖动 × 遍数
+极端顶点密度      0.001 弧度步进 ≈ 6283 顶点/遍 — 质感来自密度 (性能换质感)
+shader 后处理     颗粒滤镜 (与 Sediments grainGraphics 同习俗)
+```
+
+## 四个可提取 idiom
+
+1. **噪声-利萨茹闭环**: sin/cos 双相位喂 noise 得 x/y 半径 — 一行公式的
+   涂鸦生成器, 圆的"手绘退化"。
+2. **顶点级复笔抖动**: 毛边 = 同曲线多遍 × 每顶点独立小偏移 —
+   Apparitions 影线的稠密版。
+3. **笔法目录** (家族中的家族): 15 种命名 manner 共享基础设施、各有参数
+   性格 — 我们人格包的极端参照 (v3 若做 per-family manner 可循此)。
+4. **密度即质感**: 顶点密度是质感的第一参数 — deck 修饰必须降密
+   (0.02 步进 ≈ 314 顶点足够), 性能预算意识。
+
+## Port 判定
+
+- **recipe-only, 严格** (NC+SA): `ink-scribble` 家族 = idiom 1+2 独立重写,
+  降密度 (0.02 步进 × 2 遍 × 8-14 个), 角落加权散布, editorial/hr 亲和 —
+  手绘感与"人味"主题天然合。
+- 笔法目录记入 v3 设想 (per-family manners)。
+
+## 一句话学到的
+
+墨迹感的本质是**误差的分布**: 完美曲线 + 顶点级独立抖动 × 多遍 =
+人手的微颤 — 数字复现"手"不靠模拟肌肉, 靠模拟误差统计。

--- a/sdf-js/scripts/test-decor.mjs
+++ b/sdf-js/scripts/test-decor.mjs
@@ -456,5 +456,27 @@ function recCtx() {
   ok(seen.size >= 2, `personalities vary across hashes (${[...seen].join(',')})`);
 }
 
+// ── Sprint 50: ink-scribble (INK recipe-only) ──
+{
+  const { ctx, rec } = recCtx();
+  drawDecor(
+    ctx,
+    { family: 'ink-scribble', seed: 12 },
+    { palette, x: 0, y: 0, w: 640, h: 360, intensity: 'subtle' },
+  );
+  const strokes = rec.ops.filter((o) => o[0] === 'stroke').length;
+  ok(strokes >= 16 && strokes <= 30, `ink-scribble double-pass per shape (${strokes} strokes)`);
+  const verts = rec.ops.filter((o) => o[0] === 'lineTo').length;
+  ok(verts > 4000, `dense vertices carry the ink texture (${verts})`);
+  const a = recCtx();
+  const b = recCtx();
+  drawDecor(a.ctx, { family: 'ink-scribble', seed: 5 }, { palette, w: 640, h: 360 });
+  drawDecor(b.ctx, { family: 'ink-scribble', seed: 5 }, { palette, w: 640, h: 360 });
+  ok(
+    JSON.stringify(a.rec.ops) === JSON.stringify(b.rec.ops),
+    'ink-scribble deterministic per seed',
+  );
+}
+
 console.log(`\n${pass} passed, ${fail} failed`);
 process.exit(fail ? 1 : 0);

--- a/sdf-js/src/present/decor/registry.js
+++ b/sdf-js/src/present/decor/registry.js
@@ -667,6 +667,58 @@ function drawSedimentLayers(ctx, { palette, seed, x, y, w, h, intensity, persona
   ctx.restore();
 }
 
+// ink-scribble: noise-Lissajous closed scribbles with multi-pass vertex
+// jitter (hand-drawn ink feel). RECIPE-ONLY port after Iskra Velitchkova's
+// "INK" (Art Blocks Curated #497, CC BY-NC-SA 4.0 — independent
+// reimplementation at deck-friendly density; see docs/superpowers/
+// artblocks-study/07-ink-velitchkova.md). Two idioms, rewritten:
+//   - a closed parametric loop whose radius is noise-modulated on two
+//     phases (sin/cos) — the hand-drawn degeneration of a circle
+//   - the ink "rough edge": the SAME curve drawn twice with independent
+//     per-vertex jitter — simulating a hand by simulating error statistics
+function drawInkScribble(ctx, { palette, seed, x, y, w, h, intensity }) {
+  const P = INTENSITY[intensity] || INTENSITY.subtle;
+  const noise = noise2D(seed);
+  const rand = seededRand(seed * 61 + 37);
+  const colors = [palette.accent, ...(palette.colors || [])].filter(Boolean);
+  const COUNT = 8 + Math.floor(rand() * 7);
+  const STEP = 0.02; // ~314 vertices per pass — deck-budget density
+  ctx.save();
+  ctx.lineCap = 'round';
+  for (let i = 0; i < COUNT; i++) {
+    // corner-weighted placement (keep slide centers clear)
+    const u = rand();
+    const v = rand();
+    const cx = x + (u < 0.5 ? u * u * 2 : 1 - (1 - u) * (1 - u) * 2) * w;
+    const cy = y + (v < 0.5 ? v * v * 2 : 1 - (1 - v) * (1 - v) * 2) * h;
+    const ampX = 20 + rand() * Math.min(w, h) * 0.11;
+    const ampY = 20 + rand() * Math.min(w, h) * 0.11;
+    const freq = 0.6 + rand() * 1.8;
+    const phase = rand() * 100;
+    const color = colors[i % colors.length];
+    ctx.strokeStyle = rgba(color, P.alpha);
+    ctx.lineWidth = P.lineWidth * 0.9;
+    for (let pass = 0; pass < 2; pass++) {
+      const jitterAmp = pass === 0 ? 1.5 : 4;
+      ctx.beginPath();
+      let first = true;
+      for (let e = 0; e <= Math.PI * 2 + 1e-9; e += STEP) {
+        const rx = noise(phase + Math.sin(e) * freq, phase) * ampX;
+        const ry = noise(phase, phase + Math.cos(e) * freq) * ampY;
+        const px = cx + rx * 2 - ampX + (rand() - 0.5) * jitterAmp;
+        const py = cy + ry * 2 - ampY + (rand() - 0.5) * jitterAmp;
+        if (first) {
+          ctx.moveTo(px, py);
+          first = false;
+        } else ctx.lineTo(px, py);
+      }
+      ctx.closePath();
+      ctx.stroke();
+    }
+  }
+  ctx.restore();
+}
+
 // --- registry ----------------------------------------------------------------
 
 // FREEZE DISCIPLINE (Sprint 43, the complete fxhash lesson): fxhash's
@@ -689,17 +741,25 @@ export const DECOR_FAMILIES = {
   'wash-flow': drawWashFlow,
   'strata-lines': drawStrataLines,
   'sediment-layers': drawSedimentLayers,
+  'ink-scribble': drawInkScribble,
 };
 
 // theme macroCluster → family affinity (seeded pick between two candidates so
 // different decks in the same theme still vary)
 const CLUSTER_AFFINITY = {
-  editorial: ['flow-ribbons', 'wash-flow', 'flow-streams', 'shard-mesh', 'meadow-streaks'],
+  editorial: [
+    'flow-ribbons',
+    'wash-flow',
+    'ink-scribble',
+    'flow-streams',
+    'shard-mesh',
+    'meadow-streaks',
+  ],
   pitch: ['block-mosaic', 'weave-dashes', 'circle-pack', 'flow-ribbons'],
   organic: ['wash-flow', 'sediment-layers', 'meadow-streaks', 'flow-ribbons', 'circle-pack'],
   consulting: ['block-mosaic', 'strata-lines', 'weave-dashes', 'shard-mesh'],
   financial: ['strata-lines', 'sediment-layers', 'shard-mesh', 'weave-dashes'],
-  hr: ['circle-pack', 'meadow-streaks'],
+  hr: ['ink-scribble', 'circle-pack', 'meadow-streaks'],
 };
 
 /**


### PR DESCRIPTION
后期队列第二课。

## INK 读透 (Velitchkova, #497)

**核心洞见: 墨迹感的本质是误差的分布** — 完美曲线 + 顶点级独立抖动 × 多遍复笔 = 人手的微颤。数字复现"手"不靠模拟肌肉, 靠模拟误差统计。

Idioms: 噪声-利萨茹闭环 (sin/cos 双相位喂 noise 做半径 — 圆的"手绘退化", 一行公式的涂鸦生成器) / 顶点级复笔抖动 / **15 种命名笔法目录** (Macarra/Carboncillo/Delicado… 共享基础设施、各有性格 — 人格包思想的极端形态, 记入 per-family manner 的 v3 设想) / **密度即质感** (原作 0.001 弧度步进 ≈ 6283 顶点/遍 — deck 预算下降密到 0.02 ≈ 314, 质感保留)。

Recipe: `docs/superpowers/artblocks-study/07-ink-velitchkova.md`

## ink-scribble 家族 (recipe-only, NC+SA 严格)

角落加权的手绘涂鸦记号, 双遍抖动复笔, editorial/hr 亲和 (手绘感 × "人味"主题)。家族 **10→11**, gallery 验证 (人格标签混合分布正常)。

## Tests
131/131 (test-decor 78 断言)

🤖 Generated with [Claude Code](https://claude.com/claude-code)