### PR TITLE
feat(matrix): 第 5 个结构渲染器(象限墙)+ 真·LLM text→IR 评测(10/10)

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -146,6 +146,7 @@ const TESTS = [
   { category: 'scene', file: 'sdf-js/scripts/test-ir.mjs' },
   { category: 'scene', file: 'sdf-js/scripts/test-render-sequence.mjs' },
   { category: 'scene', file: 'sdf-js/scripts/test-stage-preset.mjs' },
+  { category: 'scene', file: 'sdf-js/scripts/test-render-matrix.mjs' },
   { category: 'scene', file: 'sdf-js/scripts/test-render-hierarchy.mjs' },
   { category: 'scene', file: 'sdf-js/scripts/test-render-network.mjs' },
   { category: 'scene', file: 'sdf-js/scripts/test-render-magnitude.mjs' },

--- a/sdf-js/scenes/ir/swot.json
+++ b/sdf-js/scenes/ir/swot.json
@@ -1,0 +1,8 @@
+{
+  "structure": "matrix",
+  "nodes": ["Strong team", "High burn", "AI wave", "Incumbents"],
+  "axes": [["Internal", "External"], ["Helpful", "Harmful"]],
+  "cells": [[0, 0], [0, 1], [1, 0], [1, 1]],
+  "emphasis": [2],
+  "title": "SWOT"
+}

--- a/sdf-js/scripts/regression/results/text-to-ir-2026-07-10-04-24-23.json
+++ b/sdf-js/scripts/regression/results/text-to-ir-2026-07-10-04-24-23.json
@@ -1,0 +1,282 @@
+[
+  {
+    "id": "funnel-en-numbers",
+    "ok": true,
+    "ms": 3409,
+    "slides": [
+      {
+        "structure": "sequence",
+        "n": 3,
+        "mag": [
+          5000,
+          800,
+          120
+        ],
+        "emphasis": [
+          2
+        ],
+        "title": "From Traffic to Revenue"
+      }
+    ],
+    "structures": [
+      "sequence"
+    ],
+    "structOk": true,
+    "assembleOk": true
+  },
+  {
+    "id": "magnitude-cn",
+    "ok": true,
+    "ms": 1855,
+    "slides": [
+      {
+        "structure": "magnitude",
+        "n": 4,
+        "mag": [
+          890,
+          620,
+          340,
+          150
+        ],
+        "emphasis": [
+          0
+        ],
+        "title": "2025年区域营收对比（万元）"
+      }
+    ],
+    "structures": [
+      "magnitude"
+    ],
+    "structOk": true,
+    "assembleOk": true
+  },
+  {
+    "id": "hierarchy-en",
+    "ok": true,
+    "ms": 2232,
+    "slides": [
+      {
+        "structure": "hierarchy",
+        "n": 7,
+        "mag": null,
+        "emphasis": [
+          0
+        ],
+        "title": "New Org Chart"
+      }
+    ],
+    "structures": [
+      "hierarchy"
+    ],
+    "structOk": true,
+    "assembleOk": true
+  },
+  {
+    "id": "network-en",
+    "ok": true,
+    "ms": 3472,
+    "slides": [
+      {
+        "structure": "network",
+        "n": 5,
+        "mag": null,
+        "emphasis": [
+          0
+        ],
+        "title": "Models at the Center of Everything"
+      }
+    ],
+    "structures": [
+      "network"
+    ],
+    "structOk": true,
+    "assembleOk": true
+  },
+  {
+    "id": "sequence-cn-nonum",
+    "ok": true,
+    "ms": 2057,
+    "slides": [
+      {
+        "structure": "sequence",
+        "n": 6,
+        "mag": [
+          100,
+          85,
+          70,
+          50,
+          30,
+          10
+        ],
+        "emphasis": [
+          5
+        ],
+        "title": "产品发布六阶段"
+      }
+    ],
+    "structures": [
+      "sequence"
+    ],
+    "structOk": true,
+    "assembleOk": true
+  },
+  {
+    "id": "ambiguous-services",
+    "ok": true,
+    "ms": 2117,
+    "slides": [
+      {
+        "structure": "network",
+        "n": 5,
+        "mag": null,
+        "emphasis": [
+          0
+        ],
+        "title": "Service Dependency Map"
+      }
+    ],
+    "structures": [
+      "network"
+    ],
+    "structOk": true,
+    "assembleOk": true
+  },
+  {
+    "id": "matrix-swot",
+    "ok": true,
+    "ms": 2578,
+    "slides": [
+      {
+        "structure": "matrix",
+        "n": 6,
+        "mag": null,
+        "emphasis": [
+          4
+        ],
+        "title": "SWOT Analysis"
+      }
+    ],
+    "structures": [
+      "matrix"
+    ],
+    "structOk": true,
+    "assembleOk": true
+  },
+  {
+    "id": "pitch-3-points",
+    "ok": true,
+    "ms": 3078,
+    "slides": [
+      {
+        "structure": "magnitude",
+        "n": 3,
+        "mag": [
+          890,
+          540,
+          310
+        ],
+        "emphasis": [
+          0
+        ],
+        "title": "Revenue by Region"
+      },
+      {
+        "structure": "sequence",
+        "n": 4,
+        "mag": [
+          1200,
+          400,
+          150,
+          45
+        ],
+        "emphasis": [
+          3
+        ],
+        "title": "Sales Funnel"
+      },
+      {
+        "structure": "hierarchy",
+        "n": 5,
+        "mag": null,
+        "emphasis": [
+          0
+        ],
+        "title": "New Org Structure"
+      }
+    ],
+    "structures": [
+      "magnitude",
+      "sequence",
+      "hierarchy"
+    ],
+    "structOk": true,
+    "assembleOk": true
+  },
+  {
+    "id": "news-cn-messy",
+    "ok": true,
+    "ms": 3074,
+    "slides": [
+      {
+        "structure": "magnitude",
+        "n": 3,
+        "mag": [
+          18.2,
+          4.5,
+          1.8
+        ],
+        "emphasis": [
+          0
+        ],
+        "title": "Q3各地区交付量（万辆）"
+      },
+      {
+        "structure": "sequence",
+        "n": 4,
+        "mag": [
+          100,
+          80,
+          60,
+          40
+        ],
+        "emphasis": [
+          3
+        ],
+        "title": "全流程数字化推进路径"
+      }
+    ],
+    "structures": [
+      "magnitude",
+      "sequence"
+    ],
+    "structOk": true,
+    "assembleOk": true
+  },
+  {
+    "id": "vague",
+    "ok": true,
+    "ms": 2359,
+    "slides": [
+      {
+        "structure": "magnitude",
+        "n": 5,
+        "mag": [
+          92,
+          88,
+          85,
+          74,
+          80
+        ],
+        "emphasis": [
+          0
+        ],
+        "title": "Our Winning Advantages"
+      }
+    ],
+    "structures": [
+      "magnitude"
+    ],
+    "structOk": true,
+    "assembleOk": true
+  }
+]

--- a/sdf-js/scripts/regression/text-to-ir-eval.mjs
+++ b/sdf-js/scripts/regression/text-to-ir-eval.mjs
@@ -1,0 +1,133 @@
+// text-to-ir-eval.mjs — REAL-LLM end-to-end eval for the text → IR front-end.
+// Needs ANTHROPIC_API_KEY (BYOK); not part of `npm test` (see regression/README).
+//
+//   ANTHROPIC_API_KEY=$(cat ~/.atlas-key) node sdf-js/scripts/regression/text-to-ir-eval.mjs
+//
+// For each case: textToIR (real model round) → structure choices vs expectation →
+// assembleDeck({stage:true}) → compile. Reports one row per case + a summary.
+// Results JSON saved next to this file (results/) for diffing across prompt changes.
+
+import { writeFileSync, mkdirSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+import { textToIR } from '../../src/scene/text-to-ir.js';
+import { assembleDeck } from '../../src/scene/assemble-deck.js';
+import { compile } from '../../src/scene/index.js';
+
+const KEY = process.env.ANTHROPIC_API_KEY;
+if (!KEY) {
+  console.log('SKIP: ANTHROPIC_API_KEY not set');
+  process.exit(0);
+}
+
+// expect: acceptable structure sets per remembered narrative point (order-free).
+// `anyOf` = the slide set must be drawn from these; `mustInclude` = at least one of each.
+const CASES = [
+  {
+    id: 'funnel-en-numbers',
+    text: 'our funnel: 5000 visitors, 800 signups, 120 paying customers — push the conversion story',
+    mustInclude: [['sequence']],
+  },
+  {
+    id: 'magnitude-cn',
+    text: '2025年营收按区域:美洲 890 万,亚太 620 万,欧洲 340 万,拉美 150 万,重点讲美洲的领先',
+    mustInclude: [['magnitude']],
+  },
+  {
+    id: 'hierarchy-en',
+    text: 'our new org: CEO on top; under her a CTO and a COO; the CTO runs platform and apps teams; the COO runs sales and support',
+    mustInclude: [['hierarchy']],
+  },
+  {
+    id: 'network-en',
+    text: 'the AI agent ecosystem: models, tooling, orchestration, evals and deployment all interconnect — models sit at the center of everything',
+    mustInclude: [['network']],
+  },
+  {
+    id: 'sequence-cn-nonum',
+    text: '产品发布流程:立项、设计、开发、内测、公测、正式发布',
+    mustInclude: [['sequence']],
+  },
+  {
+    id: 'ambiguous-services',
+    text: 'microservices: the gateway talks to auth, orders and inventory; orders also calls inventory and payments',
+    mustInclude: [['network', 'hierarchy']], // either reading is defensible
+  },
+  {
+    id: 'matrix-swot',
+    text: 'SWOT for our startup: strengths are the team and the tech; weaknesses are cash and brand; opportunities: the AI wave; threats: incumbents',
+    mustInclude: [['matrix']],
+  },
+  {
+    id: 'pitch-3-points',
+    text: 'Q3 review: revenue by region (Americas leads at 890), our sales funnel from 1200 leads to 45 closed, and the new org under the CEO',
+    mustInclude: [['magnitude'], ['sequence'], ['hierarchy']],
+  },
+  {
+    id: 'news-cn-messy',
+    text: '据报道,某新能源车企第三季度交付量创新高:国内交付 18.2 万辆,欧洲 4.5 万辆,东南亚 1.8 万辆。公司称将继续推进从预订、锁单、生产到交付的全流程数字化,并强调国内市场仍是基本盘。',
+    mustInclude: [['magnitude']], // sequence also plausible as a 2nd slide
+  },
+  {
+    id: 'vague',
+    text: 'why we win',
+    mustInclude: [], // no expectation — probing behavior on near-empty input
+  },
+];
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const OUT_DIR = resolve(__dirname, 'results');
+mkdirSync(OUT_DIR, { recursive: true });
+
+const rows = [];
+let pass = 0, fail = 0;
+
+for (const c of CASES) {
+  const row = { id: c.id, ok: false };
+  const t0 = Date.now();
+  try {
+    const deck = await textToIR(c.text, KEY);
+    row.ms = Date.now() - t0;
+    row.slides = deck.slides.map((s) => ({
+      structure: s.structure,
+      n: s.nodes.length,
+      mag: s.magnitude || null,
+      emphasis: s.emphasis ?? null,
+      title: s.title,
+    }));
+    const structures = deck.slides.map((s) => s.structure);
+    row.structures = structures;
+
+    // structure expectation
+    row.structOk = (c.mustInclude || []).every((alts) => alts.some((s) => structures.includes(s)));
+
+    // staged assembly + compile (the author-page default path)
+    try {
+      const scene = assembleDeck(deck, { stage: true });
+      compile(scene, {});
+      row.assembleOk = true;
+    } catch (e) {
+      row.assembleOk = false;
+      row.assembleErr = e.message.slice(0, 140);
+    }
+
+    row.ok = row.structOk && row.assembleOk;
+  } catch (e) {
+    row.ms = Date.now() - t0;
+    row.err = e.message.slice(0, 200);
+  }
+  rows.push(row);
+  row.ok ? pass++ : fail++;
+  console.log(
+    `${row.ok ? '✓' : '✗'} ${c.id.padEnd(20)} ${String(row.ms).padStart(6)}ms  ` +
+      `[${(row.structures || []).join(' → ') || 'ERR'}]` +
+      (row.structOk === false ? '  STRUCT-MISS' : '') +
+      (row.assembleOk === false ? `  ASSEMBLE-FAIL: ${row.assembleErr}` : '') +
+      (row.err ? `  ERR: ${row.err}` : ''),
+  );
+  await new Promise((r) => setTimeout(r, 400)); // gentle pacing
+}
+
+const stamp = new Date().toISOString().slice(0, 19).replace(/[:T]/g, '-');
+writeFileSync(resolve(OUT_DIR, `text-to-ir-${stamp}.json`), JSON.stringify(rows, null, 2));
+console.log(`\n${pass}/${CASES.length} pass — details in scripts/regression/results/text-to-ir-${stamp}.json`);

--- a/sdf-js/scripts/test-ir-matrix.mjs
+++ b/sdf-js/scripts/test-ir-matrix.mjs
@@ -501,8 +501,13 @@ function makeStubCtx() {
     }),
   );
 
-  const filtered = deckToIR(dir);
-  ok(filtered.slides.length === 0, 'deckToIR filters matrix slides by default (no 3D renderer)');
+  // matrix gained a 3D renderer (render-matrix.js, the quadrant wall) — the
+  // RENDERER_STRUCTURES-driven filter now passes it through by default.
+  const byDefault = deckToIR(dir);
+  ok(
+    byDefault.slides.length === 1 && byDefault.slides[0].structure === 'matrix',
+    'deckToIR includes matrix by default (render-matrix landed)',
+  );
 
   const included = deckToIR(dir, { structures: ['matrix'] });
   ok(

--- a/sdf-js/scripts/test-render-matrix.mjs
+++ b/sdf-js/scripts/test-render-matrix.mjs
@@ -1,0 +1,64 @@
+// test-render-matrix.mjs — structure renderer #5: matrix → quadrant wall.
+import { renderMatrix } from '../src/scene/render-matrix.js';
+import { renderIR, RENDERER_STRUCTURES } from '../src/scene/render-ir.js';
+import { assembleDeck } from '../src/scene/assemble-deck.js';
+import { compile } from '../src/scene/index.js';
+import { expandStage } from '../src/scene/stage.js';
+
+let pass = 0, fail = 0;
+const ok = (c, n) => (c ? (pass++, console.log(`  ✓ ${n}`)) : (fail++, console.log(`  ✗ ${n}`)));
+console.log('=== render-matrix (quadrant wall) ===\n');
+
+const swot = {
+  structure: 'matrix',
+  nodes: ['Strong team', 'High burn', 'AI wave', 'Incumbents'],
+  axes: [['Internal', 'External'], ['Helpful', 'Harmful']],
+  cells: [[0, 0], [0, 1], [1, 0], [1, 1]],
+  emphasis: [2],
+  title: 'SWOT',
+};
+
+ok(RENDERER_STRUCTURES.includes('matrix'), 'matrix registered in RENDERER_STRUCTURES');
+
+const scene = renderMatrix(swot);
+const cells = scene.subjects.filter((s) => s.id.startsWith('cell-'));
+const items = scene.subjects.filter((s) => s.id.startsWith('item-'));
+ok(cells.length === 4, '2×2 axes → 4 board tiles');
+ok(items.length === 4, 'one item per node');
+
+// each item sits on its cell (same XY as the tile it belongs to)
+const tileAt = (xi, yi) => cells.find((c) => c.id === `cell-${xi}-${yi}`);
+ok(
+  swot.cells.every(([xi, yi], i) => {
+    const t = tileAt(xi, yi).transform.translate;
+    const it = items.find((s) => s.id === `item-${i}`).transform.translate;
+    return Math.abs(t[0] - it[0]) < 1e-9 && Math.abs(t[1] - it[1]) < 1e-9;
+  }),
+  'items land exactly on their cells',
+);
+
+// build-in: items slam in along z with a smoothstep window, staggered
+ok(items.every((s) => s.animation && s.animation[0].channel === 'transform.translate.z'), 'items animate along z');
+ok(items.every((s) => /smoothstep\(/.test(s.animation[0].expr)), 'slam uses smoothstep');
+
+// emphasis item gets the gold treatment + a value label; camera has cut super + payoff
+ok(items.find((s) => s.id === 'item-2').material.glow > 0, 'emphasis item glows (gold)');
+ok(scene.cameraSequence.shots.some((s) => s.transition === 'cut'), 'has the punch-in super');
+ok(scene.overlay.filter((o) => o.role === 'card').length >= 2 + 2 + 3, 'axis labels + item labels in overlay');
+ok(scene.subjects.every((s) => !/text/.test(s.type)), 'no baked SDF text');
+
+// compiles; renderIR dispatch reaches it; staged deck with a matrix slide assembles
+try {
+  compile(expandStage(scene), {});
+  ok(true, 'matrix scene compiles');
+} catch (e) {
+  ok(false, `compile failed: ${e.message}`);
+}
+ok(renderIR(swot).subjects.length === scene.subjects.length, 'renderIR dispatches matrix');
+{
+  const deck = assembleDeck({ title: 't', slides: [swot] }, { stage: true });
+  ok(deck.subjects.some((s) => s.id.includes('stage-platform')), 'staged deck with matrix slide assembles');
+}
+
+console.log(`\n${pass} passed, ${fail} failed`);
+process.exit(fail ? 1 : 0);

--- a/sdf-js/src/scene/render-ir.js
+++ b/sdf-js/src/scene/render-ir.js
@@ -7,6 +7,7 @@ import { renderSequence } from './render-sequence.js';
 import { renderHierarchy } from './render-hierarchy.js';
 import { renderNetwork } from './render-network.js';
 import { renderMagnitude } from './render-magnitude.js';
+import { renderMatrix } from './render-matrix.js';
 import { stagePreset } from './environments.js';
 
 const RENDERERS = {
@@ -14,13 +15,11 @@ const RENDERERS = {
   hierarchy: renderHierarchy,
   network: renderNetwork,
   magnitude: renderMagnitude,
+  matrix: renderMatrix,
 };
 
-// The structures that HAVE a 3D renderer today — 'matrix' (Sprint 28) is a
-// valid IR structure the 2D bridges + text-to-ir emit/consume, but has no
-// entry here yet. scaffold-to-ir's deckToIR uses this list to keep matrix
-// IRs out of assembleDeck until a matrix structure renderer exists (see
-// docs/superpowers/ir-matrix-proposal.md).
+// Every IR structure has a 3D renderer now (matrix landed last — the quadrant
+// wall; see docs/superpowers/ir-matrix-proposal.md for the IR fields).
 export const RENDERER_STRUCTURES = Object.keys(RENDERERS);
 
 export function renderIR(ir, opts = {}) {

--- a/sdf-js/src/scene/render-matrix.js
+++ b/sdf-js/src/scene/render-matrix.js
@@ -1,0 +1,180 @@
+// sdf-js/src/scene/render-matrix.js
+// Structure renderer #5: matrix → the QUADRANT WALL. Reads the IR ONLY.
+//
+// Matrix is the one structure where 3D must stay HUMBLE: a 2-axis classification
+// is natively flat (the stage-idiom ledger's "3D ties or loses" list), so the
+// native form is an upright grid WALL facing the camera — a war-room board on
+// the stage — not a forced volume. What 3D adds is presentation: items SLAM onto
+// the board one by one (build-in), the camera walks the cells, and the emphasis
+// item gets the punch-in. Honest layout, theatrical delivery.
+//
+// Fighting-game grammar, matrix variation — the BRIEFING BOARD:
+//   1. establishing — the whole empty board, axes readable
+//   2. items slam on cell by cell (order), camera tracks the drops loosely
+//   3. the SUPER — punch-in at the emphasis item + shake
+//   4. payoff pull-back — the filled board in one frame
+import { validateIR } from './ir.js';
+import { getEnvironment } from './environments.js';
+
+const label = (n) => (typeof n === 'string' ? n : (n && (n.label ?? n.name)) || '');
+
+const TILE_MAT = { hue: 0.6, sat: 0.1, value: 0.3, kind: 'normal', roughness: 0.7, clearcoat: 0.1 };
+const itemMat = (emphasized) =>
+  emphasized
+    ? { hue: 0.11, sat: 0.78, value: 0.95, glow: 0.22, kind: 'normal', roughness: 0.22, clearcoat: 0.6 }
+    : { hue: 0.57, sat: 0.55, value: 0.72, kind: 'normal', roughness: 0.3, clearcoat: 0.45 };
+
+export function renderMatrix(ir, opts = {}) {
+  const v = validateIR(ir);
+  if (!v.ok) throw new Error(`renderMatrix: invalid IR — ${v.errors.join('; ')}`);
+  if (ir.structure !== 'matrix')
+    throw new Error(`renderMatrix: expected structure 'matrix', got '${ir.structure}'`);
+  const env = getEnvironment(opts.env);
+
+  const nodes = ir.nodes.map(label);
+  const N = nodes.length;
+  const [xCats, yCats] = ir.axes;
+  const X = xCats.length;
+  const Y = yCats.length;
+  const order = ir.order && ir.order.length === N ? ir.order : nodes.map((_, i) => i);
+  const emphasis = new Set(ir.emphasis && ir.emphasis.length ? ir.emphasis : []);
+  const mag = ir.magnitude || null;
+  const mMax = mag ? Math.max(...mag.map((x) => Number(x) || 0), 1e-9) : 1;
+
+  // Board layout: upright XY wall facing +z, centred at (0, cy). Cell size adapts
+  // so a 2×2 SWOT and a 5×5 heatmap both frame well.
+  const cellW = Math.min(1.7, 5.6 / X);
+  const cellH = Math.min(1.3, 3.9 / Y);
+  const gap = 0.12;
+  const boardW = X * cellW + (X - 1) * gap;
+  const boardH = Y * cellH + (Y - 1) * gap;
+  const cy = 1.15 + boardH / 2; // board bottom edge ~1.15 above the floor
+  // NOTE: studio camera is +x → screen-LEFT, so negate to keep axes[0] order
+  // reading left→right on screen (the funnel-slice lift hit the same trap).
+  const cellX = (xi) => -(xi - (X - 1) / 2) * (cellW + gap);
+  const cellY = (yi) => cy + ((Y - 1) / 2 - yi) * (cellH + gap); // row 0 on top
+
+  const subjects = [];
+
+  // the board: one thin tile per cell (self-laid, so item positions match exactly)
+  for (let yi = 0; yi < Y; yi++)
+    for (let xi = 0; xi < X; xi++)
+      subjects.push({
+        id: `cell-${xi}-${yi}`,
+        type: 'box',
+        args: { dims: [cellW, cellH, 0.1] },
+        transform: { translate: [cellX(xi), cellY(yi), 0] },
+        material: { ...TILE_MAT },
+      });
+
+  // items slam onto their cells one by one (drop along z from the camera side)
+  const introLead = 1.6;
+  const holdEach = 0.9;
+  const zFinal = 0.18; // proud of the board face
+  const zStart = 2.4; // launched from the camera side
+  order.forEach((i, k) => {
+    const [xi, yi] = ir.cells[i];
+    const size = mag ? 0.22 + 0.3 * Math.sqrt((Number(mag[i]) || 0) / mMax) : 0.3;
+    const t0 = introLead + k * holdEach - 0.35;
+    const t1 = t0 + 0.45;
+    subjects.push({
+      id: `item-${i}`,
+      type: 'rounded_box',
+      args: { dims: [size, size, 0.14], cornerR: 0.03 },
+      transform: { translate: [cellX(xi), cellY(yi), zFinal] },
+      material: itemMat(emphasis.has(i)),
+      animation: [
+        {
+          channel: 'transform.translate.z',
+          expr: `${zStart.toFixed(3)} - ${(zStart - zFinal).toFixed(3)} * smoothstep(${Math.max(0.2, t0).toFixed(2)}, ${t1.toFixed(2)}, t)`,
+        },
+      ],
+    });
+  });
+
+  // ---- camera: briefing-board beats -------------------------------------------
+  const emphasisIdx = ir.emphasis && ir.emphasis.length ? ir.emphasis[0] : order[order.length - 1];
+  const [exi, eyi] = ir.cells[emphasisIdx];
+  const viewD = Math.max(4.6, boardW * 1.05 + 1.6);
+  const shots = [
+    // 1 — establishing: the whole board, axes readable
+    {
+      duration: introLead,
+      pos: [boardW * 0.18, cy + 0.5, viewD + 1.2],
+      target: [0, cy, 0],
+      fov: 48,
+      aperture: 0.12,
+      focalDistance: viewD,
+      ease: 'out',
+    },
+  ];
+  // 2 — loose tracking: drift toward each item as it lands
+  order.forEach((i) => {
+    const [xi, yi] = ir.cells[i];
+    shots.push({
+      duration: holdEach,
+      pos: [cellX(xi) * 0.55, cellY(yi) * 0.35 + cy * 0.65, viewD * 0.78],
+      target: [cellX(xi), cellY(yi), 0],
+      fov: 46,
+      transition: 'blend',
+      aperture: 0.2,
+      focalDistance: viewD * 0.78,
+      ease: 'smooth',
+    });
+  });
+  // 3 — the super: punch-in at the emphasis item
+  shots.push({
+    duration: 0.9,
+    pos: [cellX(exi) + 0.5, cellY(eyi) + 0.2, 2.1],
+    target: [cellX(exi), cellY(eyi), 0.2],
+    fov: 44,
+    transition: 'cut',
+    aperture: [0.7, 0.35],
+    focalDistance: 2.0,
+    shake: [0.35, 0.05],
+    exposure: [1.3, 1.0],
+    ease: 'out',
+  });
+  // 4 — payoff: the filled board
+  shots.push({
+    duration: 2.2,
+    pos: [0, cy + 0.4, viewD + 0.6],
+    target: [0, cy, 0],
+    fov: 48,
+    transition: 'blend',
+    aperture: 0.1,
+    focalDistance: viewD,
+    ease: 'inout',
+  });
+
+  // ---- overlay: title, axis labels, item labels --------------------------------
+  const overlay = [
+    { text: String(ir.title || 'Matrix').toUpperCase(), anchor: [0, cy + boardH / 2 + 0.8, 0], role: 'title' },
+  ];
+  xCats.forEach((c, xi) =>
+    overlay.push({ text: String(c), anchor: [cellX(xi), cy + boardH / 2 + 0.32, 0], role: 'card', align: 'center' }),
+  );
+  yCats.forEach((c, yi) =>
+    overlay.push({ text: String(c), anchor: [-boardW / 2 - 0.55, cellY(yi), 0], role: 'card', align: 'right' }),
+  );
+  order.forEach((i, k) => {
+    const [xi, yi] = ir.cells[i];
+    overlay.push({
+      text: nodes[i],
+      anchor: [cellX(xi), cellY(yi) - 0.34, 0.2],
+      role: emphasis.has(i) ? 'value' : 'card',
+      align: 'center',
+      ...(emphasis.has(i) ? { radius: 0.4 } : {}),
+      revealAt: introLead + k * holdEach + 0.15,
+    });
+  });
+
+  return {
+    v: 1,
+    name: `(matrix) ${ir.title || 'matrix'}`,
+    subjects: env ? [...subjects, ...env.subjects] : subjects,
+    overlay,
+    cameraSequence: { loop: false, shots },
+    defaults: env ? env.defaults : { stage: { size: [Math.max(16, boardW + 8), 12, 12] } },
+  };
+}


### PR DESCRIPTION
## 真·LLM 端到端评测(第一次)

10 案例 battery(中/英、有无数字、歧义、多点、乱新闻、极模糊),真模型跑:

- **结构判定 10/10 全对**(SWOT 判 matrix 也对)
- **唯一崩点正是预测的**:textToIR 正确产出 matrix,但 renderIR 没有 matrix 渲染器 → **SWOT 输入白屏 author 页**

## 修复 = 补第 5 个结构渲染器

`render-matrix.js` —— **象限墙**:matrix 是唯一「3D 该谦逊」的结构(2 轴分类天然平面),形 = 面向相机的自摆格板;剧场感在**演绎**:item 逐个「拍」上格子(translate.z smoothstep 错峰)、emphasis 金色 + punch-in super + 收尾拉全景。轴标/项标走 overlay。顺手修一个老坑:相机 +x→屏幕左,cellX 取反保证 axes[0] 从左往右读。

- render-ir 注册 matrix —— **全部 IR 结构现在都有 3D 渲染器**;deckToIR 的过滤自动解除(测试断言翻转)
- `regression/text-to-ir-eval.mjs`:10 案例真 LLM battery(BYOK,不进 npm test)+ 基线结果 JSON —— 以后改 prompt 必重跑
- swot fixture + 13 断言单测

**看**:`figure.html?ir=swot&stage=1` —— 舞台化 SWOT 板,金色「AI wave」在 External×Helpful 格。全量 **134/134**;eval **10/10**。

🤖 Generated with [Claude Code](https://claude.com/claude-code)