### PR TITLE
perf(present): FPS HUD + 自适应降分辨率(M3 保底)+ deck 卡顿诊断

### DIFF
--- a/sdf-js/apps/present/figure-core.js
+++ b/sdf-js/apps/present/figure-core.js
@@ -21,6 +21,40 @@ export function createFigure({ outdoor = false, stage = false } = {}) {
   };
   size();
 
+  // ---- FPS HUD + adaptive resolution -----------------------------------------
+  // Live FPS readout (green ≥50 / amber ≥30 / red <30, ?fps=0 hides it) and a
+  // laptop-GPU safety net: sustained <24fps drops the render scale a notch
+  // (0.75× → 0.5× of canvas resolution), sustained >52fps climbs back. This is
+  // damage control, not the fix — heavy multi-station decks need the per-station
+  // shader work (see perf notes); the HUD exists so we SEE the problem.
+  const fpsHud = document.createElement('div');
+  fpsHud.style.cssText =
+    'position:fixed;top:10px;right:12px;z-index:40;font:700 12px ui-monospace,monospace;' +
+    'padding:3px 8px;border-radius:4px;background:rgba(14,15,18,0.72);pointer-events:none;';
+  if (new URLSearchParams(location.search).get('fps') !== '0') document.body.appendChild(fpsHud);
+  const SCALES = [1.0, 0.75, 0.5];
+  let scaleIdx = 0;
+  let lowStreak = 0;
+  let highStreak = 0;
+  const onFps = (fps) => {
+    fpsHud.textContent = `${fps.toFixed(0)} fps${scaleIdx ? ` · ${SCALES[scaleIdx]}×` : ''}`;
+    fpsHud.style.color = fps >= 50 ? '#7fd77f' : fps >= 30 ? '#e8c35c' : '#f26d6d';
+    if (fps < 24 && scaleIdx < SCALES.length - 1) {
+      if (++lowStreak >= 2) {
+        scaleIdx++;
+        lowStreak = 0;
+        if (studio.setRenderScale) studio.setRenderScale(SCALES[scaleIdx]);
+      }
+    } else lowStreak = 0;
+    if (fps > 52 && scaleIdx > 0) {
+      if (++highStreak >= 4) {
+        scaleIdx--;
+        highStreak = 0;
+        if (studio.setRenderScale) studio.setRenderScale(SCALES[scaleIdx]);
+      }
+    } else highStreak = 0;
+  };
+
   const studio = createStudioRenderer({
     canvas,
     getControls: () => ({
@@ -34,7 +68,7 @@ export function createFigure({ outdoor = false, stage = false } = {}) {
       groundOn: !outdoor,
       checkerOn: !outdoor,
     }),
-    onFps: () => {},
+    onFps,
   });
   window.addEventListener('resize', () => {
     size();


### PR DESCRIPTION
## 诊断(M3 实测数字)

| 场景 | FPS |
|---|---|
| 单站 staged figure | **54.5**(可用) |
| 3 站 deck(speech-demo) | **2**(带/不带舞台都一样) |

**结论:不是舞台的锅,是 deck 本身** —— ~36 个 subject 内联进一个巨型 fragment shader,每像素每 march 步全量评估。子树 6× → 27× 慢(超线性),符合 Apple GPU 巨 shader 寄存器压力特征。**分辨率救不了它**(0.5× 只到 7.5fps)。

## 本 PR = 仪表 + 保底

- **FPS HUD**(右上角,绿≥50/黄≥30/红<30,`?fps=0` 隐藏)—— 用户要求:看得见帧率
- **自适应分辨率**:持续 <24fps 自动降档 1.0→0.75→0.5(引擎 clamp 0.5),>52 回升。实测:deck 自动降到 0.5×(HUD 诚实显示红色「7 fps · 0.5×」),单站 54fps 绿色不降档

## 真解(待拍板,架构级)

deck 播放任意时刻相机只在一站,却评估全部站 → **按站拆 shader,随 sequence 切换 program**(预期把 deck 拉回单站的 ~54fps)。属抽象层改动,单独提案。

全量 139/139。

🤖 Generated with [Claude Code](https://claude.com/claude-code)