### PR TITLE
Sprint 63: 整本模式多 scaffold — 自动选骨架 / 21 种骨架直选

### DIFF
--- a/sdf-js/apps/present/author-2d.html
+++ b/sdf-js/apps/present/author-2d.html
@@ -62,7 +62,8 @@
         gap: 8px;
         z-index: 20;
       }
-      #mode {
+      #mode,
+      #scaffold {
         align-self: center;
         padding: 8px 6px;
         border-radius: 8px;
@@ -279,10 +280,11 @@
     <div id="status">describe what you want to present — Atlas builds the deck</div>
     <div id="bar">
       <textarea id="prompt" placeholder="e.g. our Q3: revenue by region (Americas leads at 890), the sales funnel from 1200 leads to 45 closed, and the new org under the CEO"></textarea>
-      <select id="mode" title="快速 = 1 次 LLM 调用, 3-5 张结构图. 整本 = 新闻/文章 → 10-20 页简报 (~16 次调用, ~$0.5, ~90s)">
+      <select id="mode" title="快速 = 1 次 LLM 调用, 3-5 张结构图. 整本 = 新闻/文章 → 整本简报 (~16 次调用, ~$0.5, ~90s)">
         <option value="quick">快速 · 3-5 页</option>
         <option value="full">整本 · 10-20 页</option>
       </select>
+      <select id="scaffold" hidden title="整本的骨架 — 自动会按文章内容在 21 种骨架里选"></select>
       <button id="go">Generate</button>
       <div id="exportRow">
         <select id="theme" disabled title="换主题 (零成本, 即时重渲染)"></select>

--- a/sdf-js/apps/present/author-2d.js
+++ b/sdf-js/apps/present/author-2d.js
@@ -17,6 +17,7 @@ import { ATLAS_THEMES } from '../../src/present/themes.js';
 import { exportDeckToPPTX } from '../../src/present/exporters/pptx.js';
 import { exportDeckToPDF } from '../../src/present/exporters/pdf.js';
 import { serializeDeck, deserializeDeck } from '../../src/present/deck-io.js';
+import { listScaffolds } from '../../src/present/scaffolds/registry.js';
 
 const STORAGE_KEY = 'atlas-anthropic-key'; // shared with the compositor's lift + author.js (3D)
 
@@ -90,6 +91,33 @@ themeEl.addEventListener('change', async () => {
     setStatus(`theme switch failed: ${e.message}`, true);
   }
 });
+
+// Sprint 63: scaffold choice for 整本 mode — 自动 (deterministic ranker)
+// or any of the 21 skeletons. Hidden in quick mode (quick has no scaffold).
+const scaffoldEl = document.getElementById('scaffold');
+{
+  const auto = document.createElement('option');
+  auto.value = 'auto';
+  auto.textContent = '骨架 · 自动';
+  scaffoldEl.appendChild(auto);
+  const news = document.createElement('option');
+  news.value = 'news-briefing';
+  news.textContent = 'News Briefing (默认)';
+  scaffoldEl.appendChild(news);
+  for (const sc of listScaffolds()) {
+    if (sc.id === 'news-briefing') continue;
+    const opt = document.createElement('option');
+    opt.value = sc.id;
+    opt.textContent = sc.label || sc.id;
+    scaffoldEl.appendChild(opt);
+  }
+  scaffoldEl.value = 'news-briefing';
+  const syncScaffoldVis = () => {
+    scaffoldEl.hidden = modeEl.value !== 'full';
+  };
+  modeEl.addEventListener('change', syncScaffoldVis);
+  syncScaffoldVis();
+}
 
 function syncThemeSelect() {
   if (currentDeck?.theme?.id) themeEl.value = currentDeck.theme.id;
@@ -465,6 +493,7 @@ async function generate() {
       currentDeck = await newsToFullDeck(text, {
         apiKey,
         lockedSlots,
+        scaffoldId: scaffoldEl.value,
         onProgress: (msg, pct) => setStatus(`${msg} (${Math.round(pct)}%)`),
         onPlan: (plan, meta) => {
           streamTheme = meta.theme;
@@ -511,7 +540,7 @@ async function generate() {
         : '';
       await adoptDeck(
         currentDeck,
-        `done — ${currentDeck.slots.length} pages${errNote}. 作品 #${currentDeck.decor.hash} (唯一, 持 hash 可复现). Export below.`,
+        `done — ${currentDeck.slots.length} pages · 骨架 ${currentDeck.scaffold?.label || ''}${errNote}. 作品 #${currentDeck.decor.hash} (唯一, 持 hash 可复现). Export below.`,
       );
       autosave();
       return;

--- a/sdf-js/scripts/test-deck-io.mjs
+++ b/sdf-js/scripts/test-deck-io.mjs
@@ -5,7 +5,7 @@ import {
   DECK_FORMAT,
   DECK_FORMAT_VERSION,
 } from '../src/present/deck-io.js';
-import { newsToFullDeck } from '../src/present/news/full-deck.js';
+import { newsToFullDeck, chooseScaffoldForOutline } from '../src/present/news/full-deck.js';
 
 let pass = 0;
 let fail = 0;
@@ -142,6 +142,38 @@ const deck = {
   const rt = deserializeDeck(JSON.stringify(serializeDeck(mini)));
   ok(rt.slots[0].sceneData.atoms[0].args.t === 'cover', 'streamed slot round-trips');
   ok(typeof newsToFullDeck === 'function', 'newsToFullDeck exports (streaming hooks live there)');
+}
+
+// ── Sprint 63: scaffold auto-choice (deterministic ranker over the outline) ──
+{
+  const qbrOutline = [
+    { title: 'Q3 Quarterly Business Review', body: ['quarter in review for the exec team'] },
+    { title: 'Revenue', body: ['revenue grew 40% QoQ to $12M ARR'] },
+    { title: 'KPIs', body: ['churn dropped to 2.1%, NRR 118%'] },
+    { title: 'OKR progress', body: ['7 of 9 objectives on track'] },
+    { title: 'Next quarter goals', body: ['expand EMEA, hire 12'] },
+  ];
+  const { scaffold, ranked } = chooseScaffoldForOutline(qbrOutline);
+  ok(scaffold && Array.isArray(scaffold.slots), 'auto choice returns a real scaffold');
+  ok(ranked.length >= 10 && ranked[0].score >= ranked[1].score, 'ranking is ordered');
+  ok(
+    ['qbr', 'okr-goal-setting', 'financial-summary', 'investor-update'].includes(scaffold.id),
+    `QBR-ish outline lands on a business skeleton (${scaffold.id})`,
+  );
+  const newsOutline = [
+    {
+      title: 'Breaking: major earthquake hits region',
+      body: ['news wire report, casualties unknown'],
+    },
+    { title: 'What happened', body: ['a 7.1 magnitude quake struck at dawn'] },
+  ];
+  const pick2 = chooseScaffoldForOutline(newsOutline).scaffold;
+  ok(
+    Array.isArray(pick2.slots) && pick2.slots.length > 0,
+    'news outline also resolves to a scaffold',
+  );
+  // determinism: same outline → same pick
+  ok(chooseScaffoldForOutline(qbrOutline).scaffold.id === scaffold.id, 'auto choice deterministic');
 }
 
 console.log(`\n${pass} passed, ${fail} failed`);

--- a/sdf-js/src/present/news/full-deck.js
+++ b/sdf-js/src/present/news/full-deck.js
@@ -10,6 +10,7 @@
 // =============================================================================
 import { expandNews } from './expand-core.js';
 import { getScaffold, getThemeAffinity } from '../scaffolds/registry.js';
+import { rankScaffolds } from '../scaffolds/picker.js';
 import { mapSlidesToSlotsLLM, scoreSlideForSlot } from '../scaffolds/mapper-llm.js';
 import { buildLiftSystemPrompt, liftSlotsPool, liftSlotLLM } from '../scaffolds/lift-slot-llm.js';
 
@@ -29,6 +30,19 @@ async function getSystemPrompt() {
  * @param {string} text — the raw article (~500 chars)
  * @param {object} opts — { apiKey, minPages=10, maxPages=20, onProgress(msg, pct) }
  */
+/**
+ * chooseScaffoldForOutline — Sprint 63: pick the scaffold that fits an
+ * expanded outline, via the deterministic ranker (Sprint 15E picker; zero
+ * LLM cost, reproducible). Exported for tests and for showing the ranking.
+ */
+export function chooseScaffoldForOutline(slides) {
+  const ranked = rankScaffolds({
+    title: slides[0]?.title || '',
+    bodyTexts: slides.map((sl) => [sl.title, ...(sl.body || [])].join(' ')),
+  });
+  return { scaffold: getScaffold(ranked[0].id), ranked };
+}
+
 export async function newsToFullDeck(
   text,
   {
@@ -43,6 +57,10 @@ export async function newsToFullDeck(
     // returned deck — the UI can grow the deck live instead of blocking ~90s.
     onPlan = () => {},
     onSlotReady = () => {},
+    // Sprint 63: which skeleton the deck grows on. 'news-briefing' stays the
+    // default (the acceptance-tested path); 'auto' ranks all 21 scaffolds
+    // against the expanded outline deterministically; any explicit id wins.
+    scaffoldId = 'news-briefing',
   } = {},
 ) {
   if (!apiKey) throw new Error('newsToFullDeck: apiKey required');
@@ -50,7 +68,19 @@ export async function newsToFullDeck(
   onProgress('expanding article → outline…', 2);
   const slides = await expandNews(text, { apiKey, min: Math.max(12, minPages + 2), max: maxPages });
 
-  const scaffold = getScaffold('news-briefing');
+  let scaffold;
+  if (scaffoldId === 'auto') {
+    scaffold = chooseScaffoldForOutline(slides).scaffold;
+    onProgress(`scaffold (auto): ${scaffold.label}`, 6);
+  } else {
+    scaffold = getScaffold(scaffoldId);
+  }
+  // a 7-slot scaffold cannot deliver a 10-page floor — the scaffold IS the
+  // document's shape, so the floor bends to it, not the other way round
+  minPages = Math.min(minPages, scaffold.slots.length);
+  // locked slots only survive on the SAME skeleton: slotIdx from another
+  // scaffold points at a different room
+  lockedSlots = lockedSlots.filter((ls) => ls.liftParams?.scaffold?.id === scaffold.id);
   const theme = getThemeAffinity(scaffold)[0];
 
   onProgress(`mapping ${slides.length} outline slides → ${scaffold.slots.length} slots…`, 8);


### PR DESCRIPTION
## Summary

方向 b: 整本模式不再锁死 news-briefing。骨架 (scaffold) 现在是**用户可选 + 可自动**的一级决策 — QBR 文章长成 QBR, 融资稿长成 pitch deck。

## 设计

- **三档选择**: 默认 `news-briefing` (验收测试路径, 行为零变化) / `auto` (确定性 ranker) / 21 种骨架任意直选
- **auto 复用 Sprint 15E 的确定性 picker** (`rankScaffolds`): 对展开后的 outline (标题+事实行) 做关键词/标题/槽数拟合评分 — 零 LLM 成本, 同文章永远同骨架 (可复现)
- **地板弯向骨架**: `minPages = min(minPages, slots.length)` — 7 槽的 QBR 交付 7 页是正确行为, 骨架即文档形状, 10-20 页地板只属于 14 槽的 news-briefing
- **锁页跨骨架守卫**: slotIdx 在另一副骨架里指向不同的房间 — 换骨架重生成时仅同骨架锁页存活 (静默错位是上一课的教训)

## UI

整本模式露出骨架选择器 (快速模式隐藏, 快速没有骨架概念); done 状态显示最终骨架名 (auto 时能看见 ranker 选了什么)。

## 质量

- chooseScaffoldForOutline 导出纯函数: QBR 式 outline → 业务骨架 (qbr/okr/financial 之一)、排序有序、确定性 — +5 断言, npm test 132/132
- e2e: 选择器 22 项 (自动+21)、快速隐藏/整本显示联动, 零 console 错误

🤖 Generated with [Claude Code](https://claude.com/claude-code)