### PR TITLE
chore: 刷新语料 eval.json 快照 (新 scorer 字段)

### DIFF
--- a/sdf-js/examples/scaffold-pipeline/eval-antfun-company/eval.json
+++ b/sdf-js/examples/scaffold-pipeline/eval-antfun-company/eval.json
@@ -43,6 +43,7 @@
     "number_recall": 1,
     "missing_numbers": [],
     "deck_numbers_total": 10,
+    "derived_cited_count": 0,
     "hallucinated_numbers": [],
     "deck_entities_total": 27,
     "hallucinated_entities": [
@@ -66,5 +67,5 @@
       "text": 9.3
     }
   },
-  "generatedAt": "2026-07-07T06:44:59.887Z"
+  "generatedAt": "2026-07-10T04:23:29.781Z"
 }

--- a/sdf-js/examples/scaffold-pipeline/eval-econ-news-2026/eval.json
+++ b/sdf-js/examples/scaffold-pipeline/eval-econ-news-2026/eval.json
@@ -43,6 +43,7 @@
     "number_recall": 1,
     "missing_numbers": [],
     "deck_numbers_total": 10,
+    "derived_cited_count": 0,
     "hallucinated_numbers": [],
     "deck_entities_total": 8,
     "hallucinated_entities": [],
@@ -64,5 +65,5 @@
       "text": 10
     }
   },
-  "generatedAt": "2026-07-07T06:44:59.928Z"
+  "generatedAt": "2026-07-10T04:23:29.837Z"
 }

--- a/sdf-js/examples/scaffold-pipeline/eval-edu-course-intro/eval.json
+++ b/sdf-js/examples/scaffold-pipeline/eval-edu-course-intro/eval.json
@@ -43,6 +43,7 @@
     "number_recall": 1,
     "missing_numbers": [],
     "deck_numbers_total": 20,
+    "derived_cited_count": 0,
     "hallucinated_numbers": [
       "100%"
     ],
@@ -69,5 +70,5 @@
       "text": 10
     }
   },
-  "generatedAt": "2026-07-07T06:44:59.921Z"
+  "generatedAt": "2026-07-10T04:23:29.827Z"
 }

--- a/sdf-js/examples/scaffold-pipeline/eval-news-econ/eval.json
+++ b/sdf-js/examples/scaffold-pipeline/eval-news-econ/eval.json
@@ -43,6 +43,7 @@
     "number_recall": 1,
     "missing_numbers": [],
     "deck_numbers_total": 12,
+    "derived_cited_count": 0,
     "hallucinated_numbers": [
       "2025"
     ],
@@ -66,5 +67,5 @@
       "text": 10
     }
   },
-  "generatedAt": "2026-07-07T06:44:59.932Z"
+  "generatedAt": "2026-07-10T04:23:29.842Z"
 }

--- a/sdf-js/examples/scaffold-pipeline/eval-news-policy/eval.json
+++ b/sdf-js/examples/scaffold-pipeline/eval-news-policy/eval.json
@@ -49,6 +49,7 @@
     "number_recall": 1,
     "missing_numbers": [],
     "deck_numbers_total": 19,
+    "derived_cited_count": 0,
     "hallucinated_numbers": [
       "60"
     ],
@@ -72,5 +73,5 @@
       "text": 10
     }
   },
-  "generatedAt": "2026-07-07T06:44:59.934Z"
+  "generatedAt": "2026-07-10T04:23:29.846Z"
 }

--- a/sdf-js/examples/scaffold-pipeline/eval-nonprofit-annual-report/eval.json
+++ b/sdf-js/examples/scaffold-pipeline/eval-nonprofit-annual-report/eval.json
@@ -48,6 +48,7 @@
       "5t"
     ],
     "deck_numbers_total": 31,
+    "derived_cited_count": 0,
     "hallucinated_numbers": [
       "0.5"
     ],
@@ -71,5 +72,5 @@
       "text": 10
     }
   },
-  "generatedAt": "2026-07-07T06:44:59.923Z"
+  "generatedAt": "2026-07-10T04:23:29.830Z"
 }

--- a/sdf-js/examples/scaffold-pipeline/eval-product-eng-retro/eval.json
+++ b/sdf-js/examples/scaffold-pipeline/eval-product-eng-retro/eval.json
@@ -54,6 +54,7 @@
       "54"
     ],
     "deck_numbers_total": 34,
+    "derived_cited_count": 0,
     "hallucinated_numbers": [
       "62%",
       "2024",
@@ -86,5 +87,5 @@
       "text": 10
     }
   },
-  "generatedAt": "2026-07-07T06:44:59.925Z"
+  "generatedAt": "2026-07-10T04:23:29.833Z"
 }

--- a/sdf-js/examples/scaffold-pipeline/eval-qbr-q3-2026/eval.json
+++ b/sdf-js/examples/scaffold-pipeline/eval-qbr-q3-2026/eval.json
@@ -47,6 +47,7 @@
       "11"
     ],
     "deck_numbers_total": 30,
+    "derived_cited_count": 0,
     "hallucinated_numbers": [
       "0.75",
       "0.6",
@@ -77,5 +78,5 @@
       "text": 10
     }
   },
-  "generatedAt": "2026-07-07T06:44:59.891Z"
+  "generatedAt": "2026-07-10T04:23:29.787Z"
 }

--- a/sdf-js/examples/scaffold-pipeline/eval-strategy-batch2-validation/eval.json
+++ b/sdf-js/examples/scaffold-pipeline/eval-strategy-batch2-validation/eval.json
@@ -45,6 +45,7 @@
       "43"
     ],
     "deck_numbers_total": 32,
+    "derived_cited_count": 0,
     "hallucinated_numbers": [
       "23",
       "156",
@@ -81,5 +82,5 @@
       "text": 9
     }
   },
-  "generatedAt": "2026-07-07T06:44:59.896Z"
+  "generatedAt": "2026-07-10T04:23:29.795Z"
 }

--- a/sdf-js/examples/scaffold-pipeline/eval-strategy-swot-portfolio/eval.json
+++ b/sdf-js/examples/scaffold-pipeline/eval-strategy-swot-portfolio/eval.json
@@ -43,6 +43,7 @@
     "number_recall": 1,
     "missing_numbers": [],
     "deck_numbers_total": 8,
+    "derived_cited_count": 0,
     "hallucinated_numbers": [],
     "deck_entities_total": 16,
     "hallucinated_entities": [
@@ -68,5 +69,5 @@
       "text": 10
     }
   },
-  "generatedAt": "2026-07-07T06:44:59.899Z"
+  "generatedAt": "2026-07-10T04:23:29.799Z"
 }

--- a/sdf-js/examples/scaffold-pipeline/eval-swot-portfolio-2026/eval.json
+++ b/sdf-js/examples/scaffold-pipeline/eval-swot-portfolio-2026/eval.json
@@ -64,6 +64,7 @@
     "number_recall": 1,
     "missing_numbers": [],
     "deck_numbers_total": 7,
+    "derived_cited_count": 0,
     "hallucinated_numbers": [],
     "deck_entities_total": 17,
     "hallucinated_entities": [],
@@ -85,5 +86,5 @@
       "text": 10
     }
   },
-  "generatedAt": "2026-07-07T06:44:59.901Z"
+  "generatedAt": "2026-07-10T04:23:29.803Z"
 }

--- a/sdf-js/examples/scaffold-pipeline/eval-vc-pitch/eval.json
+++ b/sdf-js/examples/scaffold-pipeline/eval-vc-pitch/eval.json
@@ -47,6 +47,7 @@
       "$2.4M"
     ],
     "deck_numbers_total": 33,
+    "derived_cited_count": 0,
     "hallucinated_numbers": [
       "1500000",
       "150000",
@@ -75,5 +76,5 @@
       "text": 10
     }
   },
-  "generatedAt": "2026-07-07T06:44:59.913Z"
+  "generatedAt": "2026-07-10T04:23:29.817Z"
 }

--- a/sdf-js/examples/scaffold-pipeline/eval-yosemite-trip-2026/eval.json
+++ b/sdf-js/examples/scaffold-pipeline/eval-yosemite-trip-2026/eval.json
@@ -46,6 +46,7 @@
       "240,40"
     ],
     "deck_numbers_total": 8,
+    "derived_cited_count": 0,
     "hallucinated_numbers": [],
     "deck_entities_total": 22,
     "hallucinated_entities": [],
@@ -67,5 +68,5 @@
       "text": 10
     }
   },
-  "generatedAt": "2026-07-07T06:44:59.917Z"
+  "generatedAt": "2026-07-10T04:23:29.822Z"
 }


### PR DESCRIPTION
Sprint 65 全语料评分的副产物: scorer 新增 derived_cited_count 字段, 13 个既有 deck 的 eval.json 快照随之更新 (分数无变化)。及时入库避免悬置脏区。

🤖 Generated with [Claude Code](https://claude.com/claude-code)