### PR TITLE
Sprint 68: 失败页 🔁 重试 — 掉页可救回

### DIFF
--- a/sdf-js/apps/present/author-2d.html
+++ b/sdf-js/apps/present/author-2d.html
@@ -246,6 +246,43 @@
       .slide-card.busy .slide-busy {
         display: flex;
       }
+      /* Sprint 68: failed-slot rescue card */
+      .slide-card.failed {
+        min-height: 160px;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        gap: 12px;
+        outline: 2px dashed rgba(255, 120, 100, 0.5);
+        outline-offset: -2px;
+      }
+      .slide-card.failed .fail-body {
+        text-align: center;
+        color: #ff9a8a;
+        font-size: 12px;
+        display: flex;
+        flex-direction: column;
+        gap: 4px;
+        padding: 0 16px;
+      }
+      .slide-card.failed .fail-body span {
+        color: rgba(255, 255, 255, 0.45);
+        font-size: 11px;
+      }
+      .slide-card.failed .retry {
+        border: none;
+        border-radius: 8px;
+        padding: 8px 14px;
+        background: #2d6fd6;
+        color: #fff;
+        font: 600 13px -apple-system, Inter, sans-serif;
+        cursor: pointer;
+      }
+      .slide-card.failed .retry:disabled {
+        opacity: 0.5;
+        cursor: wait;
+      }
       /* Sprint 67: per-slide quality light (visual audit + number grounding) */
       .qlight {
         position: absolute;

--- a/sdf-js/apps/present/author-2d.js
+++ b/sdf-js/apps/present/author-2d.js
@@ -9,7 +9,7 @@
 // Used for headless verification where a real Anthropic call can't run.
 import { textToIR } from '../../src/scene/text-to-ir.js';
 import { irDeckTo2DDeck } from '../../src/scene/ir-to-2d.js';
-import { newsToFullDeck, reliftSlot } from '../../src/present/news/full-deck.js';
+import { newsToFullDeck, reliftSlot, retryFailedSlot } from '../../src/present/news/full-deck.js';
 import { renderSceneDataToCanvas } from '../../src/present/atoms-2d/renderer.js';
 import { rethemeDeck } from '../../src/present/retheme.js';
 import { decorFromHash, mintDecorHash } from '../../src/present/decor/registry.js';
@@ -329,6 +329,8 @@ async function updateQualityLights() {
     const { bySlot, counts } = await assessDeck(currentDeck, {
       sourceTexts: [promptEl.value, ...outline],
     });
+    // slot cards precede failed-slot cards in slidesEl, so index alignment
+    // with deck.slots holds for the first slots.length children
     [...slidesEl.children].forEach((card, i) => {
       const slot = currentDeck.slots[i];
       const a = bySlot.get(slot);
@@ -373,6 +375,40 @@ async function renderDeck(deck) {
       palette: deck.theme,
       decor: slotDecor(deck, slot),
     });
+  }
+  // Sprint 68: failed slots surface as retryable cards, not console lines —
+  // a dropped page you can SEE is a page you can rescue
+  for (const errEntry of deck.errors || []) {
+    if (!errEntry.liftParams) continue;
+    const card = document.createElement('div');
+    card.className = 'slide-card failed';
+    const body = document.createElement('div');
+    body.className = 'fail-body';
+    body.innerHTML = `<b>「${errEntry.slotTitle || errEntry.slot}」lift 失败</b><span>${String(
+      errEntry.message,
+    ).slice(0, 120)}</span>`;
+    const retryBtn = document.createElement('button');
+    retryBtn.className = 'retry';
+    retryBtn.textContent = '🔁 重试这一页';
+    retryBtn.addEventListener('click', async () => {
+      const apiKey = keyEl.value.trim();
+      if (!apiKey) return setStatus('paste your Anthropic API key first', true);
+      retryBtn.disabled = true;
+      retryBtn.textContent = 're-lifting…';
+      try {
+        await retryFailedSlot(deck, errEntry, { apiKey });
+        await renderDeck(deck);
+        autosave();
+        setStatus(`「${errEntry.slotTitle || errEntry.slot}」已救回 — ${deck.slots.length} 页`);
+      } catch (e) {
+        retryBtn.disabled = false;
+        retryBtn.textContent = '🔁 重试这一页';
+        setStatus(`重试失败: ${e.message}`, true);
+      }
+    });
+    card.appendChild(body);
+    card.appendChild(retryBtn);
+    slidesEl.appendChild(card);
   }
   updateQualityLights(); // async, non-blocking — lights pop in when ready
 }

--- a/sdf-js/scripts/test-deck-io.mjs
+++ b/sdf-js/scripts/test-deck-io.mjs
@@ -5,7 +5,11 @@ import {
   DECK_FORMAT,
   DECK_FORMAT_VERSION,
 } from '../src/present/deck-io.js';
-import { newsToFullDeck, chooseScaffoldForOutline } from '../src/present/news/full-deck.js';
+import {
+  newsToFullDeck,
+  chooseScaffoldForOutline,
+  retryFailedSlot,
+} from '../src/present/news/full-deck.js';
 
 let pass = 0;
 let fail = 0;
@@ -174,6 +178,62 @@ const deck = {
   );
   // determinism: same outline → same pick
   ok(chooseScaffoldForOutline(qbrOutline).scaffold.id === scaffold.id, 'auto choice deterministic');
+}
+
+// ── Sprint 68: retryFailedSlot — a failed slot is a retryable unit ──
+{
+  const lp = (i) => ({
+    scaffold,
+    slot: { name: `s${i}`, title: `Slide ${i}` },
+    slotIdx: i,
+    slideIdx: 0,
+    theme,
+    slide: slides[0],
+    slides,
+    extraSlides: [],
+  });
+  const deck2 = {
+    slots: [
+      { slotIdx: 0, slotName: 's0', sceneData: { subjects: [] } },
+      { slotIdx: 4, slotName: 's4', sceneData: { subjects: [] } },
+    ],
+    errors: [{ slot: 's2', slotIdx: 2, slotTitle: 'Slide 2', message: 'boom', liftParams: lp(2) }],
+  };
+  const okLift = async () => ({ sceneData: { subjects: [{ type: 'kpi-card', args: {} }] } });
+  const slot = await retryFailedSlot(deck2, deck2.errors[0], { apiKey: 'k', liftFn: okLift });
+  ok(
+    slot.slotIdx === 2 && deck2.slots[1] === slot,
+    'rescued slot splices at its skeleton position',
+  );
+  ok(deck2.errors.length === 0, 'error entry removed on success');
+
+  const deck3 = {
+    slots: [],
+    errors: [{ slot: 's1', slotIdx: 1, slotTitle: 'S1', message: 'old', liftParams: lp(1) }],
+  };
+  let threw = false;
+  try {
+    await retryFailedSlot(deck3, deck3.errors[0], {
+      apiKey: 'k',
+      liftFn: async () => {
+        throw new Error('still down');
+      },
+    });
+  } catch {
+    threw = true;
+  }
+  ok(
+    threw && deck3.errors.length === 1 && deck3.errors[0].message === 'still down',
+    'failed retry keeps the entry with the fresh message',
+  );
+
+  let threw2 = false;
+  try {
+    await retryFailedSlot(deck3, { slot: 'x' }, { apiKey: 'k', liftFn: okLift });
+  } catch {
+    threw2 = true;
+  }
+  ok(threw2, 'entry without liftParams rejected');
 }
 
 console.log(`\n${pass} passed, ${fail} failed`);

--- a/sdf-js/src/present/news/full-deck.js
+++ b/sdf-js/src/present/news/full-deck.js
@@ -199,7 +199,25 @@ export async function newsToFullDeck(
     if (r && !r.error) {
       slots.push(streamed.get(i) || makeSlot(a, r));
     } else {
-      errors.push({ slot: a.slot.name, message: r?.error || 'unknown' });
+      // Sprint 68: a failed slot is a RETRYABLE unit, not just a log line —
+      // carry the same liftParams a successful slot would have, so the UI
+      // can offer 🔁 without re-deriving anything
+      errors.push({
+        slot: a.slot.name,
+        slotIdx: a.slotIdx,
+        slotTitle: a.slot.title,
+        message: r?.error || 'unknown',
+        liftParams: {
+          scaffold,
+          slot: a.slot,
+          slotIdx: a.slotIdx,
+          slideIdx: a.slideIdx,
+          theme,
+          slide: slides[a.slideIdx],
+          slides,
+          extraSlides: a.extraSlides || [],
+        },
+      });
     }
   }
 
@@ -239,6 +257,39 @@ export function mergeLockedSlots(newSlots, lockedSlots) {
  * @param {number} slotIdx — the slot's slotIdx (not array index)
  * @param {object} opts — { apiKey, revision?, liftFn? (test injection) }
  */
+/**
+ * retryFailedSlot — Sprint 68: lift a failed slot again and splice it into
+ * the deck at its skeleton position. On success the error entry is removed
+ * and the new slot object is returned; on failure the error entry stays
+ * (with the fresh message) and the error is re-thrown for the UI.
+ */
+export async function retryFailedSlot(deck, errorEntry, { apiKey, liftFn = liftSlotLLM } = {}) {
+  if (!errorEntry?.liftParams)
+    throw new Error('retryFailedSlot: error entry carries no liftParams');
+  const systemPrompt = await getSystemPrompt();
+  let sceneData;
+  try {
+    ({ sceneData } = await liftFn(errorEntry.liftParams, { apiKey, systemPrompt }));
+  } catch (e) {
+    errorEntry.message = e.message;
+    throw e;
+  }
+  const slot = {
+    slotIdx: errorEntry.slotIdx,
+    slotName: errorEntry.slot,
+    slotTitle: errorEntry.slotTitle,
+    sceneData,
+    liftParams: errorEntry.liftParams,
+  };
+  // splice at skeleton position: before the first delivered slot with a
+  // larger slotIdx (deck order = user order elsewhere, but a rescued page
+  // returns to its own room)
+  const at = deck.slots.findIndex((s) => (s.slotIdx ?? Infinity) > (slot.slotIdx ?? -1));
+  deck.slots.splice(at === -1 ? deck.slots.length : at, 0, slot);
+  deck.errors = (deck.errors || []).filter((e) => e !== errorEntry);
+  return slot;
+}
+
 export async function reliftSlot(
   deck,
   slotIdx,


### PR DESCRIPTION
## Summary

整本模式 lift 失败的 slot 此前直接掉页 (errors 只进 console + 状态栏计数)。现在: **失败页渲染成可救回的卡片**。

- **引擎**: `newsToFullDeck` 的 errors 条目携带完整 liftParams — 失败 slot 是与成功 slot 同构的可重试单元; 新增 `retryFailedSlot` — 再 lift + 按 slotIdx 骨架位 splice 回 deck (救回的页回自己的房间), 成功移除条目, 失败保留并刷新 message (可再按)
- **UI**: 失败卡 = 红虚线框 + slot 标题 + 错误摘要 + 「🔁 重试这一页」; 成功即重渲染 + autosave + 质量灯照常点亮
- 失败卡排在 slot 卡之后, 质量灯的 card↔slot 索引对位不受影响

## 质量

- 测试 +4 (骨架位插入 / 失败保留 fresh message / 无 liftParams 拒收 / 成功移除条目), npm test 136/136
- e2e: 注入失败条目经真实 renderDeck 渲染, 卡片/按钮/摘要齐全, 零 console 错误

🤖 Generated with [Claude Code](https://claude.com/claude-code)