### PR TITLE
Sprint 51: 第八课 Box Light Studies + light-edges — 首个跨端分流

### DIFF
--- a/docs/superpowers/artblocks-study/08-box-light-studies-lieberman.md
+++ b/docs/superpowers/artblocks-study/08-box-light-studies-lieberman.md
@@ -1,0 +1,41 @@
+# 第八课: Box Light Studies — Zach Lieberman (后期队列)
+
+- **ArtBlocks #499** · p5 (WebGL) · 41KB · **CC BY-NC 4.0 → recipe-only**
+- 视觉: 旋转盒体的棱线化作柔光 — 渐变光线、辉光边缘、空气感
+
+## 结构 — shader 艺术穿着 p5 外衣
+
+```
+盒体几何          rotateX/Y/Z 三函数 + 棱线投影 → 每条棱 = (ptA, ptB, colorA, colorB)
+line shader      每条棱交给 fragment shader: 沿线渐变双色 + 光晕
+距离场管线 ★      多 pass framebuffer 链:
+                 initShader (线画入 fbo) → iterShader (jump-flood 传播:
+                 3×3 邻域找最近种子) → voroShader (spiral 搜索补洞 +
+                 距离衰减) → distShader (距离→亮度) — GPU 版
+                 "到最近线段的距离场", 柔光 = 距离的函数
+稀有度/settings   colorMode / seethrough 等 hash 决策
+```
+
+这是全队列第一件**本质上是 shader 作品**的课: 美学核心 (柔光) 完全住在
+GLSL 距离场里, p5 只是宿主。
+
+## 双供给线的分流判定 (本课最重要的产出)
+
+- **→ 3D 端 (shader 语料)**: jump-flood 距离场 + spiral 补洞搜索 +
+  "光 = 到几何的距离衰减" — 完整 recipe 应该进 3D 端的 shader idiom
+  registry (他们已有 67 idiom 基础)。已在本文档记录管线解剖, 待 3D 端
+  接力时移交。
+- **→ 2D 端 (canvas 近似)**: 取视觉概念不取机器 — "盒棱作为发光渐变线"
+  用分层淡笔画近似辉光 (宽淡 → 窄亮 三层), 双色沿棱插值。
+  = `light-edges` 家族。
+
+## 三个可提取 idiom (2D 侧)
+
+1. **棱线即光源**: 构图单位不是面而是棱 — 线框的"光化"。
+2. **分层辉光**: 同一线段 宽×低α → 窄×高α 层叠 = 无 shader 的 glow。
+3. **双色棱**: 每条棱两端各取一色、沿线渐变 (2D 近似: 分段插值)。
+
+## 一句话学到的
+
+Lieberman 把"光"翻译成"距离" — 柔光不是画出来的, 是**场算出来的**;
+2D 端学它的构图 (棱线即光源), 把场留给拥有 GPU 的 3D 端。

--- a/sdf-js/scripts/test-decor.mjs
+++ b/sdf-js/scripts/test-decor.mjs
@@ -478,5 +478,24 @@ function recCtx() {
   );
 }
 
+// ── Sprint 51: light-edges (Box Light Studies recipe-only) ──
+{
+  const { ctx, rec } = recCtx();
+  drawDecor(
+    ctx,
+    { family: 'light-edges', seed: 18 },
+    { palette, x: 0, y: 0, w: 640, h: 360, intensity: 'subtle' },
+  );
+  const strokes = rec.ops.filter((o) => o[0] === 'stroke').length;
+  // per box: 12 edges × 2 halves × 3 glow layers = 72; 4-6 boxes
+  ok(strokes >= 4 * 72 && strokes <= 6 * 72, `light-edges layered glow strokes (${strokes})`);
+  ok(strokes % 3 === 0, 'three glow layers per half-edge');
+  const a = recCtx();
+  const b = recCtx();
+  drawDecor(a.ctx, { family: 'light-edges', seed: 27 }, { palette, w: 640, h: 360 });
+  drawDecor(b.ctx, { family: 'light-edges', seed: 27 }, { palette, w: 640, h: 360 });
+  ok(JSON.stringify(a.rec.ops) === JSON.stringify(b.rec.ops), 'light-edges deterministic per seed');
+}
+
 console.log(`\n${pass} passed, ${fail} failed`);
 process.exit(fail ? 1 : 0);

--- a/sdf-js/src/present/decor/registry.js
+++ b/sdf-js/src/present/decor/registry.js
@@ -719,6 +719,74 @@ function drawInkScribble(ctx, { palette, seed, x, y, w, h, intensity }) {
   ctx.restore();
 }
 
+// light-edges: box edges as glowing gradient lines. RECIPE-ONLY port (2D
+// canvas approximation) after Zach Lieberman's "Box Light Studies" (Art
+// Blocks Curated #499, CC BY-NC 4.0). The original's soft light lives in a
+// GPU jump-flood distance field — that recipe belongs to the 3D end's
+// shader corpus (see docs/superpowers/artblocks-study/
+// 08-box-light-studies-lieberman.md); here we take the COMPOSITION (edges
+// as light sources) and fake the glow with layered strokes:
+//   wide × faint → narrow × brighter, per edge, two colors interpolated
+//   along the segment.
+function drawLightEdges(ctx, { palette, seed, x, y, w, h, intensity }) {
+  const P = INTENSITY[intensity] || INTENSITY.subtle;
+  const rand = seededRand(seed * 67 + 41);
+  const colors = [palette.accent, ...(palette.colors || [])].filter(Boolean);
+  const BOXES = 4 + Math.floor(rand() * 3);
+  ctx.save();
+  ctx.lineCap = 'round';
+  for (let b = 0; b < BOXES; b++) {
+    const cx = x + rand() * w;
+    const cy = y + rand() * h;
+    const size = Math.min(w, h) * (0.1 + rand() * 0.16);
+    const ang = rand() * Math.PI;
+    const depth = size * (0.4 + rand() * 0.4);
+    const dx = Math.cos(ang + Math.PI / 5) * depth;
+    const dy = Math.sin(ang + Math.PI / 5) * depth * 0.5;
+    // front face corners (rotated square)
+    const corners = [];
+    for (let k = 0; k < 4; k++) {
+      const a = ang + (k * Math.PI) / 2;
+      corners.push([cx + Math.cos(a) * size, cy + Math.sin(a) * size]);
+    }
+    const edges = [];
+    for (let k = 0; k < 4; k++) {
+      edges.push([corners[k], corners[(k + 1) % 4]]); // front face
+      edges.push([corners[k], [corners[k][0] + dx, corners[k][1] + dy]]); // depth edge
+      edges.push([
+        [corners[k][0] + dx, corners[k][1] + dy],
+        [corners[(k + 1) % 4][0] + dx, corners[(k + 1) % 4][1] + dy],
+      ]); // back face
+    }
+    const cA = colors[b % colors.length];
+    const cB = colors[(b + 1) % colors.length];
+    for (const [[x1, y1], [x2, y2]] of edges) {
+      // two-color edge: draw as two halves meeting at the midpoint
+      const mx = (x1 + x2) / 2;
+      const my = (y1 + y2) / 2;
+      for (const [color, sx, sy, ex, ey] of [
+        [cA, x1, y1, mx, my],
+        [cB, mx, my, x2, y2],
+      ]) {
+        // layered glow: wide-faint → narrow-brighter
+        for (const [width, alpha] of [
+          [P.lineWidth * 6, P.alpha * 0.25],
+          [P.lineWidth * 3, P.alpha * 0.5],
+          [P.lineWidth * 1.2, P.alpha],
+        ]) {
+          ctx.strokeStyle = rgba(color, alpha);
+          ctx.lineWidth = width;
+          ctx.beginPath();
+          ctx.moveTo(sx, sy);
+          ctx.lineTo(ex, ey);
+          ctx.stroke();
+        }
+      }
+    }
+  }
+  ctx.restore();
+}
+
 // --- registry ----------------------------------------------------------------
 
 // FREEZE DISCIPLINE (Sprint 43, the complete fxhash lesson): fxhash's
@@ -742,6 +810,7 @@ export const DECOR_FAMILIES = {
   'strata-lines': drawStrataLines,
   'sediment-layers': drawSedimentLayers,
   'ink-scribble': drawInkScribble,
+  'light-edges': drawLightEdges,
 };
 
 // theme macroCluster → family affinity (seeded pick between two candidates so
@@ -755,9 +824,9 @@ const CLUSTER_AFFINITY = {
     'shard-mesh',
     'meadow-streaks',
   ],
-  pitch: ['block-mosaic', 'weave-dashes', 'circle-pack', 'flow-ribbons'],
+  pitch: ['block-mosaic', 'light-edges', 'weave-dashes', 'circle-pack', 'flow-ribbons'],
   organic: ['wash-flow', 'sediment-layers', 'meadow-streaks', 'flow-ribbons', 'circle-pack'],
-  consulting: ['block-mosaic', 'strata-lines', 'weave-dashes', 'shard-mesh'],
+  consulting: ['block-mosaic', 'strata-lines', 'light-edges', 'weave-dashes', 'shard-mesh'],
   financial: ['strata-lines', 'sediment-layers', 'shard-mesh', 'weave-dashes'],
   hr: ['ink-scribble', 'circle-pack', 'meadow-streaks'],
 };


### PR DESCRIPTION
后期队列第三课, **双供给线方针的第一次真实分流**。

## Box Light Studies 读透

全队列第一件本质上是 **shader 作品**的课: 柔光完全住在 GPU 距离场管线里 (jump-flood 传播 → spiral 补洞 → 距离→亮度), p5 只是宿主。**Lieberman 把"光"翻译成"距离" — 柔光不是画出来的, 是场算出来的。**

## 分流判定 (本课最重要的产出)

- **→ 3D 端**: jump-flood 距离场 recipe 完整解剖记录在课程文档, 待 3D 端接力时移交进他们的 shader idiom registry (67 idiom 基础上的新词条)
- **→ 2D 端**: 只取构图 (**棱线即光源**), 辉光用分层淡笔画近似 (宽淡→窄亮 ×3), 每条棱双色中点相接

## light-edges 家族

散布旋转线框盒 + 双色辉光棱线, pitch/consulting 亲和。家族 **11→12** — 修饰词汇谱系现在覆盖: 纹理 (weave/mesh) / 场 (flow/wash) / 构成 (mosaic/box) / 手绘 (ink) / 风景 (sediment/strata) / 光 (edges)。

## Tests
131/131 (test-decor 84 断言)

🤖 Generated with [Claude Code](https://claude.com/claude-code)