### PR TITLE
feat(author): text→IR 前端接舞台(默认开)— 文本 → 舞台化 3D 世界

### DIFF
--- a/sdf-js/apps/present/author.js
+++ b/sdf-js/apps/present/author.js
@@ -9,7 +9,10 @@ const STORAGE_KEY = 'atlas-anthropic-key'; // shared with the compositor's lift
 
 const params = new URLSearchParams(location.search);
 const env = params.get('env') || 'studio';
-const { show } = createFigure({ outdoor: env !== 'studio' });
+// Fighting-game stage ON by default for authored worlds (per-station platforms +
+// deck theatre layer) — it's the product face. ?stage=0 opts out.
+const stage = params.get('stage') !== '0';
+const { show } = createFigure({ outdoor: env !== 'studio', stage });
 
 const promptEl = document.getElementById('prompt');
 const goEl = document.getElementById('go');
@@ -39,7 +42,7 @@ async function generate() {
       `building ${deck.slides.length} station${deck.slides.length > 1 ? 's' : ''}: ${deck.slides.map((s) => s.structure).join(' → ')}`,
     );
     loading.classList.remove('done'); // shader may recompile for a new shape
-    show(assembleDeck(deck, { env }));
+    show(assembleDeck(deck, { env, stage }));
   } catch (e) {
     setStatus(e.message, true);
   } finally {

--- a/sdf-js/scripts/test-text-to-ir.mjs
+++ b/sdf-js/scripts/test-text-to-ir.mjs
@@ -76,6 +76,23 @@ ok(parseIRResponse('Here is your deck:\n' + GOOD).slides.length === 2, 'leading 
   }
 }
 
+// ---- staged loop (the author page default): platforms + theatre layer -----------
+{
+  const deck = parseIRResponse(GOOD);
+  const scene = assembleDeck(deck, { stage: true });
+  ok(
+    scene.subjects.filter((s) => s.id.includes('stage-platform')).length === deck.slides.length,
+    'staged: one fitted platform per station',
+  );
+  ok(scene.defaults.glow && scene.defaults.glow.amount > 0, 'staged: deck theatre glow on');
+  try {
+    compile(scene, {});
+    ok(true, 'text → IR → STAGED deck compiles (author-page default path)');
+  } catch (x) {
+    ok(false, `staged compile failed: ${x.message}`);
+  }
+}
+
 // ---- prompt hygiene (repo rule: prompts stay SHORT) ------------------------------
 ok(
   TEXT_TO_IR_SYSTEM.length < 2200,


### PR DESCRIPTION
## 先说一个事实

**text→IR 前端已经存在**(另一端建的):`src/scene/text-to-ir.js`(BYOK 浏览器直连、`{title, slides:[IR]}` deck 合同、validateIR + 一次重试)+ `author.html` 页面(一个输入框 → 世界)。IR 架构承诺的「文本入口一天接上」已经兑现过了。

## 本 PR 补的 gap:author 页没接舞台

- `author.js`:`createFigure({stage})` + `assembleDeck({env, stage})`,**默认开**(`?stage=0` 退出)—— 描述一个演示,得到夜色世界里一串聚光平台舞台站。
- `test-text-to-ir.mjs` +3 断言:parsed deck → staged 组装(每站合身平台 + 剧场 glow)→ **staged deck 编译通过**(正是 author 页默认路径)。

13/13;全量 **133/133**。页面冒烟无报错;真 LLM 一轮需浏览器里填 BYOK key。

**试**:`/apps/present/author.html`,填 key,输入例句(占位符里有),Generate。

🤖 Generated with [Claude Code](https://claude.com/claude-code)