### PR TITLE
Sprint 53: 第十课 while true + hex-lattice + OKLab 色彩空间

### DIFF
--- a/docs/superpowers/artblocks-study/10-while-true-wander.md
+++ b/docs/superpowers/artblocks-study/10-while-true-wander.md
@@ -1,0 +1,52 @@
+# 第十课: while true — Lars Wander (后期队列)
+
+- **ArtBlocks #498** (+ #501 fabric 变体) · 原生 WebGL · 23.7KB · **CC BY-NC-SA 4.0 → recipe-only**
+- 视觉: 六边形格上的图案织物 — 感知均匀的色彩渐变, 编程循环的视觉隐喻
+
+## 分流判定: 2D-core, WebGL 只是光栅器
+
+原生 WebGL 但 shader 极薄: vertex 只做实例化摆放 (cubic→cartesian 六边形
+坐标数学, RT3=√3), fragment 只做 **OKLab→sRGB 色彩空间转换**。图案、
+铺陈、色彩序列全在 CPU JS — 归档: 2D-core (GPU 仅加速光栅)。
+
+## 结构
+
+```
+cubic_to_cat     六边形格坐标数学: 立方坐标 (q,r) → 笛卡尔
+                 x' = √3·(x + y/2), y' = 1.5·y — hex 铺陈的规范式
+OKLab shader ★   顶点色在 OKLab 空间, fragment 转 sRGB —
+                 感知均匀渐变: RGB lerp 的"浑浊中间调"在 OKLab 中消失
+class G ★        random tape: 预抽 I 个 float 的"磁带", 每次决策显式
+                 传游标 float(t,min,max) → [下一游标, 值] —
+                 引用透明的随机: 同游标同值, 插入新决策不扰动旧游标
+图案系统          hex 格上的 while-loop 织物图案 (程序循环的视觉本体)
+```
+
+## 确定性纪律的第三种形态 (集齐)
+
+| 方案 | 出处 | 稳定性机制 |
+|---|---|---|
+| 决策位切片 | Rizzolli/Penne (L1/L5) | 固定槽位 |
+| 命名 lane | 我们 (fxhash 改) | 标签派生独立流 |
+| **random tape + 显式游标** | Wander (L10) | 游标显式传递, 引用透明 |
+
+三者同构于一个原则: **随机消费必须可寻址** — 地址是槽位、标签还是游标
+只是风格差异。
+
+## 三个可提取 idiom
+
+1. **OKLab 色彩空间** (立即可用): RGB lerp 中间调发灰发浑, OKLab lerp
+   感知均匀 — decor 新家族即刻采用 (`lerpColorOklab`);
+   已冻结家族 (wash-flow 的 RGB lerp) 按冻结纪律不动。
+2. **六边形格数学**: 立方坐标规范式 — hex 铺陈家族的骨架。
+3. **random tape**: 记入确定性纪律对照表 (上表)。
+
+## Port 判定
+
+- **recipe-only** (NC+SA): `hex-lattice` 家族 = idiom 1+2 — 六边形铺陈 +
+  OKLab 渐变染色 + 种子化稀疏填充。pitch/consulting 亲和 (科技织物感)。
+
+## 一句话学到的
+
+色彩的"高级感"一半是色彩空间的选择 — 同样两个端点色, RGB 直线穿过
+浑浊地带, OKLab 直线沿着感知等距走; 好渐变不是选好颜色, 是选好空间。

--- a/sdf-js/scripts/test-decor.mjs
+++ b/sdf-js/scripts/test-decor.mjs
@@ -134,7 +134,7 @@ function recCtx() {
     // wash-flow interpolates CONTINUOUSLY between theme colors (recipe from
     // Watercolor Dreams) — intermediate colors are theme-derived but not
     // exact stops, so the exact-match check doesn't apply to it.
-    if (!['wash-flow', 'strata-lines', 'sediment-layers'].includes(family)) {
+    if (!['wash-flow', 'strata-lines', 'sediment-layers', 'hex-lattice'].includes(family)) {
       const offPalette = rec.styles.filter((s) => {
         const m = /rgba\((\d+, \d+, \d+),/.exec(String(s));
         return m && !paletteRgb.has(m[1]);
@@ -524,6 +524,36 @@ function recCtx() {
     .filter(Boolean)
     .map((m) => parseFloat(m[1]));
   ok(Math.max(...nibAlphas) <= 0.22, 'nib-flourish thin-ribbon alpha within its own cap');
+}
+
+// ── Sprint 53: hex-lattice + OKLab (while-true recipe-only) ──
+{
+  const { lerpColorOklab } = await import('../src/present/decor/registry.js');
+  const mid = lerpColorOklab([255, 0, 0], [0, 0, 255], 0.5);
+  ok(Array.isArray(mid) && mid.every((v) => v >= 0 && v <= 255), 'oklab lerp returns valid rgb');
+  // endpoints round-trip
+  const e0 = lerpColorOklab([38, 70, 130], [200, 50, 50], 0);
+  ok(Math.abs(e0[0] - 38) <= 1 && Math.abs(e0[2] - 130) <= 1, 'oklab lerp t=0 returns first color');
+  // perceptual midpoint of red↔blue in OKLab is purple-ish, NOT the muddy
+  // rgb average (127,0,127 exactly) — assert it differs from raw rgb lerp
+  ok(
+    mid.join(',') !== '128,0,128' && mid.join(',') !== '127,0,127',
+    'oklab midpoint ≠ rgb midpoint (perceptual path)',
+  );
+
+  const { ctx, rec } = recCtx();
+  drawDecor(
+    ctx,
+    { family: 'hex-lattice', seed: 44 },
+    { palette, x: 0, y: 0, w: 640, h: 360, intensity: 'subtle' },
+  );
+  const strokes = rec.ops.filter((o) => o[0] === 'stroke').length;
+  ok(strokes > 60, `hex-lattice strokes many cells (${strokes})`);
+  const a = recCtx();
+  const b = recCtx();
+  drawDecor(a.ctx, { family: 'hex-lattice', seed: 9 }, { palette, w: 640, h: 360 });
+  drawDecor(b.ctx, { family: 'hex-lattice', seed: 9 }, { palette, w: 640, h: 360 });
+  ok(JSON.stringify(a.rec.ops) === JSON.stringify(b.rec.ops), 'hex-lattice deterministic per seed');
 }
 
 console.log(`\n${pass} passed, ${fail} failed`);

--- a/sdf-js/src/present/decor/registry.js
+++ b/sdf-js/src/present/decor/registry.js
@@ -850,6 +850,105 @@ function drawNibFlourish(ctx, { palette, seed, x, y, w, h, intensity }) {
   ctx.restore();
 }
 
+// --- OKLab color space (Sprint 53, the while-true lesson) --------------------
+// RGB-space lerp passes through muddy midtones; OKLab lerp is perceptually
+// uniform. Available to NEW families (frozen families keep their RGB lerp
+// per the freeze discipline). Conversion after Björn Ottosson's reference.
+function srgbToLinear(c) {
+  const x = c / 255;
+  return x <= 0.04045 ? x / 12.92 : Math.pow((x + 0.055) / 1.055, 2.4);
+}
+function linearToSrgb(x) {
+  const v = x <= 0.0031308 ? x * 12.92 : 1.055 * Math.pow(x, 1 / 2.4) - 0.055;
+  return Math.round(Math.max(0, Math.min(1, v)) * 255);
+}
+function rgbToOklab([r, g, b]) {
+  const lr = srgbToLinear(r);
+  const lg = srgbToLinear(g);
+  const lb = srgbToLinear(b);
+  const l = Math.cbrt(0.4122214708 * lr + 0.5363325363 * lg + 0.0514459929 * lb);
+  const m = Math.cbrt(0.2119034982 * lr + 0.6806995451 * lg + 0.1073969566 * lb);
+  const s2 = Math.cbrt(0.0883024619 * lr + 0.2817188376 * lg + 0.6299787005 * lb);
+  return [
+    0.2104542553 * l + 0.793617785 * m - 0.0040720468 * s2,
+    1.9779984951 * l - 2.428592205 * m + 0.4505937099 * s2,
+    0.0259040371 * l + 0.7827717662 * m - 0.808675766 * s2,
+  ];
+}
+function oklabToRgb([L, a, b]) {
+  const l_ = L + 0.3963377774 * a + 0.2158037573 * b;
+  const m_ = L - 0.1055613458 * a - 0.0638541728 * b;
+  const s_ = L - 0.0894841775 * a - 1.291485548 * b;
+  const l = l_ * l_ * l_;
+  const m = m_ * m_ * m_;
+  const s2 = s_ * s_ * s_;
+  return [
+    linearToSrgb(4.0767416621 * l - 3.3077115913 * m + 0.2309699292 * s2),
+    linearToSrgb(-1.2684380046 * l + 2.6097574011 * m - 0.3413193965 * s2),
+    linearToSrgb(-0.0041960863 * l - 0.7034186147 * m + 1.707614701 * s2),
+  ];
+}
+export function lerpColorOklab(c1, c2, t) {
+  const a = rgbToOklab(c1);
+  const b = rgbToOklab(c2);
+  return oklabToRgb([a[0] + (b[0] - a[0]) * t, a[1] + (b[1] - a[1]) * t, a[2] + (b[2] - a[2]) * t]);
+}
+
+// hex-lattice: hexagonal tiling with OKLab-graded sparse fills. RECIPE-ONLY
+// port after Lars Wander's "while true" (Art Blocks Curated #498,
+// CC BY-NC-SA 4.0 — independent reimplementation; see docs/superpowers/
+// artblocks-study/10-while-true-wander.md). Two idioms: cubic→cartesian
+// hex math (x' = √3(q + r/2), y' = 1.5r) and perceptually-uniform OKLab
+// gradients across the lattice.
+function drawHexLattice(ctx, { palette, seed, x, y, w, h, intensity }) {
+  const P = INTENSITY[intensity] || INTENSITY.subtle;
+  const noise = noise2D(seed);
+  const rand = seededRand(seed * 83 + 59);
+  const colors = [palette.accent, ...(palette.colors || [])].filter(Boolean);
+  const cA = colors[Math.floor(rand() * colors.length)];
+  const cB = colors[(Math.floor(rand() * colors.length) + 1) % colors.length];
+  const R = 16 + rand() * 10; // hex radius
+  const RT3 = Math.sqrt(3);
+  const gradAngle = rand() * Math.PI;
+  const cosG = Math.cos(gradAngle);
+  const sinG = Math.sin(gradAngle);
+  const diag = Math.hypot(w, h);
+  ctx.save();
+  ctx.lineWidth = P.lineWidth * 0.8;
+  const qMax = Math.ceil(w / (RT3 * R)) + 2;
+  const rMax = Math.ceil(h / (1.5 * R)) + 2;
+  for (let rr = -1; rr <= rMax; rr++) {
+    for (let q = -1; q <= qMax; q++) {
+      const cx = x + RT3 * R * (q + (rr % 2 === 0 ? 0 : 0.5));
+      const cy = y + 1.5 * R * rr;
+      const gate = noise(cx * 0.004, cy * 0.004);
+      if (gate > 0.52) continue; // sparse patches
+      // OKLab gradient along a seeded direction
+      const t = Math.max(
+        0,
+        Math.min(1, ((cx - x) * cosG + (cy - y) * sinG) / diag + 0.5 - 0.5 * (cosG + sinG) * 0.5),
+      );
+      const col = lerpColorOklab(cA, cB, t);
+      ctx.beginPath();
+      for (let k = 0; k < 6; k++) {
+        const a = Math.PI / 6 + (k * Math.PI) / 3;
+        const px = cx + Math.cos(a) * R * 0.92;
+        const py = cy + Math.sin(a) * R * 0.92;
+        if (k === 0) ctx.moveTo(px, py);
+        else ctx.lineTo(px, py);
+      }
+      ctx.closePath();
+      if ((q + rr * 3) % 4 === 0) {
+        ctx.fillStyle = rgba(col, P.alphaFill);
+        ctx.fill();
+      }
+      ctx.strokeStyle = rgba(col, P.alpha);
+      ctx.stroke();
+    }
+  }
+  ctx.restore();
+}
+
 // --- registry ----------------------------------------------------------------
 
 // FREEZE DISCIPLINE (Sprint 43, the complete fxhash lesson): fxhash's
@@ -875,6 +974,7 @@ export const DECOR_FAMILIES = {
   'ink-scribble': drawInkScribble,
   'light-edges': drawLightEdges,
   'nib-flourish': drawNibFlourish,
+  'hex-lattice': drawHexLattice,
 };
 
 // theme macroCluster → family affinity (seeded pick between two candidates so
@@ -888,9 +988,23 @@ const CLUSTER_AFFINITY = {
     'shard-mesh',
     'meadow-streaks',
   ],
-  pitch: ['block-mosaic', 'light-edges', 'weave-dashes', 'circle-pack', 'flow-ribbons'],
+  pitch: [
+    'block-mosaic',
+    'hex-lattice',
+    'light-edges',
+    'weave-dashes',
+    'circle-pack',
+    'flow-ribbons',
+  ],
   organic: ['wash-flow', 'sediment-layers', 'meadow-streaks', 'flow-ribbons', 'circle-pack'],
-  consulting: ['block-mosaic', 'strata-lines', 'light-edges', 'weave-dashes', 'shard-mesh'],
+  consulting: [
+    'block-mosaic',
+    'hex-lattice',
+    'strata-lines',
+    'light-edges',
+    'weave-dashes',
+    'shard-mesh',
+  ],
   financial: ['strata-lines', 'sediment-layers', 'shard-mesh', 'weave-dashes'],
   hr: ['nib-flourish', 'ink-scribble', 'circle-pack', 'meadow-streaks'],
 };


### PR DESCRIPTION
后期队列第五课。

## 分流判定

while true = **2D-core, WebGL 只是光栅器** — 原生 WebGL 但 shader 极薄 (顶点做六边形格实例化摆放, fragment 只做 OKLab→sRGB), 图案/铺陈/色序全在 CPU。技术地图已更新。

## 两个高价值收获

**1. OKLab 感知均匀色彩空间 (立即落地)**: 同样两个端点色, RGB 直线穿过浑浊地带, OKLab 直线沿感知等距走 — **好渐变不是选好颜色, 是选好空间**。`lerpColorOklab` (Ottosson 参考实现) 供新家族使用; 已冻结家族 (wash-flow 的 RGB lerp) 按冻结纪律不动。

**2. 确定性纪律第三形态集齐**: Wander 的 **random tape + 显式游标** (同游标同值, 插入决策不扰旧游标) — 与 Rizzolli 决策位、我们的命名 lane 同构于一条原则: **随机消费必须可寻址**。对照表进课程文档。

## hex-lattice 家族

六边形铺陈 (立方坐标规范式) + 噪声门控稀疏 + OKLab 定向渐变, pitch/consulting 亲和 (科技织物感)。家族 **13→14**。

## Tests
131/131 (test-decor 97 断言, 含 OKLab 往返与"感知中点≠RGB中点")

🤖 Generated with [Claude Code](https://claude.com/claude-code)