### PR TITLE
Sprint 52: 第九课 Cytographia + nib-flourish — 第三形态 (2D构图+shader材质)

### DIFF
--- a/docs/superpowers/artblocks-study/09-cytographia-levin.md
+++ b/docs/superpowers/artblocks-study/09-cytographia-levin.md
@@ -1,0 +1,46 @@
+# 第九课: Cytographia — Golan Levin (后期队列)
+
+- **ArtBlocks #487** · p5 (2D + WebGL 材质层) · 287KB (语料最大) · **CC BY-NC 4.0 → recipe-only**
+- 视觉: 无义生物图谱 — 伪文字 (asemic writing) + 生物细胞线描 + 古籍版面, 书法笔触
+
+## 分流判定: 第三种形态 (本课首要产出)
+
+既非纯 2D 也非 shader-core — **2D-core 构图 + shader 材质部门**:
+构图/几何 (细胞、伪文字、版面) 全是 2D; shader 只负责"材质": frag_paper
+(纸纹) / frag_blur / frag_comp (柔光合成+水印噪声) / **笔尖 vertex shader**
+(书法笔画渲染) / stamp corrupter。渲染技术地图新增第三类:
+2D-core + shader materials → **2D 队列, 材质层 idiom 可选移交 3D**。
+
+## 结构 (287KB 的图书装置)
+
+```
+asemic 字形系统   看起来像文字但无语义的字形生成 (整本"古籍"的正文)
+细胞/blob 生成    converge 增长算法 + 相交检测 — 生物形态线描
+版面系统          cell 布局 + 装饰边框 + 图注 — 完整书籍版面语法
+StyledPolyline ★  笔尖 vertex shader: 笔画宽度 =
+                  基宽 × nib(笔画方向 vs nibAngle, nibStrength)
+                  × iqPerlinNoise6 (6 倍频噪声"呼吸")
+                  — 书法的算法本体: 宽度是方向和行进的函数
+材质 shader 层    纸纹/柔光/水印 — 古籍质感全在后处理
+```
+
+## 三个可提取 idiom (2D 侧)
+
+1. **笔尖宽度调制** (最有价值): 书法感 = 笔画宽度随 (a) 笔画方向与固定
+   笔尖角的夹角 (b) 行进噪声 变化 — canvas 可廉价复现: 沿曲线逐点算宽度,
+   左右各偏移 w/2 成飘带多边形填充。
+2. **材质与构图分层**: 构图管几何、材质管质感, 两层可独立替换 —
+   与我们 palette-注入 / decor-垫底 的分层哲学同构。
+3. **asemic 概念**: 伪文字做纹理。⚠ 判定: deck 场景不 port —
+   数据文档里的"假文字"有误导嫌疑 (幻觉相邻), 修饰不能制造可读性错觉。
+
+## Port 判定
+
+- **recipe-only**: `nib-flourish` 家族 = idiom 1 独立重写 — 噪声路径 +
+  笔尖宽度调制 + 飘带填充, 优雅书法曲线点缀角落。editorial/hr 亲和。
+- asemic 字形明确不 port (上述判定); 材质 shader 层记入 3D 端可选移交。
+
+## 一句话学到的
+
+书法不是曲线的形状, 是**宽度的函数** — 同一条路径, 宽度恒定是几何,
+宽度随方向与呼吸变化就成了手迹; Levin 把整支笔装进了一个 vertex shader。

--- a/sdf-js/scripts/test-decor.mjs
+++ b/sdf-js/scripts/test-decor.mjs
@@ -118,10 +118,11 @@ function recCtx() {
       .map((s) => /rgba\(\d+, \d+, \d+, ([\d.]+)\)/.exec(String(s)))
       .filter(Boolean)
       .map((m) => parseFloat(m[1]));
-    // sediment-layers' occlusion contract REQUIRES near-opaque fills — its
-    // legibility guard is color-blending toward bg, asserted in its own
-    // block below, not the alpha cap.
-    if (family !== 'sediment-layers') {
+    // sediment-layers' occlusion contract REQUIRES near-opaque fills (its
+    // guard is color-blending toward bg); nib-flourish fills THIN ribbons —
+    // visual weight = alpha × area, and its tiny area affords a higher
+    // alpha (own cap asserted in its block). Both exempt from the generic cap.
+    if (family !== 'sediment-layers' && family !== 'nib-flourish') {
       ok(
         alphas.length > 0 && Math.max(...alphas) <= 0.1,
         `${family} subtle alpha ≤ 0.1 (legibility guard)`,
@@ -495,6 +496,34 @@ function recCtx() {
   drawDecor(a.ctx, { family: 'light-edges', seed: 27 }, { palette, w: 640, h: 360 });
   drawDecor(b.ctx, { family: 'light-edges', seed: 27 }, { palette, w: 640, h: 360 });
   ok(JSON.stringify(a.rec.ops) === JSON.stringify(b.rec.ops), 'light-edges deterministic per seed');
+}
+
+// ── Sprint 52: nib-flourish (Cytographia recipe-only) ──
+{
+  const { ctx, rec } = recCtx();
+  drawDecor(
+    ctx,
+    { family: 'nib-flourish', seed: 22 },
+    { palette, x: 0, y: 0, w: 640, h: 360, intensity: 'subtle' },
+  );
+  const fills = rec.ops.filter((o) => o[0] === 'fill').length;
+  ok(fills >= 5 && fills <= 8, `nib-flourish fills one ribbon per flourish (${fills})`);
+  // ribbon = 2×(steps+1) vertices per shape
+  const lineTos = rec.ops.filter((o) => o[0] === 'lineTo').length;
+  ok(lineTos >= fills * 50, 'ribbon polygons carry per-point width (many vertices)');
+  const a = recCtx();
+  const b = recCtx();
+  drawDecor(a.ctx, { family: 'nib-flourish', seed: 31 }, { palette, w: 640, h: 360 });
+  drawDecor(b.ctx, { family: 'nib-flourish', seed: 31 }, { palette, w: 640, h: 360 });
+  ok(
+    JSON.stringify(a.rec.ops) === JSON.stringify(b.rec.ops),
+    'nib-flourish deterministic per seed',
+  );
+  const nibAlphas = rec.styles
+    .map((s) => /rgba\(\d+, \d+, \d+, ([\d.]+)\)/.exec(String(s)))
+    .filter(Boolean)
+    .map((m) => parseFloat(m[1]));
+  ok(Math.max(...nibAlphas) <= 0.22, 'nib-flourish thin-ribbon alpha within its own cap');
 }
 
 console.log(`\n${pass} passed, ${fail} failed`);

--- a/sdf-js/src/present/decor/registry.js
+++ b/sdf-js/src/present/decor/registry.js
@@ -787,6 +787,69 @@ function drawLightEdges(ctx, { palette, seed, x, y, w, h, intensity }) {
   ctx.restore();
 }
 
+// nib-flourish: calligraphic flourish curves — stroke width modulated by
+// direction-vs-nib-angle and a travelling noise "breath", rendered as
+// filled ribbon polygons. RECIPE-ONLY port after the StyledPolyline nib
+// renderer in Golan Levin's "Cytographia" (Art Blocks Curated #487,
+// CC BY-NC 4.0 — independent reimplementation; see docs/superpowers/
+// artblocks-study/09-cytographia-levin.md). Calligraphy is not the shape
+// of the curve — it is the FUNCTION OF WIDTH.
+function drawNibFlourish(ctx, { palette, seed, x, y, w, h, intensity }) {
+  const P = INTENSITY[intensity] || INTENSITY.subtle;
+  const noise = noise2D(seed);
+  const rand = seededRand(seed * 71 + 47);
+  const colors = [palette.accent, ...(palette.colors || [])].filter(Boolean);
+  const COUNT = 5 + Math.floor(rand() * 4);
+  const nibAngle = rand() * Math.PI; // one pen per artwork
+  ctx.save();
+  for (let i = 0; i < COUNT; i++) {
+    // corner/edge-weighted anchor
+    const u = rand();
+    const v = rand();
+    const cx = x + (u < 0.5 ? u * u * 2 : 1 - (1 - u) * (1 - u) * 2) * w;
+    const cy = y + (v < 0.5 ? v * v * 2 : 1 - (1 - v) * (1 - v) * 2) * h;
+    const len = 80 + rand() * Math.min(w, h) * 0.55;
+    const baseW = 5 + rand() * 8;
+    const phase = rand() * 100;
+    const color = colors[i % colors.length];
+    // trace the flourish path
+    const pts = [];
+    let px = cx;
+    let py = cy;
+    let ang = rand() * Math.PI * 2;
+    const steps = 26;
+    for (let sIdx = 0; sIdx <= steps; sIdx++) {
+      pts.push([px, py, ang]);
+      ang += (noise(phase + sIdx * 0.18, phase) - 0.5) * 1.1;
+      px += Math.cos(ang) * (len / steps);
+      py += Math.sin(ang) * (len / steps);
+    }
+    // width per point: nib factor × noise breath × taper at both ends
+    const left = [];
+    const right = [];
+    for (let k = 0; k < pts.length; k++) {
+      const [qx, qy, qa] = pts[k];
+      const t = k / (pts.length - 1);
+      const taper = Math.sin(Math.PI * t); // pointed ends
+      const nib = 0.25 + 0.75 * Math.abs(Math.sin(qa - nibAngle));
+      const breath = 0.6 + 0.4 * noise(phase + k * 0.3, phase + 50);
+      const half = (baseW * nib * breath * taper) / 2;
+      const nx = Math.cos(qa + Math.PI / 2);
+      const ny = Math.sin(qa + Math.PI / 2);
+      left.push([qx + nx * half, qy + ny * half]);
+      right.push([qx - nx * half, qy - ny * half]);
+    }
+    ctx.fillStyle = rgba(color, Math.min(0.22, P.alpha * 2.2));
+    ctx.beginPath();
+    ctx.moveTo(left[0][0], left[0][1]);
+    for (let k = 1; k < left.length; k++) ctx.lineTo(left[k][0], left[k][1]);
+    for (let k = right.length - 1; k >= 0; k--) ctx.lineTo(right[k][0], right[k][1]);
+    ctx.closePath();
+    ctx.fill();
+  }
+  ctx.restore();
+}
+
 // --- registry ----------------------------------------------------------------
 
 // FREEZE DISCIPLINE (Sprint 43, the complete fxhash lesson): fxhash's
@@ -811,6 +874,7 @@ export const DECOR_FAMILIES = {
   'sediment-layers': drawSedimentLayers,
   'ink-scribble': drawInkScribble,
   'light-edges': drawLightEdges,
+  'nib-flourish': drawNibFlourish,
 };
 
 // theme macroCluster → family affinity (seeded pick between two candidates so
@@ -828,7 +892,7 @@ const CLUSTER_AFFINITY = {
   organic: ['wash-flow', 'sediment-layers', 'meadow-streaks', 'flow-ribbons', 'circle-pack'],
   consulting: ['block-mosaic', 'strata-lines', 'light-edges', 'weave-dashes', 'shard-mesh'],
   financial: ['strata-lines', 'sediment-layers', 'shard-mesh', 'weave-dashes'],
-  hr: ['ink-scribble', 'circle-pack', 'meadow-streaks'],
+  hr: ['nib-flourish', 'ink-scribble', 'circle-pack', 'meadow-streaks'],
 };
 
 /**


### PR DESCRIPTION
后期队列第四课, 语料中最大的作品 (287KB)。

## 分流判定: 第三形态

Cytographia 既非纯 2D 也非 shader-core — **2D-core 构图 + shader 材质部门**: 细胞/伪文字/古籍版面的几何全是 2D, shader 只负责材质 (纸纹/柔光合成/书法笔尖渲染)。渲染技术地图 (memory) 已补此类别 — 材质层与构图层可独立替换, 和我们 palette 注入/decor 垫底的分层哲学同构。

## 核心洞见

**书法不是曲线的形状, 是宽度的函数。** 同一条路径, 宽度恒定是几何; 宽度随 (笔画方向 vs 笔尖角) × (行进噪声呼吸) 变化, 就成了手迹。Levin 把整支笔装进一个 vertex shader — 我们用 canvas 飘带多边形廉价复现 (逐点算宽、左右偏移、两端收锋)。

## 一个明确的不 port 判定

asemic 伪文字不进 deck — 数据文档里的"假文字"有误导嫌疑 (幻觉相邻), **修饰不能制造可读性错觉**。这是修饰层的伦理边界第一次成文。

## nib-flourish 家族

书法飘带点缀, editorial/hr 亲和, 家族 **12→13**。细飘带面积极小 → 专属 alpha 上限 (视觉重量 = alpha × 面积, 通用上限对它错判)。

## Tests
131/131 (test-decor 90 断言)

🤖 Generated with [Claude Code](https://claude.com/claude-code)