### PR TITLE
Sprint 66: atlas-deck 契约守卫 + 3D e2e 弹药包

### DIFF
--- a/docs/atlas-deck-contract.md
+++ b/docs/atlas-deck-contract.md
@@ -1,0 +1,101 @@
+# atlas-deck 契约 (v1) — 两端机器契约的唯一真相
+
+> 3D 端 e2e 对接必读。可执行校验器: `sdf-js/src/present/deck-spec.js`
+> (零依赖, node/浏览器均可直接 import)。黄金 fixtures:
+> `sdf-js/examples/deck-handoff/`。变更此契约 = bump `version` + 更新本文档
+> + 校验器 + fixtures, 三者同 PR。
+
+## 0. 先分清三种 "deck.json" (历史方言地图)
+
+| 方言 | 形状 | 生产者 | 消费者 |
+|---|---|---|---|
+| **atlas-deck (本契约)** | `{format:'atlas-deck', version, slots[].sceneData 内联}` | author-2d 💾 / `manifest-to-deck.mjs` | author-2d 📂、**3D 端移交入口**、导出器 |
+| bake manifest | `{deckName, sourceFile, slots[].liftFile}` + `slots/*.json` | CLI 烤炉 (bake-scaffold-pipeline) | eval 五轴、scaffold-deck-viewer |
+| 3D 播放列表 | `scenes/<id>.json` = `{segments:[…]}` | 3D 端 lift/手工 | deck-player (3D) |
+
+**移交方向**: 2D 产 atlas-deck → 3D 端 lift 管线消化其中每个 slot 的
+`sceneData` (2D atoms, twin 覆盖率 100%) → 生成自己的 segments 播放列表。
+bake manifest 可用 `node sdf-js/scripts/manifest-to-deck.mjs <dir>` 一键转
+atlas-deck。
+
+## 1. 信封
+
+```jsonc
+{
+  "format": "atlas-deck",     // 必填, 字面量
+  "version": 1,               // 必填, 整数; 消费者拒读比自己新的版本
+  "title": "Q3 Review",       // 可选 string
+  "theme": { … },             // §2
+  "scaffold": { "id": "qbr", "label": "Quarterly Business Review" },  // 可选
+  "decor": { … },             // §3, 可选
+  "shared": { … },            // §4, 可选 (2D 内部再编辑用)
+  "slots": [ … ]              // §5, 必填数组
+}
+```
+
+## 2. theme
+
+字符串 id (如 `"editorial-navy"`, 消费者用自己的主题表解析) 或完整调色板
+对象: `{id, bg:[r,g,b], accent:[r,g,b], colors:[[r,g,b],…], …}`。RGB 分量
+0-255。缺失 = warning, 消费者回退默认调色板。
+
+## 3. decor (2D 风格层作品身份)
+
+```jsonc
+{ "family": "peg-wraps", "seed": 12345, "personality": "balanced",
+  "hash": "b902d873762fe5ad", "v": 3, "serial": 7, "rare": false }
+```
+
+**3D 消费者可以整体忽略此字段** (修饰是 2D 端风格层, 两端锁豁免 twin)。
+但如果携带, 必须完整保真回传 — `hash`+`v`(+`serial`) 是作品身份,
+丢字段 = 拥有者无法复现其作品。字段语义见
+`src/present/decor/registry.js` 头注 (hash 定决策 / v 定代码 / 序号定
+收藏位置)。
+
+## 4. shared
+
+`deck-io.js` 序列化时把每个 slot 重复携带的 `liftParams.scaffold/slides/
+theme` 提升到这里 (15 页 deck 省 ~10×)。**只有需要"再编辑" (重 roll/改写)
+的消费者关心它**; 纯渲染/纯移交消费者可忽略。反序列化时按引用还原进各
+slot 的 liftParams (见 `deserializeDeck`)。
+
+## 5. slots — 载荷本体
+
+```jsonc
+{
+  "slotIdx": 3,               // 可选 int; 骨架槽位号 (锁页/重烤对位用)
+  "slotName": "key-figures",  // 可选 string
+  "slotTitle": "关键数字",     // 可选 string (导航/标题条)
+  "sceneData": {              // 必填 — 没有它这页不可渲染
+    "subjects": [             // 或 "atoms" (同义, 历史别名)
+      {
+        "type": "kpi-card",   // 必填 string; 2D atom 类型名
+        "x": 40, "y": 160, "w": 280, "h": 200,   // 画布 1280×720 坐标
+        "args": { "value": "$30.6M", "label": "GAAP Operating Income" }
+      }
+    ]
+  },
+  "liftParams": { … },        // 可选; 2D 再编辑所需 (3D 消费者忽略)
+  "locked": false             // 可选; 2D 编辑态
+}
+```
+
+- **未知 atom type 是 warning 不是 error** — 渲染器对未知类型 no-op,
+  deck 跨版本保持可播 (校验器可传入消费者自己的 registry 集合做检查)。
+- 坐标系: 1280×720, 左上原点。args 内数字字符串遵守 Rule 18-24
+  (数字即载荷、衍生值带引用)。
+- slot 顺序即播放顺序 (数组序, 不是 slotIdx 序 — 用户可调序)。
+
+## 6. 校验器用法
+
+```js
+import { validateDeck } from '…/src/present/deck-spec.js';
+const { ok, errors, warnings } = validateDeck(json /* 对象或字符串 */, {
+  knownAtomTypes: myRegistrySet, // 可选
+});
+```
+
+ERROR = 拒收 (结构性不可消费); WARNING = 可继续但请记录。
+黄金 fixtures 里 `valid/` 必须全 ok, `invalid/` 每个恰好死于注释标明的
+那条 error — 两端把这批 fixtures 钉进各自 CI, 契约漂移死在 CI 里,
+不死在联调现场。

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -213,6 +213,7 @@ const TESTS = [
   { category: 'present', file: 'sdf-js/scripts/test-retheme.mjs' },
   { category: 'present', file: 'sdf-js/scripts/test-decor.mjs' },
   { category: 'present', file: 'sdf-js/scripts/test-deck-io.mjs' },
+  { category: 'present', file: 'sdf-js/scripts/test-deck-contract.mjs' },
 ];
 
 // -----------------------------------------------------------------------------

--- a/sdf-js/examples/deck-handoff/README.md
+++ b/sdf-js/examples/deck-handoff/README.md
@@ -1,0 +1,33 @@
+# deck-handoff — 3D 端 e2e 的契约 fixtures 与弹药包
+
+给 3D 端 e2e 测试的一站式输入。契约全文: [`docs/atlas-deck-contract.md`](../../../docs/atlas-deck-contract.md);
+可执行校验器: [`sdf-js/src/present/deck-spec.js`](../../src/present/deck-spec.js) (零依赖, 直接 import)。
+
+## 目录
+
+- **`ammo/`** — 15 个真实 atlas-deck (eval 语料转换而来): 中文新闻 / 英文长文 /
+  真季报 (financial-summary 骨架) / 真融资稿 (investor-update 骨架) / QBR /
+  VC pitch / SWOT / 课程 / 非营利年报…… 6-14 页不等, twin 覆盖率 100%,
+  全部通过五轴 eval。**这就是 2D 端真实产出的分布, 直接当 e2e 输入。**
+- **`valid/`** — 5 个边界 fixture, 校验器必须全 ok:
+  minimal (最小可行) / cjk-atoms-alias (中文 + `atoms` 历史别名) /
+  decor-identity (完整修饰身份, 3D 可整体忽略但须保真回传) /
+  empty-deck (零页 = warning 非 error) / unknown-atom-forward-compat
+  (未知 atom type = warning, 渲染器 no-op — 前向兼容契约)
+- **`invalid/`** — 8 个反例, 每个恰好死于文件名标明的那条 error。
+  **把 valid+invalid 钉进你们的 CI**: 契约漂移死在 CI 里, 不死在联调现场。
+
+## 重新生成
+
+```bash
+node sdf-js/scripts/manifest-to-deck.mjs --ammo      # 从 eval 语料重烤 ammo/
+node sdf-js/scripts/manifest-to-deck.mjs <烤炉目录>   # 任意 bake manifest 转 atlas-deck
+```
+
+## 消费要点 (细节见契约文档)
+
+1. `slots[]` 数组序即播放序; 每 slot 的 `sceneData.subjects[]` 是 1280×720
+   坐标系上的 2D atoms — 3D lift 的输入。
+2. `decor` / `shared` / `liftParams` 都可忽略 (2D 端内部状态), 但 `decor`
+   如果回传必须逐字段保真 (作品身份)。
+3. 未知 atom type 请 no-op + log, 不要拒收整个 deck。

--- a/sdf-js/examples/deck-handoff/ammo/eval-antfun-company.json
+++ b/sdf-js/examples/deck-handoff/ammo/eval-antfun-company.json
@@ -1,0 +1,646 @@
+{
+  "format": "atlas-deck",
+  "version": 1,
+  "title": "eval-antfun-company",
+  "theme": {
+    "id": "editorial-navy",
+    "label": "Editorial · Navy",
+    "macroCluster": "editorial",
+    "bg": [248, 246, 240],
+    "silhouetteColor": [22, 35, 70],
+    "accent": [38, 70, 130],
+    "colors": [
+      [38, 70, 130],
+      [110, 95, 75],
+      [165, 130, 90],
+      [200, 195, 180]
+    ],
+    "font": {
+      "heading": "Georgia, \"Source Serif Pro\", serif",
+      "body": "Inter, system-ui, sans-serif"
+    },
+    "featured": true
+  },
+  "scaffold": {
+    "id": "company-overview",
+    "label": "Company Overview"
+  },
+  "decor": null,
+  "shared": null,
+  "slots": [
+    {
+      "slotIdx": 0,
+      "slotName": "cover",
+      "slotTitle": "Title",
+      "sceneData": {
+        "name": "company-overview/cover",
+        "layout": "cover",
+        "subjects": [
+          {
+            "type": "cover",
+            "x": 0,
+            "y": 0,
+            "w": 1280,
+            "h": 720,
+            "args": {
+              "title": "ANTFUN",
+              "subtitle": "On-Chain Trading Super App",
+              "date": "2026-Q3",
+              "style": "gradient"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "slotIdx": 1,
+      "slotName": "mission",
+      "slotTitle": "Mission",
+      "sceneData": {
+        "name": "company-overview/mission",
+        "layout": "hierarchy",
+        "subjects": [
+          {
+            "type": "cover",
+            "x": 0,
+            "y": 0,
+            "w": 1280,
+            "h": 120,
+            "args": {
+              "title": "Mission",
+              "style": "gradient"
+            }
+          },
+          {
+            "type": "pillar-3up",
+            "x": 40,
+            "y": 160,
+            "w": 1200,
+            "h": 220,
+            "args": {
+              "pillars": [
+                {
+                  "icon": "chat-circle",
+                  "heading": "Natural Trading",
+                  "body": "Make on-chain trading as natural as messaging"
+                },
+                {
+                  "icon": "lock-key",
+                  "heading": "Self-Custodial",
+                  "body": "Replace centralized exchanges with self-custodial UX"
+                },
+                {
+                  "icon": "users",
+                  "heading": "Next 100M",
+                  "body": "Lower the barrier to DeFi for the next 100 million users"
+                }
+              ],
+              "accentLine": true
+            }
+          },
+          {
+            "type": "icon-row",
+            "x": 40,
+            "y": 420,
+            "w": 1200,
+            "h": 140,
+            "args": {
+              "title": "Our Focus",
+              "items": [
+                {
+                  "icon": "device-mobile",
+                  "label": "Mobile-First"
+                },
+                {
+                  "icon": "brain",
+                  "label": "AI Co-Pilot"
+                },
+                {
+                  "icon": "shield",
+                  "label": "Privacy Default"
+                },
+                {
+                  "icon": "flow-arrow",
+                  "label": "Cross-Chain"
+                }
+              ],
+              "iconSize": "medium",
+              "iconStyle": "circle"
+            }
+          },
+          {
+            "type": "stat-banner",
+            "x": 40,
+            "y": 600,
+            "w": 580,
+            "h": 80,
+            "args": {
+              "value": "10M+ Users",
+              "label": "Previously Shipped",
+              "bg": [38, 70, 130]
+            }
+          },
+          {
+            "type": "stat-banner",
+            "x": 660,
+            "y": 600,
+            "w": 580,
+            "h": 80,
+            "args": {
+              "value": "5 Years",
+              "label": "Crypto-Native Experience",
+              "bg": [110, 95, 75]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "slotIdx": 2,
+      "slotName": "what-we-do",
+      "slotTitle": "What We Do",
+      "sceneData": {
+        "name": "company-overview/what-we-do",
+        "layout": "grid",
+        "subjects": [
+          {
+            "type": "cover",
+            "x": 0,
+            "y": 0,
+            "w": 1280,
+            "h": 120,
+            "args": {
+              "title": "What We Do",
+              "style": "gradient"
+            }
+          },
+          {
+            "type": "icon-row",
+            "x": 40,
+            "y": 140,
+            "w": 1200,
+            "h": 200,
+            "args": {
+              "title": "Product Suite",
+              "items": [
+                {
+                  "icon": "wallet",
+                  "label": "Lightweight Wallet",
+                  "sublabel": "Mobile-first self-custodial"
+                },
+                {
+                  "icon": "chats-circle",
+                  "label": "Chat Module",
+                  "sublabel": "Social & alpha sharing"
+                },
+                {
+                  "icon": "lightning",
+                  "label": "Trading Acceleration",
+                  "sublabel": "Aggregated DEX routing"
+                }
+              ],
+              "iconStyle": "card",
+              "iconSize": "medium"
+            }
+          },
+          {
+            "type": "bullet-list",
+            "x": 40,
+            "y": 360,
+            "w": 580,
+            "h": 320,
+            "args": {
+              "title": "Competitive Advantages",
+              "items": [
+                {
+                  "icon": "gauge",
+                  "label": "Sub-second execution speed"
+                },
+                {
+                  "icon": "lock-key",
+                  "label": "Self-custodial without UX compromises"
+                },
+                {
+                  "icon": "brain",
+                  "label": "AI-native agents"
+                },
+                {
+                  "icon": "network",
+                  "label": "Network effects from social"
+                },
+                {
+                  "icon": "plugs",
+                  "label": "Open ecosystem for plugins"
+                },
+                {
+                  "icon": "shield-check",
+                  "label": "Audited by Trail of Bits"
+                }
+              ]
+            }
+          },
+          {
+            "type": "dashboard-multi-kpi-composite",
+            "x": 660,
+            "y": 360,
+            "w": 580,
+            "h": 320,
+            "args": {
+              "title": "Growth Metrics",
+              "kpis": [
+                {
+                  "value": "$300K",
+                  "label": "Daily Volume",
+                  "sublabel": "After 4 weeks",
+                  "trend": "up"
+                },
+                {
+                  "value": "12K",
+                  "label": "Monthly Wallets",
+                  "trend": "up"
+                },
+                {
+                  "value": "47%",
+                  "label": "WoW Growth",
+                  "trend": "up"
+                },
+                {
+                  "value": "92%",
+                  "label": "Day-30 Retention",
+                  "trend": "up"
+                },
+                {
+                  "value": "8 min",
+                  "label": "Avg Session",
+                  "sublabel": "3× industry norm",
+                  "trend": "up"
+                },
+                {
+                  "value": "72",
+                  "label": "NPS Score",
+                  "sublabel": "Top quartile crypto",
+                  "trend": "up"
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "slotIdx": 3,
+      "slotName": "products",
+      "slotTitle": "Products",
+      "sceneData": {
+        "name": "company-overview/products",
+        "layout": "grid",
+        "subjects": [
+          {
+            "type": "cover",
+            "x": 0,
+            "y": 0,
+            "w": 1280,
+            "h": 120,
+            "args": {
+              "title": "Products",
+              "style": "gradient"
+            }
+          },
+          {
+            "type": "icon-grid",
+            "x": 80,
+            "y": 180,
+            "w": 1120,
+            "h": 480,
+            "args": {
+              "items": [
+                {
+                  "icon": "key",
+                  "label": "Self-Custodial",
+                  "sublabel": "Browser-side keys + hardware wallet"
+                },
+                {
+                  "icon": "bridge",
+                  "label": "Multi-Chain",
+                  "sublabel": "Ethereum, Solana, Base, Arbitrum"
+                },
+                {
+                  "icon": "brain",
+                  "label": "OpenClaw AI",
+                  "sublabel": "On-device privacy + server power"
+                },
+                {
+                  "icon": "lock-key",
+                  "label": "E2E Encryption",
+                  "sublabel": "Signal protocol chat"
+                },
+                {
+                  "icon": "arrows-merge",
+                  "label": "DEX Routing",
+                  "sublabel": "Aggregator with MEV protection"
+                },
+                {
+                  "icon": "eye",
+                  "label": "Smart Money",
+                  "sublabel": "50K wallets tracked real-time"
+                }
+              ],
+              "cols": 3,
+              "iconStyle": "card",
+              "iconSize": "medium",
+              "colorMode": "auto"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "slotIdx": 4,
+      "slotName": "market",
+      "slotTitle": "Market",
+      "sceneData": {
+        "name": "company-overview/market",
+        "layout": "grid",
+        "subjects": [
+          {
+            "type": "cover",
+            "x": 0,
+            "y": 0,
+            "w": 1280,
+            "h": 120,
+            "args": {
+              "title": "Market",
+              "style": "gradient"
+            }
+          },
+          {
+            "type": "icon-grid",
+            "x": 40,
+            "y": 160,
+            "w": 580,
+            "h": 500,
+            "args": {
+              "title": "User Groups",
+              "items": [
+                {
+                  "icon": "lightning",
+                  "label": "Crypto Traders",
+                  "sublabel": "Frustrated by slow wallets"
+                },
+                {
+                  "icon": "gauge",
+                  "label": "DeFi Power Users",
+                  "sublabel": "Need unified UX"
+                },
+                {
+                  "icon": "users",
+                  "label": "Mainstream Users",
+                  "sublabel": "Want wallet + trading"
+                },
+                {
+                  "icon": "chart-line-up",
+                  "label": "Smart Money",
+                  "sublabel": "Follow on-chain alpha"
+                }
+              ],
+              "cols": 2,
+              "iconStyle": "card",
+              "iconSize": "medium",
+              "colorMode": "brand"
+            }
+          },
+          {
+            "type": "bullet-list",
+            "x": 660,
+            "y": 160,
+            "w": 580,
+            "h": 500,
+            "args": {
+              "title": "Core Differentiators",
+              "items": [
+                {
+                  "icon": "lightning",
+                  "label": "Sub-second order execution",
+                  "sublabel": "Aggregated DEXs"
+                },
+                {
+                  "icon": "brain",
+                  "label": "AI strategy automation",
+                  "sublabel": "Intelligent agents"
+                },
+                {
+                  "icon": "lock-key",
+                  "label": "Self-custodial speed",
+                  "sublabel": "No compromise"
+                },
+                {
+                  "icon": "chat-circle",
+                  "label": "Community alpha groups",
+                  "sublabel": "Embedded chat"
+                },
+                {
+                  "icon": "microphone",
+                  "label": "Live trading rooms",
+                  "sublabel": "Built-in audio"
+                },
+                {
+                  "icon": "code",
+                  "label": "Open API ecosystem",
+                  "sublabel": "Developer friendly"
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "slotIdx": 6,
+      "slotName": "team",
+      "slotTitle": "Team",
+      "sceneData": {
+        "name": "company-overview/team",
+        "layout": "stage",
+        "subjects": [
+          {
+            "type": "cover",
+            "x": 0,
+            "y": 0,
+            "w": 1280,
+            "h": 120,
+            "args": {
+              "title": "Team",
+              "style": "gradient"
+            }
+          },
+          {
+            "type": "icon-grid",
+            "x": 80,
+            "y": 180,
+            "w": 1120,
+            "h": 480,
+            "args": {
+              "title": "Strategic Capabilities",
+              "items": [
+                {
+                  "icon": "user-focus",
+                  "label": "User Persona",
+                  "sublabel": "Competitive positioning"
+                },
+                {
+                  "icon": "target",
+                  "label": "Market Gap",
+                  "sublabel": "Beyond For differentiation"
+                },
+                {
+                  "icon": "clock",
+                  "label": "1-2 Months",
+                  "sublabel": "Execution timeline"
+                },
+                {
+                  "icon": "brain",
+                  "label": "OpenClaw",
+                  "sublabel": "AI integration platform"
+                },
+                {
+                  "icon": "chats-circle",
+                  "label": "Agent Mentions",
+                  "sublabel": "Community features"
+                },
+                {
+                  "icon": "chart-line-up",
+                  "label": "4 Weeks",
+                  "sublabel": "Perp DEX launch"
+                },
+                {
+                  "icon": "currency-dollar",
+                  "label": "$300K Daily",
+                  "sublabel": "Self-built Perp DEX volume"
+                },
+                {
+                  "icon": "rocket-launch",
+                  "label": "Prototype Ready",
+                  "sublabel": "Smart money system"
+                }
+              ],
+              "cols": 4,
+              "iconStyle": "card",
+              "iconSize": "medium",
+              "colorMode": "auto"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "slotIdx": 7,
+      "slotName": "contact",
+      "slotTitle": "Get in Touch",
+      "sceneData": {
+        "name": "company-overview/contact",
+        "layout": "grid",
+        "subjects": [
+          {
+            "type": "cover",
+            "x": 0,
+            "y": 0,
+            "w": 1280,
+            "h": 120,
+            "args": {
+              "title": "Get in Touch",
+              "style": "gradient"
+            }
+          },
+          {
+            "type": "icon-row",
+            "x": 40,
+            "y": 160,
+            "w": 1200,
+            "h": 200,
+            "args": {
+              "items": [
+                {
+                  "icon": "envelope",
+                  "label": "Email",
+                  "sublabel": "team@antfun.io"
+                },
+                {
+                  "icon": "globe",
+                  "label": "Website",
+                  "sublabel": "antfun.io"
+                },
+                {
+                  "icon": "brand:telegram",
+                  "label": "Telegram",
+                  "sublabel": "@antfun-bot"
+                },
+                {
+                  "icon": "brand:discord",
+                  "label": "Discord",
+                  "sublabel": "Join community"
+                },
+                {
+                  "icon": "brand:x",
+                  "label": "Twitter Spaces",
+                  "sublabel": "Every Friday"
+                }
+              ],
+              "iconSize": "medium",
+              "iconStyle": "circle"
+            }
+          },
+          {
+            "type": "kpi-card",
+            "x": 40,
+            "y": 400,
+            "w": 280,
+            "h": 240,
+            "args": {
+              "value": "12K",
+              "label": "Community Members",
+              "sublabel": "Across all channels",
+              "icon": "users",
+              "style": "light"
+            }
+          },
+          {
+            "type": "bullet-list",
+            "x": 360,
+            "y": 400,
+            "w": 880,
+            "h": 240,
+            "args": {
+              "title": "Why Connect",
+              "items": [
+                {
+                  "icon": "rocket",
+                  "label": "Weekly releases + active feedback loop"
+                },
+                {
+                  "icon": "chat-circle",
+                  "label": "Direct founder access via Discord"
+                },
+                {
+                  "icon": "flask",
+                  "label": "Beta access for power users"
+                },
+                {
+                  "icon": "hand-coins",
+                  "label": "Revenue share for contributors"
+                },
+                {
+                  "icon": "code",
+                  "label": "Open-source SDK for developers"
+                },
+                {
+                  "icon": "chart-line",
+                  "label": "Real-time on-chain analytics dashboard"
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/sdf-js/examples/deck-handoff/ammo/eval-econ-news-2026.json
+++ b/sdf-js/examples/deck-handoff/ammo/eval-econ-news-2026.json
@@ -1,0 +1,440 @@
+{
+  "format": "atlas-deck",
+  "version": 1,
+  "title": "eval-econ-news-2026",
+  "theme": {
+    "id": "editorial-navy",
+    "label": "Editorial · Navy",
+    "macroCluster": "editorial",
+    "bg": [248, 246, 240],
+    "silhouetteColor": [22, 35, 70],
+    "accent": [38, 70, 130],
+    "colors": [
+      [38, 70, 130],
+      [110, 95, 75],
+      [165, 130, 90],
+      [200, 195, 180]
+    ],
+    "font": {
+      "heading": "Georgia, \"Source Serif Pro\", serif",
+      "body": "Inter, system-ui, sans-serif"
+    },
+    "featured": true
+  },
+  "scaffold": {
+    "id": "analysis-report",
+    "label": "Analysis Report"
+  },
+  "decor": null,
+  "shared": null,
+  "slots": [
+    {
+      "slotIdx": 0,
+      "slotName": "cover",
+      "slotTitle": "Title",
+      "sceneData": {
+        "name": "analysis-report/cover",
+        "layout": "cover",
+        "subjects": [
+          {
+            "type": "cover",
+            "x": 0,
+            "y": 0,
+            "w": 1280,
+            "h": 720,
+            "args": {
+              "title": "全球经济2026年中展望",
+              "subtitle": "摘录自国际机构与财经媒体报道",
+              "author": "国际货币基金组织 / 经合组织 / 世界银行综合观察",
+              "style": "gradient"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "slotIdx": 1,
+      "slotName": "scope",
+      "slotTitle": "Scope & Methodology",
+      "sceneData": {
+        "name": "analysis-report/scope",
+        "layout": "row",
+        "subjects": [
+          {
+            "type": "cover",
+            "x": 0,
+            "y": 0,
+            "w": 1280,
+            "h": 120,
+            "args": {
+              "title": "范围与方法论"
+            }
+          },
+          {
+            "type": "bullet-list",
+            "x": 80,
+            "y": 180,
+            "w": 520,
+            "h": 460,
+            "args": {
+              "title": "分析范围",
+              "items": [
+                {
+                  "icon": "globe-hemisphere-west",
+                  "label": "全球经济2026年中展望"
+                },
+                {
+                  "icon": "chart-line",
+                  "label": "宏观经济趋势与预测"
+                },
+                {
+                  "icon": "currency-dollar",
+                  "label": "各主要经济体表现"
+                }
+              ]
+            }
+          },
+          {
+            "type": "icon-grid",
+            "x": 680,
+            "y": 180,
+            "w": 520,
+            "h": 460,
+            "args": {
+              "title": "数据来源",
+              "items": [
+                {
+                  "icon": "bank",
+                  "label": "国际货币基金组织",
+                  "sublabel": "IMF"
+                },
+                {
+                  "icon": "buildings",
+                  "label": "经合组织",
+                  "sublabel": "OECD"
+                },
+                {
+                  "icon": "globe",
+                  "label": "世界银行",
+                  "sublabel": "World Bank"
+                },
+                {
+                  "icon": "newspaper",
+                  "label": "财经媒体报道"
+                }
+              ],
+              "cols": 2,
+              "iconStyle": "card",
+              "iconSize": "medium",
+              "colorMode": "auto"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "slotIdx": 2,
+      "slotName": "definition",
+      "slotTitle": "Context & Definition",
+      "sceneData": {
+        "name": "analysis-report/definition",
+        "layout": "grid",
+        "subjects": [
+          {
+            "type": "cover",
+            "x": 0,
+            "y": 0,
+            "w": 1280,
+            "h": 120,
+            "args": {
+              "title": "Context & Definition",
+              "style": "gradient"
+            }
+          },
+          {
+            "type": "kpi-card",
+            "x": 40,
+            "y": 160,
+            "w": 280,
+            "h": 240,
+            "args": {
+              "value": "3.3%",
+              "label": "IMF 2026全球增长",
+              "sublabel": "国际货币基金组织",
+              "style": "light",
+              "icon": "globe"
+            }
+          },
+          {
+            "type": "kpi-card",
+            "x": 340,
+            "y": 160,
+            "w": 280,
+            "h": 240,
+            "args": {
+              "value": "2.9%",
+              "label": "OECD中期预测",
+              "sublabel": "经合组织",
+              "style": "light",
+              "icon": "chart-line"
+            }
+          },
+          {
+            "type": "kpi-card",
+            "x": 640,
+            "y": 160,
+            "w": 280,
+            "h": 240,
+            "args": {
+              "value": "2.5%",
+              "label": "世界银行预测",
+              "sublabel": "最保守估计",
+              "style": "light",
+              "icon": "bank",
+              "trend": "down",
+              "trendValue": "警告"
+            }
+          },
+          {
+            "type": "kpi-card",
+            "x": 940,
+            "y": 160,
+            "w": 280,
+            "h": 240,
+            "args": {
+              "value": "3.2%",
+              "label": "IMF 2027全球增长",
+              "sublabel": "国际货币基金组织",
+              "style": "light",
+              "icon": "globe-stand"
+            }
+          },
+          {
+            "type": "bar",
+            "x": 40,
+            "y": 430,
+            "w": 1200,
+            "h": 250,
+            "args": {
+              "title": "2026年区域增长预测对比",
+              "values": [5, 1.1, 5.4],
+              "labels": ["中国", "欧元区", "低收入国家"],
+              "format": "percent",
+              "max": 6
+            }
+          }
+        ]
+      }
+    },
+    {
+      "slotIdx": 3,
+      "slotName": "data-findings",
+      "slotTitle": "Data & Findings",
+      "sceneData": {
+        "name": "analysis-report/data-findings",
+        "layout": "grid",
+        "subjects": [
+          {
+            "type": "cover",
+            "x": 0,
+            "y": 0,
+            "w": 1280,
+            "h": 100,
+            "args": {
+              "title": "数据与发现",
+              "style": "gradient"
+            }
+          },
+          {
+            "type": "kpi-card",
+            "x": 40,
+            "y": 140,
+            "w": 280,
+            "h": 220,
+            "args": {
+              "value": "3.3%",
+              "label": "国际货币基金组织",
+              "sublabel": "2026年全球增长预期",
+              "icon": "globe",
+              "style": "light"
+            }
+          },
+          {
+            "type": "kpi-card",
+            "x": 340,
+            "y": 140,
+            "w": 280,
+            "h": 220,
+            "args": {
+              "value": "2.9%",
+              "label": "经合组织",
+              "sublabel": "全球GDP增速预测",
+              "icon": "chart-line",
+              "style": "light"
+            }
+          },
+          {
+            "type": "kpi-card",
+            "x": 640,
+            "y": 140,
+            "w": 280,
+            "h": 220,
+            "args": {
+              "value": "2.5%",
+              "label": "世界银行",
+              "sublabel": "保守预测",
+              "icon": "trend-down",
+              "style": "light",
+              "trend": "down",
+              "trendValue": "最弱增长"
+            }
+          },
+          {
+            "type": "kpi-card",
+            "x": 960,
+            "y": 140,
+            "w": 280,
+            "h": 220,
+            "args": {
+              "value": "3.2%",
+              "label": "国际货币基金组织",
+              "sublabel": "2027年全球增长预期",
+              "icon": "calendar",
+              "style": "light"
+            }
+          },
+          {
+            "type": "bar",
+            "x": 40,
+            "y": 390,
+            "w": 1200,
+            "h": 290,
+            "args": {
+              "title": "2026年分地区实际GDP增长预测",
+              "values": [5, 5.4, 1.1],
+              "labels": ["中国", "低收入国家", "欧元区"],
+              "format": "percent",
+              "max": 6
+            }
+          }
+        ]
+      }
+    },
+    {
+      "slotIdx": 4,
+      "slotName": "framework-analysis",
+      "slotTitle": "Framework Analysis",
+      "sceneData": {
+        "name": "analysis-report/framework-analysis",
+        "layout": "grid",
+        "subjects": [
+          {
+            "type": "cover",
+            "x": 0,
+            "y": 0,
+            "w": 1280,
+            "h": 120,
+            "args": {
+              "title": "Framework Analysis",
+              "style": "gradient"
+            }
+          },
+          {
+            "type": "risk-heatmap",
+            "x": 40,
+            "y": 160,
+            "w": 1200,
+            "h": 520,
+            "args": {
+              "title": "主要风险评估",
+              "xAxis": "发生概率",
+              "yAxis": "冲击程度",
+              "xLabels": ["低", "中低", "中等", "中高", "高"],
+              "yLabels": ["低", "中低", "中等", "中高", "深"],
+              "risks": [
+                {
+                  "id": "energy-crisis",
+                  "label": "霍尔木兹海峡航运中断",
+                  "likelihood": 5,
+                  "impact": 5,
+                  "severity": "critical"
+                },
+                {
+                  "id": "inflation",
+                  "label": "能源价格激增·通胀重新抬头",
+                  "likelihood": 5,
+                  "impact": 4,
+                  "severity": "high"
+                },
+                {
+                  "id": "tech-investment",
+                  "label": "科技投资持续性不确定",
+                  "likelihood": 3,
+                  "impact": 3,
+                  "severity": "medium"
+                },
+                {
+                  "id": "employment",
+                  "label": "就业市场超预期走弱",
+                  "likelihood": 3,
+                  "impact": 3,
+                  "severity": "medium"
+                },
+                {
+                  "id": "market-valuation",
+                  "label": "金融市场估值回调",
+                  "likelihood": 2,
+                  "impact": 4,
+                  "severity": "medium"
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "slotIdx": 5,
+      "slotName": "interpretation",
+      "slotTitle": "Interpretation",
+      "sceneData": {
+        "name": "analysis-report/interpretation",
+        "layout": "row",
+        "subjects": [
+          {
+            "type": "cover",
+            "x": 0,
+            "y": 0,
+            "w": 1280,
+            "h": 120,
+            "args": {
+              "title": "货币政策路径",
+              "style": "gradient"
+            }
+          },
+          {
+            "type": "balance-scale",
+            "x": 80,
+            "y": 180,
+            "w": 1120,
+            "h": 480,
+            "args": {
+              "title": "降息路径预测",
+              "leftLabel": "近期预期",
+              "rightLabel": "中期前景",
+              "leftItems": ["美联储4月前继续降息", "前提：就业增长放缓", "核心通胀涨幅温和"],
+              "rightItems": [
+                "政策利率降至3%-3.25%",
+                "进入较长观望期",
+                "美联储、英国央行、欧洲央行均有空间"
+              ],
+              "leftAccent": "rgb(38, 70, 130)",
+              "rightAccent": "rgb(110, 95, 75)",
+              "verdict": "多数主要经济体通胀持续回落"
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/sdf-js/examples/deck-handoff/ammo/eval-edu-course-intro.json
+++ b/sdf-js/examples/deck-handoff/ammo/eval-edu-course-intro.json
@@ -1,0 +1,466 @@
+{
+  "format": "atlas-deck",
+  "version": 1,
+  "title": "eval-edu-course-intro",
+  "theme": {
+    "id": "editorial-navy",
+    "label": "Editorial · Navy",
+    "macroCluster": "editorial",
+    "bg": [248, 246, 240],
+    "silhouetteColor": [22, 35, 70],
+    "accent": [38, 70, 130],
+    "colors": [
+      [38, 70, 130],
+      [110, 95, 75],
+      [165, 130, 90],
+      [200, 195, 180]
+    ],
+    "font": {
+      "heading": "Georgia, \"Source Serif Pro\", serif",
+      "body": "Inter, system-ui, sans-serif"
+    },
+    "featured": true
+  },
+  "scaffold": {
+    "id": "course-syllabus",
+    "label": "Course Syllabus"
+  },
+  "decor": null,
+  "shared": null,
+  "slots": [
+    {
+      "slotIdx": 0,
+      "slotName": "cover",
+      "slotTitle": "Course Title",
+      "sceneData": {
+        "name": "course-syllabus/cover",
+        "layout": "cover",
+        "subjects": [
+          {
+            "type": "cover",
+            "x": 0,
+            "y": 0,
+            "w": 1280,
+            "h": 720,
+            "args": {
+              "title": "CS 340: Distributed Systems",
+              "subtitle": "Fall 2026 · Department of Computer Science",
+              "author": "Instructor: Prof. Elena Vasquez",
+              "date": "Meets Tue/Thu 2:00-3:30pm, Room 220",
+              "style": "gradient"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "slotIdx": 1,
+      "slotName": "overview",
+      "slotTitle": "Course Overview",
+      "sceneData": {
+        "name": "course-syllabus/overview",
+        "layout": "grid",
+        "subjects": [
+          {
+            "type": "cover",
+            "x": 0,
+            "y": 0,
+            "w": 1280,
+            "h": 120,
+            "args": {
+              "title": "Course Overview",
+              "style": "gradient"
+            }
+          },
+          {
+            "type": "bullet-list",
+            "x": 60,
+            "y": 160,
+            "w": 560,
+            "h": 500,
+            "args": {
+              "title": "What You'll Learn",
+              "items": [
+                {
+                  "icon": "network",
+                  "label": "Distributed systems theory & practice"
+                },
+                {
+                  "icon": "circuitry",
+                  "label": "Consensus algorithms & replication"
+                },
+                {
+                  "icon": "chart-scatter",
+                  "label": "Partitioning & consistency models"
+                },
+                {
+                  "icon": "shield-check",
+                  "label": "Fault tolerance strategies"
+                }
+              ]
+            }
+          },
+          {
+            "type": "icon-grid",
+            "x": 660,
+            "y": 160,
+            "w": 560,
+            "h": 240,
+            "args": {
+              "title": "Course Format",
+              "items": [
+                {
+                  "icon": "presentation-chart",
+                  "label": "2 Lectures",
+                  "sublabel": "Per week"
+                },
+                {
+                  "icon": "flask",
+                  "label": "Weekly Lab",
+                  "sublabel": "Hands-on practice"
+                },
+                {
+                  "icon": "users-three",
+                  "label": "Group Project",
+                  "sublabel": "1 semester-long"
+                }
+              ],
+              "cols": 3,
+              "iconStyle": "card",
+              "iconSize": "medium"
+            }
+          },
+          {
+            "type": "bullet-list",
+            "x": 660,
+            "y": 440,
+            "w": 560,
+            "h": 220,
+            "args": {
+              "title": "Prerequisites",
+              "items": [
+                {
+                  "icon": "cpu",
+                  "label": "CS 240 Operating Systems"
+                },
+                {
+                  "icon": "code",
+                  "label": "Proficiency in Go or Rust"
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "slotIdx": 2,
+      "slotName": "objectives",
+      "slotTitle": "Learning Objectives",
+      "sceneData": {
+        "name": "course-syllabus/objectives",
+        "layout": "row",
+        "subjects": [
+          {
+            "type": "cover",
+            "x": 0,
+            "y": 0,
+            "w": 1280,
+            "h": 120,
+            "args": {
+              "title": "Learning Objectives",
+              "style": "gradient"
+            }
+          },
+          {
+            "type": "number-list",
+            "x": 80,
+            "y": 160,
+            "w": 1120,
+            "h": 520,
+            "args": {
+              "items": [
+                {
+                  "label": "Explain CAP theorem tradeoffs",
+                  "sublabel": "Apply to real system designs"
+                },
+                {
+                  "label": "Implement Raft consensus module",
+                  "sublabel": "Working implementation from scratch"
+                },
+                {
+                  "label": "Diagnose split-brain failure modes",
+                  "sublabel": "Network partition scenarios"
+                },
+                {
+                  "label": "Design sharded replicated store",
+                  "sublabel": "Under failure conditions"
+                },
+                {
+                  "label": "Critique distributed systems papers",
+                  "sublabel": "3 seminal research publications"
+                }
+              ],
+              "numberStyle": "circle",
+              "numberColor": "rgb(38, 70, 130)"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "slotIdx": 3,
+      "slotName": "schedule",
+      "slotTitle": "Schedule",
+      "sceneData": {
+        "name": "course-syllabus/schedule",
+        "layout": "row",
+        "subjects": [
+          {
+            "type": "cover",
+            "x": 0,
+            "y": 0,
+            "w": 1280,
+            "h": 120,
+            "args": {
+              "title": "Schedule",
+              "style": "gradient"
+            }
+          },
+          {
+            "type": "vertical-timeline",
+            "x": 80,
+            "y": 160,
+            "w": 1120,
+            "h": 520,
+            "args": {
+              "events": [
+                {
+                  "date": "Week 1-2",
+                  "label": "Networking fundamentals + RPC"
+                },
+                {
+                  "date": "Week 3-4",
+                  "label": "Replication and consistency models"
+                },
+                {
+                  "date": "Week 5-6",
+                  "label": "Consensus — Paxos and Raft"
+                },
+                {
+                  "date": "Week 7-8",
+                  "label": "Partitioning and sharding"
+                },
+                {
+                  "date": "Week 9-10",
+                  "label": "Fault tolerance and failure detection"
+                },
+                {
+                  "date": "Week 11-12",
+                  "label": "Distributed transactions"
+                },
+                {
+                  "date": "Week 13-14",
+                  "label": "Case studies — Spanner, DynamoDB, Kafka"
+                },
+                {
+                  "date": "Week 15",
+                  "label": "Final project presentations"
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "slotIdx": 4,
+      "slotName": "grading",
+      "slotTitle": "Grading",
+      "sceneData": {
+        "name": "course-syllabus/grading",
+        "layout": "stage",
+        "subjects": [
+          {
+            "type": "cover",
+            "x": 0,
+            "y": 0,
+            "w": 1280,
+            "h": 120,
+            "args": {
+              "title": "Grading"
+            }
+          },
+          {
+            "type": "donut-with-center",
+            "x": 140,
+            "y": 180,
+            "w": 1000,
+            "h": 480,
+            "args": {
+              "centerValue": "100%",
+              "centerLabel": "Final Grade",
+              "segments": [
+                {
+                  "label": "Group Project · 35%",
+                  "value": 35,
+                  "color": [38, 70, 130]
+                },
+                {
+                  "label": "Weekly Labs · 25%",
+                  "value": 25,
+                  "color": [110, 95, 75]
+                },
+                {
+                  "label": "Midterm Exam · 20%",
+                  "value": 20,
+                  "color": [165, 130, 90]
+                },
+                {
+                  "label": "Final Exam · 15%",
+                  "value": 15,
+                  "color": [200, 195, 180]
+                },
+                {
+                  "label": "Participation · 5%",
+                  "value": 5,
+                  "color": [150, 145, 130]
+                }
+              ],
+              "showPct": true
+            }
+          }
+        ]
+      }
+    },
+    {
+      "slotIdx": 5,
+      "slotName": "materials",
+      "slotTitle": "Materials",
+      "sceneData": {
+        "name": "course-syllabus/materials",
+        "layout": "row",
+        "subjects": [
+          {
+            "type": "cover",
+            "x": 0,
+            "y": 0,
+            "w": 1280,
+            "h": 120,
+            "args": {
+              "title": "Materials",
+              "style": "gradient"
+            }
+          },
+          {
+            "type": "bullet-list",
+            "x": 80,
+            "y": 180,
+            "w": 1120,
+            "h": 480,
+            "args": {
+              "title": "Required Reading",
+              "items": [
+                {
+                  "icon": "book-open",
+                  "label": "Designing Data-Intensive Applications",
+                  "sublabel": "Martin Kleppmann (primary textbook)"
+                },
+                {
+                  "icon": "file-text",
+                  "label": "Raft Consensus Algorithm",
+                  "sublabel": "Ongaro & Ousterhout"
+                },
+                {
+                  "icon": "file-text",
+                  "label": "Google File System",
+                  "sublabel": "Ghemawat, Gobioff, Leung"
+                },
+                {
+                  "icon": "file-text",
+                  "label": "Dynamo Key-Value Store",
+                  "sublabel": "DeCandia et al."
+                },
+                {
+                  "icon": "calendar-check",
+                  "label": "Weekly Paper Summaries",
+                  "sublabel": "Posted before Thursday lectures"
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "slotIdx": 6,
+      "slotName": "logistics",
+      "slotTitle": "Logistics & Support",
+      "sceneData": {
+        "name": "course-syllabus/logistics",
+        "layout": "grid",
+        "subjects": [
+          {
+            "type": "cover",
+            "x": 0,
+            "y": 0,
+            "w": 1280,
+            "h": 120,
+            "args": {
+              "title": "Logistics & Support",
+              "style": "gradient"
+            }
+          },
+          {
+            "type": "icon-grid",
+            "x": 40,
+            "y": 160,
+            "w": 1200,
+            "h": 360,
+            "args": {
+              "title": "Office Hours",
+              "items": [
+                {
+                  "icon": "user-circle",
+                  "label": "Prof. Vasquez",
+                  "sublabel": "Mon 10am-12pm, Wed 3-4pm · CS 412"
+                },
+                {
+                  "icon": "chalkboard-teacher",
+                  "label": "TA Jordan Kim",
+                  "sublabel": "Tue/Thu 4-5:30pm · CS Lab 105"
+                },
+                {
+                  "icon": "chalkboard-teacher",
+                  "label": "TA Priya Nair",
+                  "sublabel": "Fri 1-3pm · CS Lab 105"
+                },
+                {
+                  "icon": "brand:discord",
+                  "label": "Discord Channel",
+                  "sublabel": "Async help · <24hr response target"
+                }
+              ],
+              "cols": 2,
+              "iconStyle": "card",
+              "iconSize": "medium",
+              "colorMode": "auto"
+            }
+          },
+          {
+            "type": "quote-pull",
+            "x": 80,
+            "y": 540,
+            "w": 1120,
+            "h": 140,
+            "args": {
+              "quote": "Office hours saved me during the Raft implementation — the TAs actually debug with you line by line.",
+              "attribution": "Student course evaluation, Spring 2026",
+              "align": "center"
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/sdf-js/examples/deck-handoff/ammo/eval-funding-round.json
+++ b/sdf-js/examples/deck-handoff/ammo/eval-funding-round.json
@@ -1,0 +1,534 @@
+{
+  "format": "atlas-deck",
+  "version": 1,
+  "title": "eval-funding-round",
+  "theme": {
+    "id": "financial-navy-cerulean",
+    "label": "Financial Navy",
+    "macroCluster": "pitch",
+    "bg": [26, 40, 66],
+    "silhouetteColor": [240, 248, 255],
+    "accent": [58, 138, 200],
+    "colors": [
+      [58, 138, 200],
+      [26, 40, 66],
+      [100, 150, 200],
+      [180, 210, 235],
+      [240, 248, 255]
+    ],
+    "font": {
+      "heading": "\"Inter Display\", Inter, system-ui, sans-serif",
+      "body": "Inter, system-ui, sans-serif"
+    },
+    "featured": true
+  },
+  "scaffold": {
+    "id": "investor-update",
+    "label": "Investor Update"
+  },
+  "decor": null,
+  "shared": null,
+  "slots": [
+    {
+      "slotIdx": 0,
+      "slotName": "cover",
+      "slotTitle": "Title",
+      "sceneData": {
+        "name": "investor-update/cover",
+        "layout": "cover",
+        "subjects": [
+          {
+            "type": "cover",
+            "x": 0,
+            "y": 0,
+            "w": 1280,
+            "h": 720,
+            "args": {
+              "title": "Redo Announces $81 Million Series B to Support Commerce Technology Expansion",
+              "subtitle": "Series B financing announcement · Commerce technology platform",
+              "author": "Draper, Utah",
+              "date": "June 23, 2026",
+              "style": "gradient"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "slotIdx": 1,
+      "slotName": "tldr",
+      "slotTitle": "TL;DR",
+      "sceneData": {
+        "name": "investor-update/tldr",
+        "layout": "grid",
+        "subjects": [
+          {
+            "type": "cover",
+            "x": 0,
+            "y": 0,
+            "w": 1280,
+            "h": 120,
+            "args": {
+              "title": "TL;DR",
+              "style": "gradient"
+            }
+          },
+          {
+            "type": "quote-pull",
+            "x": 40,
+            "y": 160,
+            "w": 580,
+            "h": 240,
+            "args": {
+              "quote": "Every merchant is fighting to own the relationship with their shoppers",
+              "author": "Sterling Snow",
+              "attribution": "Co-founder and CEO",
+              "align": "left"
+            }
+          },
+          {
+            "type": "stat-banner",
+            "x": 660,
+            "y": 160,
+            "w": 580,
+            "h": 240,
+            "args": {
+              "value": "AI-Driven Personalization",
+              "label": "Agentic shopping + marketing agents",
+              "bg": [58, 138, 200]
+            }
+          },
+          {
+            "type": "pillar-3up",
+            "x": 40,
+            "y": 440,
+            "w": 1200,
+            "h": 240,
+            "args": {
+              "pillars": [
+                {
+                  "icon": "rocket-launch",
+                  "heading": "Platform Evolution",
+                  "body": "Expanded from post-purchase trust into comprehensive shopper relationship infrastructure",
+                  "accent": [58, 138, 200]
+                },
+                {
+                  "icon": "brain",
+                  "heading": "AI Agents",
+                  "body": "Personalized email, text campaigns, and tailored shopping experiences per individual",
+                  "accent": [100, 150, 200]
+                },
+                {
+                  "icon": "currency-dollar",
+                  "heading": "Funding Acceleration",
+                  "body": "Strategic capital to build infrastructure brands need to own customer relationships",
+                  "accent": [180, 210, 235]
+                }
+              ],
+              "accentLine": true
+            }
+          }
+        ]
+      }
+    },
+    {
+      "slotIdx": 2,
+      "slotName": "metrics",
+      "slotTitle": "Key Metrics",
+      "sceneData": {
+        "name": "investor-update/metrics",
+        "layout": "row",
+        "subjects": [
+          {
+            "type": "cover",
+            "x": 0,
+            "y": 0,
+            "w": 1280,
+            "h": 120,
+            "args": {
+              "title": "Key Metrics",
+              "style": "gradient"
+            }
+          },
+          {
+            "type": "donut-with-center",
+            "x": 80,
+            "y": 200,
+            "w": 500,
+            "h": 440,
+            "args": {
+              "title": "Platform Adoption",
+              "centerValue": "4,100",
+              "centerLabel": "Total Brands",
+              "segments": [
+                {
+                  "label": "Single Product · 2,350",
+                  "value": 2350,
+                  "color": [58, 138, 200]
+                },
+                {
+                  "label": "Multi-Product · 1,750",
+                  "value": 1750,
+                  "color": [100, 150, 200]
+                }
+              ],
+              "showPct": true
+            }
+          },
+          {
+            "type": "kpi-card",
+            "x": 660,
+            "y": 200,
+            "w": 540,
+            "h": 200,
+            "args": {
+              "value": "1,750",
+              "label": "Multi-Product Merchants",
+              "sublabel": "Cross-platform engagement",
+              "icon": "briefcase",
+              "style": "light"
+            }
+          },
+          {
+            "type": "kpi-card",
+            "x": 660,
+            "y": 440,
+            "w": 540,
+            "h": 200,
+            "args": {
+              "value": "43%",
+              "label": "Suite Adoption Rate",
+              "sublabel": "1,750 of 4,100 brands",
+              "icon": "chart-pie",
+              "trend": "up",
+              "style": "light"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "slotIdx": 3,
+      "slotName": "wins",
+      "slotTitle": "Wins",
+      "sceneData": {
+        "name": "investor-update/wins",
+        "layout": "row",
+        "subjects": [
+          {
+            "type": "cover",
+            "x": 0,
+            "y": 0,
+            "w": 1280,
+            "h": 120,
+            "args": {
+              "title": "Wins",
+              "style": "gradient"
+            }
+          },
+          {
+            "type": "icon-grid",
+            "x": 40,
+            "y": 160,
+            "w": 1200,
+            "h": 500,
+            "args": {
+              "items": [
+                {
+                  "icon": "handshake",
+                  "label": "ReturnBear Acquisition",
+                  "sublabel": "Announced strategic acquisition"
+                },
+                {
+                  "icon": "globe-hemisphere-west",
+                  "label": "100+ Countries",
+                  "sublabel": "Returns servicing coverage extended"
+                },
+                {
+                  "icon": "network",
+                  "label": "International Infrastructure",
+                  "sublabel": "Significantly expanded returns network"
+                }
+              ],
+              "cols": 3,
+              "iconStyle": "card",
+              "iconSize": "large",
+              "colorMode": "auto"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "slotIdx": 4,
+      "slotName": "challenges",
+      "slotTitle": "Challenges",
+      "sceneData": {
+        "name": "investor-update/challenges",
+        "layout": "row",
+        "subjects": [
+          {
+            "type": "cover",
+            "x": 0,
+            "y": 0,
+            "w": 1280,
+            "h": 120,
+            "args": {
+              "title": "Challenges",
+              "style": "gradient"
+            }
+          },
+          {
+            "type": "fishbone",
+            "x": 40,
+            "y": 160,
+            "w": 1200,
+            "h": 520,
+            "args": {
+              "effect": "Returns Network Scaling",
+              "branches": [
+                {
+                  "label": "Infrastructure",
+                  "causes": [
+                    "Local processing nodes",
+                    "Inspection facilities",
+                    "Refurbishment capacity"
+                  ]
+                },
+                {
+                  "label": "Operations",
+                  "causes": [
+                    "Inventory recovery time",
+                    "Re-fulfillment logistics",
+                    "Quality control standards"
+                  ]
+                },
+                {
+                  "label": "Network",
+                  "causes": [
+                    "Geographic coverage gaps",
+                    "Partner integration",
+                    "Customer access points"
+                  ]
+                },
+                {
+                  "label": "Efficiency",
+                  "causes": ["Process optimization", "Turnaround speed", "Cost per unit"]
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "slotIdx": 5,
+      "slotName": "next-quarter",
+      "slotTitle": "Next Quarter",
+      "sceneData": {
+        "name": "investor-update/next-quarter",
+        "layout": "grid",
+        "subjects": [
+          {
+            "type": "cover",
+            "x": 0,
+            "y": 0,
+            "w": 1280,
+            "h": 120,
+            "args": {
+              "title": "Next Quarter",
+              "style": "gradient"
+            }
+          },
+          {
+            "type": "kanban-board",
+            "x": 40,
+            "y": 160,
+            "w": 1200,
+            "h": 520,
+            "args": {
+              "title": "Q4 Priorities",
+              "columns": [
+                {
+                  "name": "Platform Evolution",
+                  "cards": [
+                    {
+                      "label": "Transition to comprehensive commerce platform",
+                      "sublabel": "Post-purchase specialist evolution"
+                    },
+                    {
+                      "label": "Multi-product adoption strategy",
+                      "sublabel": "Network effects activation"
+                    }
+                  ]
+                },
+                {
+                  "name": "International Expansion",
+                  "cards": [
+                    {
+                      "label": "Global merchant network scaling",
+                      "sublabel": "ReturnBear acquisition integration"
+                    },
+                    {
+                      "label": "Beyond domestic market reach",
+                      "sublabel": "Returns infrastructure extension"
+                    }
+                  ]
+                },
+                {
+                  "name": "AI Development",
+                  "cards": [
+                    {
+                      "label": "Three AI product initiatives",
+                      "sublabel": "Personalization and automation focus"
+                    },
+                    {
+                      "label": "AI-driven commerce tools",
+                      "sublabel": "Product roadmap execution"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "slotIdx": 6,
+      "slotName": "ask",
+      "slotTitle": "Ask",
+      "sceneData": {
+        "name": "investor-update/ask",
+        "layout": "stage",
+        "subjects": [
+          {
+            "type": "cover",
+            "x": 0,
+            "y": 0,
+            "w": 1280,
+            "h": 120,
+            "args": {
+              "title": "Ask",
+              "style": "gradient"
+            }
+          },
+          {
+            "type": "icon-row",
+            "x": 40,
+            "y": 180,
+            "w": 1200,
+            "h": 480,
+            "args": {
+              "items": [
+                {
+                  "icon": "handshake",
+                  "label": "Strategic Intros",
+                  "sublabel": "E-commerce brands seeking post-purchase solutions"
+                },
+                {
+                  "icon": "users",
+                  "label": "Hiring Support",
+                  "sublabel": "Product and engineering talent referrals"
+                },
+                {
+                  "icon": "lightbulb",
+                  "label": "Retention Expertise",
+                  "sublabel": "Advice on scaling customer lifetime value"
+                }
+              ],
+              "iconSize": "large",
+              "iconStyle": "circle",
+              "colorMode": "auto"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "slotIdx": 7,
+      "slotName": "cap-table-burn",
+      "slotTitle": "Financials",
+      "sceneData": {
+        "name": "investor-update/cap-table-burn",
+        "layout": "grid",
+        "subjects": [
+          {
+            "type": "cover",
+            "x": 0,
+            "y": 0,
+            "w": 1280,
+            "h": 120,
+            "args": {
+              "title": "Financials",
+              "style": "gradient"
+            }
+          },
+          {
+            "type": "kpi-card",
+            "x": 40,
+            "y": 180,
+            "w": 380,
+            "h": 220,
+            "args": {
+              "value": "$81M",
+              "label": "Series B Financing",
+              "icon": "currency-dollar",
+              "style": "light"
+            }
+          },
+          {
+            "type": "kpi-card",
+            "x": 450,
+            "y": 180,
+            "w": 380,
+            "h": 220,
+            "args": {
+              "value": "$1.25B",
+              "label": "Valuation",
+              "icon": "chart-line-up",
+              "style": "light"
+            }
+          },
+          {
+            "type": "kpi-card",
+            "x": 860,
+            "y": 180,
+            "w": 380,
+            "h": 220,
+            "args": {
+              "value": "Smash Capital",
+              "label": "Lead Investor",
+              "icon": "handshake",
+              "style": "light"
+            }
+          },
+          {
+            "type": "bullet-list",
+            "x": 40,
+            "y": 440,
+            "w": 1200,
+            "h": 220,
+            "args": {
+              "title": "Investor Participation",
+              "items": [
+                {
+                  "icon": "users",
+                  "label": "Smash Capital (lead investor)"
+                },
+                {
+                  "icon": "briefcase",
+                  "label": "Pelion Venture Partners (existing)"
+                },
+                {
+                  "icon": "briefcase",
+                  "label": "Cervin Ventures (existing)"
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/sdf-js/examples/deck-handoff/ammo/eval-news-econ.json
+++ b/sdf-js/examples/deck-handoff/ammo/eval-news-econ.json
@@ -1,0 +1,770 @@
+{
+  "format": "atlas-deck",
+  "version": 1,
+  "title": "eval-news-econ",
+  "theme": {
+    "id": "editorial-navy",
+    "label": "Editorial · Navy",
+    "macroCluster": "editorial",
+    "bg": [248, 246, 240],
+    "silhouetteColor": [22, 35, 70],
+    "accent": [38, 70, 130],
+    "colors": [
+      [38, 70, 130],
+      [110, 95, 75],
+      [165, 130, 90],
+      [200, 195, 180]
+    ],
+    "font": {
+      "heading": "Georgia, \"Source Serif Pro\", serif",
+      "body": "Inter, system-ui, sans-serif"
+    },
+    "featured": true
+  },
+  "scaffold": {
+    "id": "news-briefing",
+    "label": "News Briefing"
+  },
+  "decor": null,
+  "shared": null,
+  "slots": [
+    {
+      "slotIdx": 0,
+      "slotName": "cover",
+      "slotTitle": "Headline",
+      "sceneData": {
+        "name": "news-briefing/cover",
+        "layout": "cover",
+        "subjects": [
+          {
+            "type": "cover",
+            "x": 0,
+            "y": 0,
+            "w": 1280,
+            "h": 720,
+            "args": {
+              "title": "全球经济2026年中展望",
+              "subtitle": "摘录自国际机构与财经媒体报道",
+              "author": "覆盖全球增长预测、区域表现、货币政策与主要风险",
+              "style": "gradient"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "slotIdx": 1,
+      "slotName": "agenda",
+      "slotTitle": "Overview",
+      "sceneData": {
+        "name": "news-briefing/agenda",
+        "layout": "row",
+        "subjects": [
+          {
+            "type": "cover",
+            "x": 0,
+            "y": 0,
+            "w": 1280,
+            "h": 120,
+            "args": {
+              "title": "核心议题概览",
+              "style": "gradient"
+            }
+          },
+          {
+            "type": "agenda-list",
+            "x": 80,
+            "y": 160,
+            "w": 1120,
+            "h": 520,
+            "args": {
+              "items": [
+                {
+                  "label": "三大国际机构2026-2027预测差异",
+                  "sublabel": "经合组织中期展望稳定在2.9%，较IMF更为保守"
+                },
+                {
+                  "label": "主要经济体增长分化格局",
+                  "sublabel": "欧元区1.1%温和增长，低收入国家5.4%增速最快"
+                },
+                {
+                  "label": "美联储等央行货币政策调整路径"
+                },
+                {
+                  "label": "四类风险评估",
+                  "sublabel": "中东冲突、科技投资、就业市场下行、金融市场估值回调"
+                }
+              ],
+              "numbered": true,
+              "style": "showcase"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "slotIdx": 2,
+      "slotName": "key-figures",
+      "slotTitle": "Key Figures",
+      "sceneData": {
+        "name": "news-briefing/key-figures",
+        "layout": "grid",
+        "subjects": [
+          {
+            "type": "cover",
+            "x": 0,
+            "y": 0,
+            "w": 1280,
+            "h": 120,
+            "args": {
+              "title": "关键数据",
+              "style": "gradient"
+            }
+          },
+          {
+            "type": "stat-grid-large",
+            "x": 80,
+            "y": 200,
+            "w": 1120,
+            "h": 420,
+            "args": {
+              "title": "国际货币基金组织增长预测",
+              "stats": [
+                {
+                  "value": "3.3%",
+                  "label": "2026年全球增长预期",
+                  "trend": "《世界经济展望》"
+                },
+                {
+                  "value": "3.2%",
+                  "label": "2027年全球增长预期",
+                  "trend": "中期温和扩张"
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "slotIdx": 3,
+      "slotName": "theme-1-lead",
+      "slotTitle": "Theme 1 — Lead",
+      "sceneData": {
+        "name": "news-briefing/theme-1-lead",
+        "layout": "grid",
+        "subjects": [
+          {
+            "type": "cover",
+            "x": 0,
+            "y": 0,
+            "w": 1280,
+            "h": 120,
+            "args": {
+              "title": "国际货币基金组织增长预测",
+              "style": "gradient"
+            }
+          },
+          {
+            "type": "kpi-card",
+            "x": 80,
+            "y": 200,
+            "w": 480,
+            "h": 400,
+            "args": {
+              "value": "3.3%",
+              "label": "2026年全球增长",
+              "sublabel": "《世界经济展望》",
+              "icon": "chart-line-up",
+              "style": "dark"
+            }
+          },
+          {
+            "type": "kpi-card",
+            "x": 720,
+            "y": 200,
+            "w": 480,
+            "h": 400,
+            "args": {
+              "value": "3.2%",
+              "label": "2027年全球增长",
+              "sublabel": "中期温和扩张",
+              "icon": "globe",
+              "style": "light"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "slotIdx": 4,
+      "slotName": "theme-1-detail",
+      "slotTitle": "Theme 1 — Detail",
+      "sceneData": {
+        "name": "news-briefing/theme-1-detail",
+        "layout": "row",
+        "subjects": [
+          {
+            "type": "cover",
+            "x": 0,
+            "y": 0,
+            "w": 1280,
+            "h": 120,
+            "args": {
+              "title": "中国经济增长预期",
+              "style": "gradient"
+            }
+          },
+          {
+            "type": "kpi-card",
+            "x": 80,
+            "y": 200,
+            "w": 340,
+            "h": 420,
+            "args": {
+              "value": "5%",
+              "label": "2026年实际GDP增长",
+              "sublabel": "中国",
+              "icon": "chart-line-up",
+              "style": "dark",
+              "trend": "up",
+              "trendValue": "领先"
+            }
+          },
+          {
+            "type": "stat-with-icon",
+            "x": 480,
+            "y": 200,
+            "w": 340,
+            "h": 200,
+            "args": {
+              "value": "领先",
+              "label": "主要经济体中",
+              "sublabel": "增速排名",
+              "icon": "trophy",
+              "iconColor": "rgb(38, 70, 130)"
+            }
+          },
+          {
+            "type": "stat-with-icon",
+            "x": 480,
+            "y": 420,
+            "w": 340,
+            "h": 200,
+            "args": {
+              "value": "重要",
+              "label": "全球增长动力",
+              "sublabel": "贡献来源",
+              "icon": "globe-hemisphere-west",
+              "iconColor": "rgb(38, 70, 130)"
+            }
+          },
+          {
+            "type": "icon-badge",
+            "x": 880,
+            "y": 260,
+            "w": 280,
+            "h": 300,
+            "args": {
+              "name": "chart-bar",
+              "label": "经济增长",
+              "color": [38, 70, 130]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "slotIdx": 5,
+      "slotName": "theme-2-lead",
+      "slotTitle": "Theme 2 — Lead",
+      "sceneData": {
+        "name": "news-briefing/theme-2-lead",
+        "layout": "stage",
+        "subjects": [
+          {
+            "type": "cover",
+            "x": 0,
+            "y": 0,
+            "w": 1280,
+            "h": 120,
+            "args": {
+              "title": "通胀回落与降息空间",
+              "style": "gradient"
+            }
+          },
+          {
+            "type": "process-arrows",
+            "x": 80,
+            "y": 200,
+            "w": 1120,
+            "h": 420,
+            "args": {
+              "steps": [
+                {
+                  "label": "通胀持续回落",
+                  "sublabel": "多数主要经济体"
+                },
+                {
+                  "label": "央行降息空间",
+                  "sublabel": "美联储、英国央行与欧洲央行"
+                },
+                {
+                  "label": "宽松货币政策",
+                  "sublabel": "转向条件创造"
+                }
+              ],
+              "color": "gradient"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "slotIdx": 6,
+      "slotName": "theme-2-detail",
+      "slotTitle": "Theme 2 — Detail",
+      "sceneData": {
+        "name": "news-briefing/theme-2-detail",
+        "layout": "row",
+        "subjects": [
+          {
+            "type": "cover",
+            "x": 0,
+            "y": 0,
+            "w": 1280,
+            "h": 120,
+            "args": {
+              "title": "美联储降息路径预期",
+              "style": "gradient"
+            }
+          },
+          {
+            "type": "timeline",
+            "x": 80,
+            "y": 180,
+            "w": 1120,
+            "h": 280,
+            "args": {
+              "events": [
+                {
+                  "date": "4月前",
+                  "label": "继续降息",
+                  "sublabel": "前提: 就业增长放缓 + 核心通胀温和"
+                },
+                {
+                  "date": "3%-3.25%",
+                  "label": "进入观望期",
+                  "sublabel": "政策利率降至目标区间"
+                },
+                {
+                  "date": "观望期",
+                  "label": "较长时间暂停",
+                  "sublabel": "节奏取决于劳动力市场与通胀数据"
+                }
+              ],
+              "axisLabel": "降息周期时间线"
+            }
+          },
+          {
+            "type": "bullet-list",
+            "x": 80,
+            "y": 500,
+            "w": 1120,
+            "h": 180,
+            "args": {
+              "title": "关键前提条件",
+              "items": [
+                {
+                  "icon": "users",
+                  "label": "美国就业增长放缓"
+                },
+                {
+                  "icon": "chart-line",
+                  "label": "核心通胀涨幅温和"
+                },
+                {
+                  "icon": "gauge",
+                  "label": "政策利率降至3%-3.25%区间后观望"
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "slotIdx": 7,
+      "slotName": "theme-3-lead",
+      "slotTitle": "Theme 3 — Lead",
+      "sceneData": {
+        "name": "news-briefing/theme-3-lead",
+        "layout": "stage",
+        "subjects": [
+          {
+            "type": "cover",
+            "x": 0,
+            "y": 0,
+            "w": 1280,
+            "h": 120,
+            "args": {
+              "title": "能源价格冲击",
+              "style": "gradient"
+            }
+          },
+          {
+            "type": "icon-grid",
+            "x": 80,
+            "y": 180,
+            "w": 1120,
+            "h": 480,
+            "args": {
+              "title": "中东冲突能源价格冲击",
+              "items": [
+                {
+                  "icon": "chart-line-up",
+                  "label": "能源价格大幅上涨",
+                  "sublabel": "通胀重新抬头"
+                },
+                {
+                  "icon": "currency-dollar",
+                  "label": "货币政策收紧",
+                  "sublabel": "预期强化"
+                },
+                {
+                  "icon": "boat",
+                  "label": "霍尔木兹海峡",
+                  "sublabel": "航运中断"
+                },
+                {
+                  "icon": "plugs",
+                  "label": "能源基础设施",
+                  "sublabel": "部分关闭"
+                },
+                {
+                  "icon": "lightning-slash",
+                  "label": "能源价格激增",
+                  "sublabel": "全球供应扰乱"
+                },
+                {
+                  "icon": "warning-diamond",
+                  "label": "高概率深冲击",
+                  "sublabel": "风险显著"
+                }
+              ],
+              "cols": 3,
+              "iconStyle": "circle",
+              "iconSize": "medium",
+              "colorMode": "brand"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "slotIdx": 8,
+      "slotName": "risk-matrix",
+      "slotTitle": "Risk Matrix",
+      "sceneData": {
+        "name": "news-briefing/risk-matrix",
+        "layout": "grid",
+        "subjects": [
+          {
+            "type": "cover",
+            "x": 0,
+            "y": 0,
+            "w": 1280,
+            "h": 120,
+            "args": {
+              "title": "风险矩阵总览",
+              "style": "gradient"
+            }
+          },
+          {
+            "type": "risk-heatmap",
+            "x": 80,
+            "y": 180,
+            "w": 1120,
+            "h": 480,
+            "args": {
+              "xAxis": "概率",
+              "yAxis": "影响",
+              "xLabels": ["低", "中低", "中等", "中高", "高"],
+              "yLabels": ["低", "中低", "中等", "中高", "高"],
+              "risks": [
+                {
+                  "x": 4,
+                  "y": 4,
+                  "label": "中东冲突能源冲击",
+                  "severity": "critical"
+                },
+                {
+                  "x": 3,
+                  "y": 2,
+                  "label": "科技投资势头",
+                  "severity": "medium"
+                },
+                {
+                  "x": 2,
+                  "y": 2,
+                  "label": "就业市场走弱",
+                  "severity": "medium"
+                },
+                {
+                  "x": 1,
+                  "y": 4,
+                  "label": "金融估值回调",
+                  "severity": "high"
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "slotIdx": 9,
+      "slotName": "risk-detail-1",
+      "slotTitle": "Top Risk — Detail",
+      "sceneData": {
+        "name": "news-briefing/risk-detail-1",
+        "layout": "stage",
+        "subjects": [
+          {
+            "type": "cover",
+            "x": 0,
+            "y": 0,
+            "w": 1280,
+            "h": 120,
+            "args": {
+              "title": "中东冲突能源价格冲击",
+              "style": "gradient"
+            }
+          },
+          {
+            "type": "callout-banner",
+            "x": 80,
+            "y": 180,
+            "w": 1120,
+            "h": 140,
+            "args": {
+              "type_": "warning",
+              "heading": "高概率 · 深冲击",
+              "body": "中东冲突已引发能源价格大幅上涨、通胀重新抬头以及货币政策收紧的预期",
+              "icon": "warning-diamond"
+            }
+          },
+          {
+            "type": "icon-row",
+            "x": 80,
+            "y": 360,
+            "w": 1120,
+            "h": 300,
+            "args": {
+              "items": [
+                {
+                  "icon": "boat",
+                  "label": "霍尔木兹海峡",
+                  "sublabel": "航运中断"
+                },
+                {
+                  "icon": "factory",
+                  "label": "能源基础设施",
+                  "sublabel": "部分关闭"
+                },
+                {
+                  "icon": "trend-up",
+                  "label": "能源价格",
+                  "sublabel": "激增"
+                },
+                {
+                  "icon": "arrows-split",
+                  "label": "全球供应",
+                  "sublabel": "大宗商品扰乱"
+                }
+              ],
+              "iconSize": "large",
+              "iconStyle": "card"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "slotIdx": 10,
+      "slotName": "risk-detail-2",
+      "slotTitle": "Secondary Risks",
+      "sceneData": {
+        "name": "news-briefing/risk-detail-2",
+        "layout": "row",
+        "subjects": [
+          {
+            "type": "cover",
+            "x": 0,
+            "y": 0,
+            "w": 1280,
+            "h": 120,
+            "args": {
+              "title": "Secondary Risks",
+              "style": "gradient"
+            }
+          },
+          {
+            "type": "balance-scale",
+            "x": 80,
+            "y": 180,
+            "w": 1120,
+            "h": 480,
+            "args": {
+              "title": "科技投资上行支撑",
+              "leftLabel": "上行因素",
+              "rightLabel": "不确定性",
+              "leftItems": ["科技投资强劲势头", "生产增长支撑", "全球经济积极因素"],
+              "rightItems": ["持续性存在不确定性", "投资波动风险"],
+              "leftAccent": "rgb(38, 70, 130)",
+              "rightAccent": "rgb(110, 95, 75)"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "slotIdx": 11,
+      "slotName": "quote",
+      "slotTitle": "Key Quote",
+      "sceneData": {
+        "name": "news-briefing/quote",
+        "layout": "stage",
+        "subjects": [
+          {
+            "type": "cover",
+            "x": 0,
+            "y": 0,
+            "w": 1280,
+            "h": 120,
+            "args": {
+              "title": "Key Quote",
+              "style": "gradient"
+            }
+          },
+          {
+            "type": "pull-quote-banner",
+            "x": 80,
+            "y": 180,
+            "w": 1120,
+            "h": 460,
+            "args": {
+              "quote": "新兴市场和发展中经济体将面临疫情以来最弱的人均收入增长",
+              "author": "世界银行",
+              "attribution": "2025年全球经济展望 · 2.5%增长预测",
+              "bg": "accent"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "slotIdx": 12,
+      "slotName": "outlook",
+      "slotTitle": "Outlook",
+      "sceneData": {
+        "name": "news-briefing/outlook",
+        "layout": "row",
+        "subjects": [
+          {
+            "type": "cover",
+            "x": 0,
+            "y": 0,
+            "w": 1280,
+            "h": 120,
+            "args": {
+              "title": "Outlook",
+              "style": "gradient"
+            }
+          },
+          {
+            "type": "timeline",
+            "x": 80,
+            "y": 180,
+            "w": 1120,
+            "h": 480,
+            "args": {
+              "title": "美联储降息路径预期",
+              "events": [
+                {
+                  "date": "4月前",
+                  "label": "继续降息",
+                  "sublabel": "前提：就业增长放缓、核心通胀温和"
+                },
+                {
+                  "date": "3%-3.25%",
+                  "label": "进入观望期",
+                  "sublabel": "政策利率区间"
+                },
+                {
+                  "date": "后续",
+                  "label": "节奏取决数据",
+                  "sublabel": "劳动力市场与通胀指标"
+                }
+              ],
+              "axisLabel": "降息周期"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "slotIdx": 13,
+      "slotName": "summary",
+      "slotTitle": "Summary",
+      "sceneData": {
+        "name": "news-briefing/summary",
+        "layout": "grid",
+        "subjects": [
+          {
+            "type": "cover",
+            "x": 0,
+            "y": 0,
+            "w": 1280,
+            "h": 120,
+            "args": {
+              "title": "Summary",
+              "style": "gradient"
+            }
+          },
+          {
+            "type": "numbered-grid",
+            "x": 80,
+            "y": 180,
+            "w": 1120,
+            "h": 480,
+            "args": {
+              "title": "2026年展望总结",
+              "items": [
+                {
+                  "label": "全球经济温和增长",
+                  "sublabel": "三大机构预测2.5%-3.3%区间"
+                },
+                {
+                  "label": "区域分化显著",
+                  "sublabel": "中国与低收入国家增速领先，欧元区相对疲弱"
+                },
+                {
+                  "label": "货币政策转向宽松",
+                  "sublabel": "降息路径取决于通胀与就业数据"
+                },
+                {
+                  "label": "地缘政治与能源供应构成下行风险",
+                  "sublabel": "科技投资提供上行可能"
+                }
+              ],
+              "cols": 2,
+              "numberStyle": "circle",
+              "numberColor": [38, 70, 130]
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/sdf-js/examples/deck-handoff/ammo/eval-news-policy.json
+++ b/sdf-js/examples/deck-handoff/ammo/eval-news-policy.json
@@ -1,0 +1,745 @@
+{
+  "format": "atlas-deck",
+  "version": 1,
+  "title": "eval-news-policy",
+  "theme": {
+    "id": "editorial-navy",
+    "label": "Editorial · Navy",
+    "macroCluster": "editorial",
+    "bg": [248, 246, 240],
+    "silhouetteColor": [22, 35, 70],
+    "accent": [38, 70, 130],
+    "colors": [
+      [38, 70, 130],
+      [110, 95, 75],
+      [165, 130, 90],
+      [200, 195, 180]
+    ],
+    "font": {
+      "heading": "Georgia, \"Source Serif Pro\", serif",
+      "body": "Inter, system-ui, sans-serif"
+    },
+    "featured": true
+  },
+  "scaffold": {
+    "id": "news-briefing",
+    "label": "News Briefing"
+  },
+  "decor": null,
+  "shared": null,
+  "slots": [
+    {
+      "slotIdx": 0,
+      "slotName": "cover",
+      "slotTitle": "Headline",
+      "sceneData": {
+        "name": "news-briefing/cover",
+        "layout": "cover",
+        "subjects": [
+          {
+            "type": "cover",
+            "x": 0,
+            "y": 0,
+            "w": 1280,
+            "h": 720,
+            "args": {
+              "title": "全国新能源汽车下乡政策成效与挑战",
+              "subtitle": "财经报纸报道",
+              "author": "工业和信息化部、国家能源局数据",
+              "date": "今年前五个月",
+              "style": "gradient"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "slotIdx": 1,
+      "slotName": "agenda",
+      "slotTitle": "Overview",
+      "sceneData": {
+        "name": "news-briefing/agenda",
+        "layout": "row",
+        "subjects": [
+          {
+            "type": "cover",
+            "x": 0,
+            "y": 0,
+            "w": 1280,
+            "h": 120,
+            "args": {
+              "title": "Overview",
+              "style": "gradient"
+            }
+          },
+          {
+            "type": "agenda-list",
+            "x": 40,
+            "y": 160,
+            "w": 580,
+            "h": 500,
+            "args": {
+              "items": [
+                {
+                  "label": "下乡车型销量与市场表现"
+                },
+                {
+                  "label": "配套充电设施建设现状与规划"
+                },
+                {
+                  "label": "产业格局与车型价格分布"
+                },
+                {
+                  "label": "面临的主要挑战与风险"
+                }
+              ],
+              "numbered": true
+            }
+          },
+          {
+            "type": "kpi-card",
+            "x": 660,
+            "y": 160,
+            "w": 280,
+            "h": 220,
+            "args": {
+              "value": ">15%",
+              "label": "微型电动车占比",
+              "sublabel": "五菱宏光MINI等单一车型贡献",
+              "icon": "car-simple",
+              "style": "light"
+            }
+          },
+          {
+            "type": "kpi-card",
+            "x": 960,
+            "y": 160,
+            "w": 280,
+            "h": 220,
+            "args": {
+              "value": "63%",
+              "label": "5-10万元车型占比",
+              "sublabel": "中低价位占据主流",
+              "icon": "currency-cny",
+              "style": "light"
+            }
+          },
+          {
+            "type": "stat-banner",
+            "x": 660,
+            "y": 420,
+            "w": 580,
+            "h": 100,
+            "args": {
+              "value": "低价优势",
+              "label": "微型车在农村市场受欢迎",
+              "bg": [38, 70, 130]
+            }
+          },
+          {
+            "type": "callout-banner",
+            "x": 660,
+            "y": 540,
+            "w": 580,
+            "h": 120,
+            "args": {
+              "type_": "insight",
+              "heading": "价格带特征",
+              "body": "5万至10万元价格带集中体现农村消费能力特征",
+              "icon": "chart-bar"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "slotIdx": 2,
+      "slotName": "key-figures",
+      "slotTitle": "Key Figures",
+      "sceneData": {
+        "name": "news-briefing/key-figures",
+        "layout": "grid",
+        "subjects": [
+          {
+            "type": "cover",
+            "x": 0,
+            "y": 0,
+            "w": 1280,
+            "h": 120,
+            "args": {
+              "title": "Key Figures",
+              "style": "gradient"
+            }
+          },
+          {
+            "type": "stat-grid-large",
+            "x": 40,
+            "y": 180,
+            "w": 1200,
+            "h": 480,
+            "args": {
+              "stats": [
+                {
+                  "value": "187万辆",
+                  "label": "下乡车型销量",
+                  "trend": "+61%",
+                  "trendDirection": "up"
+                },
+                {
+                  "value": "34%",
+                  "label": "占全国总销量"
+                },
+                {
+                  "value": "前五个月",
+                  "label": "统计周期"
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "slotIdx": 3,
+      "slotName": "theme-1-lead",
+      "slotTitle": "Theme 1 — Lead",
+      "sceneData": {
+        "name": "news-briefing/theme-1-lead",
+        "layout": "row",
+        "subjects": [
+          {
+            "type": "cover",
+            "x": 0,
+            "y": 0,
+            "w": 1280,
+            "h": 120,
+            "args": {
+              "title": "下乡车型销量快速增长",
+              "style": "gradient"
+            }
+          },
+          {
+            "type": "kpi-card",
+            "x": 80,
+            "y": 200,
+            "w": 340,
+            "h": 380,
+            "args": {
+              "value": "187万辆",
+              "label": "前五个月销量",
+              "sublabel": "新能源汽车下乡车型",
+              "icon": "car",
+              "style": "dark"
+            }
+          },
+          {
+            "type": "kpi-card",
+            "x": 470,
+            "y": 200,
+            "w": 340,
+            "h": 380,
+            "args": {
+              "value": "61%",
+              "label": "同比增长",
+              "trend": "up",
+              "trendValue": "+61%",
+              "icon": "chart-line-up",
+              "style": "dark"
+            }
+          },
+          {
+            "type": "kpi-card",
+            "x": 860,
+            "y": 200,
+            "w": 340,
+            "h": 380,
+            "args": {
+              "value": "34%",
+              "label": "全国总销量占比",
+              "sublabel": "新能源汽车市场份额",
+              "icon": "chart-pie",
+              "style": "dark"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "slotIdx": 4,
+      "slotName": "theme-1-detail",
+      "slotTitle": "Theme 1 — Detail",
+      "sceneData": {
+        "name": "news-briefing/theme-1-detail",
+        "layout": "row",
+        "subjects": [
+          {
+            "type": "cover",
+            "x": 0,
+            "y": 0,
+            "w": 1280,
+            "h": 120,
+            "args": {
+              "title": "主题1 — 详情",
+              "style": "gradient"
+            }
+          },
+          {
+            "type": "bar",
+            "x": 40,
+            "y": 160,
+            "w": 1200,
+            "h": 520,
+            "args": {
+              "title": "县乡市场渗透率提升但仍有差距",
+              "labels": ["县乡市场 (去年)", "县乡市场 (今年)", "一二线城市"],
+              "values": [17, 28, 54],
+              "format": "percent",
+              "max": 60
+            }
+          }
+        ]
+      }
+    },
+    {
+      "slotIdx": 5,
+      "slotName": "theme-2-lead",
+      "slotTitle": "Theme 2 — Lead",
+      "sceneData": {
+        "name": "news-briefing/theme-2-lead",
+        "layout": "stage",
+        "subjects": [
+          {
+            "type": "cover",
+            "x": 0,
+            "y": 0,
+            "w": 1280,
+            "h": 120,
+            "args": {
+              "title": "充电桩配套设施严重不足",
+              "style": "gradient"
+            }
+          },
+          {
+            "type": "dashboard-multi-kpi-composite",
+            "x": 40,
+            "y": 160,
+            "w": 1200,
+            "h": 520,
+            "args": {
+              "kpis": [
+                {
+                  "value": "98万台",
+                  "label": "县域公共充电桩",
+                  "sublabel": "截至5月底全国保有量",
+                  "color": [38, 70, 130]
+                },
+                {
+                  "value": "21%",
+                  "label": "占全国总量",
+                  "sublabel": "县域充电桩占比",
+                  "trend": "down",
+                  "color": [110, 95, 75]
+                },
+                {
+                  "value": "350台",
+                  "label": "平均每县",
+                  "sublabel": "充电桩数量不足",
+                  "trend": "down",
+                  "color": [165, 130, 90]
+                },
+                {
+                  "value": "配套设施",
+                  "label": "最大短板",
+                  "sublabel": "基础设施建设滞后",
+                  "color": [200, 195, 180]
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "slotIdx": 6,
+      "slotName": "theme-2-detail",
+      "slotTitle": "Theme 2 — Detail",
+      "sceneData": {
+        "name": "news-briefing/theme-2-detail",
+        "layout": "row",
+        "subjects": [
+          {
+            "type": "cover",
+            "x": 0,
+            "y": 0,
+            "w": 1280,
+            "h": 120,
+            "args": {
+              "title": "国家充电设施覆盖目标",
+              "style": "gradient"
+            }
+          },
+          {
+            "type": "timeline",
+            "x": 140,
+            "y": 200,
+            "w": 1000,
+            "h": 420,
+            "args": {
+              "events": [
+                {
+                  "date": "现状",
+                  "label": "充电网络建设启动",
+                  "sublabel": "城市重点区域覆盖"
+                },
+                {
+                  "date": "2026年底",
+                  "label": "县县全覆盖",
+                  "sublabel": "所有县级行政区建成充电设施"
+                },
+                {
+                  "date": "2026年底",
+                  "label": "乡乡有站点",
+                  "sublabel": "乡级充电网络全面铺开"
+                }
+              ],
+              "title": "国家能源局覆盖时间表",
+              "axisLabel": "部署进度"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "slotIdx": 7,
+      "slotName": "theme-3-lead",
+      "slotTitle": "Theme 3 — Lead",
+      "sceneData": {
+        "name": "news-briefing/theme-3-lead",
+        "layout": "stage",
+        "subjects": [
+          {
+            "type": "cover",
+            "x": 0,
+            "y": 0,
+            "w": 1280,
+            "h": 120,
+            "args": {
+              "title": "头部车企主导下乡市场",
+              "style": "gradient"
+            }
+          },
+          {
+            "type": "stat-banner",
+            "x": 40,
+            "y": 200,
+            "w": 1200,
+            "h": 180,
+            "args": {
+              "value": "58%",
+              "label": "三家头部企业市场份额",
+              "bg": [38, 70, 130]
+            }
+          },
+          {
+            "type": "icon-row",
+            "x": 140,
+            "y": 440,
+            "w": 1000,
+            "h": 200,
+            "args": {
+              "items": [
+                {
+                  "icon": "car",
+                  "label": "比亚迪"
+                },
+                {
+                  "icon": "car",
+                  "label": "吉利"
+                },
+                {
+                  "icon": "car",
+                  "label": "长安"
+                }
+              ],
+              "iconSize": "large",
+              "iconStyle": "circle",
+              "colorMode": "brand"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "slotIdx": 8,
+      "slotName": "risk-matrix",
+      "slotTitle": "Risk Matrix",
+      "sceneData": {
+        "name": "news-briefing/risk-matrix",
+        "layout": "stage",
+        "subjects": [
+          {
+            "type": "cover",
+            "x": 0,
+            "y": 0,
+            "w": 1280,
+            "h": 100,
+            "args": {
+              "title": "Risk Matrix",
+              "style": "gradient"
+            }
+          },
+          {
+            "type": "risk-heatmap",
+            "x": 40,
+            "y": 140,
+            "w": 1200,
+            "h": 540,
+            "args": {
+              "title": "挑战一：农村电网改造滞后",
+              "xAxis": "影响程度",
+              "yAxis": "发生概率",
+              "xLabels": ["低", "中", "高"],
+              "yLabels": ["低", "中", "高"],
+              "risks": [
+                {
+                  "x": 1,
+                  "y": 2,
+                  "label": "变压器容量不足",
+                  "description": "部分乡镇变压器容量不足，夏季用电高峰期充电功率受限"
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "slotIdx": 9,
+      "slotName": "risk-detail-1",
+      "slotTitle": "Top Risk — Detail",
+      "sceneData": {
+        "name": "news-briefing/risk-detail-1",
+        "layout": "row",
+        "subjects": [
+          {
+            "type": "cover",
+            "x": 0,
+            "y": 0,
+            "w": 1280,
+            "h": 120,
+            "args": {
+              "title": "挑战详情"
+            }
+          },
+          {
+            "type": "callout-banner",
+            "x": 80,
+            "y": 180,
+            "w": 1120,
+            "h": 160,
+            "args": {
+              "type_": "warning",
+              "heading": "二手车残值体系缺失",
+              "body": "导致置换意愿低，制约农村消费者换车积极性",
+              "icon": "warning-diamond"
+            }
+          },
+          {
+            "type": "kpi-card",
+            "x": 80,
+            "y": 380,
+            "w": 520,
+            "h": 260,
+            "args": {
+              "value": "中等",
+              "label": "发生概率",
+              "icon": "gauge",
+              "style": "light",
+              "trend": "neutral"
+            }
+          },
+          {
+            "type": "kpi-card",
+            "x": 680,
+            "y": 380,
+            "w": 520,
+            "h": 260,
+            "args": {
+              "value": "深远",
+              "label": "影响程度",
+              "icon": "trend-up",
+              "style": "accent-border",
+              "trendDirection": "up"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "slotIdx": 10,
+      "slotName": "risk-detail-2",
+      "slotTitle": "Secondary Risks",
+      "sceneData": {
+        "name": "news-briefing/risk-detail-2",
+        "layout": "row",
+        "subjects": [
+          {
+            "type": "cover",
+            "x": 0,
+            "y": 0,
+            "w": 1280,
+            "h": 120,
+            "args": {
+              "title": "Secondary Risks",
+              "style": "gradient"
+            }
+          },
+          {
+            "type": "balance-scale",
+            "x": 40,
+            "y": 160,
+            "w": 1200,
+            "h": 500,
+            "args": {
+              "title": "挑战三：补贴退坡影响预期",
+              "leftLabel": "当前状态",
+              "rightLabel": "明年预期",
+              "leftItems": ["购置补贴政策支持", "高速增长态势"],
+              "rightItems": ["补贴按期退坡", "增速回落至30%以下", "政策变动压力"],
+              "leftAccent": "rgb(110, 95, 75)",
+              "rightAccent": "rgb(38, 70, 130)",
+              "verdict": "政策变动对市场增长构成压力"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "slotIdx": 12,
+      "slotName": "outlook",
+      "slotTitle": "Outlook",
+      "sceneData": {
+        "name": "news-briefing/outlook",
+        "layout": "stage",
+        "subjects": [
+          {
+            "type": "cover",
+            "x": 0,
+            "y": 0,
+            "w": 1280,
+            "h": 120,
+            "args": {
+              "title": "Outlook",
+              "style": "gradient"
+            }
+          },
+          {
+            "type": "kpi-card",
+            "x": 40,
+            "y": 180,
+            "w": 360,
+            "h": 240,
+            "args": {
+              "value": "120亿元",
+              "label": "中央财政专项补贴",
+              "icon": "bank",
+              "style": "light"
+            }
+          },
+          {
+            "type": "kpi-card",
+            "x": 460,
+            "y": 180,
+            "w": 360,
+            "h": 240,
+            "args": {
+              "value": "200亿元",
+              "label": "地方配套资金",
+              "icon": "buildings",
+              "style": "light"
+            }
+          },
+          {
+            "type": "kpi-card",
+            "x": 880,
+            "y": 180,
+            "w": 360,
+            "h": 240,
+            "args": {
+              "value": "320亿元",
+              "label": "总投入规模",
+              "icon": "currency-cny",
+              "style": "dark",
+              "trend": "up"
+            }
+          },
+          {
+            "type": "pie",
+            "x": 140,
+            "y": 460,
+            "w": 1000,
+            "h": 220,
+            "args": {
+              "values": [120, 200],
+              "labels": ["中央财政 120亿元", "地方配套 200亿元"],
+              "title": "资金来源构成",
+              "format": "number"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "slotIdx": 13,
+      "slotName": "summary",
+      "slotTitle": "Summary",
+      "sceneData": {
+        "name": "news-briefing/summary",
+        "layout": "grid",
+        "subjects": [
+          {
+            "type": "cover",
+            "x": 0,
+            "y": 0,
+            "w": 1280,
+            "h": 120,
+            "args": {
+              "title": "Summary",
+              "style": "gradient"
+            }
+          },
+          {
+            "type": "numbered-grid",
+            "x": 40,
+            "y": 160,
+            "w": 1200,
+            "h": 520,
+            "args": {
+              "items": [
+                {
+                  "label": "县乡市场渗透率显著提升",
+                  "sublabel": "下乡政策带动"
+                },
+                {
+                  "label": "基础设施建设加速",
+                  "sublabel": "中央地方投入超300亿元"
+                },
+                {
+                  "label": "三大挑战待解决",
+                  "sublabel": "电网容量、残值体系、补贴退坡"
+                },
+                {
+                  "label": "长期增长取决配套服务",
+                  "sublabel": "服务体系完善程度是关键"
+                }
+              ],
+              "cols": 2,
+              "numberStyle": "circle",
+              "numberColor": [38, 70, 130]
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/sdf-js/examples/deck-handoff/ammo/eval-nonprofit-annual-report.json
+++ b/sdf-js/examples/deck-handoff/ammo/eval-nonprofit-annual-report.json
@@ -1,0 +1,485 @@
+{
+  "format": "atlas-deck",
+  "version": 1,
+  "title": "eval-nonprofit-annual-report",
+  "theme": {
+    "id": "financial-navy-cerulean",
+    "label": "Financial Navy",
+    "macroCluster": "pitch",
+    "bg": [26, 40, 66],
+    "silhouetteColor": [240, 248, 255],
+    "accent": [58, 138, 200],
+    "colors": [
+      [58, 138, 200],
+      [26, 40, 66],
+      [100, 150, 200],
+      [180, 210, 235],
+      [240, 248, 255]
+    ],
+    "font": {
+      "heading": "\"Inter Display\", Inter, system-ui, sans-serif",
+      "body": "Inter, system-ui, sans-serif"
+    },
+    "featured": true
+  },
+  "scaffold": {
+    "id": "financial-summary",
+    "label": "Financial Summary"
+  },
+  "decor": null,
+  "shared": null,
+  "slots": [
+    {
+      "slotIdx": 0,
+      "slotName": "cover",
+      "slotTitle": "Title",
+      "sceneData": {
+        "name": "financial-summary/cover",
+        "layout": "cover",
+        "subjects": [
+          {
+            "type": "cover",
+            "x": 0,
+            "y": 0,
+            "w": 1280,
+            "h": 720,
+            "args": {
+              "title": "Clearwater Trust — 2026 Annual Report",
+              "subtitle": "Clean water access for rural communities",
+              "author": "Fiscal Year 2026",
+              "date": "Prepared for donors and board",
+              "style": "gradient"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "slotIdx": 1,
+      "slotName": "exec-statement",
+      "slotTitle": "Executive Statement",
+      "sceneData": {
+        "name": "financial-summary/exec-statement",
+        "layout": "stage",
+        "subjects": [
+          {
+            "type": "cover",
+            "x": 0,
+            "y": 0,
+            "w": 1280,
+            "h": 120,
+            "args": {
+              "title": "Executive Statement",
+              "style": "gradient"
+            }
+          },
+          {
+            "type": "quote-pull",
+            "x": 80,
+            "y": 180,
+            "w": 1120,
+            "h": 280,
+            "args": {
+              "quote": "Access to clean water is a human right, not a privilege",
+              "author": "Clearwater Trust",
+              "align": "center"
+            }
+          },
+          {
+            "type": "icon-row",
+            "x": 140,
+            "y": 500,
+            "w": 1000,
+            "h": 160,
+            "args": {
+              "items": [
+                {
+                  "icon": "drop",
+                  "label": "Clean Water",
+                  "sublabel": "Rural infrastructure"
+                },
+                {
+                  "icon": "calendar",
+                  "label": "Since 2011",
+                  "sublabel": "15 years operations"
+                },
+                {
+                  "icon": "globe",
+                  "label": "4 Countries",
+                  "sublabel": "Kenya · Tanzania · Malawi · Mozambique"
+                }
+              ],
+              "iconSize": "medium",
+              "iconStyle": "circle"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "slotIdx": 2,
+      "slotName": "highlights-kpi",
+      "slotTitle": "Financial Highlights",
+      "sceneData": {
+        "name": "financial-summary/highlights-kpi",
+        "layout": "grid",
+        "subjects": [
+          {
+            "type": "cover",
+            "x": 0,
+            "y": 0,
+            "w": 1280,
+            "h": 120,
+            "args": {
+              "title": "Financial Highlights",
+              "style": "gradient"
+            }
+          },
+          {
+            "type": "dashboard-multi-kpi-composite",
+            "x": 40,
+            "y": 160,
+            "w": 1200,
+            "h": 280,
+            "args": {
+              "kpis": [
+                {
+                  "value": "$4.2M",
+                  "label": "Total Donations",
+                  "sublabel": "2026",
+                  "trend": "up",
+                  "trendValue": "+18%",
+                  "color": [58, 138, 200]
+                },
+                {
+                  "value": "1,340",
+                  "label": "Active Volunteers",
+                  "sublabel": "4 countries",
+                  "trend": "neutral",
+                  "color": [100, 150, 200]
+                },
+                {
+                  "value": "87",
+                  "label": "Wells Constructed",
+                  "sublabel": "new this year",
+                  "trend": "neutral",
+                  "color": [58, 138, 200]
+                },
+                {
+                  "value": "210,000",
+                  "label": "People Served",
+                  "sublabel": "water access",
+                  "trend": "neutral",
+                  "color": [100, 150, 200]
+                },
+                {
+                  "value": "84%",
+                  "label": "Program Cost Ratio",
+                  "sublabel": "direct to programs",
+                  "trend": "neutral",
+                  "color": [58, 138, 200]
+                }
+              ]
+            }
+          },
+          {
+            "type": "testimonial-wall",
+            "x": 40,
+            "y": 460,
+            "w": 1200,
+            "h": 220,
+            "args": {
+              "testimonials": [
+                {
+                  "quote": "Seeing the well go live in Kilifi was the proudest moment of my giving career — clean water changed that village overnight.",
+                  "name": "Margaret Ho",
+                  "role": "Monthly donor since 2019"
+                },
+                {
+                  "quote": "Clearwater didn't just build a well, they trained our own people to keep it running for the next 50 years.",
+                  "name": "Chief Amara Kessy",
+                  "role": "Village Chief, Tanzania"
+                },
+                {
+                  "quote": "Their financial transparency is why our foundation renewed for a third consecutive year.",
+                  "name": "Daniel Reyes",
+                  "role": "Foundation Program Officer"
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "slotIdx": 3,
+      "slotName": "income",
+      "slotTitle": "Income Statement",
+      "sceneData": {
+        "name": "financial-summary/income",
+        "layout": "grid",
+        "subjects": [
+          {
+            "type": "cover",
+            "x": 0,
+            "y": 0,
+            "w": 1280,
+            "h": 120,
+            "args": {
+              "title": "Income Statement"
+            }
+          },
+          {
+            "type": "pie",
+            "x": 40,
+            "y": 160,
+            "w": 580,
+            "h": 520,
+            "args": {
+              "title": "Spending Breakdown",
+              "values": [3530000, 378000, 294000],
+              "labels": [
+                "Program Services · $3.53M",
+                "Fundraising · $378K",
+                "Administrative · $294K"
+              ],
+              "format": "percent",
+              "donutRatio": 0.5,
+              "centerLabel": "$4.2M Total"
+            }
+          },
+          {
+            "type": "pie",
+            "x": 660,
+            "y": 160,
+            "w": 580,
+            "h": 520,
+            "args": {
+              "title": "Revenue Sources",
+              "values": [52, 31, 17],
+              "labels": [
+                "Individual Donors · 52%",
+                "Foundation Grants · 31%",
+                "Corporate Partners · 17%"
+              ],
+              "format": "percent",
+              "donutRatio": 0.5
+            }
+          }
+        ]
+      }
+    },
+    {
+      "slotIdx": 7,
+      "slotName": "segments",
+      "slotTitle": "Segment Analysis",
+      "sceneData": {
+        "name": "financial-summary/segments",
+        "layout": "grid",
+        "subjects": [
+          {
+            "type": "cover",
+            "x": 0,
+            "y": 0,
+            "w": 1280,
+            "h": 120,
+            "args": {
+              "title": "Segment Analysis",
+              "style": "gradient"
+            }
+          },
+          {
+            "type": "icon-grid",
+            "x": 80,
+            "y": 180,
+            "w": 1120,
+            "h": 480,
+            "args": {
+              "title": "Program Highlights",
+              "items": [
+                {
+                  "icon": "wrench",
+                  "label": "Rapid Repair",
+                  "sublabel": "6 weeks → 9 days"
+                },
+                {
+                  "icon": "graduation-cap",
+                  "label": "School Hydration",
+                  "sublabel": "40 new stations"
+                },
+                {
+                  "icon": "solar-panel",
+                  "label": "Solar Pumps",
+                  "sublabel": "12 villages, 60% cost cut"
+                },
+                {
+                  "icon": "users",
+                  "label": "Technician Training",
+                  "sublabel": "210 local experts"
+                },
+                {
+                  "icon": "handshake",
+                  "label": "Policy Advocacy",
+                  "sublabel": "3 regional governments"
+                }
+              ],
+              "cols": 3,
+              "iconStyle": "card",
+              "iconSize": "medium",
+              "colorMode": "brand"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "slotIdx": 8,
+      "slotName": "outlook",
+      "slotTitle": "Outlook & Forecast",
+      "sceneData": {
+        "name": "financial-summary/outlook",
+        "layout": "grid",
+        "subjects": [
+          {
+            "type": "cover",
+            "x": 0,
+            "y": 0,
+            "w": 1280,
+            "h": 120,
+            "args": {
+              "title": "Outlook & Forecast",
+              "style": "gradient"
+            }
+          },
+          {
+            "type": "kpi-card",
+            "x": 40,
+            "y": 160,
+            "w": 280,
+            "h": 240,
+            "args": {
+              "value": "110",
+              "label": "New Wells",
+              "sublabel": "+26% vs 2026",
+              "icon": "drop",
+              "style": "light",
+              "trend": "up",
+              "trendValue": "+26%"
+            }
+          },
+          {
+            "type": "kpi-card",
+            "x": 340,
+            "y": 160,
+            "w": 280,
+            "h": 240,
+            "args": {
+              "value": "5",
+              "label": "Countries",
+              "sublabel": "Uganda pilot launch",
+              "icon": "globe",
+              "style": "light",
+              "trend": "up",
+              "trendValue": "+1"
+            }
+          },
+          {
+            "type": "kpi-card",
+            "x": 640,
+            "y": 160,
+            "w": 280,
+            "h": 240,
+            "args": {
+              "value": "50",
+              "label": "Solar Villages",
+              "sublabel": "Pump deployment",
+              "icon": "sun",
+              "style": "light"
+            }
+          },
+          {
+            "type": "kpi-card",
+            "x": 940,
+            "y": 160,
+            "w": 280,
+            "h": 240,
+            "args": {
+              "value": "350",
+              "label": "Technicians",
+              "sublabel": "Training graduates",
+              "icon": "wrench",
+              "style": "light"
+            }
+          },
+          {
+            "type": "kpi-card",
+            "x": 340,
+            "y": 420,
+            "w": 600,
+            "h": 260,
+            "args": {
+              "value": "$5.5M",
+              "label": "Funding Target",
+              "sublabel": "+31% expansion capital",
+              "icon": "currency-dollar",
+              "style": "dark",
+              "trend": "up",
+              "trendValue": "+31%"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "slotIdx": 9,
+      "slotName": "appendix",
+      "slotTitle": "Appendix",
+      "sceneData": {
+        "name": "financial-summary/appendix",
+        "layout": "grid",
+        "subjects": [
+          {
+            "type": "cover",
+            "x": 0,
+            "y": 0,
+            "w": 1280,
+            "h": 120,
+            "args": {
+              "title": "Appendix",
+              "style": "gradient"
+            }
+          },
+          {
+            "type": "bullet-list",
+            "x": 80,
+            "y": 180,
+            "w": 1120,
+            "h": 480,
+            "args": {
+              "title": "How to Help & Resources",
+              "items": [
+                {
+                  "icon": "drop",
+                  "label": "$25 = clean water for one person yearly",
+                  "status": "highlight"
+                },
+                {
+                  "icon": "hand-heart",
+                  "label": "Volunteer opportunities open in 4 countries"
+                },
+                {
+                  "icon": "briefcase",
+                  "label": "Corporate matching programs available — contact partnerships team"
+                },
+                {
+                  "icon": "file-text",
+                  "label": "Board of Directors & full audit at clearwatertrust.org/reports"
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/sdf-js/examples/deck-handoff/ammo/eval-product-eng-retro.json
+++ b/sdf-js/examples/deck-handoff/ammo/eval-product-eng-retro.json
@@ -1,0 +1,423 @@
+{
+  "format": "atlas-deck",
+  "version": 1,
+  "title": "eval-product-eng-retro",
+  "theme": {
+    "id": "editorial-navy",
+    "label": "Editorial · Navy",
+    "macroCluster": "editorial",
+    "bg": [248, 246, 240],
+    "silhouetteColor": [22, 35, 70],
+    "accent": [38, 70, 130],
+    "colors": [
+      [38, 70, 130],
+      [110, 95, 75],
+      [165, 130, 90],
+      [200, 195, 180]
+    ],
+    "font": {
+      "heading": "Georgia, \"Source Serif Pro\", serif",
+      "body": "Inter, system-ui, sans-serif"
+    },
+    "featured": true
+  },
+  "scaffold": {
+    "id": "qbr",
+    "label": "Quarterly Business Review"
+  },
+  "decor": null,
+  "shared": null,
+  "slots": [
+    {
+      "slotIdx": 0,
+      "slotName": "cover",
+      "slotTitle": "Title",
+      "sceneData": {
+        "name": "qbr/cover",
+        "layout": "cover",
+        "subjects": [
+          {
+            "type": "cover",
+            "x": 0,
+            "y": 0,
+            "w": 1280,
+            "h": 720,
+            "args": {
+              "title": "Platform Engineering — Q3 2026 Retro",
+              "subtitle": "Quarterly engineering retrospective",
+              "author": "Platform Team",
+              "date": "Eng org + leadership",
+              "style": "gradient"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "slotIdx": 1,
+      "slotName": "executive-summary",
+      "slotTitle": "Executive Summary",
+      "sceneData": {
+        "name": "qbr/executive-summary",
+        "layout": "grid",
+        "subjects": [
+          {
+            "type": "cover",
+            "x": 0,
+            "y": 0,
+            "w": 1280,
+            "h": 120,
+            "args": {
+              "title": "Executive Summary",
+              "style": "gradient"
+            }
+          },
+          {
+            "type": "dashboard-multi-kpi-composite",
+            "x": 40,
+            "y": 160,
+            "w": 1200,
+            "h": 520,
+            "args": {
+              "title": "Velocity Metrics",
+              "kpis": [
+                {
+                  "value": "412",
+                  "label": "Story Points",
+                  "sublabel": "Target 380",
+                  "trend": "up",
+                  "trendValue": "+8%",
+                  "color": [38, 70, 130]
+                },
+                {
+                  "value": "34",
+                  "label": "Deploys/Week",
+                  "sublabel": "Up from 21/week",
+                  "trend": "up",
+                  "trendValue": "+62%",
+                  "color": [110, 95, 75]
+                },
+                {
+                  "value": "4.2h",
+                  "label": "Lead Time",
+                  "sublabel": "Down from 11h",
+                  "trend": "down",
+                  "trendValue": "-62%",
+                  "color": [165, 130, 90]
+                },
+                {
+                  "value": "3.1%",
+                  "label": "Failure Rate",
+                  "sublabel": "Target <5%",
+                  "trend": "neutral",
+                  "color": [38, 70, 130]
+                },
+                {
+                  "value": "22min",
+                  "label": "MTTR",
+                  "sublabel": "Target <30min",
+                  "trend": "neutral",
+                  "color": [110, 95, 75]
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "slotIdx": 2,
+      "slotName": "kpis",
+      "slotTitle": "KPI Dashboard",
+      "sceneData": {
+        "name": "qbr/kpis",
+        "layout": "grid",
+        "subjects": [
+          {
+            "type": "cover",
+            "x": 0,
+            "y": 0,
+            "w": 1280,
+            "h": 120,
+            "args": {
+              "title": "KPI Dashboard",
+              "style": "gradient"
+            }
+          },
+          {
+            "type": "dashboard-multi-kpi-composite",
+            "x": 80,
+            "y": 160,
+            "w": 1120,
+            "h": 520,
+            "args": {
+              "title": "Incident Metrics Q3",
+              "kpis": [
+                {
+                  "value": "6",
+                  "label": "Total Incidents",
+                  "sublabel": "Q3 2024",
+                  "trend": "down",
+                  "trendValue": "-45%",
+                  "color": [38, 70, 130]
+                },
+                {
+                  "value": "1",
+                  "label": "Severity-1",
+                  "sublabel": "47 min downtime",
+                  "trend": "neutral",
+                  "color": [165, 130, 90]
+                },
+                {
+                  "value": "2",
+                  "label": "Severity-2",
+                  "sublabel": "Auth + DB pool",
+                  "trend": "neutral",
+                  "color": [110, 95, 75]
+                },
+                {
+                  "value": "67%",
+                  "label": "Load Test Gap",
+                  "sublabel": "4 of 6 incidents",
+                  "trend": "down",
+                  "color": [200, 195, 180]
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "slotIdx": 3,
+      "slotName": "wins",
+      "slotTitle": "Wins",
+      "sceneData": {
+        "name": "qbr/wins",
+        "layout": "grid",
+        "subjects": [
+          {
+            "type": "cover",
+            "x": 0,
+            "y": 0,
+            "w": 1280,
+            "h": 120,
+            "args": {
+              "title": "Wins",
+              "style": "gradient"
+            }
+          },
+          {
+            "type": "bullet-list",
+            "x": 80,
+            "y": 180,
+            "w": 1120,
+            "h": 480,
+            "args": {
+              "items": [
+                {
+                  "icon": "users-three",
+                  "label": "Real-time collaboration — 100% rollout",
+                  "sublabel": "Launched Aug 3",
+                  "status": "done"
+                },
+                {
+                  "icon": "rocket-launch",
+                  "label": "New onboarding flow",
+                  "sublabel": "12min → 4min time-to-first-value",
+                  "status": "done"
+                },
+                {
+                  "icon": "device-mobile",
+                  "label": "Mobile offline mode",
+                  "sublabel": "30-day sync capability",
+                  "status": "done"
+                },
+                {
+                  "icon": "shield-check",
+                  "label": "Admin audit log",
+                  "sublabel": "SOC 2 requirement, shipped 2 weeks early",
+                  "status": "done"
+                },
+                {
+                  "icon": "code",
+                  "label": "API v3 migration",
+                  "sublabel": "92% customer adoption by quarter end",
+                  "status": "done"
+                }
+              ],
+              "title": "Q3 Shipped Features"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "slotIdx": 4,
+      "slotName": "challenges",
+      "slotTitle": "Challenges",
+      "sceneData": {
+        "name": "qbr/challenges",
+        "layout": "grid",
+        "subjects": [
+          {
+            "type": "cover",
+            "x": 0,
+            "y": 0,
+            "w": 1280,
+            "h": 120,
+            "args": {
+              "title": "Challenges",
+              "style": "gradient"
+            }
+          },
+          {
+            "type": "bullet-list",
+            "x": 80,
+            "y": 180,
+            "w": 560,
+            "h": 460,
+            "args": {
+              "title": "Tech Debt & Infrastructure",
+              "items": [
+                {
+                  "icon": "cube-segmented",
+                  "label": "Monolith decomposition 43% complete",
+                  "sublabel": "6 of 14 services extracted"
+                },
+                {
+                  "icon": "shield-check",
+                  "label": "Test coverage raised to 74%",
+                  "sublabel": "From 61% across core services"
+                },
+                {
+                  "icon": "lightning",
+                  "label": "Build time cut to 6 min",
+                  "sublabel": "From 18 min via cache restructure"
+                },
+                {
+                  "icon": "code",
+                  "label": "Node 22 standardization complete",
+                  "sublabel": "Deprecated Node 16 across all services"
+                },
+                {
+                  "icon": "database",
+                  "label": "Postgres sharding 40% live",
+                  "sublabel": "2 of 5 shards operational"
+                }
+              ]
+            }
+          },
+          {
+            "type": "kpi-card",
+            "x": 680,
+            "y": 180,
+            "w": 520,
+            "h": 140,
+            "args": {
+              "value": "43%",
+              "label": "Services Extracted",
+              "sublabel": "6 of 14 microservices",
+              "icon": "cube-segmented",
+              "trend": "+6 services",
+              "trendDirection": "up",
+              "style": "light"
+            }
+          },
+          {
+            "type": "kpi-card",
+            "x": 680,
+            "y": 340,
+            "w": 520,
+            "h": 140,
+            "args": {
+              "value": "74%",
+              "label": "Test Coverage",
+              "sublabel": "Core services",
+              "icon": "shield-check",
+              "trend": "+13%",
+              "trendDirection": "up",
+              "style": "light"
+            }
+          },
+          {
+            "type": "kpi-card",
+            "x": 680,
+            "y": 500,
+            "w": 520,
+            "h": 140,
+            "args": {
+              "value": "6 min",
+              "label": "Build Time",
+              "sublabel": "Cache restructuring impact",
+              "icon": "lightning",
+              "trend": "-67%",
+              "trendDirection": "down",
+              "style": "light"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "slotIdx": 5,
+      "slotName": "outlook",
+      "slotTitle": "Outlook",
+      "sceneData": {
+        "name": "qbr/outlook",
+        "layout": "hierarchy",
+        "subjects": [
+          {
+            "type": "cover",
+            "x": 0,
+            "y": 0,
+            "w": 1280,
+            "h": 120,
+            "args": {
+              "title": "Outlook",
+              "style": "gradient"
+            }
+          },
+          {
+            "type": "okr-tree",
+            "x": 60,
+            "y": 160,
+            "w": 1160,
+            "h": 520,
+            "args": {
+              "objective": "Q4 Platform Excellence & Efficiency",
+              "keyResults": [
+                {
+                  "label": "Platform uptime",
+                  "sublabel": "99.91% → 99.95%",
+                  "progress": 0.8
+                },
+                {
+                  "label": "Infrastructure cost per user",
+                  "sublabel": "Reduce 20%",
+                  "progress": 0.15
+                },
+                {
+                  "label": "Monolith decomposition",
+                  "sublabel": "43% → 80%",
+                  "progress": 0.54
+                },
+                {
+                  "label": "Real-time analytics dashboard",
+                  "sublabel": "Enterprise tier launch",
+                  "progress": 0.25
+                },
+                {
+                  "label": "PR review time",
+                  "sublabel": "18h → <6h",
+                  "progress": 0.35
+                }
+              ],
+              "quarter": "Q4 2024"
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/sdf-js/examples/deck-handoff/ammo/eval-qbr-earnings.json
+++ b/sdf-js/examples/deck-handoff/ammo/eval-qbr-earnings.json
@@ -1,0 +1,893 @@
+{
+  "format": "atlas-deck",
+  "version": 1,
+  "title": "eval-qbr-earnings",
+  "theme": {
+    "id": "financial-navy-cerulean",
+    "label": "Financial Navy",
+    "macroCluster": "pitch",
+    "bg": [26, 40, 66],
+    "silhouetteColor": [240, 248, 255],
+    "accent": [58, 138, 200],
+    "colors": [
+      [58, 138, 200],
+      [26, 40, 66],
+      [100, 150, 200],
+      [180, 210, 235],
+      [240, 248, 255]
+    ],
+    "font": {
+      "heading": "\"Inter Display\", Inter, system-ui, sans-serif",
+      "body": "Inter, system-ui, sans-serif"
+    },
+    "featured": true
+  },
+  "scaffold": {
+    "id": "financial-summary",
+    "label": "Financial Summary"
+  },
+  "decor": null,
+  "shared": null,
+  "slots": [
+    {
+      "slotIdx": 0,
+      "slotName": "cover",
+      "slotTitle": "Title",
+      "sceneData": {
+        "name": "financial-summary/cover",
+        "layout": "cover",
+        "subjects": [
+          {
+            "type": "cover",
+            "x": 0,
+            "y": 0,
+            "w": 1280,
+            "h": 720,
+            "args": {
+              "title": "Guidewire Q3 FY2026 Financial Results",
+              "subtitle": "Fiscal quarter ended April 30, 2026",
+              "author": "NYSE: GWRE",
+              "style": "gradient"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "slotIdx": 1,
+      "slotName": "exec-statement",
+      "slotTitle": "Executive Statement",
+      "sceneData": {
+        "name": "financial-summary/exec-statement",
+        "layout": "stage",
+        "subjects": [
+          {
+            "type": "cover",
+            "x": 0,
+            "y": 0,
+            "w": 1280,
+            "h": 120,
+            "args": {
+              "title": "Executive Statement",
+              "style": "gradient"
+            }
+          },
+          {
+            "type": "quote-pull",
+            "x": 40,
+            "y": 160,
+            "w": 1200,
+            "h": 280,
+            "args": {
+              "quote": "Third-quarter results reinforce confidence in the strength and continuing momentum of the business. Results set the company up well for what should be a record fourth quarter.",
+              "author": "CEO",
+              "align": "left"
+            }
+          },
+          {
+            "type": "bullet-list",
+            "x": 40,
+            "y": 460,
+            "w": 580,
+            "h": 220,
+            "args": {
+              "title": "Strategic Position",
+              "items": [
+                {
+                  "icon": "target",
+                  "label": "Strategy resonating with insurers"
+                },
+                {
+                  "icon": "gear-six",
+                  "label": "Focus on modernizing core systems"
+                }
+              ]
+            }
+          },
+          {
+            "type": "kpi-card",
+            "x": 660,
+            "y": 460,
+            "w": 280,
+            "h": 100,
+            "args": {
+              "value": "1,696,180",
+              "label": "Shares Repurchased",
+              "sublabel": "Q3 Activity",
+              "icon": "arrow-fat-down",
+              "style": "light"
+            }
+          },
+          {
+            "type": "kpi-card",
+            "x": 960,
+            "y": 460,
+            "w": 280,
+            "h": 100,
+            "args": {
+              "value": "$147.07",
+              "label": "Average Price",
+              "sublabel": "Per Share",
+              "icon": "currency-dollar",
+              "style": "light"
+            }
+          },
+          {
+            "type": "kpi-card",
+            "x": 660,
+            "y": 580,
+            "w": 580,
+            "h": 100,
+            "args": {
+              "value": "$240.5M",
+              "label": "Remaining Authorization",
+              "sublabel": "Share Repurchase Program",
+              "icon": "wallet",
+              "style": "accent-border"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "slotIdx": 2,
+      "slotName": "highlights-kpi",
+      "slotTitle": "Financial Highlights",
+      "sceneData": {
+        "name": "financial-summary/highlights-kpi",
+        "layout": "grid",
+        "subjects": [
+          {
+            "type": "cover",
+            "x": 0,
+            "y": 0,
+            "w": 1280,
+            "h": 120,
+            "args": {
+              "title": "Financial Highlights",
+              "style": "gradient"
+            }
+          },
+          {
+            "type": "stat-banner",
+            "x": 40,
+            "y": 140,
+            "w": 1200,
+            "h": 100,
+            "args": {
+              "value": "ARR +19% · Revenue +27%",
+              "label": "Q3 Growth Metrics",
+              "bg": "accent"
+            }
+          },
+          {
+            "type": "dashboard-multi-kpi-composite",
+            "x": 40,
+            "y": 260,
+            "w": 590,
+            "h": 200,
+            "args": {
+              "title": "Revenue Components",
+              "kpis": [
+                {
+                  "value": "$56.0M",
+                  "label": "License Revenue",
+                  "sublabel": "Q3",
+                  "trend": "down",
+                  "trendValue": "-2%",
+                  "color": [100, 150, 200]
+                },
+                {
+                  "value": "$71.8M",
+                  "label": "Services Revenue",
+                  "sublabel": "Q3",
+                  "trend": "up",
+                  "trendValue": "+32%",
+                  "color": [58, 138, 200]
+                }
+              ]
+            }
+          },
+          {
+            "type": "dashboard-multi-kpi-composite",
+            "x": 650,
+            "y": 260,
+            "w": 590,
+            "h": 200,
+            "args": {
+              "title": "GAAP Performance",
+              "kpis": [
+                {
+                  "value": "$30.6M",
+                  "label": "Operating Income",
+                  "sublabel": "+580% (30.6 vs 4.5)",
+                  "trend": "up",
+                  "color": [58, 138, 200]
+                },
+                {
+                  "value": "$16.5M",
+                  "label": "Net Income",
+                  "sublabel": "-64% (16.5 vs 46.0)",
+                  "trend": "down",
+                  "color": [100, 150, 200]
+                },
+                {
+                  "value": "$0.19",
+                  "label": "EPS",
+                  "sublabel": "vs $0.54 prior year",
+                  "trend": "down",
+                  "color": [100, 150, 200]
+                }
+              ]
+            }
+          },
+          {
+            "type": "dashboard-multi-kpi-composite",
+            "x": 40,
+            "y": 480,
+            "w": 590,
+            "h": 200,
+            "args": {
+              "title": "Non-GAAP Performance",
+              "kpis": [
+                {
+                  "value": "$77.8M",
+                  "label": "Operating Income",
+                  "sublabel": "+69% (77.8 vs 46.1)",
+                  "trend": "up",
+                  "color": [58, 138, 200]
+                },
+                {
+                  "value": "$69.6M",
+                  "label": "Net Income",
+                  "sublabel": "+47% (69.6 vs 47.4)",
+                  "trend": "up",
+                  "color": [58, 138, 200]
+                },
+                {
+                  "value": "$0.82",
+                  "label": "EPS",
+                  "sublabel": "vs $0.55 prior year",
+                  "trend": "up",
+                  "color": [58, 138, 200]
+                }
+              ]
+            }
+          },
+          {
+            "type": "dashboard-multi-kpi-composite",
+            "x": 650,
+            "y": 480,
+            "w": 590,
+            "h": 200,
+            "args": {
+              "title": "Q4 FY26 Guidance",
+              "kpis": [
+                {
+                  "value": "$1,229-$1,237M",
+                  "label": "Ending ARR",
+                  "color": [180, 210, 235]
+                },
+                {
+                  "value": "$259-$265M",
+                  "label": "Subscription & Support",
+                  "color": [180, 210, 235]
+                },
+                {
+                  "value": "$396-$406M",
+                  "label": "Total Revenue",
+                  "color": [180, 210, 235]
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "slotIdx": 3,
+      "slotName": "income",
+      "slotTitle": "Income Statement",
+      "sceneData": {
+        "name": "financial-summary/income",
+        "layout": "grid",
+        "subjects": [
+          {
+            "type": "cover",
+            "x": 0,
+            "y": 0,
+            "w": 1280,
+            "h": 120,
+            "args": {
+              "title": "Income Statement",
+              "style": "gradient"
+            }
+          },
+          {
+            "type": "kpi-card",
+            "x": 40,
+            "y": 160,
+            "w": 360,
+            "h": 240,
+            "args": {
+              "value": "$372.5M",
+              "label": "Q3 Total Revenue",
+              "trend": "up",
+              "trendValue": "+27% YoY",
+              "icon": "chart-line-up",
+              "style": "dark"
+            }
+          },
+          {
+            "type": "kpi-card",
+            "x": 440,
+            "y": 160,
+            "w": 360,
+            "h": 240,
+            "args": {
+              "value": "$36-46M",
+              "label": "Q4 GAAP Operating Income",
+              "sublabel": "Guidance",
+              "icon": "currency-dollar",
+              "style": "light"
+            }
+          },
+          {
+            "type": "kpi-card",
+            "x": 840,
+            "y": 160,
+            "w": 360,
+            "h": 240,
+            "args": {
+              "value": "$86-96M",
+              "label": "Q4 Non-GAAP Operating Income",
+              "sublabel": "Guidance",
+              "icon": "chart-bar",
+              "style": "light"
+            }
+          },
+          {
+            "type": "stat-banner",
+            "x": 40,
+            "y": 440,
+            "w": 1160,
+            "h": 220,
+            "args": {
+              "value": "Record Q4 Projected",
+              "label": "CEO guidance supports record fourth quarter performance",
+              "bg": [58, 138, 200]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "slotIdx": 4,
+      "slotName": "balance-sheet",
+      "slotTitle": "Balance Sheet",
+      "sceneData": {
+        "name": "financial-summary/balance-sheet",
+        "layout": "grid",
+        "subjects": [
+          {
+            "type": "cover",
+            "x": 0,
+            "y": 0,
+            "w": 1280,
+            "h": 120,
+            "args": {
+              "title": "Balance Sheet",
+              "style": "gradient"
+            }
+          },
+          {
+            "type": "kpi-card",
+            "x": 40,
+            "y": 180,
+            "w": 560,
+            "h": 240,
+            "args": {
+              "value": "$1,146.8M",
+              "label": "Current Cash Position",
+              "sublabel": "Cash, equivalents, and investments",
+              "icon": "currency-dollar",
+              "style": "dark"
+            }
+          },
+          {
+            "type": "kpi-card",
+            "x": 680,
+            "y": 180,
+            "w": 560,
+            "h": 240,
+            "args": {
+              "value": "$1,483.2M",
+              "label": "Prior Year-End",
+              "sublabel": "Fiscal year 2025 close",
+              "icon": "calendar",
+              "style": "light"
+            }
+          },
+          {
+            "type": "kpi-card",
+            "x": 360,
+            "y": 440,
+            "w": 560,
+            "h": 240,
+            "args": {
+              "value": "-22.7%",
+              "label": "Quarter Change",
+              "sublabel": "Capital allocation activities",
+              "trend": "down",
+              "trendValue": "-$336.4M (1,483.2 vs 1,146.8)",
+              "icon": "arrow-down",
+              "style": "accent-border"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "slotIdx": 5,
+      "slotName": "cashflow",
+      "slotTitle": "Cash Flow",
+      "sceneData": {
+        "name": "financial-summary/cashflow",
+        "layout": "row",
+        "subjects": [
+          {
+            "type": "cover",
+            "x": 0,
+            "y": 0,
+            "w": 1280,
+            "h": 120,
+            "args": {
+              "title": "Cash Flow",
+              "style": "gradient"
+            }
+          },
+          {
+            "type": "kpi-card",
+            "x": 40,
+            "y": 180,
+            "w": 360,
+            "h": 200,
+            "args": {
+              "value": "$124-134M",
+              "label": "GAAP Operating Income",
+              "sublabel": "FY 2026 Outlook",
+              "icon": "chart-line",
+              "style": "light"
+            }
+          },
+          {
+            "type": "kpi-card",
+            "x": 460,
+            "y": 180,
+            "w": 360,
+            "h": 200,
+            "args": {
+              "value": "$314-324M",
+              "label": "Non-GAAP Operating Income",
+              "sublabel": "FY 2026 Outlook",
+              "icon": "chart-bar",
+              "style": "light"
+            }
+          },
+          {
+            "type": "kpi-card",
+            "x": 880,
+            "y": 180,
+            "w": 360,
+            "h": 200,
+            "args": {
+              "value": "$365-380M",
+              "label": "Operating Cash Flow",
+              "sublabel": "FY 2026 Outlook",
+              "icon": "currency-dollar",
+              "style": "dark",
+              "trend": "up"
+            }
+          },
+          {
+            "type": "bar",
+            "x": 40,
+            "y": 420,
+            "w": 1200,
+            "h": 260,
+            "args": {
+              "values": [129, 319, 372.5],
+              "labels": [
+                "GAAP Operating Income",
+                "Non-GAAP Operating Income",
+                "Operating Cash Flow"
+              ],
+              "format": "currency",
+              "title": "FY 2026 Outlook (Midpoints)"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "slotIdx": 6,
+      "slotName": "ratios",
+      "slotTitle": "Key Ratios",
+      "sceneData": {
+        "name": "financial-summary/ratios",
+        "layout": "grid",
+        "subjects": [
+          {
+            "type": "cover",
+            "x": 0,
+            "y": 0,
+            "w": 1280,
+            "h": 120,
+            "args": {
+              "title": "Key Ratios",
+              "style": "gradient"
+            }
+          },
+          {
+            "type": "dashboard-multi-kpi-composite",
+            "x": 40,
+            "y": 160,
+            "w": 1200,
+            "h": 520,
+            "args": {
+              "title": "Profitability Metrics",
+              "kpis": [
+                {
+                  "value": "+69%",
+                  "label": "Non-GAAP Operating Income",
+                  "sublabel": "Year over year growth",
+                  "trend": "up",
+                  "trendValue": "+69%",
+                  "color": [58, 138, 200]
+                },
+                {
+                  "value": "+49%",
+                  "label": "Non-GAAP EPS",
+                  "sublabel": "Year over year growth",
+                  "trend": "up",
+                  "trendValue": "+49%",
+                  "color": [100, 150, 200]
+                },
+                {
+                  "value": "Q3",
+                  "label": "Sharp Improvement",
+                  "sublabel": "Profitability gained momentum",
+                  "trend": "up",
+                  "color": [180, 210, 235]
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "slotIdx": 7,
+      "slotName": "segments",
+      "slotTitle": "Segment Analysis",
+      "sceneData": {
+        "name": "financial-summary/segments",
+        "layout": "grid",
+        "subjects": [
+          {
+            "type": "cover",
+            "x": 0,
+            "y": 0,
+            "w": 1280,
+            "h": 120,
+            "args": {
+              "title": "Segment Analysis",
+              "style": "gradient"
+            }
+          },
+          {
+            "type": "kpi-card",
+            "x": 40,
+            "y": 160,
+            "w": 360,
+            "h": 240,
+            "args": {
+              "value": "$244.7M",
+              "label": "Subscription & Support Revenue",
+              "trend": "up",
+              "trendValue": "+35%",
+              "icon": "chart-line-up",
+              "style": "dark"
+            }
+          },
+          {
+            "type": "kpi-card",
+            "x": 460,
+            "y": 160,
+            "w": 360,
+            "h": 240,
+            "args": {
+              "value": "$1,147M",
+              "label": "Annual Recurring Revenue",
+              "sublabel": "vs $1,041M prior year",
+              "trend": "up",
+              "trendValue": "+10.2% ($1,147 vs $1,041)",
+              "icon": "currency-dollar",
+              "style": "dark"
+            }
+          },
+          {
+            "type": "stat-banner",
+            "x": 880,
+            "y": 160,
+            "w": 360,
+            "h": 240,
+            "args": {
+              "value": "Strongest Growth",
+              "label": "Subscription segment leads revenue mix",
+              "trend": "Market modernization demand",
+              "trendDirection": "up",
+              "bg": [58, 138, 200]
+            }
+          },
+          {
+            "type": "icon-grid",
+            "x": 40,
+            "y": 440,
+            "w": 1200,
+            "h": 240,
+            "args": {
+              "title": "Strategic Market Position",
+              "items": [
+                {
+                  "icon": "cloud",
+                  "label": "Cloud Migration",
+                  "sublabel": "Critical business functions to cloud platform"
+                },
+                {
+                  "icon": "brain",
+                  "label": "AI Adoption",
+                  "sublabel": "Customers adopting AI across applications"
+                },
+                {
+                  "icon": "trend-up",
+                  "label": "Market Resonance",
+                  "sublabel": "Strategy aligns with modernization demand"
+                },
+                {
+                  "icon": "arrow-clockwise",
+                  "label": "Recurring Model",
+                  "sublabel": "Expansion of subscription-based business"
+                }
+              ],
+              "cols": 4,
+              "iconStyle": "card",
+              "iconSize": "medium",
+              "colorMode": "auto"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "slotIdx": 8,
+      "slotName": "outlook",
+      "slotTitle": "Outlook & Forecast",
+      "sceneData": {
+        "name": "financial-summary/outlook",
+        "layout": "grid",
+        "subjects": [
+          {
+            "type": "cover",
+            "x": 0,
+            "y": 0,
+            "w": 1280,
+            "h": 120,
+            "args": {
+              "title": "Outlook & Forecast",
+              "style": "gradient"
+            }
+          },
+          {
+            "type": "kpi-card",
+            "x": 40,
+            "y": 160,
+            "w": 360,
+            "h": 180,
+            "args": {
+              "value": "$963–969M",
+              "label": "Subscription & Support Revenue",
+              "sublabel": "FY2026 Expected",
+              "icon": "chart-line-up",
+              "style": "light"
+            }
+          },
+          {
+            "type": "kpi-card",
+            "x": 460,
+            "y": 160,
+            "w": 360,
+            "h": 180,
+            "args": {
+              "value": "$1,460–1,470M",
+              "label": "Total Revenue",
+              "sublabel": "FY2026 Expected",
+              "icon": "currency-dollar",
+              "style": "light"
+            }
+          },
+          {
+            "type": "kpi-card",
+            "x": 880,
+            "y": 160,
+            "w": 360,
+            "h": 180,
+            "args": {
+              "value": "27%",
+              "label": "Revenue Growth",
+              "sublabel": "Q3 Performance",
+              "trend": "up",
+              "trendValue": "+27%",
+              "icon": "trend-up",
+              "style": "light"
+            }
+          },
+          {
+            "type": "kpi-card",
+            "x": 40,
+            "y": 360,
+            "w": 360,
+            "h": 180,
+            "args": {
+              "value": "19%",
+              "label": "ARR Growth",
+              "sublabel": "Q3 Performance",
+              "trend": "up",
+              "trendValue": "+19%",
+              "icon": "arrow-fat-up",
+              "style": "light"
+            }
+          },
+          {
+            "type": "bullet-list",
+            "x": 460,
+            "y": 360,
+            "w": 780,
+            "h": 320,
+            "args": {
+              "title": "FY2026 Positioning",
+              "items": [
+                {
+                  "icon": "chart-line-up",
+                  "label": "Raised full-year guidance",
+                  "sublabel": "Revenue, operating income, and cash flow"
+                },
+                {
+                  "icon": "trophy",
+                  "label": "Record Q4 expected",
+                  "sublabel": "Positioned for strongest quarter"
+                },
+                {
+                  "icon": "cloud",
+                  "label": "Cloud adoption momentum",
+                  "sublabel": "Continued growth driver"
+                },
+                {
+                  "icon": "brain",
+                  "label": "AI adoption momentum",
+                  "sublabel": "Strategic growth catalyst"
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "slotIdx": 9,
+      "slotName": "appendix",
+      "slotTitle": "Appendix",
+      "sceneData": {
+        "name": "financial-summary/appendix",
+        "layout": "grid",
+        "subjects": [
+          {
+            "type": "cover",
+            "x": 0,
+            "y": 0,
+            "w": 1280,
+            "h": 120,
+            "args": {
+              "title": "Appendix",
+              "style": "gradient"
+            }
+          },
+          {
+            "type": "bullet-list",
+            "x": 40,
+            "y": 160,
+            "w": 560,
+            "h": 520,
+            "args": {
+              "title": "Methodology Notes",
+              "items": [
+                {
+                  "icon": "chart-line",
+                  "label": "Revenue growth YoY comparison",
+                  "sublabel": "Constant currency basis"
+                },
+                {
+                  "icon": "calculator",
+                  "label": "Profitability metrics normalized",
+                  "sublabel": "Excludes one-time items"
+                },
+                {
+                  "icon": "calendar",
+                  "label": "Fiscal 2026 projections",
+                  "sublabel": "Based on current run rate"
+                },
+                {
+                  "icon": "database",
+                  "label": "Segment reporting aligned",
+                  "sublabel": "Per GAAP standards"
+                }
+              ]
+            }
+          },
+          {
+            "type": "bullet-list",
+            "x": 680,
+            "y": 160,
+            "w": 560,
+            "h": 520,
+            "args": {
+              "title": "Key Assumptions",
+              "items": [
+                {
+                  "icon": "globe",
+                  "label": "Macroeconomic conditions stable",
+                  "sublabel": "No major disruptions"
+                },
+                {
+                  "icon": "currency-dollar",
+                  "label": "Currency fluctuation normalized",
+                  "sublabel": "Within historical ranges"
+                },
+                {
+                  "icon": "users",
+                  "label": "Customer retention sustained",
+                  "sublabel": "At current levels"
+                },
+                {
+                  "icon": "chart-bar",
+                  "label": "Market share trajectory",
+                  "sublabel": "Continues current trend"
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/sdf-js/examples/deck-handoff/ammo/eval-qbr-q3-2026.json
+++ b/sdf-js/examples/deck-handoff/ammo/eval-qbr-q3-2026.json
@@ -1,0 +1,507 @@
+{
+  "format": "atlas-deck",
+  "version": 1,
+  "title": "eval-qbr-q3-2026",
+  "theme": {
+    "id": "editorial-navy",
+    "label": "Editorial · Navy",
+    "macroCluster": "editorial",
+    "bg": [248, 246, 240],
+    "silhouetteColor": [22, 35, 70],
+    "accent": [38, 70, 130],
+    "colors": [
+      [38, 70, 130],
+      [110, 95, 75],
+      [165, 130, 90],
+      [200, 195, 180]
+    ],
+    "font": {
+      "heading": "Georgia, \"Source Serif Pro\", serif",
+      "body": "Inter, system-ui, sans-serif"
+    },
+    "featured": true
+  },
+  "scaffold": {
+    "id": "qbr",
+    "label": "Quarterly Business Review"
+  },
+  "decor": null,
+  "shared": null,
+  "slots": [
+    {
+      "slotIdx": 0,
+      "slotName": "cover",
+      "slotTitle": "Title",
+      "sceneData": {
+        "name": "qbr/cover",
+        "layout": "cover",
+        "subjects": [
+          {
+            "type": "cover",
+            "x": 0,
+            "y": 0,
+            "w": 1280,
+            "h": 720,
+            "args": {
+              "title": "Q3 2026 Quarterly Business Review",
+              "subtitle": "Operations + Product + GTM",
+              "author": "ANTFUN team review",
+              "date": "2026-09-30",
+              "style": "gradient"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "slotIdx": 1,
+      "slotName": "executive-summary",
+      "slotTitle": "Executive Summary",
+      "sceneData": {
+        "name": "qbr/executive-summary",
+        "layout": "grid",
+        "subjects": [
+          {
+            "type": "cover",
+            "x": 0,
+            "y": 0,
+            "w": 1280,
+            "h": 120,
+            "args": {
+              "title": "Executive Summary",
+              "style": "gradient"
+            }
+          },
+          {
+            "type": "dashboard-multi-kpi-composite",
+            "x": 40,
+            "y": 160,
+            "w": 1200,
+            "h": 280,
+            "args": {
+              "kpis": [
+                {
+                  "value": "$740K",
+                  "label": "Q3 ARR",
+                  "trend": "up",
+                  "trendValue": "+117% QoQ",
+                  "color": [38, 70, 130]
+                },
+                {
+                  "value": "12.5K",
+                  "label": "Daily Active Wallets",
+                  "sublabel": "crossed threshold",
+                  "trend": "up",
+                  "color": [110, 95, 75]
+                },
+                {
+                  "value": "Week 8",
+                  "label": "Insurance Policy",
+                  "sublabel": "launched",
+                  "trend": "neutral",
+                  "color": [165, 130, 90]
+                }
+              ]
+            }
+          },
+          {
+            "type": "bullet-list",
+            "x": 40,
+            "y": 480,
+            "w": 580,
+            "h": 180,
+            "args": {
+              "items": [
+                {
+                  "icon": "rocket-launch",
+                  "label": "Perp DEX prototype shipped",
+                  "status": "done"
+                }
+              ]
+            }
+          },
+          {
+            "type": "kpi-card",
+            "x": 660,
+            "y": 480,
+            "w": 580,
+            "h": 180,
+            "args": {
+              "value": "3",
+              "label": "Strategic Risks",
+              "sublabel": "See risks slide",
+              "icon": "warning",
+              "style": "accent-border"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "slotIdx": 2,
+      "slotName": "kpis",
+      "slotTitle": "KPI Dashboard",
+      "sceneData": {
+        "name": "qbr/kpis",
+        "layout": "grid",
+        "subjects": [
+          {
+            "type": "cover",
+            "x": 0,
+            "y": 0,
+            "w": 1280,
+            "h": 120,
+            "args": {
+              "title": "KPI Dashboard",
+              "style": "gradient"
+            }
+          },
+          {
+            "type": "kpi-card",
+            "x": 40,
+            "y": 160,
+            "w": 380,
+            "h": 240,
+            "args": {
+              "value": "$740K",
+              "label": "ARR",
+              "sublabel": "Target $600K",
+              "trend": "up",
+              "trendValue": "+23%",
+              "icon": "chart-line-up",
+              "style": "light"
+            }
+          },
+          {
+            "type": "kpi-card",
+            "x": 450,
+            "y": 160,
+            "w": 380,
+            "h": 240,
+            "args": {
+              "value": "12,500",
+              "label": "Daily Active Users",
+              "sublabel": "Target 8,000",
+              "trend": "up",
+              "trendValue": "+56%",
+              "icon": "users",
+              "style": "light"
+            }
+          },
+          {
+            "type": "kpi-card",
+            "x": 860,
+            "y": 160,
+            "w": 380,
+            "h": 240,
+            "args": {
+              "value": "$4.2M",
+              "label": "Daily Volume",
+              "sublabel": "Target $3M",
+              "trend": "up",
+              "trendValue": "+40%",
+              "icon": "arrows-clockwise",
+              "style": "light"
+            }
+          },
+          {
+            "type": "kpi-card",
+            "x": 40,
+            "y": 430,
+            "w": 380,
+            "h": 240,
+            "args": {
+              "value": "92%",
+              "label": "Retention D30",
+              "sublabel": "Target 85%",
+              "trend": "up",
+              "trendValue": "+7pt",
+              "icon": "hand-heart",
+              "style": "light"
+            }
+          },
+          {
+            "type": "kpi-card",
+            "x": 450,
+            "y": 430,
+            "w": 380,
+            "h": 240,
+            "args": {
+              "value": "72",
+              "label": "NPS",
+              "sublabel": "Target 60",
+              "trend": "up",
+              "trendValue": "+12pt",
+              "icon": "star",
+              "style": "light"
+            }
+          },
+          {
+            "type": "kpi-card",
+            "x": 860,
+            "y": 430,
+            "w": 380,
+            "h": 240,
+            "args": {
+              "value": "$180K/mo",
+              "label": "Burn Rate",
+              "sublabel": "Budget $250K",
+              "trend": "down",
+              "trendValue": "Under $70K",
+              "icon": "currency-dollar",
+              "style": "light"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "slotIdx": 3,
+      "slotName": "wins",
+      "slotTitle": "Wins",
+      "sceneData": {
+        "name": "qbr/wins",
+        "layout": "grid",
+        "subjects": [
+          {
+            "type": "cover",
+            "x": 0,
+            "y": 0,
+            "w": 1280,
+            "h": 120,
+            "args": {
+              "title": "Wins",
+              "style": "gradient"
+            }
+          },
+          {
+            "type": "icon-grid",
+            "x": 80,
+            "y": 180,
+            "w": 1120,
+            "h": 480,
+            "args": {
+              "items": [
+                {
+                  "icon": "trophy",
+                  "label": "Web3 Award",
+                  "sublabel": "Self-custodial UX"
+                },
+                {
+                  "icon": "currency-dollar",
+                  "label": "$25M Signed",
+                  "sublabel": "Sequoia follow-on"
+                },
+                {
+                  "icon": "users",
+                  "label": "Elite Hires",
+                  "sublabel": "4 Coinbase + 2 Anthropic"
+                },
+                {
+                  "icon": "newspaper",
+                  "label": "Press Coverage",
+                  "sublabel": "TechCrunch + Bloomberg"
+                },
+                {
+                  "icon": "chats-circle",
+                  "label": "24K Members",
+                  "sublabel": "Discord community"
+                }
+              ],
+              "cols": 3,
+              "iconSize": "large",
+              "iconStyle": "card",
+              "colorMode": "brand"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "slotIdx": 4,
+      "slotName": "challenges",
+      "slotTitle": "Challenges",
+      "sceneData": {
+        "name": "qbr/challenges",
+        "layout": "grid",
+        "subjects": [
+          {
+            "type": "cover",
+            "x": 0,
+            "y": 0,
+            "w": 1280,
+            "h": 120,
+            "args": {
+              "title": "Challenges",
+              "style": "gradient"
+            }
+          },
+          {
+            "type": "risk-heatmap",
+            "x": 60,
+            "y": 160,
+            "w": 1160,
+            "h": 500,
+            "args": {
+              "title": "Q3 Challenges by Impact & Likelihood",
+              "xAxis": "Likelihood",
+              "yAxis": "Impact",
+              "xLabels": ["Low", "Medium", "High", "Very High", "Critical"],
+              "yLabels": ["Minor", "Moderate", "Significant", "Major", "Severe"],
+              "risks": [
+                {
+                  "label": "Bridge API instability",
+                  "likelihood": 4,
+                  "impact": 4,
+                  "description": "Third-party integration delayed"
+                },
+                {
+                  "label": "Perp DEX latency",
+                  "likelihood": 5,
+                  "impact": 3,
+                  "description": "2s vs 800ms goal"
+                },
+                {
+                  "label": "Asia GTM delay",
+                  "likelihood": 3,
+                  "impact": 4,
+                  "description": "Regulatory uncertainty"
+                },
+                {
+                  "label": "Support SLA breach",
+                  "likelihood": 5,
+                  "impact": 3,
+                  "description": "8h avg vs 2h target"
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "slotIdx": 5,
+      "slotName": "outlook",
+      "slotTitle": "Outlook",
+      "sceneData": {
+        "name": "qbr/outlook",
+        "layout": "hierarchy",
+        "subjects": [
+          {
+            "type": "cover",
+            "x": 0,
+            "y": 0,
+            "w": 1280,
+            "h": 120,
+            "args": {
+              "title": "Q4 Outlook",
+              "style": "gradient"
+            }
+          },
+          {
+            "type": "okr-tree",
+            "x": 80,
+            "y": 160,
+            "w": 1120,
+            "h": 520,
+            "args": {
+              "objective": "Scale to $2.4M ARR",
+              "keyResults": [
+                {
+                  "label": "Launch Perp DEX",
+                  "sublabel": "Sub-second matching engine",
+                  "progress": 0.75
+                },
+                {
+                  "label": "Insurance expansion",
+                  "sublabel": "10-token coverage",
+                  "progress": 0.6
+                },
+                {
+                  "label": "Asia regulatory clearance",
+                  "sublabel": "Singapore + Hong Kong",
+                  "progress": 0.4
+                },
+                {
+                  "label": "Series B exploration",
+                  "sublabel": "Investor conversations",
+                  "progress": 0.2
+                }
+              ],
+              "quarter": "Q4 2024"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "slotIdx": 6,
+      "slotName": "next-steps",
+      "slotTitle": "Next Steps",
+      "sceneData": {
+        "name": "qbr/next-steps",
+        "layout": "row",
+        "subjects": [
+          {
+            "type": "cover",
+            "x": 0,
+            "y": 0,
+            "w": 1280,
+            "h": 120,
+            "args": {
+              "title": "Next Steps",
+              "style": "gradient"
+            }
+          },
+          {
+            "type": "kanban-board",
+            "x": 80,
+            "y": 160,
+            "w": 1120,
+            "h": 520,
+            "args": {
+              "columns": [
+                {
+                  "label": "Engineering",
+                  "cards": [
+                    {
+                      "label": "Ship Perp DEX engine",
+                      "sublabel": "Due: Oct 15"
+                    }
+                  ]
+                },
+                {
+                  "label": "Product",
+                  "cards": [
+                    {
+                      "label": "Insurance API beta",
+                      "sublabel": "Due: Oct 30"
+                    }
+                  ]
+                },
+                {
+                  "label": "Legal",
+                  "cards": [
+                    {
+                      "label": "Asia compliance docs",
+                      "sublabel": "Due: Nov 10"
+                    }
+                  ]
+                },
+                {
+                  "label": "CEO",
+                  "cards": [
+                    {
+                      "label": "B-round pitch deck v1",
+                      "sublabel": "Due: Nov 30"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/sdf-js/examples/deck-handoff/ammo/eval-strategy-batch2-validation.json
+++ b/sdf-js/examples/deck-handoff/ammo/eval-strategy-batch2-validation.json
@@ -1,0 +1,683 @@
+{
+  "format": "atlas-deck",
+  "version": 1,
+  "title": "eval-strategy-batch2-validation",
+  "theme": {
+    "id": "consulting-charcoal",
+    "label": "Consulting Charcoal",
+    "macroCluster": "pitch",
+    "bg": [26, 26, 34],
+    "silhouetteColor": [220, 215, 200],
+    "accent": [156, 142, 110],
+    "colors": [
+      [156, 142, 110],
+      [100, 95, 82],
+      [200, 193, 174],
+      [60, 60, 72],
+      [220, 215, 200]
+    ],
+    "font": {
+      "heading": "\"Inter Display\", Inter, system-ui, sans-serif",
+      "body": "Inter, system-ui, sans-serif"
+    },
+    "featured": true
+  },
+  "scaffold": {
+    "id": "change-roadmap",
+    "label": "Change & Transformation Roadmap"
+  },
+  "decor": null,
+  "shared": null,
+  "slots": [
+    {
+      "slotIdx": 0,
+      "slotName": "cover",
+      "slotTitle": "Title",
+      "sceneData": {
+        "name": "change-roadmap/cover",
+        "layout": "cover",
+        "subjects": [
+          {
+            "type": "cover",
+            "x": 0,
+            "y": 0,
+            "w": 1280,
+            "h": 720,
+            "args": {
+              "title": "Digital Transformation Roadmap 2026",
+              "subtitle": "Organization-wide transformation program led by Executive Steering Committee",
+              "date": "Q1 2026",
+              "style": "gradient"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "slotIdx": 1,
+      "slotName": "case-for-change",
+      "slotTitle": "Case for Change",
+      "sceneData": {
+        "name": "change-roadmap/case-for-change",
+        "layout": "grid",
+        "subjects": [
+          {
+            "type": "cover",
+            "x": 0,
+            "y": 0,
+            "w": 1280,
+            "h": 120,
+            "args": {
+              "title": "Case for Change",
+              "style": "gradient"
+            }
+          },
+          {
+            "type": "stat-banner",
+            "x": 40,
+            "y": 150,
+            "w": 1200,
+            "h": 100,
+            "args": {
+              "value": "$24M ARR",
+              "label": "Annual Recurring Revenue",
+              "trend": "↑117% YoY",
+              "trendDirection": "up",
+              "bg": [156, 142, 110]
+            }
+          },
+          {
+            "type": "kpi-card",
+            "x": 40,
+            "y": 280,
+            "w": 280,
+            "h": 180,
+            "args": {
+              "value": "3%",
+              "label": "Revenue Growth",
+              "sublabel": "vs. industry 12%",
+              "trend": "down",
+              "trendValue": "-9pp gap",
+              "icon": "chart-line-down",
+              "style": "light"
+            }
+          },
+          {
+            "type": "kpi-card",
+            "x": 340,
+            "y": 280,
+            "w": 280,
+            "h": 180,
+            "args": {
+              "value": "$4.2M",
+              "label": "Annual Inefficiency",
+              "sublabel": "Legacy systems cost",
+              "icon": "warning-octagon",
+              "style": "light"
+            }
+          },
+          {
+            "type": "kpi-card",
+            "x": 640,
+            "y": 280,
+            "w": 280,
+            "h": 180,
+            "args": {
+              "value": "44",
+              "label": "Customer NPS",
+              "sublabel": "Dropped from 67",
+              "trend": "down",
+              "trendValue": "-23 pts",
+              "icon": "smiley-sad",
+              "style": "light"
+            }
+          },
+          {
+            "type": "kpi-card",
+            "x": 940,
+            "y": 280,
+            "w": 280,
+            "h": 180,
+            "args": {
+              "value": "128%",
+              "label": "Net Revenue Retention",
+              "sublabel": "Enterprise expansion",
+              "trend": "up",
+              "icon": "trend-up",
+              "style": "light"
+            }
+          },
+          {
+            "type": "bullet-list",
+            "x": 40,
+            "y": 490,
+            "w": 580,
+            "h": 190,
+            "args": {
+              "title": "Transformation Drivers",
+              "items": [
+                {
+                  "icon": "users-four",
+                  "label": "Competitor pressure intensifying"
+                },
+                {
+                  "icon": "scales",
+                  "label": "New regulatory requirements"
+                },
+                {
+                  "icon": "user-minus",
+                  "label": "Critical talent attrition"
+                }
+              ]
+            }
+          },
+          {
+            "type": "kpi-card",
+            "x": 640,
+            "y": 490,
+            "w": 280,
+            "h": 190,
+            "args": {
+              "value": "11 mo",
+              "label": "CAC Payback",
+              "sublabel": "Customer acquisition efficiency",
+              "icon": "clock",
+              "style": "accent-border"
+            }
+          },
+          {
+            "type": "kpi-card",
+            "x": 940,
+            "y": 490,
+            "w": 280,
+            "h": 190,
+            "args": {
+              "value": "End 2026",
+              "label": "Board Mandate",
+              "sublabel": "Digital acceleration deadline",
+              "icon": "flag-checkered",
+              "style": "accent-border"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "slotIdx": 2,
+      "slotName": "current-state",
+      "slotTitle": "Current State",
+      "sceneData": {
+        "name": "change-roadmap/current-state",
+        "layout": "grid",
+        "subjects": [
+          {
+            "type": "cover",
+            "x": 0,
+            "y": 0,
+            "w": 1280,
+            "h": 120,
+            "args": {
+              "title": "Current State",
+              "style": "gradient"
+            }
+          },
+          {
+            "type": "swot",
+            "x": 40,
+            "y": 160,
+            "w": 1200,
+            "h": 520,
+            "args": {
+              "title": "Current State Assessment",
+              "strengths": [
+                "Strong brand · 78% recognition",
+                "Loyal customers · 15-year avg relationship"
+              ],
+              "weaknesses": [
+                "Siloed data · 7 separate systems",
+                "Manual processes · 40% of tasks",
+                "Outdated CRM · 2014"
+              ],
+              "opportunities": [
+                "AI automation · $2M potential savings",
+                "Cloud migration · scalability",
+                "Open banking API"
+              ],
+              "threats": [
+                "FinTech disruptors · 3 new entrants",
+                "Talent war · 22% tech turnover",
+                "Regulatory complexity"
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "slotIdx": 3,
+      "slotName": "target-state",
+      "slotTitle": "Target State",
+      "sceneData": {
+        "name": "change-roadmap/target-state",
+        "layout": "grid",
+        "subjects": [
+          {
+            "type": "cover",
+            "x": 0,
+            "y": 0,
+            "w": 1280,
+            "h": 120,
+            "args": {
+              "title": "Target State",
+              "style": "gradient"
+            }
+          },
+          {
+            "type": "kpi-card",
+            "x": 40,
+            "y": 160,
+            "w": 380,
+            "h": 220,
+            "args": {
+              "value": "40%",
+              "label": "Processing Time Reduction",
+              "sublabel": "Digital Core automation by Q3",
+              "icon": "lightning",
+              "trend": "down",
+              "trendValue": "Target Q3",
+              "style": "dark"
+            }
+          },
+          {
+            "type": "icon-grid",
+            "x": 460,
+            "y": 160,
+            "w": 780,
+            "h": 520,
+            "args": {
+              "title": "12-Month Transformation Dimensions",
+              "items": [
+                {
+                  "icon": "gear-six",
+                  "label": "Process Automation",
+                  "sublabel": "Core workflows digitized"
+                },
+                {
+                  "icon": "pulse",
+                  "label": "Real-time Data",
+                  "sublabel": "Live operational visibility"
+                },
+                {
+                  "icon": "user-focus",
+                  "label": "Customer Self-Service",
+                  "sublabel": "Autonomous experience channels"
+                },
+                {
+                  "icon": "brain",
+                  "label": "AI Decision Support",
+                  "sublabel": "Intelligent recommendations"
+                },
+                {
+                  "icon": "plugs-connected",
+                  "label": "API Ecosystem",
+                  "sublabel": "Partner integration platform"
+                },
+                {
+                  "icon": "cloud",
+                  "label": "Cloud-native Architecture",
+                  "sublabel": "Scalable infrastructure"
+                }
+              ],
+              "cols": 2,
+              "iconStyle": "card",
+              "iconSize": "medium",
+              "colorMode": "auto"
+            }
+          },
+          {
+            "type": "stat-banner",
+            "x": 40,
+            "y": 420,
+            "w": 380,
+            "h": 100,
+            "args": {
+              "value": "Digital Core",
+              "label": "Foundation Layer Complete",
+              "trend": "On Track",
+              "trendDirection": "up",
+              "bg": [156, 142, 110]
+            }
+          },
+          {
+            "type": "bullet-list",
+            "x": 40,
+            "y": 560,
+            "w": 380,
+            "h": 120,
+            "args": {
+              "items": [
+                {
+                  "icon": "check-circle",
+                  "label": "Cost reduction via automation",
+                  "status": "highlight"
+                },
+                {
+                  "icon": "rocket",
+                  "label": "Faster processing cycles",
+                  "status": "highlight"
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "slotIdx": 4,
+      "slotName": "journey-phases",
+      "slotTitle": "Change Journey",
+      "sceneData": {
+        "name": "change-roadmap/journey-phases",
+        "layout": "stage",
+        "subjects": [
+          {
+            "type": "cover",
+            "x": 0,
+            "y": 0,
+            "w": 1280,
+            "h": 120,
+            "args": {
+              "title": "Change Journey",
+              "style": "gradient"
+            }
+          },
+          {
+            "type": "change-curve-chart",
+            "x": 40,
+            "y": 160,
+            "w": 760,
+            "h": 380,
+            "args": {
+              "title": "Transformation Curve",
+              "xAxis": "Timeline",
+              "yAxis": "Performance",
+              "phases": [
+                {
+                  "label": "Q1: Mobilise",
+                  "sublabel": "Governance + Quick Wins"
+                },
+                {
+                  "label": "Q2-Q3: Transform",
+                  "sublabel": "Core Migration + Redesign"
+                },
+                {
+                  "label": "Q4: Sustain",
+                  "sublabel": "Embed + Measure"
+                }
+              ]
+            }
+          },
+          {
+            "type": "traffic-light",
+            "x": 840,
+            "y": 160,
+            "w": 400,
+            "h": 380,
+            "args": {
+              "title": "Risk Register",
+              "lights": [
+                {
+                  "color": "red",
+                  "active": true,
+                  "label": "Change Fatigue"
+                },
+                {
+                  "color": "amber",
+                  "active": true,
+                  "label": "Data Migration"
+                },
+                {
+                  "color": "green",
+                  "active": true,
+                  "label": "Vendor Delays"
+                }
+              ]
+            }
+          },
+          {
+            "type": "progression",
+            "x": 40,
+            "y": 560,
+            "w": 1200,
+            "h": 120,
+            "args": {
+              "steps": [
+                {
+                  "label": "Q1 Mobilise",
+                  "status": "current"
+                },
+                {
+                  "label": "Q2-Q3 Transform",
+                  "status": "todo"
+                },
+                {
+                  "label": "Q4 Sustain",
+                  "status": "todo"
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "slotIdx": 5,
+      "slotName": "enablers",
+      "slotTitle": "Enablers",
+      "sceneData": {
+        "name": "change-roadmap/enablers",
+        "layout": "stage",
+        "subjects": [
+          {
+            "type": "cover",
+            "x": 0,
+            "y": 0,
+            "w": 1280,
+            "h": 120,
+            "args": {
+              "title": "Enablers",
+              "style": "gradient"
+            }
+          },
+          {
+            "type": "radial-wheel-segmented",
+            "x": 80,
+            "y": 160,
+            "w": 1120,
+            "h": 520,
+            "args": {
+              "title": "Five Strategic Pillars",
+              "hub": "Transformation Core",
+              "segments": [
+                {
+                  "label": "Digitise Core",
+                  "description": "Automate top 20 workflows"
+                },
+                {
+                  "label": "Data First",
+                  "description": "Unified platform — single truth"
+                },
+                {
+                  "label": "Customer 360",
+                  "description": "Real-time personalisation engine"
+                },
+                {
+                  "label": "Talent Uplift",
+                  "description": "Digital upskilling — 800 employees"
+                },
+                {
+                  "label": "Ecosystem Play",
+                  "description": "API partnerships — 12 fintechs"
+                }
+              ],
+              "segmentColors": [
+                [156, 142, 110],
+                [100, 95, 82],
+                [200, 193, 174],
+                [60, 60, 72],
+                [220, 215, 200]
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "slotIdx": 6,
+      "slotName": "risks",
+      "slotTitle": "Risks & Mitigations",
+      "sceneData": {
+        "name": "change-roadmap/risks",
+        "layout": "grid",
+        "subjects": [
+          {
+            "type": "cover",
+            "x": 0,
+            "y": 0,
+            "w": 1280,
+            "h": 120,
+            "args": {
+              "title": "Risks & Mitigations",
+              "style": "gradient"
+            }
+          },
+          {
+            "type": "risk-heatmap",
+            "x": 40,
+            "y": 160,
+            "w": 580,
+            "h": 500,
+            "args": {
+              "title": "Risk Assessment",
+              "xAxis": "Likelihood",
+              "yAxis": "Impact",
+              "xLabels": ["Very Low", "Low", "Medium", "High", "Very High"],
+              "yLabels": ["Very Low", "Low", "Medium", "High", "Very High"],
+              "risks": [
+                {
+                  "label": "Change Fatigue",
+                  "likelihood": 4,
+                  "impact": 4,
+                  "color": [220, 53, 69]
+                },
+                {
+                  "label": "Data Migration Errors",
+                  "likelihood": 2,
+                  "impact": 3,
+                  "color": [255, 193, 7]
+                },
+                {
+                  "label": "Vendor Delays",
+                  "likelihood": 1,
+                  "impact": 2,
+                  "color": [156, 142, 110]
+                }
+              ]
+            }
+          },
+          {
+            "type": "timeline",
+            "x": 660,
+            "y": 160,
+            "w": 580,
+            "h": 500,
+            "args": {
+              "title": "Change Journey",
+              "events": [
+                {
+                  "date": "Q1",
+                  "label": "Mobilise",
+                  "sublabel": "Governance & quick wins"
+                },
+                {
+                  "date": "Q2-Q3",
+                  "label": "Transform",
+                  "sublabel": "Core migration & redesign"
+                },
+                {
+                  "date": "Q4",
+                  "label": "Sustain",
+                  "sublabel": "Embed & measure"
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "slotIdx": 7,
+      "slotName": "timeline",
+      "slotTitle": "Delivery Timeline",
+      "sceneData": {
+        "name": "change-roadmap/timeline",
+        "layout": "stage",
+        "subjects": [
+          {
+            "type": "cover",
+            "x": 0,
+            "y": 0,
+            "w": 1280,
+            "h": 120,
+            "args": {
+              "title": "Delivery Timeline",
+              "style": "gradient"
+            }
+          },
+          {
+            "type": "timeline",
+            "x": 80,
+            "y": 180,
+            "w": 1120,
+            "h": 480,
+            "args": {
+              "title": "Programme Timeline 2026",
+              "events": [
+                {
+                  "date": "Jan 2026",
+                  "label": "Programme Launch",
+                  "sublabel": "Steering committee formation"
+                },
+                {
+                  "date": "Mar 2026",
+                  "label": "Design Complete",
+                  "sublabel": "Core systems architecture"
+                },
+                {
+                  "date": "Jun 2026",
+                  "label": "Wave 1 Go-Live",
+                  "sublabel": "Finance + HR modules"
+                },
+                {
+                  "date": "Sep 2026",
+                  "label": "Wave 2 Go-Live",
+                  "sublabel": "Operations + Customer"
+                },
+                {
+                  "date": "Dec 2026",
+                  "label": "Programme Completion",
+                  "sublabel": "Full deployment + retrospective"
+                },
+                {
+                  "date": "Q1 2027",
+                  "label": "Benefits Review",
+                  "sublabel": "Realisation assessment"
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/sdf-js/examples/deck-handoff/ammo/eval-strategy-swot-portfolio.json
+++ b/sdf-js/examples/deck-handoff/ammo/eval-strategy-swot-portfolio.json
@@ -1,0 +1,458 @@
+{
+  "format": "atlas-deck",
+  "version": 1,
+  "title": "eval-strategy-swot-portfolio",
+  "theme": {
+    "id": "editorial-navy",
+    "label": "Editorial · Navy",
+    "macroCluster": "editorial",
+    "bg": [248, 246, 240],
+    "silhouetteColor": [22, 35, 70],
+    "accent": [38, 70, 130],
+    "colors": [
+      [38, 70, 130],
+      [110, 95, 75],
+      [165, 130, 90],
+      [200, 195, 180]
+    ],
+    "font": {
+      "heading": "Georgia, \"Source Serif Pro\", serif",
+      "body": "Inter, system-ui, sans-serif"
+    },
+    "featured": true
+  },
+  "scaffold": {
+    "id": "analysis-report",
+    "label": "Analysis Report"
+  },
+  "decor": null,
+  "shared": null,
+  "slots": [
+    {
+      "slotIdx": 0,
+      "slotName": "cover",
+      "slotTitle": "Title",
+      "sceneData": {
+        "name": "analysis-report/cover",
+        "layout": "cover",
+        "subjects": [
+          {
+            "type": "cover",
+            "x": 0,
+            "y": 0,
+            "w": 1280,
+            "h": 720,
+            "args": {
+              "title": "Strategic Portfolio Analysis 2026",
+              "subtitle": "Independent analyst review — Q3 2026",
+              "author": "Strategy Team",
+              "date": "Framework: SWOT + Porter Value Chain",
+              "style": "gradient"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "slotIdx": 1,
+      "slotName": "scope",
+      "slotTitle": "Scope & Methodology",
+      "sceneData": {
+        "name": "analysis-report/scope",
+        "layout": "row",
+        "subjects": [
+          {
+            "type": "cover",
+            "x": 0,
+            "y": 0,
+            "w": 1280,
+            "h": 120,
+            "args": {
+              "title": "Scope & Methodology",
+              "style": "gradient"
+            }
+          },
+          {
+            "type": "bullet-list",
+            "x": 80,
+            "y": 180,
+            "w": 560,
+            "h": 480,
+            "args": {
+              "title": "Analysis Scope",
+              "items": [
+                {
+                  "icon": "package",
+                  "label": "6 product lines reviewed",
+                  "sublabel": "NA + EMEA + APAC markets"
+                },
+                {
+                  "icon": "calendar",
+                  "label": "11-quarter time window",
+                  "sublabel": "2024-Q1 through 2026-Q3"
+                },
+                {
+                  "icon": "database",
+                  "label": "Internal KPI dashboard",
+                  "sublabel": "Primary data source"
+                },
+                {
+                  "icon": "users",
+                  "label": "32 customer interviews",
+                  "sublabel": "Qualitative insights"
+                },
+                {
+                  "icon": "chart-bar",
+                  "label": "Gartner Magic Quadrant 2025",
+                  "sublabel": "Competitive positioning"
+                }
+              ]
+            }
+          },
+          {
+            "type": "icon-row",
+            "x": 680,
+            "y": 180,
+            "w": 520,
+            "h": 480,
+            "args": {
+              "title": "Frameworks Applied",
+              "items": [
+                {
+                  "icon": "matrix-grid",
+                  "label": "SWOT",
+                  "sublabel": "Strategic positioning"
+                },
+                {
+                  "icon": "network",
+                  "label": "Porter Value Chain",
+                  "sublabel": "Activity analysis"
+                },
+                {
+                  "icon": "chart-line",
+                  "label": "Change Curve",
+                  "sublabel": "Adoption assessment"
+                }
+              ],
+              "iconStyle": "card",
+              "iconSize": "medium"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "slotIdx": 2,
+      "slotName": "definition",
+      "slotTitle": "Context & Definition",
+      "sceneData": {
+        "name": "analysis-report/definition",
+        "layout": "stage",
+        "subjects": [
+          {
+            "type": "cover",
+            "x": 0,
+            "y": 0,
+            "w": 1280,
+            "h": 120,
+            "args": {
+              "title": "Context & Definition",
+              "style": "gradient"
+            }
+          },
+          {
+            "type": "value-chain-diagram",
+            "x": 40,
+            "y": 160,
+            "w": 1200,
+            "h": 520,
+            "args": {
+              "title": "Porter Value Chain Framework",
+              "primary": [
+                "Inbound Logistics",
+                "Operations",
+                "Outbound Logistics",
+                "Marketing & Sales",
+                "Service"
+              ],
+              "support": [
+                "Firm Infrastructure",
+                "Human Resource Management",
+                "Technology Development",
+                "Procurement"
+              ],
+              "outcome": "Margin"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "slotIdx": 3,
+      "slotName": "data-findings",
+      "slotTitle": "Data & Findings",
+      "sceneData": {
+        "name": "analysis-report/data-findings",
+        "layout": "stage",
+        "subjects": [
+          {
+            "type": "cover",
+            "x": 0,
+            "y": 0,
+            "w": 1280,
+            "h": 120,
+            "args": {
+              "title": "Data & Findings"
+            }
+          },
+          {
+            "type": "testimonial-wall",
+            "x": 40,
+            "y": 160,
+            "w": 1200,
+            "h": 520,
+            "args": {
+              "title": "Voice of the Customer",
+              "testimonials": [
+                {
+                  "quote": "This platform changed how our team coordinates across timezones — we no longer lose context in handoffs.",
+                  "name": "Sarah Chen",
+                  "role": "VP Engineering at Meridian Analytics"
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "slotIdx": 4,
+      "slotName": "framework-analysis",
+      "slotTitle": "Framework Analysis",
+      "sceneData": {
+        "name": "analysis-report/framework-analysis",
+        "layout": "stage",
+        "subjects": [
+          {
+            "type": "cover",
+            "x": 0,
+            "y": 0,
+            "w": 1280,
+            "h": 120,
+            "args": {
+              "title": "Framework Analysis",
+              "style": "gradient"
+            }
+          },
+          {
+            "type": "swot",
+            "x": 40,
+            "y": 160,
+            "w": 1200,
+            "h": 520,
+            "args": {
+              "title": "SWOT Analysis Results",
+              "strengths": [
+                "Market-leading retention 92%",
+                "Top-tier engineering velocity",
+                "Proprietary ML pipeline",
+                "Founder-led culture"
+              ],
+              "weaknesses": [
+                "Thin EMEA presence",
+                "Slow enterprise sales cycle",
+                "Customer support response time",
+                "Technical debt in billing layer"
+              ],
+              "opportunities": [
+                "Regulatory tailwind in EU AI Act",
+                "Partner channel under-leveraged",
+                "Vertical expansion to healthcare and education",
+                "Acquisition targets cheap post-2025 correction"
+              ],
+              "threats": [
+                "New entrants well-funded (3 Series B in 2026)",
+                "Incumbent platforms bundling",
+                "Talent retention pressure from AI labs",
+                "FX headwind from USD strength"
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "slotIdx": 5,
+      "slotName": "interpretation",
+      "slotTitle": "Interpretation",
+      "sceneData": {
+        "name": "analysis-report/interpretation",
+        "layout": "stage",
+        "subjects": [
+          {
+            "type": "cover",
+            "x": 0,
+            "y": 0,
+            "w": 1280,
+            "h": 120,
+            "args": {
+              "title": "Interpretation",
+              "style": "gradient"
+            }
+          },
+          {
+            "type": "change-curve-chart",
+            "x": 40,
+            "y": 160,
+            "w": 1200,
+            "h": 520,
+            "args": {
+              "title": "Change Journey Forecast",
+              "xAxis": "Timeline",
+              "yAxis": "Adoption",
+              "phases": [
+                {
+                  "label": "Shock",
+                  "sublabel": "Leadership announcement",
+                  "period": "Q1 2027"
+                },
+                {
+                  "label": "Denial",
+                  "sublabel": "Middle-management push-back",
+                  "period": "Q1-Q2 2027"
+                },
+                {
+                  "label": "Frustration",
+                  "sublabel": "Process friction",
+                  "period": "Q2 2027"
+                },
+                {
+                  "label": "Experimentation",
+                  "sublabel": "Pilot teams adopt",
+                  "period": "Q3 2027"
+                },
+                {
+                  "label": "Decision",
+                  "sublabel": "Org-wide rollout",
+                  "period": "Q4 2027"
+                },
+                {
+                  "label": "Integration",
+                  "sublabel": "New normal",
+                  "period": "Q1 2028"
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "slotIdx": 6,
+      "slotName": "recommendations",
+      "slotTitle": "Recommendations",
+      "sceneData": {
+        "name": "analysis-report/recommendations",
+        "layout": "grid",
+        "subjects": [
+          {
+            "type": "cover",
+            "x": 0,
+            "y": 0,
+            "w": 1280,
+            "h": 120,
+            "args": {
+              "title": "Recommendations",
+              "style": "gradient"
+            }
+          },
+          {
+            "type": "bullet-list",
+            "x": 80,
+            "y": 180,
+            "w": 1120,
+            "h": 480,
+            "args": {
+              "items": [
+                {
+                  "icon": "building",
+                  "label": "Open Berlin office Q1 2027",
+                  "sublabel": "Double down on EMEA hiring"
+                },
+                {
+                  "icon": "currency-dollar",
+                  "label": "3-tier pricing with usage add-ons",
+                  "sublabel": "Restructure revenue model"
+                },
+                {
+                  "icon": "briefcase",
+                  "label": "Acquire 1-2 healthcare AI specialists",
+                  "sublabel": "Vertical market expansion"
+                },
+                {
+                  "icon": "headset",
+                  "label": "Target 2h SLA response time",
+                  "sublabel": "Invest in customer support"
+                },
+                {
+                  "icon": "handshake",
+                  "label": "Partner with 10 systems integrators",
+                  "sublabel": "Launch channel program"
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "slotIdx": 7,
+      "slotName": "appendix",
+      "slotTitle": "Appendix",
+      "sceneData": {
+        "name": "analysis-report/appendix",
+        "layout": "row",
+        "subjects": [
+          {
+            "type": "cover",
+            "x": 0,
+            "y": 0,
+            "w": 1280,
+            "h": 120,
+            "args": {
+              "title": "Appendix",
+              "style": "gradient"
+            }
+          },
+          {
+            "type": "bullet-list",
+            "x": 80,
+            "y": 180,
+            "w": 1120,
+            "h": 480,
+            "args": {
+              "items": [
+                {
+                  "icon": "matrix-grid",
+                  "label": "Full SWOT scoring matrix available on request"
+                },
+                {
+                  "icon": "chat-circle",
+                  "label": "Customer interview transcripts redacted for confidentiality"
+                },
+                {
+                  "icon": "chart-bar",
+                  "label": "Porter value chain breakdown per product line in supplementary deck"
+                },
+                {
+                  "icon": "chart-line",
+                  "label": "Change curve model based on Bridges (2017) revision of Kübler-Ross framework"
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/sdf-js/examples/deck-handoff/ammo/eval-swot-portfolio-2026.json
+++ b/sdf-js/examples/deck-handoff/ammo/eval-swot-portfolio-2026.json
@@ -1,0 +1,408 @@
+{
+  "format": "atlas-deck",
+  "version": 1,
+  "title": "eval-swot-portfolio-2026",
+  "theme": {
+    "id": "financial-navy-cerulean",
+    "label": "Financial Navy",
+    "macroCluster": "pitch",
+    "bg": [26, 40, 66],
+    "silhouetteColor": [240, 248, 255],
+    "accent": [58, 138, 200],
+    "colors": [
+      [58, 138, 200],
+      [26, 40, 66],
+      [100, 150, 200],
+      [180, 210, 235],
+      [240, 248, 255]
+    ],
+    "font": {
+      "heading": "\"Inter Display\", Inter, system-ui, sans-serif",
+      "body": "Inter, system-ui, sans-serif"
+    },
+    "featured": true
+  },
+  "scaffold": {
+    "id": "investor-update",
+    "label": "Investor Update"
+  },
+  "decor": null,
+  "shared": null,
+  "slots": [
+    {
+      "slotIdx": 0,
+      "slotName": "cover",
+      "slotTitle": "Title",
+      "sceneData": {
+        "name": "investor-update/cover",
+        "layout": "cover",
+        "subjects": [
+          {
+            "type": "cover",
+            "x": 0,
+            "y": 0,
+            "w": 1280,
+            "h": 720,
+            "args": {
+              "title": "Q3 2026 Portfolio Strategic Review",
+              "subtitle": "12 active holdings across SaaS, FinTech, and DeepTech",
+              "author": "Investment Committee",
+              "date": "September 2026",
+              "style": "gradient"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "slotIdx": 1,
+      "slotName": "tldr",
+      "slotTitle": "TL;DR",
+      "sceneData": {
+        "name": "investor-update/tldr",
+        "layout": "grid",
+        "subjects": [
+          {
+            "type": "cover",
+            "x": 0,
+            "y": 0,
+            "w": 1280,
+            "h": 120,
+            "args": {
+              "title": "TL;DR",
+              "style": "gradient"
+            }
+          },
+          {
+            "type": "stat-banner",
+            "x": 40,
+            "y": 160,
+            "w": 1200,
+            "h": 100,
+            "args": {
+              "value": "$420M",
+              "label": "Total AUM across 12 companies",
+              "trend": "+62% ARR",
+              "trendDirection": "up",
+              "bg": [58, 138, 200]
+            }
+          },
+          {
+            "type": "kpi-card",
+            "x": 40,
+            "y": 290,
+            "w": 380,
+            "h": 160,
+            "args": {
+              "value": "$38M",
+              "label": "Combined ARR",
+              "sublabel": "Up 62% YoY",
+              "trend": "+62%",
+              "trendDirection": "up",
+              "icon": "chart-line-up",
+              "style": "light"
+            }
+          },
+          {
+            "type": "kpi-card",
+            "x": 450,
+            "y": 290,
+            "w": 380,
+            "h": 160,
+            "args": {
+              "value": "3",
+              "label": "Series B Track",
+              "sublabel": "Next 18 months",
+              "icon": "rocket-launch",
+              "style": "light"
+            }
+          },
+          {
+            "type": "kpi-card",
+            "x": 860,
+            "y": 290,
+            "w": 380,
+            "h": 160,
+            "args": {
+              "value": "2",
+              "label": "Strategic Pivots",
+              "sublabel": "Completed H1 2026",
+              "icon": "arrows-clockwise",
+              "style": "light"
+            }
+          },
+          {
+            "type": "quote-pull",
+            "x": 40,
+            "y": 480,
+            "w": 1200,
+            "h": 200,
+            "args": {
+              "quote": "The best venture returns come not from picking winners, but from refusing to lose on the ones you have.",
+              "author": "Senior Partner",
+              "attribution": "Investment Review 2026 · 47 exits over 12 years",
+              "align": "center"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "slotIdx": 2,
+      "slotName": "metrics",
+      "slotTitle": "Key Metrics",
+      "sceneData": {
+        "name": "investor-update/metrics",
+        "layout": "grid",
+        "subjects": [
+          {
+            "type": "cover",
+            "x": 0,
+            "y": 0,
+            "w": 1280,
+            "h": 120,
+            "args": {
+              "title": "Key Metrics",
+              "style": "gradient"
+            }
+          },
+          {
+            "type": "dashboard-multi-kpi-composite",
+            "x": 40,
+            "y": 160,
+            "w": 1200,
+            "h": 280,
+            "args": {
+              "title": "Portfolio Performance",
+              "kpis": [
+                {
+                  "value": "$420M",
+                  "label": "Total AUM",
+                  "sublabel": "12 companies"
+                },
+                {
+                  "value": "$38M",
+                  "label": "Combined ARR",
+                  "trend": "up",
+                  "trendValue": "+62% YoY"
+                },
+                {
+                  "value": "3",
+                  "label": "Series B Track",
+                  "sublabel": "Next 18 months"
+                },
+                {
+                  "value": "2",
+                  "label": "Strategic Pivots",
+                  "sublabel": "H1 2026",
+                  "trend": "neutral"
+                }
+              ]
+            }
+          },
+          {
+            "type": "value-chain-diagram",
+            "x": 40,
+            "y": 460,
+            "w": 1200,
+            "h": 220,
+            "args": {
+              "title": "Investment Operations",
+              "primary": [
+                "Deal Sourcing",
+                "Due Diligence",
+                "Term Sheet",
+                "Post-Investment",
+                "Exit"
+              ],
+              "support": ["LP Relations", "Portfolio Ops", "Legal & Compliance", "Network & Brand"],
+              "outcome": "Risk-Adjusted Returns"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "slotIdx": 3,
+      "slotName": "wins",
+      "slotTitle": "Wins",
+      "sceneData": {
+        "name": "investor-update/wins",
+        "layout": "grid",
+        "subjects": [
+          {
+            "type": "cover",
+            "x": 0,
+            "y": 0,
+            "w": 1280,
+            "h": 120,
+            "args": {
+              "title": "Wins",
+              "style": "gradient"
+            }
+          },
+          {
+            "type": "swot",
+            "x": 40,
+            "y": 160,
+            "w": 1200,
+            "h": 520,
+            "args": {
+              "title": "Portfolio SWOT Analysis",
+              "strengths": [
+                "Deep AI/ML expertise",
+                "Strong co-investor network",
+                "Proprietary university deal flow",
+                "3 unicorn exits in Fund I"
+              ],
+              "weaknesses": [
+                "Bay Area concentration",
+                "Limited late-stage reserves",
+                "Single GP bottleneck"
+              ],
+              "opportunities": [
+                "AI regulatory tailwind",
+                "Secondary market for Fund I",
+                "Emerging market expansion"
+              ],
+              "threats": [
+                "Growth stage compression",
+                "Mega-fund competition",
+                "LP redemption pressure"
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "slotIdx": 4,
+      "slotName": "challenges",
+      "slotTitle": "Challenges",
+      "sceneData": {
+        "name": "investor-update/challenges",
+        "layout": "stage",
+        "subjects": [
+          {
+            "type": "cover",
+            "x": 0,
+            "y": 0,
+            "w": 1280,
+            "h": 120,
+            "args": {
+              "title": "Challenges",
+              "style": "gradient"
+            }
+          },
+          {
+            "type": "change-curve-chart",
+            "x": 40,
+            "y": 160,
+            "w": 1200,
+            "h": 520,
+            "args": {
+              "title": "Portfolio AI Transformation",
+              "xAxis": "Timeline",
+              "yAxis": "Performance",
+              "phases": [
+                {
+                  "label": "Awareness",
+                  "sublabel": "Learning AI impact"
+                },
+                {
+                  "label": "Resistance",
+                  "sublabel": "Pushback on disruptors"
+                },
+                {
+                  "label": "Exploration",
+                  "sublabel": "Pilots & evaluation"
+                },
+                {
+                  "label": "Adoption",
+                  "sublabel": "First products launched"
+                },
+                {
+                  "label": "Integration",
+                  "sublabel": "AI in core ops"
+                },
+                {
+                  "label": "Advantage",
+                  "sublabel": "Differentiation"
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "slotIdx": 5,
+      "slotName": "next-quarter",
+      "slotTitle": "Next Quarter",
+      "sceneData": {
+        "name": "investor-update/next-quarter",
+        "layout": "grid",
+        "subjects": [
+          {
+            "type": "cover",
+            "x": 0,
+            "y": 0,
+            "w": 1280,
+            "h": 120,
+            "args": {
+              "title": "Next Quarter",
+              "style": "gradient"
+            }
+          },
+          {
+            "type": "kanban-board",
+            "x": 40,
+            "y": 160,
+            "w": 1200,
+            "h": 520,
+            "args": {
+              "title": "Q4 2026 Portfolio Priorities",
+              "columns": [
+                {
+                  "name": "Fundraising",
+                  "cards": [
+                    {
+                      "title": "Series B bridge prep",
+                      "subtitle": "ANTFUN + NovaTech"
+                    },
+                    {
+                      "title": "Fund III final close",
+                      "subtitle": "$300M target by Dec 2026"
+                    }
+                  ]
+                },
+                {
+                  "name": "Portfolio Operations",
+                  "cards": [
+                    {
+                      "title": "AI transformation audit",
+                      "subtitle": "All 12 portfolio companies"
+                    },
+                    {
+                      "title": "Exit roadmap",
+                      "subtitle": "Fund I · 3 candidates"
+                    }
+                  ]
+                },
+                {
+                  "name": "Strategic Expansion",
+                  "cards": [
+                    {
+                      "title": "Geographic expansion review",
+                      "subtitle": "Southeast Asia LP program"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/sdf-js/examples/deck-handoff/ammo/eval-vc-pitch.json
+++ b/sdf-js/examples/deck-handoff/ammo/eval-vc-pitch.json
@@ -1,0 +1,638 @@
+{
+  "format": "atlas-deck",
+  "version": 1,
+  "title": "eval-vc-pitch",
+  "theme": {
+    "id": "pitch-cobalt-orange",
+    "label": "Pitch · Cobalt Orange",
+    "macroCluster": "pitch",
+    "bg": [255, 255, 255],
+    "silhouetteColor": [20, 25, 50],
+    "accent": [255, 120, 40],
+    "colors": [
+      [255, 120, 40],
+      [20, 60, 180],
+      [220, 220, 235],
+      [60, 65, 90]
+    ],
+    "font": {
+      "heading": "\"Inter Display\", Inter, system-ui, sans-serif",
+      "body": "Inter, system-ui, sans-serif"
+    },
+    "featured": true
+  },
+  "scaffold": {
+    "id": "pitch-deck-vc",
+    "label": "VC Pitch Deck"
+  },
+  "decor": null,
+  "shared": null,
+  "slots": [
+    {
+      "slotIdx": 0,
+      "slotName": "cover",
+      "slotTitle": "Title",
+      "sceneData": {
+        "name": "pitch-deck-vc/cover",
+        "layout": "cover",
+        "subjects": [
+          {
+            "type": "cover",
+            "x": 0,
+            "y": 0,
+            "w": 1280,
+            "h": 720,
+            "args": {
+              "title": "Atlas",
+              "subtitle": "LLM-native illustration platform",
+              "author": "Series A fundraise · 2026-Q3",
+              "date": "$15M to scale supply + distribution",
+              "style": "gradient"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "slotIdx": 1,
+      "slotName": "problem",
+      "slotTitle": "Problem",
+      "sceneData": {
+        "name": "pitch-deck-vc/problem",
+        "layout": "stage",
+        "subjects": [
+          {
+            "type": "cover",
+            "x": 0,
+            "y": 0,
+            "w": 1280,
+            "h": 120,
+            "args": {
+              "title": "Problem"
+            }
+          },
+          {
+            "type": "icon-grid",
+            "x": 40,
+            "y": 160,
+            "w": 1200,
+            "h": 520,
+            "args": {
+              "items": [
+                {
+                  "icon": "calendar",
+                  "label": "Stuck in 2008",
+                  "sublabel": "Presentation visuals outdated",
+                  "color": [255, 120, 40]
+                },
+                {
+                  "icon": "image-broken",
+                  "label": "Dead Visuals",
+                  "sublabel": "PowerPoint icons and clipart",
+                  "color": [20, 60, 180]
+                },
+                {
+                  "icon": "robot",
+                  "label": "AI Fixed Text",
+                  "sublabel": "Visuals still lifeless",
+                  "color": [255, 120, 40]
+                },
+                {
+                  "icon": "clock",
+                  "label": "60% Wasted",
+                  "sublabel": "Designers on layout busywork",
+                  "color": [20, 60, 180]
+                }
+              ],
+              "cols": 2,
+              "iconStyle": "card",
+              "iconSize": "large",
+              "colorMode": "auto"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "slotIdx": 2,
+      "slotName": "market-size",
+      "slotTitle": "Market Size",
+      "sceneData": {
+        "name": "pitch-deck-vc/market-size",
+        "layout": "hierarchy",
+        "subjects": [
+          {
+            "type": "cover",
+            "x": 0,
+            "y": 0,
+            "w": 1280,
+            "h": 120,
+            "args": {
+              "title": "Market Size",
+              "style": "gradient"
+            }
+          },
+          {
+            "type": "pyramid",
+            "x": 80,
+            "y": 180,
+            "w": 500,
+            "h": 480,
+            "args": {
+              "layers": [
+                {
+                  "label": "AI-Augmented Productivity",
+                  "sublabel": "$48B by 2028",
+                  "value": 48000000000
+                },
+                {
+                  "label": "PPT/Keynote/Slides",
+                  "sublabel": "$4.8B annually",
+                  "value": 4800000000
+                },
+                {
+                  "label": "Editorial + Infographic",
+                  "sublabel": "$2.1B",
+                  "value": 2100000000
+                }
+              ],
+              "title": "Total Addressable Market",
+              "inverted": true
+            }
+          },
+          {
+            "type": "kpi-card",
+            "x": 640,
+            "y": 180,
+            "w": 560,
+            "h": 480,
+            "args": {
+              "value": "18M",
+              "label": "Knowledge Workers",
+              "sublabel": "Making decks weekly",
+              "icon": "users",
+              "style": "dark"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "slotIdx": 3,
+      "slotName": "solution",
+      "slotTitle": "Our Solution",
+      "sceneData": {
+        "name": "pitch-deck-vc/solution",
+        "layout": "stage",
+        "subjects": [
+          {
+            "type": "cover",
+            "x": 0,
+            "y": 0,
+            "w": 1280,
+            "h": 120,
+            "args": {
+              "title": "Our Solution",
+              "style": "gradient"
+            }
+          },
+          {
+            "type": "flow-chart",
+            "x": 40,
+            "y": 160,
+            "w": 1200,
+            "h": 520,
+            "args": {
+              "steps": [
+                "LLM writes structured intent",
+                "Atlas runtime renders deterministically",
+                "Multi-renderer output (silhouette/3D/lines/crayon)",
+                "Edit intent → regenerate visual"
+              ],
+              "orientation": "horizontal",
+              "title": "Content-to-Visual Pipeline"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "slotIdx": 4,
+      "slotName": "product",
+      "slotTitle": "Product Demo",
+      "sceneData": {
+        "name": "pitch-deck-vc/product",
+        "layout": "stage",
+        "subjects": [
+          {
+            "type": "cover",
+            "x": 0,
+            "y": 0,
+            "w": 1280,
+            "h": 120,
+            "args": {
+              "title": "Product Demo"
+            }
+          },
+          {
+            "type": "device-mockup-frame",
+            "x": 80,
+            "y": 160,
+            "w": 480,
+            "h": 500,
+            "args": {
+              "device": "laptop",
+              "title": "Atlas Canvas",
+              "content": "Live 3D editing environment"
+            }
+          },
+          {
+            "type": "bullet-list",
+            "x": 600,
+            "y": 160,
+            "w": 600,
+            "h": 500,
+            "args": {
+              "items": [
+                {
+                  "icon": "file-pdf",
+                  "label": "Upload PDF → scaffolded deck"
+                },
+                {
+                  "icon": "lightning",
+                  "label": "Inline paragraph trigger"
+                },
+                {
+                  "icon": "pencil-line",
+                  "label": "Live-edit with LLM loop"
+                },
+                {
+                  "icon": "export",
+                  "label": "Export PPT/PDF/MP4"
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "slotIdx": 6,
+      "slotName": "traction",
+      "slotTitle": "Traction",
+      "sceneData": {
+        "name": "pitch-deck-vc/traction",
+        "layout": "row",
+        "subjects": [
+          {
+            "type": "cover",
+            "x": 0,
+            "y": 0,
+            "w": 1280,
+            "h": 120,
+            "args": {
+              "title": "Traction"
+            }
+          },
+          {
+            "type": "line",
+            "x": 40,
+            "y": 160,
+            "w": 1200,
+            "h": 380,
+            "args": {
+              "values": [0, 120000, 740000, 2400000],
+              "labels": ["Q1 2026", "Q2 2026", "Q3 2026", "Q4 2026F"],
+              "format": "currency",
+              "title": "ARR Growth",
+              "showPoints": true,
+              "showValues": true
+            }
+          },
+          {
+            "type": "dashboard-multi-kpi-composite",
+            "x": 40,
+            "y": 560,
+            "w": 1200,
+            "h": 120,
+            "args": {
+              "kpis": [
+                {
+                  "value": "10",
+                  "label": "Design Teams",
+                  "sublabel": "Q2 2026"
+                },
+                {
+                  "value": "47",
+                  "label": "Teams",
+                  "sublabel": "Q3 2026"
+                },
+                {
+                  "value": "3",
+                  "label": "Design Agencies",
+                  "sublabel": "Q3 2026"
+                },
+                {
+                  "value": "110%",
+                  "label": "Net Retention",
+                  "sublabel": "Q4 Forecast",
+                  "trend": "up"
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "slotIdx": 7,
+      "slotName": "business-model",
+      "slotTitle": "Business Model",
+      "sceneData": {
+        "name": "pitch-deck-vc/business-model",
+        "layout": "grid",
+        "subjects": [
+          {
+            "type": "cover",
+            "x": 0,
+            "y": 0,
+            "w": 1280,
+            "h": 120,
+            "args": {
+              "title": "Business Model",
+              "style": "gradient"
+            }
+          },
+          {
+            "type": "comparison-table",
+            "x": 40,
+            "y": 160,
+            "w": 760,
+            "h": 420,
+            "args": {
+              "title": "Pricing Tiers",
+              "columns": [
+                {
+                  "name": "Pro",
+                  "accent": [255, 120, 40]
+                },
+                {
+                  "name": "Team",
+                  "accent": [20, 60, 180]
+                },
+                {
+                  "name": "Studio",
+                  "accent": [60, 65, 90]
+                }
+              ],
+              "features": [
+                {
+                  "name": "Price",
+                  "Pro": "$30/user/mo",
+                  "Team": "$200/seat/mo",
+                  "Studio": "$50K/year"
+                },
+                {
+                  "name": "Target",
+                  "Pro": "Knowledge workers",
+                  "Team": "Design teams",
+                  "Studio": "Agencies + Enterprise"
+                },
+                {
+                  "name": "Min Seats",
+                  "Pro": "1",
+                  "Team": "10+",
+                  "Studio": "Custom"
+                },
+                {
+                  "name": "Features",
+                  "Pro": "✓",
+                  "Team": "✓",
+                  "Studio": "Custom themes"
+                }
+              ]
+            }
+          },
+          {
+            "type": "break-even",
+            "x": 840,
+            "y": 160,
+            "w": 400,
+            "h": 420,
+            "args": {
+              "fixedCost": 1500000,
+              "variableCostPerUnit": 8,
+              "pricePerUnit": 30,
+              "maxUnits": 150000,
+              "title": "Break-Even Analysis",
+              "currency": "$"
+            }
+          },
+          {
+            "type": "kpi-card",
+            "x": 440,
+            "y": 610,
+            "w": 400,
+            "h": 90,
+            "args": {
+              "value": "$3M ARR",
+              "label": "Break-Even Target",
+              "sublabel": "Projected Q3 2027",
+              "icon": "target",
+              "style": "accent-border"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "slotIdx": 8,
+      "slotName": "team",
+      "slotTitle": "Team",
+      "sceneData": {
+        "name": "pitch-deck-vc/team",
+        "layout": "row",
+        "subjects": [
+          {
+            "type": "cover",
+            "x": 0,
+            "y": 0,
+            "w": 1280,
+            "h": 120,
+            "args": {
+              "title": "Team",
+              "style": "gradient"
+            }
+          },
+          {
+            "type": "circle-image-hub-spoke",
+            "x": 80,
+            "y": 180,
+            "w": 520,
+            "h": 480,
+            "args": {
+              "center": {
+                "label": "Leadership",
+                "color": [255, 120, 40]
+              },
+              "satellites": [
+                {
+                  "label": "Sarah Chen · CEO",
+                  "color": [255, 120, 40]
+                },
+                {
+                  "label": "Alex Wu · CTO",
+                  "color": [20, 60, 180]
+                },
+                {
+                  "label": "Diana Liu · Head of Design",
+                  "color": [60, 65, 90]
+                }
+              ]
+            }
+          },
+          {
+            "type": "bullet-list",
+            "x": 660,
+            "y": 180,
+            "w": 540,
+            "h": 240,
+            "args": {
+              "title": "Experience",
+              "items": [
+                {
+                  "icon": "briefcase",
+                  "label": "Ex-Figma design infra lead",
+                  "sublabel": "Sarah Chen"
+                },
+                {
+                  "icon": "brain",
+                  "label": "Ex-Anthropic research engineer",
+                  "sublabel": "Alex Wu"
+                },
+                {
+                  "icon": "palette",
+                  "label": "Ex-Apple Keynote team",
+                  "sublabel": "Diana Liu"
+                }
+              ]
+            }
+          },
+          {
+            "type": "isotype-stat-comparison",
+            "x": 660,
+            "y": 460,
+            "w": 540,
+            "h": 200,
+            "args": {
+              "title": "Team Size",
+              "stats": [
+                {
+                  "iconName": "code",
+                  "count": 20,
+                  "label": "Engineers"
+                },
+                {
+                  "iconName": "palette",
+                  "count": 5,
+                  "label": "Designers"
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "slotIdx": 9,
+      "slotName": "ask",
+      "slotTitle": "The Ask",
+      "sceneData": {
+        "name": "pitch-deck-vc/ask",
+        "layout": "grid",
+        "subjects": [
+          {
+            "type": "cover",
+            "x": 0,
+            "y": 0,
+            "w": 1280,
+            "h": 120,
+            "args": {
+              "title": "The Ask",
+              "style": "gradient"
+            }
+          },
+          {
+            "type": "kpi-card",
+            "x": 40,
+            "y": 160,
+            "w": 380,
+            "h": 220,
+            "args": {
+              "value": "$15M",
+              "label": "Series A",
+              "sublabel": "18-month runway",
+              "icon": "rocket-launch",
+              "style": "dark"
+            }
+          },
+          {
+            "type": "kpi-card",
+            "x": 450,
+            "y": 160,
+            "w": 380,
+            "h": 220,
+            "args": {
+              "value": "$10M",
+              "label": "Next Milestone",
+              "sublabel": "ARR Target",
+              "icon": "target",
+              "style": "dark"
+            }
+          },
+          {
+            "type": "pie",
+            "x": 860,
+            "y": 160,
+            "w": 380,
+            "h": 220,
+            "args": {
+              "title": "Use of Funds",
+              "values": [60, 25, 15],
+              "labels": ["Engineering", "Sales + Community", "Reserve"],
+              "format": "percent",
+              "donutRatio": 0.6
+            }
+          },
+          {
+            "type": "bullet-list",
+            "x": 40,
+            "y": 420,
+            "w": 1200,
+            "h": 260,
+            "args": {
+              "title": "Allocation Details",
+              "items": [
+                {
+                  "icon": "code",
+                  "label": "Engineering · 2D+3D atom library",
+                  "sublabel": "Scale to 200 atoms"
+                },
+                {
+                  "icon": "handshake",
+                  "label": "Sales + Community · agency partners",
+                  "sublabel": "Partner program expansion"
+                },
+                {
+                  "icon": "piggy-bank",
+                  "label": "Reserve · 18-month runway",
+                  "sublabel": "Path to profitability"
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/sdf-js/examples/deck-handoff/ammo/eval-yosemite-trip-2026.json
+++ b/sdf-js/examples/deck-handoff/ammo/eval-yosemite-trip-2026.json
@@ -1,0 +1,437 @@
+{
+  "format": "atlas-deck",
+  "version": 1,
+  "title": "eval-yosemite-trip-2026",
+  "theme": {
+    "id": "editorial-navy",
+    "label": "Editorial · Navy",
+    "macroCluster": "editorial",
+    "bg": [248, 246, 240],
+    "silhouetteColor": [22, 35, 70],
+    "accent": [38, 70, 130],
+    "colors": [
+      [38, 70, 130],
+      [110, 95, 75],
+      [165, 130, 90],
+      [200, 195, 180]
+    ],
+    "font": {
+      "heading": "Georgia, \"Source Serif Pro\", serif",
+      "body": "Inter, system-ui, sans-serif"
+    },
+    "featured": true
+  },
+  "scaffold": {
+    "id": "generic-deck",
+    "label": "Generic Deck"
+  },
+  "decor": null,
+  "shared": null,
+  "slots": [
+    {
+      "slotIdx": 0,
+      "slotName": "cover",
+      "slotTitle": "Title",
+      "sceneData": {
+        "name": "generic-deck/cover",
+        "layout": "cover",
+        "subjects": [
+          {
+            "type": "image",
+            "x": 0,
+            "y": 0,
+            "w": 1280,
+            "h": 720,
+            "args": {
+              "src": "data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 640 360'><defs><linearGradient id='g' x1='0' y1='0' x2='0' y2='1'><stop offset='0' stop-color='%23ffa654'/><stop offset='1' stop-color='%23c44a4a'/></linearGradient></defs><rect width='640' height='360' fill='url(%23g)'/><polygon fill='%23332244' points='0,360 120,180 220,260 340,160 460,250 560,140 640,220 640,360'/><text x='320' y='340' fill='white' font-size='14' text-anchor='middle' opacity='0.6'>Yosemite valley sunrise (embedded photo placeholder)</text></svg>",
+              "fit": "cover"
+            }
+          },
+          {
+            "type": "cover",
+            "x": 0,
+            "y": 520,
+            "w": 1280,
+            "h": 200,
+            "args": {
+              "title": "Yosemite Trip Report",
+              "subtitle": "5-day backcountry + valley itinerary",
+              "author": "Group of 4",
+              "date": "September 2026",
+              "style": "gradient"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "slotIdx": 1,
+      "slotName": "opening",
+      "slotTitle": "Opening",
+      "sceneData": {
+        "name": "generic-deck/opening",
+        "layout": "stage",
+        "subjects": [
+          {
+            "type": "cover",
+            "x": 0,
+            "y": 0,
+            "w": 1280,
+            "h": 120,
+            "args": {
+              "title": "Opening"
+            }
+          },
+          {
+            "type": "mountain-path",
+            "x": 140,
+            "y": 160,
+            "w": 1000,
+            "h": 500,
+            "args": {
+              "title": "Our Goal",
+              "summit": "45 Miles Complete",
+              "milestones": [
+                {
+                  "label": "High Country",
+                  "sublabel": "3 days granite peaks"
+                },
+                {
+                  "label": "Alpine Lakes",
+                  "sublabel": "Crystal waters"
+                },
+                {
+                  "label": "Big Waterfalls",
+                  "sublabel": "Valley descent"
+                },
+                {
+                  "label": "Valley Floor",
+                  "sublabel": "2 days relaxed pace"
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "slotIdx": 2,
+      "slotName": "section-1",
+      "slotTitle": "Section 1",
+      "sceneData": {
+        "name": "generic-deck/section-1",
+        "layout": "stage",
+        "subjects": [
+          {
+            "type": "cover",
+            "x": 0,
+            "y": 0,
+            "w": 1280,
+            "h": 120,
+            "args": {
+              "title": "El Capitan",
+              "style": "gradient"
+            }
+          },
+          {
+            "type": "image",
+            "x": 40,
+            "y": 150,
+            "w": 580,
+            "h": 520,
+            "args": {
+              "src": "data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 640 360'><rect width='640' height='360' fill='%23b8c8d8'/><polygon fill='%23556677' points='80,360 240,40 320,360'/><polygon fill='%23445566' points='240,40 320,360 380,360'/><circle cx='500' cy='80' r='28' fill='%23ffe' opacity='0.7'/><text x='320' y='340' fill='%23223' font-size='14' text-anchor='middle' opacity='0.55'>El Capitan (embedded photo placeholder)</text></svg>",
+              "fit": "cover",
+              "caption": "Yosemite Valley — North Side"
+            }
+          },
+          {
+            "type": "bullet-list",
+            "x": 660,
+            "y": 150,
+            "w": 580,
+            "h": 520,
+            "args": {
+              "title": "Day 2 Highlights",
+              "items": [
+                {
+                  "icon": "mountains",
+                  "label": "Granite monolith view",
+                  "sublabel": "North side of Yosemite Valley"
+                },
+                {
+                  "icon": "person-simple-walk",
+                  "label": "Base trail hike",
+                  "sublabel": "3 miles round trip"
+                },
+                {
+                  "icon": "person-simple-tai-chi",
+                  "label": "Spotted 4 climbers",
+                  "sublabel": "Attempting the Nose route"
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "slotIdx": 3,
+      "slotName": "section-2",
+      "slotTitle": "Section 2",
+      "sceneData": {
+        "name": "generic-deck/section-2",
+        "layout": "stage",
+        "subjects": [
+          {
+            "type": "cover",
+            "x": 0,
+            "y": 0,
+            "w": 1280,
+            "h": 120,
+            "args": {
+              "title": "Tuolumne Meadows",
+              "style": "gradient"
+            }
+          },
+          {
+            "type": "bullet-list",
+            "x": 80,
+            "y": 180,
+            "w": 1120,
+            "h": 480,
+            "args": {
+              "items": [
+                {
+                  "icon": "mountains",
+                  "label": "Alpine meadow at 8,600 ft",
+                  "sublabel": "Day 3 basecamp"
+                },
+                {
+                  "icon": "tent",
+                  "label": "Camp by Cathedral Lake"
+                },
+                {
+                  "icon": "moon-stars",
+                  "label": "Milky Way crystal clear",
+                  "sublabel": "Stargazing incredible"
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "slotIdx": 4,
+      "slotName": "section-3",
+      "slotTitle": "Section 3",
+      "sceneData": {
+        "name": "generic-deck/section-3",
+        "layout": "stage",
+        "subjects": [
+          {
+            "type": "cover",
+            "x": 0,
+            "y": 0,
+            "w": 1280,
+            "h": 120,
+            "args": {
+              "title": "Section 3",
+              "style": "gradient"
+            }
+          },
+          {
+            "type": "image",
+            "x": 40,
+            "y": 160,
+            "w": 580,
+            "h": 500,
+            "args": {
+              "src": "data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 640 360'><defs><linearGradient id='sky' x1='0' y1='0' x2='0' y2='1'><stop offset='0' stop-color='%2370a0d0'/><stop offset='1' stop-color='%23ffe0a0'/></linearGradient></defs><rect width='640' height='360' fill='url(%23sky)'/><path fill='%23667780' d='M40,360 Q 140,180 260,260 Q 360,330 460,200 Q 540,140 640,260 L 640,360 Z'/><circle cx='100' cy='80' r='35' fill='%23ffeebb' opacity='0.9'/><text x='320' y='340' fill='%23223' font-size='14' text-anchor='middle' opacity='0.55'>Half Dome summit (embedded photo placeholder)</text></svg>",
+              "fit": "cover",
+              "caption": "Half Dome summit climb",
+              "captionPosition": "bottom"
+            }
+          },
+          {
+            "type": "bullet-list",
+            "x": 660,
+            "y": 160,
+            "w": 580,
+            "h": 500,
+            "args": {
+              "title": "Half Dome Ascent",
+              "items": [
+                {
+                  "icon": "calendar",
+                  "label": "Day 4 summit climb",
+                  "sublabel": "Cables route"
+                },
+                {
+                  "icon": "navigation-arrow",
+                  "label": "16 miles round trip",
+                  "sublabel": "~10 hours total"
+                },
+                {
+                  "icon": "clock",
+                  "label": "Early start 4am",
+                  "sublabel": "Cables busy but manageable"
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "slotIdx": 5,
+      "slotName": "numbers",
+      "slotTitle": "By the Numbers",
+      "sceneData": {
+        "name": "generic-deck/numbers",
+        "layout": "grid",
+        "subjects": [
+          {
+            "type": "cover",
+            "x": 0,
+            "y": 0,
+            "w": 1280,
+            "h": 120,
+            "args": {
+              "title": "By the Numbers",
+              "style": "gradient"
+            }
+          },
+          {
+            "type": "kpi-card",
+            "x": 40,
+            "y": 160,
+            "w": 380,
+            "h": 240,
+            "args": {
+              "value": "47",
+              "label": "Miles Hiked",
+              "icon": "map-trifold",
+              "style": "light"
+            }
+          },
+          {
+            "type": "kpi-card",
+            "x": 450,
+            "y": 160,
+            "w": 380,
+            "h": 240,
+            "args": {
+              "value": "11,200 ft",
+              "label": "Elevation Gain",
+              "icon": "mountains",
+              "style": "light"
+            }
+          },
+          {
+            "type": "kpi-card",
+            "x": 860,
+            "y": 160,
+            "w": 380,
+            "h": 240,
+            "args": {
+              "value": "1,432",
+              "label": "Photos Taken",
+              "icon": "camera",
+              "style": "light"
+            }
+          },
+          {
+            "type": "stat-with-icon",
+            "x": 140,
+            "y": 430,
+            "w": 480,
+            "h": 240,
+            "args": {
+              "value": "Half Dome",
+              "label": "Best Day",
+              "sublabel": "No contest",
+              "icon": "star",
+              "iconColor": "rgb(38, 70, 130)",
+              "trend": "↑",
+              "trendDirection": "up"
+            }
+          },
+          {
+            "type": "callout-banner",
+            "x": 660,
+            "y": 430,
+            "w": 580,
+            "h": 240,
+            "args": {
+              "type_": "warning",
+              "heading": "Worst Moment",
+              "body": "Dropped phone at Glacier Point lookout",
+              "icon": "device-mobile-slash"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "slotIdx": 6,
+      "slotName": "closing",
+      "slotTitle": "Closing",
+      "sceneData": {
+        "name": "generic-deck/closing",
+        "layout": "stage",
+        "subjects": [
+          {
+            "type": "cover",
+            "x": 0,
+            "y": 0,
+            "w": 1280,
+            "h": 120,
+            "args": {
+              "title": "What's Next",
+              "style": "gradient"
+            }
+          },
+          {
+            "type": "timeline",
+            "x": 80,
+            "y": 180,
+            "w": 1120,
+            "h": 400,
+            "args": {
+              "events": [
+                {
+                  "date": "Jan 2027",
+                  "label": "Permit Window Opens",
+                  "sublabel": "Set calendar reminders"
+                },
+                {
+                  "date": "Spring 2027",
+                  "label": "Return for Waterfall Season",
+                  "sublabel": "Best viewing conditions"
+                }
+              ],
+              "axisLabel": "2027 Timeline"
+            }
+          },
+          {
+            "type": "bullet-list",
+            "x": 80,
+            "y": 600,
+            "w": 1120,
+            "h": 80,
+            "args": {
+              "items": [
+                {
+                  "icon": "camera",
+                  "label": "Bring real camera next time"
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/sdf-js/examples/deck-handoff/invalid/bad-decor.json
+++ b/sdf-js/examples/deck-handoff/invalid/bad-decor.json
@@ -1,0 +1,8 @@
+{
+  "format": "atlas-deck",
+  "version": 1,
+  "decor": {
+    "seed": "not-an-int"
+  },
+  "slots": []
+}

--- a/sdf-js/examples/deck-handoff/invalid/bad-theme-rgb.json
+++ b/sdf-js/examples/deck-handoff/invalid/bad-theme-rgb.json
@@ -1,0 +1,9 @@
+{
+  "format": "atlas-deck",
+  "version": 1,
+  "theme": {
+    "id": "x",
+    "bg": [300, -1, "red"]
+  },
+  "slots": []
+}

--- a/sdf-js/examples/deck-handoff/invalid/future-version.json
+++ b/sdf-js/examples/deck-handoff/invalid/future-version.json
@@ -1,0 +1,5 @@
+{
+  "format": "atlas-deck",
+  "version": 99,
+  "slots": []
+}

--- a/sdf-js/examples/deck-handoff/invalid/slot-missing-scenedata.json
+++ b/sdf-js/examples/deck-handoff/invalid/slot-missing-scenedata.json
@@ -1,0 +1,10 @@
+{
+  "format": "atlas-deck",
+  "version": 1,
+  "slots": [
+    {
+      "slotIdx": 0,
+      "slotTitle": "no payload"
+    }
+  ]
+}

--- a/sdf-js/examples/deck-handoff/invalid/slots-not-array.json
+++ b/sdf-js/examples/deck-handoff/invalid/slots-not-array.json
@@ -1,0 +1,26 @@
+{
+  "format": "atlas-deck",
+  "version": 1,
+  "slots": {
+    "0": {
+      "slotIdx": 0,
+      "slotName": "s0",
+      "slotTitle": "x",
+      "sceneData": {
+        "subjects": [
+          {
+            "type": "kpi-card",
+            "x": 40,
+            "y": 160,
+            "w": 280,
+            "h": 200,
+            "args": {
+              "value": "$30.6M",
+              "label": "GAAP Operating Income"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/sdf-js/examples/deck-handoff/invalid/subject-bad-geometry.json
+++ b/sdf-js/examples/deck-handoff/invalid/subject-bad-geometry.json
@@ -1,0 +1,20 @@
+{
+  "format": "atlas-deck",
+  "version": 1,
+  "slots": [
+    {
+      "slotIdx": 0,
+      "sceneData": {
+        "subjects": [
+          {
+            "type": "kpi-card",
+            "x": "left",
+            "y": 0,
+            "w": 10,
+            "h": 10
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/sdf-js/examples/deck-handoff/invalid/subject-missing-type.json
+++ b/sdf-js/examples/deck-handoff/invalid/subject-missing-type.json
@@ -1,0 +1,20 @@
+{
+  "format": "atlas-deck",
+  "version": 1,
+  "slots": [
+    {
+      "slotIdx": 0,
+      "sceneData": {
+        "subjects": [
+          {
+            "x": 0,
+            "y": 0,
+            "w": 10,
+            "h": 10,
+            "args": {}
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/sdf-js/examples/deck-handoff/invalid/wrong-format.json
+++ b/sdf-js/examples/deck-handoff/invalid/wrong-format.json
@@ -1,0 +1,5 @@
+{
+  "format": "powerpoint",
+  "version": 1,
+  "slots": []
+}

--- a/sdf-js/examples/deck-handoff/valid/cjk-atoms-alias.json
+++ b/sdf-js/examples/deck-handoff/valid/cjk-atoms-alias.json
@@ -1,0 +1,26 @@
+{
+  "format": "atlas-deck",
+  "version": 1,
+  "title": "中文简报 · 三季度",
+  "theme": "editorial-navy",
+  "slots": [
+    {
+      "slotTitle": "关键数字",
+      "sceneData": {
+        "atoms": [
+          {
+            "type": "stat-banner",
+            "x": 0,
+            "y": 0,
+            "w": 1280,
+            "h": 720,
+            "args": {
+              "value": "营收 12.4 亿",
+              "label": "同比 +40% (12.4 vs 8.9)"
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/sdf-js/examples/deck-handoff/valid/decor-identity.json
+++ b/sdf-js/examples/deck-handoff/valid/decor-identity.json
@@ -1,0 +1,64 @@
+{
+  "format": "atlas-deck",
+  "version": 1,
+  "title": "Rare Artifact",
+  "theme": {
+    "id": "pitch-bold",
+    "bg": [16, 18, 24],
+    "accent": [90, 150, 250],
+    "colors": [[200, 60, 60]]
+  },
+  "decor": {
+    "family": "peg-wraps",
+    "seed": 987654321,
+    "personality": "wild",
+    "hash": "b902d873762fe5ad",
+    "v": 3,
+    "serial": 7,
+    "rare": true,
+    "janky": false,
+    "grain": 0.8
+  },
+  "slots": [
+    {
+      "slotIdx": 0,
+      "slotName": "s0",
+      "slotTitle": "Cover",
+      "sceneData": {
+        "subjects": [
+          {
+            "type": "kpi-card",
+            "x": 40,
+            "y": 160,
+            "w": 280,
+            "h": 200,
+            "args": {
+              "value": "$30.6M",
+              "label": "GAAP Operating Income"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "slotIdx": 1,
+      "slotName": "s1",
+      "slotTitle": "Body",
+      "sceneData": {
+        "subjects": [
+          {
+            "type": "kpi-card",
+            "x": 40,
+            "y": 160,
+            "w": 280,
+            "h": 200,
+            "args": {
+              "value": "$30.6M",
+              "label": "GAAP Operating Income"
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/sdf-js/examples/deck-handoff/valid/empty-deck.json
+++ b/sdf-js/examples/deck-handoff/valid/empty-deck.json
@@ -1,0 +1,7 @@
+{
+  "format": "atlas-deck",
+  "version": 1,
+  "title": "Empty",
+  "theme": "editorial-navy",
+  "slots": []
+}

--- a/sdf-js/examples/deck-handoff/valid/minimal.json
+++ b/sdf-js/examples/deck-handoff/valid/minimal.json
@@ -1,0 +1,28 @@
+{
+  "format": "atlas-deck",
+  "version": 1,
+  "title": "Minimal",
+  "theme": "editorial-navy",
+  "slots": [
+    {
+      "slotIdx": 0,
+      "slotName": "s0",
+      "slotTitle": "Cover",
+      "sceneData": {
+        "subjects": [
+          {
+            "type": "kpi-card",
+            "x": 40,
+            "y": 160,
+            "w": 280,
+            "h": 200,
+            "args": {
+              "value": "$30.6M",
+              "label": "GAAP Operating Income"
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/sdf-js/examples/deck-handoff/valid/unknown-atom-forward-compat.json
+++ b/sdf-js/examples/deck-handoff/valid/unknown-atom-forward-compat.json
@@ -1,0 +1,23 @@
+{
+  "format": "atlas-deck",
+  "version": 1,
+  "title": "Future",
+  "theme": "editorial-navy",
+  "slots": [
+    {
+      "slotIdx": 0,
+      "sceneData": {
+        "subjects": [
+          {
+            "type": "atom-from-the-future",
+            "x": 0,
+            "y": 0,
+            "w": 100,
+            "h": 100,
+            "args": {}
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/sdf-js/scripts/manifest-to-deck.mjs
+++ b/sdf-js/scripts/manifest-to-deck.mjs
@@ -1,0 +1,95 @@
+#!/usr/bin/env node
+// =============================================================================
+// manifest-to-deck.mjs — Sprint 66: bake-manifest → atlas-deck converter.
+//
+// The CLI bake pipeline writes the manifest dialect (deck.json + slots/*.json
+// with liftFile pointers); the machine contract for handoff is atlas-deck
+// (docs/atlas-deck-contract.md, sceneData inline). This converter bridges
+// them — used to build the 3D end's e2e ammo pack from the eval corpus.
+//
+// Usage:
+//   node sdf-js/scripts/manifest-to-deck.mjs <bakedDeckDir> [outFile]
+//   node sdf-js/scripts/manifest-to-deck.mjs --ammo    # all eval-* corpus decks
+// =============================================================================
+import { readFileSync, writeFileSync, readdirSync, existsSync, mkdirSync } from 'node:fs';
+import { join, resolve, basename } from 'node:path';
+import { validateDeck, DECK_FORMAT, DECK_FORMAT_VERSION } from '../src/present/deck-spec.js';
+import { getTheme } from '../src/present/themes.js';
+
+const REPO = resolve(new URL('../..', import.meta.url).pathname);
+
+export function manifestDirToDeck(dir) {
+  const manifest = JSON.parse(readFileSync(join(dir, 'deck.json'), 'utf8'));
+  const slots = [];
+  for (const s of manifest.slots || []) {
+    if (!s.liftFile || s.error || s.mappingEmpty) continue;
+    const slotFile = JSON.parse(readFileSync(join(dir, s.liftFile), 'utf8'));
+    slots.push({
+      slotIdx: s.slotIdx,
+      slotName: s.slotName,
+      slotTitle: s.slotTitle,
+      sceneData: slotFile.sceneData,
+    });
+  }
+  const themeId = typeof manifest.theme === 'string' ? manifest.theme : manifest.theme?.id;
+  let theme = themeId;
+  try {
+    theme = getTheme(themeId) || themeId;
+  } catch {
+    /* keep the id string — consumers resolve with their own table */
+  }
+  return {
+    format: DECK_FORMAT,
+    version: DECK_FORMAT_VERSION,
+    title: manifest.deckName,
+    theme,
+    scaffold:
+      typeof manifest.scaffold === 'object'
+        ? { id: manifest.scaffold.id, label: manifest.scaffold.label }
+        : { id: manifest.scaffold },
+    decor: null, // handoff fixtures carry no 2D style layer by default
+    shared: null,
+    slots,
+  };
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const args = process.argv.slice(2);
+  if (args[0] === '--ammo') {
+    const src = join(REPO, 'sdf-js/examples/scaffold-pipeline');
+    const out = join(REPO, 'sdf-js/examples/deck-handoff/ammo');
+    mkdirSync(out, { recursive: true });
+    let n = 0;
+    for (const name of readdirSync(src)) {
+      if (!name.startsWith('eval-') || name.endsWith('.json')) continue;
+      const dir = join(src, name);
+      if (!existsSync(join(dir, 'deck.json'))) continue;
+      const deck = manifestDirToDeck(dir);
+      const v = validateDeck(deck);
+      if (!v.ok) {
+        console.error(`  ✗ ${name}: ${v.errors.join('; ')}`);
+        continue;
+      }
+      writeFileSync(join(out, `${name}.json`), JSON.stringify(deck, null, 1));
+      console.log(
+        `  ✓ ${name}: ${deck.slots.length} slots${v.warnings.length ? ` (${v.warnings.length} warnings)` : ''}`,
+      );
+      n++;
+    }
+    console.log(`ammo pack: ${n} atlas-decks → ${out}`);
+  } else if (args[0]) {
+    const dir = resolve(args[0]);
+    const deck = manifestDirToDeck(dir);
+    const v = validateDeck(deck);
+    if (!v.ok) {
+      console.error(`invalid: ${v.errors.join('; ')}`);
+      process.exit(1);
+    }
+    const out = args[1] || `${basename(dir)}.atlas-deck.json`;
+    writeFileSync(out, JSON.stringify(deck, null, 1));
+    console.log(`wrote ${out} (${deck.slots.length} slots)`);
+  } else {
+    console.error('usage: manifest-to-deck.mjs <bakedDeckDir> [outFile] | --ammo');
+    process.exit(2);
+  }
+}

--- a/sdf-js/scripts/test-deck-contract.mjs
+++ b/sdf-js/scripts/test-deck-contract.mjs
@@ -1,0 +1,120 @@
+// test-deck-contract.mjs — Sprint 66: the contract's own CI invariants.
+// 1. every valid/ golden fixture validates ok (warnings allowed)
+// 2. every invalid/ fixture fails, and on a message matching its filename
+// 3. the full ammo pack validates (15 real corpus decks)
+// 4. deck-io serialize output validates; deserializeDeck rejects contract breaks
+// 5. warning semantics: empty deck / unknown atom / duplicate slotIdx warn, not err
+import { readFileSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { validateDeck } from '../src/present/deck-spec.js';
+import { serializeDeck, deserializeDeck } from '../src/present/deck-io.js';
+
+const REPO = new URL('../..', import.meta.url).pathname;
+const HANDOFF = join(REPO, 'sdf-js/examples/deck-handoff');
+
+let pass = 0;
+let fail = 0;
+const ok = (cond, msg) => {
+  if (cond) {
+    pass++;
+    console.log(`  ✓ ${msg}`);
+  } else {
+    fail++;
+    console.error(`  ✗ ${msg}`);
+  }
+};
+
+// ── 1. valid golden fixtures ──
+for (const f of readdirSync(join(HANDOFF, 'valid'))) {
+  const v = validateDeck(readFileSync(join(HANDOFF, 'valid', f), 'utf8'));
+  ok(v.ok, `valid/${f} validates (errors: ${v.errors.join('; ') || 'none'})`);
+}
+
+// ── 2. invalid fixtures fail on the named violation ──
+const EXPECT = {
+  'wrong-format.json': /format must be/,
+  'future-version.json': /newer than this validator/,
+  'slots-not-array.json': /slots must be an array/,
+  'slot-missing-scenedata.json': /sceneData must be an object/,
+  'subject-missing-type.json': /type must be a string/,
+  'bad-theme-rgb.json': /theme\.bg/,
+  'bad-decor.json': /decor\.(family|seed)/,
+  'subject-bad-geometry.json': /\.x must be a number/,
+};
+for (const [f, re] of Object.entries(EXPECT)) {
+  const v = validateDeck(readFileSync(join(HANDOFF, 'invalid', f), 'utf8'));
+  ok(
+    !v.ok && v.errors.some((e) => re.test(e)),
+    `invalid/${f} dies on its named violation (${v.errors[0] || 'no error?!'})`,
+  );
+}
+
+// ── 3. ammo pack (real corpus decks) ──
+{
+  const files = readdirSync(join(HANDOFF, 'ammo')).filter((f) => f.endsWith('.json'));
+  ok(files.length >= 15, `ammo pack has the full corpus (${files.length} decks)`);
+  const bad = files.filter((f) => !validateDeck(readFileSync(join(HANDOFF, 'ammo', f), 'utf8')).ok);
+  ok(bad.length === 0, `all ammo decks validate (${bad.join(', ') || 'none bad'})`);
+}
+
+// ── 4. deck-io round-trip through the validator ──
+{
+  const deck = {
+    title: 'io',
+    theme: { id: 'editorial-navy', bg: [248, 246, 240], accent: [38, 70, 130] },
+    decor: { family: 'peg-wraps', seed: 1, personality: 'calm', hash: 'ff', v: 3 },
+    scaffold: { id: 'qbr', label: 'QBR' },
+    slots: [
+      {
+        slotIdx: 0,
+        slotName: 'cover',
+        sceneData: { subjects: [{ type: 'kpi-card', x: 0, y: 0, w: 100, h: 100, args: {} }] },
+      },
+    ],
+    errors: [],
+  };
+  const ser = serializeDeck(deck);
+  const v = validateDeck(ser);
+  ok(v.ok, `serializeDeck output honors the contract (${v.errors.join('; ') || 'clean'})`);
+  const back = deserializeDeck(JSON.stringify(ser));
+  ok(back.slots.length === 1, 'deserializeDeck accepts its own output');
+  let threw = null;
+  try {
+    deserializeDeck(JSON.stringify({ format: 'atlas-deck', version: 1, slots: [{ slotIdx: 0 }] }));
+  } catch (e) {
+    threw = e.message;
+  }
+  ok(
+    /sceneData/.test(threw || ''),
+    `deserializeDeck rejects contract breaks with the violation (${threw})`,
+  );
+}
+
+// ── 5. warning semantics ──
+{
+  const w1 = validateDeck({ format: 'atlas-deck', version: 1, theme: 'x', slots: [] });
+  ok(w1.ok && w1.warnings.some((w) => /zero slots/.test(w)), 'empty deck = warning, not error');
+  const w2 = validateDeck(
+    {
+      format: 'atlas-deck',
+      version: 1,
+      theme: 'x',
+      slots: [
+        { slotIdx: 0, sceneData: { subjects: [{ type: 'mystery-atom', args: {} }] } },
+        { slotIdx: 0, sceneData: { subjects: [{ type: 'kpi-card', args: {} }] } },
+      ],
+    },
+    { knownAtomTypes: new Set(['kpi-card']) },
+  );
+  ok(
+    w2.ok && w2.warnings.some((w) => /not in consumer registry/.test(w)),
+    'unknown atom type = forward-compat warning',
+  );
+  ok(
+    w2.warnings.some((w) => /duplicated/.test(w)),
+    'duplicate slotIdx = warning',
+  );
+}
+
+console.log(`\n${pass} passed, ${fail} failed`);
+process.exit(fail ? 1 : 0);

--- a/sdf-js/src/present/deck-io.js
+++ b/sdf-js/src/present/deck-io.js
@@ -12,8 +12,11 @@
 // same references — round-trip identical in structure, ~10× smaller on disk.
 // =============================================================================
 
-export const DECK_FORMAT = 'atlas-deck';
-export const DECK_FORMAT_VERSION = 1;
+import { validateDeck, DECK_FORMAT, DECK_FORMAT_VERSION } from './deck-spec.js';
+
+// re-exported so existing importers keep working; deck-spec.js is the
+// single source of truth for the contract (docs/atlas-deck-contract.md)
+export { DECK_FORMAT, DECK_FORMAT_VERSION };
 
 export function serializeDeck(deck) {
   if (!deck || !Array.isArray(deck.slots)) throw new Error('serializeDeck: not a deck');
@@ -49,10 +52,12 @@ export function serializeDeck(deck) {
 
 export function deserializeDeck(data) {
   if (typeof data === 'string') data = JSON.parse(data);
-  if (data?.format !== DECK_FORMAT) throw new Error('deserializeDeck: not an atlas-deck file');
-  if (data.version > DECK_FORMAT_VERSION)
+  // Sprint 66: the full contract validator gates every open — structural
+  // errors are rejected with the exact contract violation, not a late crash
+  const v = validateDeck(data);
+  if (!v.ok)
     throw new Error(
-      `deserializeDeck: file is version ${data.version}, this build reads ≤ ${DECK_FORMAT_VERSION}`,
+      `deserializeDeck: ${v.errors[0]}${v.errors.length > 1 ? ` (+${v.errors.length - 1} more)` : ''}`,
     );
   const shared = data.shared || null;
   return {

--- a/sdf-js/src/present/deck-spec.js
+++ b/sdf-js/src/present/deck-spec.js
@@ -1,0 +1,132 @@
+// =============================================================================
+// deck-spec.js — Sprint 66: THE atlas-deck contract validator.
+//
+// deck.json is the machine contract between the two ends (two-ends lock:
+// the 2D end produces and renders it, the 3D end eats it). Until now the
+// contract lived implicitly in three code paths; this module is the single
+// executable source of truth. It is deliberately DEPENDENCY-FREE (no
+// renderer, no canvas, no registry imports) so the 3D end — or any consumer
+// — can run it as-is in node or browser.
+//
+// Contract doc: docs/atlas-deck-contract.md (field-by-field, plus the map of
+// the three deck dialects). Golden fixtures: sdf-js/examples/deck-handoff/.
+//
+// Verdicts: ERRORS make a deck unconsumable (reject it); WARNINGS mean a
+// consumer can proceed but should log (e.g. unknown atom type — renderers
+// no-op unknowns by design, decks stay playable across versions).
+// =============================================================================
+
+export const DECK_FORMAT = 'atlas-deck';
+export const DECK_FORMAT_VERSION = 1;
+
+const isObj = (v) => v != null && typeof v === 'object' && !Array.isArray(v);
+const isStr = (v) => typeof v === 'string';
+const isInt = (v) => Number.isInteger(v);
+const isRgb = (v) =>
+  Array.isArray(v) && v.length === 3 && v.every((c) => Number.isFinite(c) && c >= 0 && c <= 255);
+
+/**
+ * validateDeck(data, opts) → { ok, errors: string[], warnings: string[] }
+ *
+ * @param {object|string} data — parsed atlas-deck JSON (or a JSON string)
+ * @param {object} [opts]
+ * @param {Set<string>} [opts.knownAtomTypes] — when provided, atom types not
+ *   in the set are reported as warnings (pass the consumer's own registry;
+ *   the validator itself stays registry-free)
+ */
+export function validateDeck(data, { knownAtomTypes = null } = {}) {
+  const errors = [];
+  const warnings = [];
+  const err = (m) => errors.push(m);
+  const warn = (m) => warnings.push(m);
+
+  if (typeof data === 'string') {
+    try {
+      data = JSON.parse(data);
+    } catch (e) {
+      return { ok: false, errors: [`not JSON: ${e.message}`], warnings };
+    }
+  }
+  if (!isObj(data)) return { ok: false, errors: ['root must be an object'], warnings };
+
+  // ── envelope ──
+  if (data.format !== DECK_FORMAT)
+    err(`format must be "${DECK_FORMAT}" (got ${JSON.stringify(data.format)})`);
+  if (!isInt(data.version)) err('version must be an integer');
+  else if (data.version > DECK_FORMAT_VERSION)
+    err(`version ${data.version} is newer than this validator (reads ≤ ${DECK_FORMAT_VERSION})`);
+  if (data.title != null && !isStr(data.title)) err('title must be a string when present');
+
+  // ── theme: id string or a palette object carrying at least bg+accent ──
+  const t = data.theme;
+  if (t == null) warn('theme missing — consumers will fall back to their default palette');
+  else if (!isStr(t)) {
+    if (!isObj(t)) err('theme must be a string id or an object');
+    else {
+      if (!isStr(t.id)) warn('theme.id missing');
+      if (t.bg != null && !isRgb(t.bg)) err('theme.bg must be [r,g,b] 0-255');
+      if (t.accent != null && !isRgb(t.accent)) err('theme.accent must be [r,g,b] 0-255');
+    }
+  }
+
+  // ── scaffold (optional descriptor) ──
+  if (data.scaffold != null) {
+    if (!isObj(data.scaffold)) err('scaffold must be an object');
+    else if (!isStr(data.scaffold.id)) err('scaffold.id must be a string');
+  }
+
+  // ── decor (optional artifact — the 2D style layer; 3D consumers may
+  // ignore it entirely, but if present it must be well-formed so a 2D
+  // re-open reproduces the exact artifact) ──
+  const d = data.decor;
+  if (d != null) {
+    if (!isObj(d)) err('decor must be an object');
+    else {
+      if (!isStr(d.family)) err('decor.family must be a string');
+      if (d.seed != null && !isInt(d.seed)) err('decor.seed must be an integer');
+      if (d.hash != null && !isStr(String(d.hash))) err('decor.hash must be stringable');
+      if (d.v != null && !isInt(d.v)) err('decor.v must be an integer');
+      if (d.serial != null && !isInt(d.serial)) err('decor.serial must be an integer');
+    }
+  }
+
+  // ── shared block (hoisted liftParams state; see deck-io.js) ──
+  if (data.shared != null && !isObj(data.shared)) err('shared must be an object when present');
+
+  // ── slots ──
+  if (!Array.isArray(data.slots)) {
+    err('slots must be an array');
+    return { ok: errors.length === 0, errors, warnings };
+  }
+  if (data.slots.length === 0) warn('deck has zero slots');
+  const seenIdx = new Set();
+  data.slots.forEach((s, i) => {
+    const at = `slots[${i}]`;
+    if (!isObj(s)) return err(`${at} must be an object`);
+    if (s.slotIdx != null) {
+      if (!isInt(s.slotIdx)) err(`${at}.slotIdx must be an integer`);
+      else if (seenIdx.has(s.slotIdx)) warn(`${at}.slotIdx ${s.slotIdx} duplicated`);
+      seenIdx.add(s.slotIdx);
+    }
+    if (s.slotName != null && !isStr(s.slotName)) err(`${at}.slotName must be a string`);
+    if (s.slotTitle != null && !isStr(s.slotTitle)) err(`${at}.slotTitle must be a string`);
+    // sceneData is the payload — a slot without one is unrenderable
+    if (!isObj(s.sceneData)) return err(`${at}.sceneData must be an object`);
+    const subjects = s.sceneData.subjects ?? s.sceneData.atoms;
+    if (!Array.isArray(subjects))
+      return err(`${at}.sceneData.subjects (or .atoms) must be an array`);
+    subjects.forEach((a, j) => {
+      const aat = `${at}.sceneData.subjects[${j}]`;
+      if (!isObj(a)) return err(`${aat} must be an object`);
+      if (!isStr(a.type)) return err(`${aat}.type must be a string`);
+      if (knownAtomTypes && !knownAtomTypes.has(a.type))
+        warn(`${aat}.type "${a.type}" not in consumer registry (renderers no-op unknowns)`);
+      for (const k of ['x', 'y', 'w', 'h']) {
+        if (a[k] != null && !Number.isFinite(a[k])) err(`${aat}.${k} must be a number`);
+      }
+      if (a.args != null && !isObj(a.args)) err(`${aat}.args must be an object`);
+    });
+  });
+
+  return { ok: errors.length === 0, errors, warnings };
+}


### PR DESCRIPTION
## Summary

3D 端 e2e 进行时的接口保险 (方向 A+C): 把"deck.json 机器契约"从三份代码里的隐式形状, 变成**一份文档 + 一个两端可跑的校验器 + 一批钉进 CI 的黄金 fixtures + 15 个真实 deck 弹药**。

## 交付物

1. **`docs/atlas-deck-contract.md`** — 契约唯一真相: 三方言地图 (atlas-deck / bake manifest / 3D segments 播放列表, 谁产谁吃)、逐字段规范、变更纪律 (bump version 时文档+校验器+fixtures 三件套同 PR)
2. **`src/present/deck-spec.js`** — 零依赖校验器 (无 renderer/canvas/registry import, 3D 端 node 或浏览器直接用)。判决语义: ERROR=结构性不可消费拒收; WARNING=可继续 (未知 atom type no-op = 前向兼容契约、空 deck、重复 slotIdx)
3. **`examples/deck-handoff/`** — 给 3D 团队的一站式:
   - `ammo/` 15 个真实 atlas-deck (eval 语料一键转换: 中文新闻/真季报/真融资稿/QBR/VC pitch…, 6-14 页, twin 100%) — 2D 真实产出分布, 直接当 e2e 输入
   - `valid/` 5 边界 (CJK+atoms 别名 / decor 完整身份 / 空 deck / 未知 atom 前向兼容 / 最小可行)
   - `invalid/` 8 反例, 每个恰好死于文件名标明的那条违约
   - README (消费要点三条)
4. **`manifest-to-deck.mjs`** — bake manifest → atlas-deck 转换器 (--ammo 批量重烤)
5. **deck-io 收紧**: 常量统一到 deck-spec 单一来源; 每次 📂 打开跑全量校验, 违约报具体条款

## 质量

- test-deck-contract.mjs 21 断言 (valid 全过 / invalid 各死其名 / 弹药全过 / serialize 输出自证合规 / warning 语义) 进 runner — npm test **134/134**
- author-2d 恢复路径过新校验器, e2e 零 console 错误

🤖 Generated with [Claude Code](https://claude.com/claude-code)