### PR TITLE
Sprint 60: 稀有 trait — 旗舰 5 家族签名件 + affinity 覆盖不变量

### DIFF
--- a/sdf-js/apps/present/author-2d.js
+++ b/sdf-js/apps/present/author-2d.js
@@ -163,7 +163,7 @@ function syncProvenance() {
   provEl.hidden = false;
   redressEl.disabled = false;
   decorVisEl.disabled = false;
-  provEl.textContent = `作品 #${String(d.hash).slice(0, 8)} · ${d.family} · ${d.personality} · v${d.v ?? 1}`;
+  provEl.textContent = `作品 #${String(d.hash).slice(0, 8)} · ${d.family} · ${d.personality} · v${d.v ?? 1}${d.rare ? ' · ✨稀有' : ''}`;
   // the address bar IS the provenance link (safe: ?hash is consume-once);
   // preserve other params (?demo=1 etc.) — only the hash slot is ours
   const qs = new URLSearchParams(location.search);
@@ -191,7 +191,9 @@ redressEl.addEventListener('click', async () => {
     await renderDeck(currentDeck);
     syncProvenance();
     const d = currentDeck.decor;
-    setStatus(`已换装 — 作品 #${String(d.hash).slice(0, 8)} (${d.family} · ${d.personality})`);
+    setStatus(
+      `已换装 — 作品 #${String(d.hash).slice(0, 8)} (${d.family} · ${d.personality}${d.rare ? ' · ✨稀有件!' : ''})`,
+    );
   } catch (e) {
     setStatus(`换装失败: ${e.message}`, true);
   } finally {

--- a/sdf-js/examples/atoms-2d-demo/decor-gallery.html
+++ b/sdf-js/examples/atoms-2d-demo/decor-gallery.html
@@ -53,11 +53,19 @@
           ctx.fillRect(0, 0, W, H);
           drawDecor(
             ctx,
-            { family, seed: minted.seed, personality: minted.personality, hash, v: minted.v, at },
+            {
+              family,
+              seed: minted.seed,
+              personality: minted.personality,
+              hash,
+              v: minted.v,
+              rare: minted.rare && minted.family === family,
+              at,
+            },
             { palette: theme, x: 0, y: 0, w: W, h: H, intensity },
           );
           const cap = document.createElement('figcaption');
-          cap.textContent = `#${hash.slice(0, 8)} · ${minted.personality} · v${minted.v}`;
+          cap.textContent = `#${hash.slice(0, 8)} · ${minted.personality} · v${minted.v}${minted.rare && minted.family === family ? ' · ✨' : ''}`;
           fig.appendChild(c);
           fig.appendChild(cap);
           row.appendChild(fig);

--- a/sdf-js/examples/atoms-2d-demo/decor-showcase.html
+++ b/sdf-js/examples/atoms-2d-demo/decor-showcase.html
@@ -214,7 +214,7 @@
         const hash = mintDecorHash();
         const d = decorFromHash(deck.theme, hash);
         await renderSlide(mintCanvas, d);
-        mintId.textContent = `作品 #${hash} · ${d.family} · ${d.personality} · v${d.v}`;
+        mintId.textContent = `作品 #${hash} · ${d.family} · ${d.personality} · v${d.v}${d.rare ? ' · ✨稀有件 (~3%)' : ''}`;
       }
       document.getElementById('mint-btn').addEventListener('click', mintOne);
       mintOne();
@@ -236,7 +236,14 @@
           const minted = decorFromHash(theme, hash);
           drawDecor(
             ctx,
-            { family, seed: minted.seed, personality: minted.personality, hash, v: minted.v },
+            {
+              family,
+              seed: minted.seed,
+              personality: minted.personality,
+              hash,
+              v: minted.v,
+              rare: minted.rare && minted.family === family,
+            },
             { palette: theme, x: 0, y: 0, w: 320, h: 180, intensity: 'medium' },
           );
           row.appendChild(c);

--- a/sdf-js/scripts/test-decor.mjs
+++ b/sdf-js/scripts/test-decor.mjs
@@ -932,5 +932,100 @@ function recCtx() {
   );
 }
 
+// ── Sprint 60: rare traits (collectible gate) ──
+{
+  const { RARE_TRAIT_FAMILIES } = await import('../src/present/decor/registry.js');
+  ok(
+    RARE_TRAIT_FAMILIES.length === 5,
+    `five flagship families carry signature elements (${RARE_TRAIT_FAMILIES.length})`,
+  );
+  // gate statistics: ~3% of mints, artifact-level, deterministic per hash
+  const t = { id: 'pitch-bold', macroCluster: 'pitch' };
+  let rares = 0;
+  let eligible = 0;
+  for (let i = 0; i < 600; i++) {
+    const d = decorFromHash(t, `stat-${i}`);
+    if (RARE_TRAIT_FAMILIES.includes(d.family)) {
+      eligible++;
+      if (d.rare) rares++;
+    } else {
+      ok2: if (d.rare) {
+        ok(false, 'non-flagship family minted rare');
+        break ok2;
+      }
+    }
+  }
+  ok(eligible > 50, `flagship families appear in mints (${eligible}/600)`);
+  ok(rares >= 1 && rares <= eligible * 0.12, `rare gate ~3% (${rares}/${eligible})`);
+  const again = decorFromHash(t, 'stat-7');
+  ok(again.rare === decorFromHash(t, 'stat-7').rare, 'rare gate deterministic per hash');
+
+  // rare adds signature ops over the same family/seed; deterministic
+  const base = recCtx();
+  drawDecor(
+    base.ctx,
+    { family: 'peg-wraps', seed: 9, hash: 'raretest', v: 2 },
+    { palette, w: 640, h: 360 },
+  );
+  const rare1 = recCtx();
+  drawDecor(
+    rare1.ctx,
+    { family: 'peg-wraps', seed: 9, hash: 'raretest', v: 2, rare: true },
+    { palette, w: 640, h: 360 },
+  );
+  const rare2 = recCtx();
+  drawDecor(
+    rare2.ctx,
+    { family: 'peg-wraps', seed: 9, hash: 'raretest', v: 2, rare: true },
+    { palette, w: 640, h: 360 },
+  );
+  ok(rare1.rec.ops.length > base.rec.ops.length, 'rare signature adds ops');
+  ok(
+    JSON.stringify(rare1.rec.ops) === JSON.stringify(rare2.rec.ops),
+    'rare signature deterministic per hash',
+  );
+  // the signature speaks metal: a non-palette gold/crimson appears
+  const metals = rare1.rec.styles.filter((st) =>
+    /rgba\(212, 175, 55|rgba\(178, 34, 52/.test(String(st)),
+  );
+  ok(metals.length > 0, 'rare signature uses a metallic constant');
+  // v1 artifacts ignore the rare flag entirely
+  const v1rare = recCtx();
+  drawDecor(
+    v1rare.ctx,
+    { family: 'peg-wraps', seed: 9, hash: 'raretest', v: 1, rare: true },
+    { palette, w: 640, h: 360 },
+  );
+  const v1base = recCtx();
+  drawDecor(
+    v1base.ctx,
+    { family: 'peg-wraps', seed: 9, hash: 'raretest', v: 1 },
+    { palette, w: 640, h: 360 },
+  );
+  ok(
+    JSON.stringify(v1rare.rec.ops) === JSON.stringify(v1base.rec.ops),
+    'v1 artifacts ignore the rare flag',
+  );
+}
+
+// ── Sprint 60: affinity coverage invariant ──
+// Sprint 56-57 silently DROPPED families from CLUSTER_AFFINITY (a prettier-
+// reformat made string replaces no-op) — torn-paper ended up reachable in
+// NO cluster. This invariant makes that class of bug impossible to ship.
+{
+  const { CLUSTER_AFFINITY, DECOR_FAMILIES } = await import('../src/present/decor/registry.js');
+  const reachable = new Set(Object.values(CLUSTER_AFFINITY).flat());
+  const orphans = Object.keys(DECOR_FAMILIES).filter((f) => !reachable.has(f));
+  ok(
+    orphans.length === 0,
+    `every family reachable in ≥1 cluster (orphans: ${orphans.join(', ') || 'none'})`,
+  );
+  const ghosts = [...reachable].filter((f) => !(f in DECOR_FAMILIES));
+  ok(
+    ghosts.length === 0,
+    `affinity references only real families (ghosts: ${ghosts.join(', ') || 'none'})`,
+  );
+}
+
 console.log(`\n${pass} passed, ${fail} failed`);
 process.exit(fail ? 1 : 0);

--- a/sdf-js/src/present/decor/registry.js
+++ b/sdf-js/src/present/decor/registry.js
@@ -2058,6 +2058,122 @@ export function guardPalette(palette) {
   };
 }
 
+// --- rare traits (Sprint 60, v2 pipeline) -------------------------------------
+// ~3% of mints carry a SIGNATURE ELEMENT drawn over the (frozen) family in
+// its own visual language — the collectible hook (Fidenza rare-palette /
+// Watercolor rarity-ladder lesson). Two deliberate rule-breaks, both scoped
+// to rares only: they may use the two METALLIC constants below (off the
+// theme palette — preciousness needs a foreign material), and their alpha
+// runs hotter than the whisper cap (thread-thin area affords it, same
+// argument as nib-flourish). The rare gate lives on its own hash lane, so
+// it is an ARTIFACT-level property: a rare deck is rare on every slide.
+const RARE_GOLD = [212, 175, 55];
+const RARE_CRIMSON = [178, 34, 52];
+
+const RARE_TRAITS = {
+  // one long gilded streamline weaving through the ribbons
+  'flow-ribbons': (ctx, R, { x, y, w, h }) => {
+    const noise = noise2D(R.int('gild-seed', 1, 1e9));
+    let px = x + R.range('gild-x', 0.05, 0.2) * w;
+    let py = y + R.range('gild-y', 0.2, 0.8) * h;
+    ctx.strokeStyle = rgba(RARE_GOLD, 0.5);
+    ctx.lineWidth = 1.6;
+    ctx.lineCap = 'round';
+    ctx.beginPath();
+    ctx.moveTo(px, py);
+    for (let i = 0; i < 110; i++) {
+      const a = noise(px * 0.003, py * 0.003) * Math.PI * 4;
+      px += Math.cos(a) * 7;
+      py += Math.sin(a) * 7;
+      if (px < x || px > x + w || py < y || py > y + h) break;
+      ctx.lineTo(px, py);
+    }
+    ctx.stroke();
+  },
+  // the red string of fate: a crimson thread visiting three pegs
+  'peg-wraps': (ctx, R, { x, y, w, h }) => {
+    ctx.strokeStyle = rgba(RARE_CRIMSON, 0.55);
+    ctx.lineWidth = 1.3;
+    ctx.lineCap = 'round';
+    ctx.beginPath();
+    let px = x + R.range('red-x0', 0.1, 0.9) * w;
+    let py = y + R.range('red-y0', 0.1, 0.9) * h;
+    ctx.moveTo(px, py);
+    for (let k = 1; k <= 3; k++) {
+      const nx = x + R.range(`red-x${k}`, 0.1, 0.9) * w;
+      const ny = y + R.range(`red-y${k}`, 0.1, 0.9) * h;
+      // slack in the thread: a soft quadratic sag toward the floor
+      ctx.quadraticCurveTo((px + nx) / 2, Math.max(py, ny) + h * 0.06, nx, ny);
+      px = nx;
+      py = ny;
+    }
+    ctx.stroke();
+  },
+  // one growth ring gilded
+  'growth-loops': (ctx, R, { x, y, w, h }) => {
+    const cx = x + R.range('ring-x', 0.25, 0.75) * w;
+    const cy = y + R.range('ring-y', 0.25, 0.75) * h;
+    const r0 = Math.min(w, h) * R.range('ring-r', 0.08, 0.16);
+    const noise = noise2D(R.int('ring-seed', 1, 1e9));
+    ctx.strokeStyle = rgba(RARE_GOLD, 0.5);
+    ctx.lineWidth = 1.4;
+    ctx.beginPath();
+    const K = 60;
+    for (let k = 0; k <= K; k++) {
+      const a = (k / K) * Math.PI * 2;
+      const r = r0 * (1 + (noise(Math.cos(a) * 2 + 5, Math.sin(a) * 2 + 5) - 0.5) * 0.35);
+      const qx = cx + Math.cos(a) * r;
+      const qy = cy + Math.sin(a) * r;
+      if (k === 0) ctx.moveTo(qx, qy);
+      else ctx.lineTo(qx, qy);
+    }
+    ctx.closePath();
+    ctx.stroke();
+  },
+  // a golden tributary meandering across one band of the region
+  'river-courses': (ctx, R, { x, y, w, h }) => {
+    const noise = noise2D(R.int('trib-seed', 1, 1e9));
+    const y0 = y + R.range('trib-y', 0.15, 0.85) * h;
+    ctx.strokeStyle = rgba(RARE_GOLD, 0.5);
+    ctx.lineWidth = 1.2;
+    ctx.beginPath();
+    let py = y0;
+    ctx.moveTo(x, py);
+    const step = w / 60;
+    for (let k = 1; k <= 60; k++) {
+      py += (noise(k * 0.15, y0 * 0.01) - 0.5) * h * 0.06;
+      ctx.lineTo(x + k * step, py);
+    }
+    ctx.stroke();
+  },
+  // a small gold-leaf scrap among the torn paper
+  'torn-paper': (ctx, R, { x, y, w, h }) => {
+    const cx = x + R.range('leaf-x', 0.2, 0.8) * w;
+    const cy = y + R.range('leaf-y', 0.2, 0.8) * h;
+    const rBase = Math.min(w, h) * R.range('leaf-r', 0.04, 0.07);
+    const noise = noise2D(R.int('leaf-seed', 1, 1e9));
+    ctx.fillStyle = rgba(RARE_GOLD, 0.4);
+    ctx.beginPath();
+    const K = 26;
+    for (let k = 0; k < K; k++) {
+      const a = (k / K) * Math.PI * 2;
+      const r = rBase * (1 + (noise(Math.cos(a) * 3 + 9, Math.sin(a) * 3 + 9) - 0.5) * 0.5);
+      const qx = cx + Math.cos(a) * r;
+      const qy = cy + Math.sin(a) * r * 0.75;
+      if (k === 0) ctx.moveTo(qx, qy);
+      else ctx.lineTo(qx, qy);
+    }
+    ctx.closePath();
+    ctx.fill();
+    ctx.strokeStyle = rgba(RARE_GOLD, 0.55);
+    ctx.lineWidth = 0.8;
+    ctx.stroke();
+  },
+};
+
+export const RARE_TRAIT_FAMILIES = Object.keys(RARE_TRAITS);
+const RARE_CHANCE = 0.03;
+
 const DECOR_EVENTS = [
   // New Year's Day: the deck wears a small gold-confetti corner burst
   { id: 'new-year', match: (d) => d.getMonth() === 0 && d.getDate() === 1 },
@@ -2152,7 +2268,7 @@ export const DECOR_FAMILIES = {
 
 // theme macroCluster → family affinity (seeded pick between two candidates so
 // different decks in the same theme still vary)
-const CLUSTER_AFFINITY = {
+export const CLUSTER_AFFINITY = {
   editorial: [
     'folded-screens',
     'scan-tides',
@@ -2180,6 +2296,10 @@ const CLUSTER_AFFINITY = {
   ],
   organic: [
     'wash-flow',
+    'river-courses',
+    'torn-paper',
+    'growth-loops',
+    'paper-folds',
     'halftone-fade',
     'sediment-layers',
     'meadow-streaks',
@@ -2200,6 +2320,7 @@ const CLUSTER_AFFINITY = {
   financial: ['strata-lines', 'folded-screens', 'sediment-layers', 'shard-mesh', 'weave-dashes'],
   hr: [
     'nib-flourish',
+    'torn-paper',
     'growth-loops',
     'paper-folds',
     'ink-scribble',
@@ -2243,6 +2364,12 @@ export function drawDecor(ctx, decor, { palette, x = 0, y = 0, w, h, intensity =
     personality: decor.personality,
   });
   if (v >= 2) {
+    if (decor.rare && RARE_TRAITS[decor.family]) {
+      // rare signature element: lanes off the artifact hash, so every
+      // slide of a rare deck carries the same signature deterministically
+      const R = makeHashRand(`${decor.hash ?? decor.seed}:rare`);
+      RARE_TRAITS[decor.family](ctx, R, { x, y, w, h });
+    }
     const ev = activeDecorEvent(decor.at);
     if (ev) drawEventFlourish(ctx, decor, ev, { palette: pal, x, y, w, h });
   }
@@ -2373,8 +2500,12 @@ export function decorFromHash(theme, hash, { v } = {}) {
   const R = makeHashRand(hash);
   const cluster = String(theme?.macroCluster || theme?.id || '').split('-')[0];
   const candidates = CLUSTER_AFFINITY[cluster] || ['flow-streams', 'weave-dashes'];
+  const family = R.pick('family', candidates);
   return {
-    family: R.pick('family', candidates),
+    family,
+    // Sprint 60: the collectible gate — its own lane, artifact-level.
+    // Only families with a signature element can come up rare.
+    rare: family in RARE_TRAITS && R.chance('rare-trait', RARE_CHANCE),
     seed: R.int('seed', 1, 0x7ffffffe),
     // Sprint 49 (Golid personality bundles + Watercolor rarity ladder):
     // most mints are 'balanced', a weighted minority carry a distinct


### PR DESCRIPTION
## Summary

decor v2 清单的头牌落地: **~3% 的铸造携带家族签名件** — 收藏钩子, 也是传播点。顺手抓出并根治一个潜伏三个 sprint 的静默 bug。

## 签名件 (v2 管线覆盖层, 冻结家族零触碰)

| 家族 | 签名件 |
|---|---|
| flow-ribbons | 一根金线彩带穿行其间 |
| peg-wraps | 绯红命运线 (带垂坠的红绳访三钉) |
| growth-loops | 一圈描金年轮 |
| river-courses | 一条金色支流 |
| torn-paper | 一片金箔碎纸 |

- **两处规则特批, 仅限稀有件**: 金属常量 (金 212,175,55 / 绯 178,34,52) 刻意出调色板 — 珍品需要异质材料; 线径级面积允许更高 alpha (同 nib-flourish 论证)
- rare 门走独立 hash lane → **作品级属性**: 稀有 deck 每一页带同一签名, 持 hash 永久复现; 徽章/换装状态/gallery/showcase 全部显示 ✨
- 冻结不变量 (S59 仪器) 全程绿 — lane 独立性 + v-dispatch 正是为这类升级设计的

## 附带修复: torn-paper 曾全局不可达

CLUSTER_AFFINITY 自 S56 起被 prettier 重排导致后续 python replace **静默 no-op** — organic 丢 4 家族, hr 丢 torn-paper → torn-paper 在任何主题下都铸不出来。修表 + 新增 **affinity 覆盖不变量** (每家族 ≥1 cluster 可达 / 无幽灵引用), 这类 bug 从此进不了 main。

## 质量

- test-decor 178→188, npm test 131/131
- 视觉验证: 5/5 签名件原生像素成立 (深底金线/浅底金箔两个方向都可读, WCAG 守卫双向工作)

🤖 Generated with [Claude Code](https://claude.com/claude-code)