### PR TITLE
docs(stage): 3D 舞台/氛围 idiom 清单 + funnel 计划 Phase 2(格斗游戏舞台)

### DIFF
--- a/docs/superpowers/artblocks-study/3d-stage-idioms.md
+++ b/docs/superpowers/artblocks-study/3d-stage-idioms.md
@@ -1,0 +1,98 @@
+# 3D 端「舞台/氛围」idiom 清单 — ArtBlocks shader-core 移交的沉淀 (2026-07-10)
+
+> 来源:2D 端 ArtBlocks 学习(50/108 课)判给 3D 端的 8+ 课 shader-core 移交
+> (L05/08/11/12/14/15/16/18/20/30/35/40)。本清单按**格斗游戏舞台**框架归类
+> (背景 recede / 舞台打光 / 前景质感 / post 底座),并对照 studio 现有能力标注接入档位。
+> 全部 recipe-only(CC BY-NC 系)——**只重实现通用技术,不 port NC 代码**。
+>
+> 档位:✅ 直接接(studio 已有对接点,配置/调参即用)· 🔩 小改(有基础,补一块)· 🏗 新建 · 📚 仅参考
+
+## studio 现有对接点(核实于 2026-07-10 main)
+
+| 能力 | 入口 | 备注 |
+|---|---|---|
+| 暗色环幕 + spec/rim/vignette | `defaults.studioBg='dark'` | stage.js **已默认 dark**(showcase 模式) |
+| 剧场压暗(天光 0-1) | `defaults.interiorDark` | 让聚光灯凸显 |
+| 舞台灯 rig(区域灯+聚光锥) | `defaults.lights[]`(带 `dir` 成聚光) | MAX_EXTRA_LIGHTS 个 |
+| DOF(背景虚化) | `shots[].aperture / focalDistance` | cameraSequence 每 shot 可调 |
+| 体积氛围 | volumes kind 0-3(smoke/flame/fog/godray) | u_time 驱动,`setVolumes` |
+| 程序化环境 | `environments.js getEnvironment('alpine')` + `horizonSilhouettes` | 注册表已建,studio/alpine 两档 |
+| 一次性 build-in 动画 | expr builtins(#193 smoothstep/clamp/step/…) | `transform.translate` 通道 |
+| 连续世界 deck | `assembleDeck`(line/radial/grid stations) | 舞台间穿行 |
+
+## A. 背景 recede(炫但退后)
+
+1. **texture-flow — 噪声位移采样坐标**(Torrent L14)🔩
+   `uv' = uv + fbm(uv)·flow + t·scroll` —— 位移**采样**而非几何,一行出「流动感」,
+   便宜一个数量级。studio 已有 sea(sdWaves 位移几何面)是重版近亲;给环幕/背景面
+   加一个采样位移材质即可。**接入点**:cyclorama 着色分支(studioBgDark 路径)或
+   environments.js 新 env 的背景面材质。
+   附:tile 化(`u_tileoffset/divisor` 单 shader 多窗格)、恒等 hash 颗粒防 banding。
+
+2. **地层色带**(Apparitions L05,与我们 Subscapes/alpine 美学跨端呼应)✅
+   band 内 lerp、band 间跳变 = 层理感颜色本体。alpine env 已有同族;做新背景 env 时
+   直接用此配色法。
+
+3. **DOF + 压暗 + 降对比 = 背景退后三件套** ✅
+   全部现成:`aperture`(shot 级)+ `interiorDark` + dark cyclorama。**舞台 v0 的
+   背景纪律就是这三个参数**,不需要新代码。
+
+## B. 舞台打光 / 辉光
+
+4. **光 = 到几何的距离衰减**(Box Light Studies L08)🔩(对 raymarcher 几乎免费)
+   L08 在光栅世界要 jump-flood 近似距离场;**我们是 raymarcher,SDF 的 d 就在手上**。
+   march 循环里累积 `glow += exp(-k·d)·stepLen` 即得几何辉光(棱线/轮廓自发光感)。
+   **接入点**:studio.js march 主循环(volumes 累积同位置旁),一个 uniform 开关。
+   附思想:「棱线即光源」—— 构图单位是棱不是面;辉光是**场算出来的**不是画的。
+
+5. **聚光舞台**(studio 现成)✅
+   `interiorDark: 0.18` + `lights: [{pos, dir, color, intensity}]` 聚光锥打主体
+   = 剧场感。纯配置。
+
+6. **软影拼接**(Väzt L15)📚
+   每遮挡体贡献 `smoothstep(-k,0,-d)·step(-d,0)` 累加 —— O(N) 内联无循环。
+   对照我们现有 shadow 实现的参考;架构背书(元编程 shader 三例之一)。
+
+## C. 前景质感(舞台上的「角色」)
+
+7. **有机软体调音**(Gumbo L11)✅(纯调参 recipe)
+   「有机软体感 = 圆角半径 + smin 系数的调音」。rc 圆角盒 / 轴对齐旋转 / 角度量化
+   棱柱 / soft-min 堆融 —— 我们的 IQ 图元库全都有,这课给的是**调参配方**:
+   前景结构件(funnel 段、node 球)加大圆角 + smin 融合 → 高级软体质感。
+
+8. **一行 trait 轴**(Edifice L35)✅
+   L2 范数换 L∞ = 圆变方 —— SDF 域上一行代码的风格轴。结构渲染器的 style 变体
+   (圆润/硬朗)可以这么给。
+
+9. **构图目录**(Skulptuur L40)📚
+   12 组行列比例抽两组做构图 —— 「构图先于形体,比例目录即风格」。舞台构图
+   preset(主体位/镜头框)可借此法做成目录而非自由参数。
+
+## D. post 底座(远期,新建)
+
+10. **单三角覆屏**(Solar Transits L18)🏗(post pass 入门件)
+    3 顶点 (-1,-1)(3,-1)(-1,3) 盖满 clip space,比 quad 少一条对角线插值缝 ——
+    未来加全屏 post pass(bloom/曝光)的标准姿势。
+11. **多 pass 曝光累积**(L18)🏗 —— 帧间亮度累积 = 长曝光感;cameraSequence
+    「轨迹可视化」直接可用的 recipe。
+12. **UV warp 字典**(Trichromatic L12)🏗 —— waveWarpX/Y、uvSpiralize、
+    paletteSwapWarp,挂在未来 post pass 上的 fragment 后处理词表。
+13. **反馈 warp**(Raster L20)🏗 —— self-sampling + offset;远期。
+14. **blur-then-blend + pass 命名纪律**(Phase L30)📚 —— 模糊是混合**前置件**
+    不是后处理;multi-pass 起名 pl0/pl1 顺序化(重构会强迫改名)。
+
+## E. 架构背书(非技术,记录在案)
+
+- **元编程 shader 三例**(Väzt L15 / Skulptuur L40 / Gumbo L11 近似):顶级 Curated
+  作者的惯用架构 = 「生成器不画像素,生成 shader」= 我们 `sdf3.compile.js` 的架构。
+  thesis 的社区共识背书。
+- **Proscenium L16**(名字即「舞台拱」):CPU-3D + painter 排序策略字典;我们
+  raymarch 不需要,仅参考。
+
+## 轻量舞台 v0 的结论
+
+**✅+🔩 两档就够拼出 fighting-game stage v0**:
+dark cyclorama + interiorDark + 聚光 rig + DOF(全现成、纯配置)
++ SDF glow(🔩 march 循环一段)+ texture-flow 背景(🔩 环幕材质一段)
++ 前景 smin/圆角调音(✅ 调参)。
+post 底座(D 组)是舞台 v1+ 的事,不阻塞。

--- a/docs/superpowers/plans/2026-07-02-sequence-funnel-3d.md
+++ b/docs/superpowers/plans/2026-07-02-sequence-funnel-3d.md
@@ -757,3 +757,95 @@ Stop. Report the PR URL + the blind-pick result to the user.
 2. `http://127.0.0.1:8001/apps/present/figure.html?ir=funnel-sales` → funnel renders, stages **drop in** top→bottom (build-in), camera flies *through*, labels reveal in order. (Playwright screenshots at ~1/4/8s.)
 3. `http://127.0.0.1:8001/apps/present/blind.html?ir=funnel-sales` → 2D and 3D side by side, randomized. (Playwright screenshot.)
 4. Run the blind pick with 5–8 people → GO/NO-GO on the direction.
+
+---
+
+# Phase 2: Fighting-Game Stage — 轻量舞台 (added 2026-07-10)
+
+> **Status note:** Phase 1 (Tasks 1-8) shipped as PR #196 and grew beyond the plan —
+> all four structure renderers exist (`render-ir.js` dispatch), plus `assembleDeck`
+> (continuous world) and `environments.js` (studio/alpine). Phase 2 adds the
+> **fighting-game stage** framing: a dark receding backdrop + spotlight rig + platform
+> for the foreground structure, so the blind test measures a STAGED 3D figure vs 2D.
+> Recipes come from the ArtBlocks shader-core handoffs — see
+> `docs/superpowers/artblocks-study/3d-stage-idioms.md` (idiom ledger with hook-in
+> points). Phase 2 uses only the ✅ (config-only) and 🔩 (small-shader) tiers.
+
+## Phase 2 Global Constraints
+
+- Same repo rules as Phase 1 (branch → PR → stop; tests green; two-text-systems).
+- **Stage discipline (the fighting-game contract):** the backdrop must RECEDE —
+  dark + defocused + low-contrast; the structure sits lit on a platform; the camera
+  keeps the audience oriented (establishing shot first, then the emphasis push-in).
+- Shader edits (Tasks 10-11) are guarded behind uniforms defaulting OFF — zero
+  visual change for every existing scene unless the stage preset opts in.
+
+### Task 9: `stagePreset()` — config-only stage (lights + platform + DOF)
+
+**Files:**
+- Modify: `sdf-js/src/scene/environments.js` (add `stagePreset`)
+- Modify: `sdf-js/src/scene/render-ir.js` (apply preset when `opts.stage`)
+- Modify: `sdf-js/apps/present/figure.js` (`?stage=1` param)
+- Test: `sdf-js/scripts/test-stage-preset.mjs`
+
+**Interfaces:**
+- Produces: `stagePreset(scene, { center=[0,1.6,0] }) → scene` — returns the scene with
+  (a) `defaults.studioBg='dark'` + `defaults.interiorDark=0.22`,
+  (b) `defaults.lights = [key spotlight above-front of center (dir aimed at center), cool rim light behind]`,
+  (c) a `platform` subject: flat cylinder under the structure (`cylinder`-family atom, radius ~2.6, height 0.12, at y≈0), dark matte material,
+  (d) every `cameraSequence.shots[i]` gets `aperture: 0.06, focalDistance: |pos−target|` (backdrop defocus) unless the shot already sets aperture > 0.
+
+- [ ] Step 1: failing test — `stagePreset(renderIR(ir))` adds platform subject + 2 lights + interiorDark + every shot has aperture>0; a scene that already has aperture keeps it; original scene object not mutated (returns copy).
+- [ ] Step 2: implement in environments.js (pure function, no studio imports).
+- [ ] Step 3: `render-ir.js`: `if (opts.stage) scene = stagePreset(scene)` after the renderer returns. figure.js: `renderIR(ir, { env, stage: params.get('stage') === '1' })`.
+- [ ] Step 4: register test in run-tests; full suite green.
+- [ ] Step 5: Playwright — `figure.html?ir=funnel-sales&stage=1`: dark backdrop, spotlit funnel on a platform, backdrop soft. Screenshot vs `stage=0`.
+- [ ] Step 6: commit `feat(stage): stagePreset — spotlight rig + platform + DOF (config-only stage v0)`.
+
+### Task 10: SDF glow — march-loop accumulation (idiom L08)
+
+The Box Light lesson's "light = distance falloff" is nearly free in a raymarcher: the
+march loop already has `d` each step. Accumulate `glow += exp(-glowK * d) * stepScale`
+and add `glowColor * glow * u_glowAmt` to the final color. `u_glowAmt` defaults **0.0**
+(off — zero change for existing scenes); the stage preset sets a small value (~0.35).
+
+**Files:**
+- Modify: `sdf-js/src/render/studio.js` — locate the primary march loop (near the
+  volume-density accumulation, `smokeDensity`/`fogDensity` calls ~line 600-740) and the
+  uniform upload block; add `u_glowAmt`/`u_glowK` uniforms + accumulation + composite.
+- Modify: `sdf-js/src/scene/environments.js` — `stagePreset` sets `defaults.glow = { amount: 0.35, k: 6.0 }`; `apply-studio-scene.js` forwards it via `setPostFx` path (follow how `interiorDark` flows — same plumbing).
+- Test: compile-check (scene with glow compiles; GLSL contains `u_glowAmt`) + Playwright screenshot compare stage=1 (subtle silhouette glow) vs stage=0 (unchanged).
+
+- [ ] Steps: locate insertion points → add uniforms (default 0) → accumulate in march loop → plumb `defaults.glow` through setPostFx like interiorDark → verify OFF = pixel-identical on an existing scene (screenshot diff) → verify ON = visible rim/silhouette glow → commit.
+
+### Task 11: texture-flow backdrop (idiom L14)
+
+Give the dark cyclorama a slow flowing grain: in the cyclorama/background shading
+branch (the `studioBgDark` path), displace the shading coordinate by fbm before
+sampling the gradient: `p' = p + flowAmp * fbm(p * flowScale + u_time * flowSpeed)`,
+plus the hash-grain anti-banding line (`fract(sin(dot(uv,vec2(12.9898,78.233)))*43758.5453)/N`).
+Guarded by `u_flowAmt` default **0.0**; stage preset sets ~0.15. Keep it LOW-contrast —
+the backdrop must recede (stage discipline).
+
+**Files:**
+- Modify: `sdf-js/src/render/studio.js` (cyclorama branch — find via `studioBgDark`).
+- Modify: `sdf-js/src/scene/environments.js` (`stagePreset` sets `defaults.flow`).
+- Test: compile + Playwright at t≈0 vs t≈3s with stage=1 — backdrop visibly but subtly moves; stage=0 pixel-identical.
+
+- [ ] Steps: locate cyclorama branch → add guarded displacement + grain → plumb via stagePreset → screenshot verify (subtle motion; contrast stays low) → commit.
+
+### Task 12: staged blind test — go/no-go v2
+
+- [ ] `blind.html`: point the 3D iframe at `figure.html?ir=<name>&stage=1`.
+- [ ] Full suite green; Playwright screenshots (2D | staged-3D side by side).
+- [ ] Re-run the 5-8 person blind pick with the STAGED figure. Same criterion: 3D ≥70% → GO for staging all four structures; else strip the stage back and reassess which layer failed (structure vs stage).
+- [ ] Push branch + open PR; stop and report.
+
+## Phase 2 Self-Review
+
+- Fighting-game contract encoded as constraints (recede/orient/lit platform) ✓
+- Only ✅/🔩 idiom tiers used; 🏗 post-pass items (bloom/UV-warp/feedback) explicitly deferred ✓
+- Every shader edit uniform-guarded, default off, with a pixel-identical regression check ✓
+- Task 10/11 leave exact-line insertion to the implementer ON PURPOSE (studio.js is
+  ~3000 lines and moving; anchors given are the volume-accumulation block and the
+  `studioBgDark` branch) — the recipes and guards are fully specified.


### PR DESCRIPTION
## 1. idiom 清单 — `docs/superpowers/artblocks-study/3d-stage-idioms.md`

把 2D 端 ArtBlocks 学习判给 3D 端的 8+ 课 shader-core 移交,按**格斗游戏舞台**框架归类(背景 recede / 舞台打光 / 前景质感 / post 底座),逐条对照 studio **实际对接点**(studioBg=dark / interiorDark / lights[] 聚光 rig / volumes / shot aperture DOF / environments.js / #193 builtins)标三档:✅ 纯配置 · 🔩 小 shader 改动 · 🏗 新 pass 底座。

**关键发现**:L08「光=距离衰减」在光栅世界要 jump-flood,在我们 raymarcher 里**几乎免费**(march 每步 d 就在手上)。

## 2. 计划 Phase 2 — 轻量舞台

Phase 1 已 ship(#196,且长到 4 渲染器 + assembleDeck + environments)。Phase 2 append 到原 plan:

- **Task 9** `stagePreset()` —— 纯配置舞台(聚光 rig + 地台 + DOF + interiorDark)
- **Task 10** SDF glow —— march 循环辉光累积(uniform 守卫,默认关,现有场景零变化)
- **Task 11** texture-flow 环幕 —— L14 噪声位移采样(守卫,低对比,背景必须 recede)
- **Task 12** 舞台化盲选 v2 —— staged 3D vs 2D,≥70% GO

只用 ✅/🔩 两档;🏗(bloom/UV-warp/反馈 pass)明确推迟。

🤖 Generated with [Claude Code](https://claude.com/claude-code)