### PR TITLE
feat(stage): fighting-game stage — stagePreset + SDF glow + theatrical room (Phase 2)

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -145,6 +145,7 @@ const TESTS = [
   { category: 'scene', file: 'sdf-js/scripts/test-lift-scaffold.mjs' },
   { category: 'scene', file: 'sdf-js/scripts/test-ir.mjs' },
   { category: 'scene', file: 'sdf-js/scripts/test-render-sequence.mjs' },
+  { category: 'scene', file: 'sdf-js/scripts/test-stage-preset.mjs' },
   { category: 'scene', file: 'sdf-js/scripts/test-render-hierarchy.mjs' },
   { category: 'scene', file: 'sdf-js/scripts/test-render-network.mjs' },
   { category: 'scene', file: 'sdf-js/scripts/test-render-magnitude.mjs' },

--- a/sdf-js/apps/present/blind.html
+++ b/sdf-js/apps/present/blind.html
@@ -81,7 +81,10 @@
       }
       function make3d() {
         const f = document.createElement('iframe');
-        f.src = `./figure.html?ir=${encodeURIComponent(name)}`;
+        // stage=1: the fighting-game stage preset — the blind test measures the
+        // STAGED figure vs 2D (plan Phase 2 Task 12). ?stage=0 opts back out.
+        const st = new URLSearchParams(location.search).get('stage') || '1';
+        f.src = `./figure.html?ir=${encodeURIComponent(name)}&stage=${st}`;
         return f;
       }
       // randomize left/right, unlabelled

--- a/sdf-js/apps/present/figure-core.js
+++ b/sdf-js/apps/present/figure-core.js
@@ -5,11 +5,14 @@ import { createStudioRenderer } from '../../src/render/studio.js';
 import { applyStudioScene } from '../../src/runtime/apply-studio-scene.js';
 
 /**
- * createFigure({ outdoor }) → { studio, show(sceneData) }.
+ * createFigure({ outdoor, stage }) → { studio, show(sceneData) }.
  * `show` may be called repeatedly (the author page regenerates in place) —
  * old overlay labels are removed and the new scene's sequence starts fresh.
+ * `stage`: fighting-game stage lighting — the main directional light drops low
+ * and rakes from the side, so the backdrop walls fall dark and the spotlight
+ * rig (scene defaults.lights from stagePreset) carries the subject.
  */
-export function createFigure({ outdoor = false } = {}) {
+export function createFigure({ outdoor = false, stage = false } = {}) {
   const wrap = document.getElementById('wrap');
   const canvas = document.getElementById('c');
   const size = () => {
@@ -21,8 +24,8 @@ export function createFigure({ outdoor = false } = {}) {
   const studio = createStudioRenderer({
     canvas,
     getControls: () => ({
-      lightAzim: 0.5,
-      lightAlt: 0.7,
+      lightAzim: stage ? 1.15 : 0.5,
+      lightAlt: stage ? 0.32 : 0.7,
       lightDist: 30,
       fov: 1.5,
       shadowsOn: true,

--- a/sdf-js/apps/present/figure.js
+++ b/sdf-js/apps/present/figure.js
@@ -9,10 +9,11 @@ import { createFigure } from './figure-core.js';
 
 const params = new URLSearchParams(location.search);
 const env = params.get('env') || 'studio';
-const { show } = createFigure({ outdoor: env !== 'studio' });
+const stage = params.get('stage') === '1'; // ?stage=1 → fighting-game stage preset
+const { show } = createFigure({ outdoor: env !== 'studio', stage });
 
 const deckName = params.get('deck');
 const layout = params.get('layout') || undefined; // line | radial | grid
 const name = params.get('ir') || 'funnel-sales';
 const ir = await (await fetch(`../../scenes/ir/${deckName || name}.json`)).json();
-show(deckName ? assembleDeck(ir, { env, layout }) : renderIR(ir, { env }));
+show(deckName ? assembleDeck(ir, { env, layout }) : renderIR(ir, { env, stage }));

--- a/sdf-js/scripts/test-stage-preset.mjs
+++ b/sdf-js/scripts/test-stage-preset.mjs
@@ -1,0 +1,57 @@
+// test-stage-preset.mjs — the fighting-game stage preset (config-only stage v0).
+// stagePreset(scene) adds: dark backdrop + interiorDark, a spotlight rig
+// (defaults.lights), a platform subject under the structure, and per-shot DOF.
+import { stagePreset } from '../src/scene/environments.js';
+import { renderIR } from '../src/scene/render-ir.js';
+
+let pass = 0, fail = 0;
+const ok = (c, n) => (c ? (pass++, console.log(`  ✓ ${n}`)) : (fail++, console.log(`  ✗ ${n}`)));
+console.log('=== stage-preset (fighting-game stage v0) ===\n');
+
+const ir = {
+  structure: 'sequence',
+  nodes: ['Leads', 'Qualified', 'Proposal', 'Closed'],
+  magnitude: [1000, 400, 150, 40],
+  emphasis: [3],
+  title: 'Sales Funnel',
+};
+
+const base = renderIR(ir);
+const staged = stagePreset(base);
+
+// (a) backdrop recedes: dark cyclorama + dimmed sky ambient
+ok(staged.defaults.studioBg === 'dark', 'studioBg = dark');
+ok(typeof staged.defaults.interiorDark === 'number' && staged.defaults.interiorDark < 1, 'interiorDark set (< 1)');
+
+// (b) spotlight rig: at least a key spot (with dir) + a rim light
+const lights = staged.defaults.lights || [];
+ok(lights.length >= 2, 'at least 2 stage lights');
+ok(lights.some((L) => Array.isArray(L.dir)), 'key light is a spotlight (has dir)');
+
+// (c) platform under the structure
+const platform = staged.subjects.find((s) => s.id === 'stage-platform');
+ok(!!platform && platform.type === 'cylinder', 'platform subject added (cylinder)');
+ok(platform.args.height <= 0.2, 'platform is a flat disc');
+ok(platform.transform.translate[1] <= 0.1, 'platform sits at ground level');
+
+// (d) every shot gets DOF unless it already has aperture
+ok(staged.cameraSequence.shots.every((s) => s.aperture > 0 && s.focalDistance > 0), 'every shot has aperture + focalDistance');
+{
+  const custom = JSON.parse(JSON.stringify(base));
+  custom.cameraSequence.shots[0].aperture = 0.42;
+  const s2 = stagePreset(custom);
+  ok(Math.abs(s2.cameraSequence.shots[0].aperture - 0.42) < 1e-9, 'a shot that already sets aperture keeps it');
+}
+
+// immutability: the input scene is not mutated
+ok(base.subjects.every((s) => s.id !== 'stage-platform'), 'original scene not mutated (no platform)');
+ok(!base.defaults.lights, 'original defaults not mutated (no lights)');
+
+// renderIR opts.stage applies the preset
+const viaOpts = renderIR(ir, { stage: true });
+ok(viaOpts.subjects.some((s) => s.id === 'stage-platform'), 'renderIR(ir, {stage:true}) applies the preset');
+const noStage = renderIR(ir, {});
+ok(!noStage.subjects.some((s) => s.id === 'stage-platform'), 'renderIR without stage is unchanged');
+
+console.log(`\n${pass} passed, ${fail} failed`);
+process.exit(fail ? 1 : 0);

--- a/sdf-js/src/render/studio.js
+++ b/sdf-js/src/render/studio.js
@@ -109,6 +109,11 @@ uniform vec3  u_extraLightColor[MAX_EXTRA_LIGHTS];   // rgb * intensity (premult
 uniform float u_extraLightRadius[MAX_EXTRA_LIGHTS];  // penumbra softness, world units
 uniform vec3  u_extraLightDir[MAX_EXTRA_LIGHTS];     // spotlight aim; zero vec = omni point
 uniform float u_ambientScale;  // 1 = normal; ~0.18 for theatrical dark interior
+// SDF glow (idiom L08 "light = distance falloff"): accumulated along the march —
+// nearly free in a raymarcher since dm.x is in hand every step. 0 = off (default;
+// existing scenes byte-identical). Stage preset sets a small amount (~0.35).
+uniform float u_glowAmt;
+uniform float u_glowK;
 uniform float u_shadowsOn;
 uniform float u_groundOn;
 uniform float u_checkerOn;
@@ -782,10 +787,14 @@ void main() {
   float matId = 0.0;
   float hitIdx = 0.0;  // captured at hit; downstream sceneSDF calls clobber minIndex
   bool hit = false;
+  float glowAcc = 0.0;  // SDF glow: near-miss accumulation (u_glowAmt gates it)
   // + int(u_loopGuard) == +0: unroll defeat — see the u_loopGuard declaration.
   for (int i = 0; i < MAX_STEPS + int(u_loopGuard); i++) {
     vec3 p = ro + rd * t;
     vec2 dm = mapWithGround(p);
+    // glow = inverse-square of the miss distance (IQ-style), so rays that graze
+    // the structure pick up a halo. Uniform branch — free when glow is off.
+    if (u_glowAmt > 0.0) glowAcc += 1.0 / (1.0 + u_glowK * dm.x * dm.x);
     if (dm.x < EPS * (1.0 + 0.4 * t)) {
       hit = true; matId = dm.y;
       hitIdx = minIndex;  // capture immediately — normal/shadow/AO calls below will overwrite
@@ -1808,6 +1817,14 @@ void main() {
     col *= 1.0 - (0.24 + u_studioBg * 0.30) * dot(vd, vd);
   }
 
+  // SDF glow composite: cool-white halo where rays grazed the structure. glowAcc
+  // is O(steps) so normalize by MAX_STEPS; tanh-style soft cap keeps it HDR-safe.
+  if (u_glowAmt > 0.0) {
+    float g = glowAcc / float(MAX_STEPS);
+    g = g / (1.0 + g);  // soft cap
+    col += vec3(0.62, 0.74, 1.0) * g * u_glowAmt * 3.0;
+  }
+
   // Sprint 2 (2026-05-24): HDR-output sanitation. rgba16f preserves NaN/Inf
   // which propagates through bloom Gaussian + DoF taps and explodes as black
   // rectangles on canvas (~30-40 px each). Replace NaN per-channel with 0,
@@ -1987,6 +2004,8 @@ export function createStudioRenderer({
   const extraLightDirLUT = new Float32Array(MAX_EXTRA_LIGHTS * 3);
   let numExtraLights = 0;
   let ambientScale = 1.0; // theatrical interiorDark drops sky-ambient near 0
+  let glowAmt = 0.0; // SDF glow (idiom L08) — set by setPostFx from scene.defaults.glow
+  let glowK = 6.0;
   // Sprint 6: heat-haze flame positions (xyz, radius) for postfx composite.
   // Mirrors MAX_HEAT_HAZE = 8 in postfx.js. Packed each frame from the active
   // flame subset of the volume LUTs.
@@ -2297,6 +2316,8 @@ export function createStudioRenderer({
       'u_extraLightRadius[0]',
       'u_extraLightDir[0]',
       'u_ambientScale',
+      'u_glowAmt',
+      'u_glowK',
       // Sprint 4 subject motion offset uniform array
       'u_subjectOffset[0]',
       // Sprint 8 Blueprint-as-shot toggle
@@ -2610,6 +2631,8 @@ export function createStudioRenderer({
         sequenceAmbient != null ? ambientScale * sequenceAmbient : ambientScale,
       );
     }
+    if (uniformsCache['u_glowAmt'] != null) gl.uniform1f(uniformsCache['u_glowAmt'], glowAmt);
+    if (uniformsCache['u_glowK'] != null) gl.uniform1f(uniformsCache['u_glowK'], glowK);
     if (numExtraLights > 0) {
       if (uniformsCache['u_extraLightPos[0]'] != null)
         gl.uniform3fv(uniformsCache['u_extraLightPos[0]'], extraLightPosLUT);
@@ -2984,6 +3007,10 @@ export function createStudioRenderer({
       const idark = scene && scene.defaults ? scene.defaults.interiorDark : null;
       ambientScale =
         idark == null || idark === false ? 1.0 : typeof idark === 'number' ? idark : 0.18;
+      // SDF glow: scene.defaults.glow = { amount, k } (absent → off, byte-identical)
+      const glowDef = scene && scene.defaults ? scene.defaults.glow : null;
+      glowAmt = glowDef && typeof glowDef.amount === 'number' ? glowDef.amount : 0.0;
+      glowK = glowDef && typeof glowDef.k === 'number' ? glowDef.k : 6.0;
       // Stage area lights: pack scene.defaults.lights → LUTs (color premultiplied
       // by intensity; 0-255 auto-normalized like volumes). A light with `dir`
       // becomes a spotlight cone. Absent/empty → 0 lights = no-op.

--- a/sdf-js/src/scene/environments.js
+++ b/sdf-js/src/scene/environments.js
@@ -211,6 +211,8 @@ export function stagePreset(scene, { center = [0, 1.6, 0] } = {}) {
     bloomMix: 0.24,
     ...(out.defaults.postFx || {}),
   };
+  // SDF glow (march-loop halo, idiom L08) — subtle silhouette light on the backdrop
+  if (out.defaults.glow == null) out.defaults.glow = { amount: 0.35, k: 6.0 };
 
   // (b) spotlight rig: warm key spot above-front aimed at the structure + cool rim behind
   if (!Array.isArray(out.defaults.lights) || out.defaults.lights.length === 0) {

--- a/sdf-js/src/scene/environments.js
+++ b/sdf-js/src/scene/environments.js
@@ -179,3 +179,76 @@ export function horizonSilhouettes(center = [0, 0], ringRadius = 140) {
   }
   return hills;
 }
+
+// ---------------------------------------------------------------------------
+// stagePreset — the fighting-game stage, config-only tier (v0).
+// Backdrop recedes (dark cyclorama + dimmed sky), the structure stands lit on a
+// platform under a spotlight rig, and every shot gets DOF so the backdrop
+// defocuses. Pure function: returns a copy, never mutates the input scene.
+// Idiom ledger: docs/superpowers/artblocks-study/3d-stage-idioms.md (tier ✅).
+// ---------------------------------------------------------------------------
+
+export function stagePreset(scene, { center = [0, 1.6, 0] } = {}) {
+  const out = {
+    ...scene,
+    subjects: [...(scene.subjects || [])],
+    defaults: { ...(scene.defaults || {}) },
+    cameraSequence: scene.cameraSequence
+      ? { ...scene.cameraSequence, shots: (scene.cameraSequence.shots || []).map((s) => ({ ...s })) }
+      : scene.cameraSequence,
+  };
+
+  // (a) backdrop recede: dark cyclorama + dim the sky ambient (theatre dark)
+  // + strong vignette / slight under-exposure (postfx pipeline) so the frame
+  // edges — the backdrop walls — fall off while the lit centre keeps its punch.
+  // The main directional light is controls-owned (not scene-settable), so the
+  // spotlight look comes from vignette + interiorDark + the rig below.
+  out.defaults.studioBg = 'dark';
+  if (out.defaults.interiorDark == null) out.defaults.interiorDark = 0.22;
+  out.defaults.postFx = {
+    vignetteStrength: 0.62,
+    exposure: 0.9,
+    bloomMix: 0.24,
+    ...(out.defaults.postFx || {}),
+  };
+
+  // (b) spotlight rig: warm key spot above-front aimed at the structure + cool rim behind
+  if (!Array.isArray(out.defaults.lights) || out.defaults.lights.length === 0) {
+    const keyPos = [center[0] + 1.6, center[1] + 4.2, center[2] + 3.4];
+    const dir = [center[0] - keyPos[0], center[1] - keyPos[1], center[2] - keyPos[2]];
+    const dl = Math.hypot(dir[0], dir[1], dir[2]) || 1;
+    out.defaults.lights = [
+      { pos: keyPos, dir: dir.map((c) => c / dl), color: [1.0, 0.96, 0.88], intensity: 1.4 },
+      { pos: [center[0] - 2.6, center[1] + 1.4, center[2] - 3.2], color: [0.45, 0.62, 1.0], intensity: 0.7 },
+    ];
+  }
+
+  // (c) platform: flat dark disc under the structure (the "stage floor")
+  if (!out.subjects.some((s) => s.id === 'stage-platform')) {
+    out.subjects.push({
+      id: 'stage-platform',
+      type: 'cylinder',
+      args: { radius: 2.6, height: 0.12 },
+      transform: { translate: [center[0], 0.06, center[2]] },
+      material: { hue: 0.62, sat: 0.12, value: 0.22, kind: 'normal', roughness: 0.75, clearcoat: 0.1 },
+    });
+  }
+
+  // (d) DOF on every shot that doesn't set its own aperture
+  if (out.cameraSequence && Array.isArray(out.cameraSequence.shots)) {
+    for (const s of out.cameraSequence.shots) {
+      if (!(s.aperture > 0)) {
+        const t = s.target || center;
+        const p = s.pos || [0, 0, 8];
+        s.aperture = 0.06;
+        s.focalDistance = Math.hypot(p[0] - t[0], p[1] - t[1], p[2] - t[2]) || 8;
+      } else if (!(s.focalDistance > 0)) {
+        const t = s.target || center;
+        const p = s.pos || [0, 0, 8];
+        s.focalDistance = Math.hypot(p[0] - t[0], p[1] - t[1], p[2] - t[2]) || 8;
+      }
+    }
+  }
+
+  return out;
+}

--- a/sdf-js/src/scene/environments.js
+++ b/sdf-js/src/scene/environments.js
@@ -205,6 +205,11 @@ export function stagePreset(scene, { center = [0, 1.6, 0] } = {}) {
   // spotlight look comes from vignette + interiorDark + the rig below.
   out.defaults.studioBg = 'dark';
   if (out.defaults.interiorDark == null) out.defaults.interiorDark = 0.22;
+  // theatrical show mode: near-black room shell (stage.js WALL_DARK family) so the
+  // spotlight rig + glow read against darkness instead of a lit mid-grey room
+  if (out.defaults.stage && typeof out.defaults.stage === 'object' && out.defaults.stage.show == null) {
+    out.defaults.stage = { ...out.defaults.stage, show: true };
+  }
   out.defaults.postFx = {
     vignetteStrength: 0.62,
     exposure: 0.9,

--- a/sdf-js/src/scene/render-ir.js
+++ b/sdf-js/src/scene/render-ir.js
@@ -7,6 +7,7 @@ import { renderSequence } from './render-sequence.js';
 import { renderHierarchy } from './render-hierarchy.js';
 import { renderNetwork } from './render-network.js';
 import { renderMagnitude } from './render-magnitude.js';
+import { stagePreset } from './environments.js';
 
 const RENDERERS = {
   sequence: renderSequence,
@@ -28,5 +29,8 @@ export function renderIR(ir, opts = {}) {
     throw new Error(
       `renderIR: no structure renderer for '${ir?.structure}' (have: ${Object.keys(RENDERERS).join(', ')})`,
     );
-  return r(ir, opts);
+  const scene = r(ir, opts);
+  // opts.stage → fighting-game stage preset (spotlight rig + platform + DOF);
+  // applied here so every structure renderer gets it through one seam.
+  return opts.stage ? stagePreset(scene) : scene;
 }


### PR DESCRIPTION
## Phase 2 执行完成:格斗游戏舞台 v0

计划(#258 里的 Tasks 9-12)执行结果,`figure.html?ir=funnel-sales&stage=1` 一眼看效果:**暗剧场 + 轮廓辉光 + 聚光舞台上的漏斗**。

### Task 9 — `stagePreset()`(纯配置)
environments.js 纯函数,`renderIR(ir, {stage:true})` 单点接入全部 4 个结构渲染器:
- 背景 recede:studioBg=dark + interiorDark 0.22 + postFx(vignette 0.62 / exposure 0.9 / bloom 0.24 —— **postfx 管线发现已存在**,idiom 清单的 🏗 档其实是 ✅)
- 聚光 rig:暖 key spot(dir 指向主体)+ 冷 rim(`defaults.lights[]`)
- 舞台地台:圆盘 platform subject;DOF:每 shot aperture+focalDistance
- figure `?stage=1` 同时把主光切低侧 rake
- `test-stage-preset.mjs` 13 断言(rig/平台/DOF/不可变性/opt-in)

### Task 10 — SDF glow(L08 idiom,🔩)
「光=距离衰减」在 raymarcher 里几乎免费:march 主循环累积 `1/(1+k·d²)`,soft-cap 合成冷白轮廓光。uniform 守卫默认 0 —— **现有场景逐字节不变**(截图回归验证)。plumbing 镜像 interiorDark(`defaults.glow={amount,k}`)。

### Task 11 — texture-flow:**推迟(有因)**
执行发现:可见背景是 stage 房间几何(走完整 PBR hit 路径,无 per-wall 着色钩子),不是 flow 配方针对的 miss 环幕 —— 今天没有可见画布。改用 stage.js **现成的 theatrical show mode**(`stage.show=true` → 近黑房壳),恰好让聚光+glow 显形。#258 落地后补 plan 文档注记。

### Task 12 — 舞台化盲选
`blind.html` 3D 侧指向 `?stage=1`(`blind.html?stage=0` 可退)。**go/no-go 现在测的是舞台化 3D vs 2D。**

全量 132/132。**剩下一步是你的**:找 5-8 人跑盲选(`/apps/present/blind.html?ir=funnel-sales`),3D ≥70% → GO。

🤖 Generated with [Claude Code](https://claude.com/claude-code)