### PR TITLE
feat(stage): 舞台铺到全部 4 结构 + deck(自适应平台 + deck 剧场层)

### DIFF
--- a/sdf-js/apps/present/figure.js
+++ b/sdf-js/apps/present/figure.js
@@ -16,4 +16,4 @@ const deckName = params.get('deck');
 const layout = params.get('layout') || undefined; // line | radial | grid
 const name = params.get('ir') || 'funnel-sales';
 const ir = await (await fetch(`../../scenes/ir/${deckName || name}.json`)).json();
-show(deckName ? assembleDeck(ir, { env, layout }) : renderIR(ir, { env, stage }));
+show(deckName ? assembleDeck(ir, { env, layout, stage }) : renderIR(ir, { env, stage }));

--- a/sdf-js/scripts/test-stage-preset.mjs
+++ b/sdf-js/scripts/test-stage-preset.mjs
@@ -53,5 +53,42 @@ ok(viaOpts.subjects.some((s) => s.id === 'stage-platform'), 'renderIR(ir, {stage
 const noStage = renderIR(ir, {});
 ok(!noStage.subjects.some((s) => s.id === 'stage-platform'), 'renderIR without stage is unchanged');
 
+// platform fits the structure: a wide magnitude row gets a bigger disc than a funnel
+{
+  const wideIr = {
+    structure: 'magnitude',
+    nodes: ['ANZ', 'LATAM', 'Americas', 'APAC', 'EMEA'],
+    magnitude: [95, 150, 890, 620, 340],
+    title: 'Revenue',
+  };
+  const wide = renderIR(wideIr, { stage: true });
+  const pWide = wide.subjects.find((s) => s.id === 'stage-platform');
+  const pFunnel = viaOpts.subjects.find((s) => s.id === 'stage-platform');
+  ok(pWide.args.radius > pFunnel.args.radius, 'platform radius adapts to the structure spread');
+  // every non-stage subject sits within the disc (XZ)
+  const inside = wide.subjects
+    .filter((s) => s.id !== 'stage-platform' && !s.id.startsWith('__stage'))
+    .every((s) => {
+      const tr = (s.transform && s.transform.translate) || [0, 0, 0];
+      return Math.hypot(tr[0] - pWide.transform.translate[0], tr[2] - pWide.transform.translate[2]) <= pWide.args.radius;
+    });
+  ok(inside, 'all structure subjects sit on the platform');
+}
+
+// deck: assembleDeck({stage:true}) → per-station platforms + deck theatre defaults
+{
+  const { assembleDeck } = await import('../src/scene/assemble-deck.js');
+  const deck = { title: 't', slides: [ir, { structure: 'hierarchy', nodes: ['A', 'B', 'C'], relations: [[0, 1], [0, 2]], title: 'Org' }] };
+  const staged = assembleDeck(deck, { stage: true });
+  const platforms = staged.subjects.filter((s) => s.id.includes('stage-platform'));
+  ok(platforms.length === 2, 'deck: one platform per station');
+  ok(platforms[0].transform.translate[0] !== platforms[1].transform.translate[0], 'platforms sit at their stations');
+  ok(staged.defaults.glow && staged.defaults.glow.amount > 0, 'deck theatre: glow on');
+  ok(staged.defaults.postFx && staged.defaults.postFx.vignetteStrength > 0, 'deck theatre: vignette on');
+  const plain = assembleDeck(deck, {});
+  ok(!plain.subjects.some((s) => s.id.includes('stage-platform')), 'deck without stage unchanged (no platforms)');
+  ok(!plain.defaults.glow, 'deck without stage unchanged (no glow)');
+}
+
 console.log(`\n${pass} passed, ${fail} failed`);
 process.exit(fail ? 1 : 0);

--- a/sdf-js/src/scene/assemble-deck.js
+++ b/sdf-js/src/scene/assemble-deck.js
@@ -93,7 +93,12 @@ export function assembleDeck(deck, opts = {}) {
 
   deck.slides.forEach((ir, k) => {
     // Render the station at the origin on its own clock, then transplant.
-    const st = renderIR(ir); // no env here — the deck owns the world
+    // opts.stage: each station gets its own fitted platform disc (a subject, so
+    // it transplants with the station); the station's stage DEFAULTS (lights /
+    // postFx / room shell) are discarded here on purpose — the deck owns the
+    // world and applies ONE theatre layer below (walls would slice the deck
+    // axis, and MAX_EXTRA_LIGHTS=4 can't do per-station rigs).
+    const st = renderIR(ir, opts.stage ? { stage: true } : {});
     const origin = origins[k];
 
     // Transit shot: whip from the previous station's payoff toward this one's
@@ -225,6 +230,34 @@ export function assembleDeck(deck, opts = {}) {
         origins.reduce((s, o) => s + o[2], 0) / origins.length,
       ]);
 
+  const baseDefaults = env
+    ? env.defaults
+    : {
+        camera: {
+          yaw: 0,
+          pitch: -0.1,
+          distance: 12,
+          focal: 1.2,
+          targetX: 0,
+          targetY: 2,
+          targetZ: 0,
+        },
+        light: { azimuth: 0.5, altitude: 0.7, distance: 40, intensity: 1.1 },
+      };
+
+  // Deck theatre layer (opts.stage): the open-world version of the fighting-game
+  // stage — dark miss-sky, mildly dimmed ambient (transits must stay readable),
+  // silhouette glow on every station, vignette + a touch of bloom. No room shell,
+  // no per-station lights (see the station comment above).
+  const stageDefaults = opts.stage
+    ? {
+        studioBg: 'dark',
+        interiorDark: 0.4,
+        glow: { amount: 0.3, k: 6.0 },
+        postFx: { vignetteStrength: 0.58, exposure: 0.92, bloomMix: 0.24 },
+      }
+    : null;
+
   return {
     v: 1,
     name: `(deck) ${deck.title || `${deck.slides.length} stations`}${opts.env ? ` · ${opts.env}` : ''}`,
@@ -233,19 +266,6 @@ export function assembleDeck(deck, opts = {}) {
     cameraSequence: { loop: false, shots, hitstops },
     // One shared open world — no per-station stage room (walls would slice the
     // deck axis). Ground/sky come from the environment or the page defaults.
-    defaults: env
-      ? env.defaults
-      : {
-          camera: {
-            yaw: 0,
-            pitch: -0.1,
-            distance: 12,
-            focal: 1.2,
-            targetX: 0,
-            targetY: 2,
-            targetZ: 0,
-          },
-          light: { azimuth: 0.5, altitude: 0.7, distance: 40, intensity: 1.1 },
-        },
+    defaults: stageDefaults ? { ...baseDefaults, ...stageDefaults } : baseDefaults,
   };
 }

--- a/sdf-js/src/scene/environments.js
+++ b/sdf-js/src/scene/environments.js
@@ -230,13 +230,29 @@ export function stagePreset(scene, { center = [0, 1.6, 0] } = {}) {
     ];
   }
 
-  // (c) platform: flat dark disc under the structure (the "stage floor")
+  // (c) platform: flat dark disc under the structure (the "stage floor").
+  // Fit to the structure: different renderers spread differently (a funnel is a
+  // column; a tree or a bar row spans ±3 in X) — size/centre the disc from the
+  // subjects' XZ footprint so nothing hangs off the stage.
   if (!out.subjects.some((s) => s.id === 'stage-platform')) {
+    let minX = Infinity, maxX = -Infinity, minZ = Infinity, maxZ = -Infinity;
+    for (const s of out.subjects) {
+      if (typeof s.id === 'string' && s.id.startsWith('__stage')) continue;
+      const tr = (s.transform && s.transform.translate) || [0, 0, 0];
+      minX = Math.min(minX, tr[0]); maxX = Math.max(maxX, tr[0]);
+      minZ = Math.min(minZ, tr[2]); maxZ = Math.max(maxZ, tr[2]);
+    }
+    const cx = Number.isFinite(minX) ? (minX + maxX) / 2 : center[0];
+    const cz = Number.isFinite(minZ) ? (minZ + maxZ) / 2 : center[2];
+    const spread = Number.isFinite(minX)
+      ? Math.max(Math.hypot(maxX - cx, maxZ - cz), Math.hypot(cx - minX, cz - minZ))
+      : 0;
+    const radius = Math.max(2.6, spread + 1.6);
     out.subjects.push({
       id: 'stage-platform',
       type: 'cylinder',
-      args: { radius: 2.6, height: 0.12 },
-      transform: { translate: [center[0], 0.06, center[2]] },
+      args: { radius, height: 0.12 },
+      transform: { translate: [cx, 0.06, cz] },
       material: { hue: 0.62, sat: 0.12, value: 0.22, kind: 'normal', roughness: 0.75, clearcoat: 0.1 },
     });
   }


### PR DESCRIPTION
## 舞台全量铺开

### 1. 平台自适应(修 fit bug)
stagePreset 现在从 subjects 的 **XZ footprint** 算平台盘的中心和半径(`max(2.6, spread+1.6)`)—— funnel 得小盘,org tree / bar 排得宽盘。之前 hierarchy/magnitude 的元素悬在硬编码 r=2.6 的台外。断言「全部主体都在台上」。

### 2. Deck 剧场层
`assembleDeck(deck, {stage:true})`:
- **每站自己的合身平台**(subject,随 transplant 平移)
- 站级舞台 defaults **有意丢弃**,deck 统一一层:暗天空 + ambient 0.4(transit 要可读)+ 轮廓 glow + vignette/bloom
- **不加房壳**(墙会切 deck 轴)、**不加每站灯**(MAX_EXTRA_LIGHTS=4)

`figure.html?deck=deck-pitch&stage=1` 看效果。

### 验证(Playwright)
- org-tree:整树立在合身圆盘上,emphasis 节点发光
- revenue-regions:**暗剧场里发光的金色 890 柱**(相当惊艳)
- deck finale:**夜色平原三个舞台站,虚线路径串联,聚光洒地** —— 「deck 是一个世界,每页一个舞台」

`test-stage-preset` 21 断言;全量 **133/133**。

🤖 Generated with [Claude Code](https://claude.com/claude-code)