### PR TITLE
Sprint 70: ranker CJK 词汇 + 弱信号回退 + 塌缩救援 (真实中文文档暴露的连锁 bug)

### DIFF
--- a/sdf-js/scripts/test-deck-io.mjs
+++ b/sdf-js/scripts/test-deck-io.mjs
@@ -9,6 +9,7 @@ import {
   newsToFullDeck,
   chooseScaffoldForOutline,
   retryFailedSlot,
+  rescueEmptyMapping,
 } from '../src/present/news/full-deck.js';
 
 let pass = 0;
@@ -234,6 +235,51 @@ const deck = {
     threw2 = true;
   }
   ok(threw2, 'entry without liftParams rejected');
+}
+
+// ── Sprint 70: CJK ranker + weak-signal fallback + collapse rescue ──
+{
+  // CJK keywords: a Chinese QBR outline lands qbr with a strong signal
+  const cjkQbr = [
+    { title: '三季度业务复盘', body: ['季度营收与增长回顾'] },
+    { title: '下季度规划', body: ['战略目标'] },
+  ];
+  const p1 = chooseScaffoldForOutline(cjkQbr);
+  ok(!p1.weakSignal && p1.scaffold.id === 'qbr', `CJK 季度复盘 → qbr (${p1.scaffold.id})`);
+
+  // weak signal → news-briefing fallback (the ANTFUN lesson)
+  const nonsense = [{ title: '完全不知所云的内容', body: ['既无关键词也无结构信号的一段话'] }];
+  const p2 = chooseScaffoldForOutline(nonsense);
+  ok(
+    p2.weakSignal === true && p2.scaffold.id === 'news-briefing',
+    `weak signal falls back to news-briefing (${p2.scaffold.id})`,
+  );
+
+  // collapse rescue: only cover mapped → fill empties by heuristic score
+  const mkSlot2 = (name) => ({ name, title: name, purpose: name, recommendedAtoms: [] });
+  const asn = [
+    { slotIdx: 0, slot: mkSlot2('cover'), slideIdx: 0, empty: false },
+    { slotIdx: 1, slot: mkSlot2('overview'), empty: true },
+    { slotIdx: 2, slot: mkSlot2('details'), empty: true },
+    { slotIdx: 3, slot: mkSlot2('summary'), empty: true },
+  ];
+  const outlineSlides = [
+    { title: 'Cover', body: ['t'] },
+    { title: 'A', body: ['overview of the system'] },
+    { title: 'B', body: ['details of the design'] },
+    { title: 'C', body: ['summary and outlook'] },
+  ];
+  const did = rescueEmptyMapping(asn, outlineSlides, 4);
+  ok(did === true, 'collapse detected and rescued');
+  ok(
+    asn.filter((a) => !a.empty).length === 4,
+    `deck no longer collapses to cover (${asn.filter((a) => !a.empty).length} filled)`,
+  );
+  const healthy = [
+    { slotIdx: 0, slot: mkSlot2('cover'), slideIdx: 0, empty: false },
+    { slotIdx: 1, slot: mkSlot2('body'), slideIdx: 1, empty: false },
+  ];
+  ok(rescueEmptyMapping(healthy, outlineSlides, 4) === false, 'healthy mapping untouched');
 }
 
 console.log(`\n${pass} passed, ${fail} failed`);

--- a/sdf-js/src/present/news/full-deck.js
+++ b/sdf-js/src/present/news/full-deck.js
@@ -40,7 +40,50 @@ export function chooseScaffoldForOutline(slides) {
     title: slides[0]?.title || '',
     bodyTexts: slides.map((sl) => [sl.title, ...(sl.body || [])].join(' ')),
   });
+  // Sprint 70 (ANTFUN doc lesson): a score this low is NOISE, not a signal —
+  // one stray keyword once picked 'HR & People Update' for a token-launchpad
+  // design doc and the mis-matched skeleton collapsed the deck to 1 page.
+  // Under the floor we fall back to news-briefing: the 14-slot general
+  // skeleton proven on arbitrary long text.
+  const MIN_SIGNAL = 6;
+  if (!ranked.length || ranked[0].score < MIN_SIGNAL) {
+    return { scaffold: getScaffold('news-briefing'), ranked, weakSignal: true };
+  }
   return { scaffold: getScaffold(ranked[0].id), ranked };
+}
+
+/**
+ * rescueEmptyMapping — Sprint 70: when the LLM mapper maps (almost) nothing
+ * beyond the cover — the mis-matched-skeleton failure mode — the deck must
+ * NEVER collapse to one page. Deterministically assign the best-scoring
+ * unmapped slides into empty non-cover slots until minPages is reachable.
+ * Mutates assignments in place; pure logic, exported for tests.
+ */
+export function rescueEmptyMapping(assignments, slides, minPages) {
+  const filledNonCover = assignments.filter((a) => !a.empty && a.slot.name !== 'cover');
+  if (filledNonCover.length > 0) return false; // mapper did its job
+  const taken = new Set(assignments.filter((a) => !a.empty).map((a) => a.slideIdx));
+  const empties = assignments.filter((a) => a.empty && a.slot.name !== 'cover');
+  let delivered = assignments.filter((a) => !a.empty).length;
+  for (const a of empties) {
+    if (delivered >= minPages) break;
+    let best = -1;
+    let bestScore = -Infinity;
+    for (let i = 0; i < slides.length; i++) {
+      if (taken.has(i)) continue;
+      const sc = scoreSlideForSlot(slides[i], a.slot);
+      if (sc > bestScore) {
+        bestScore = sc;
+        best = i;
+      }
+    }
+    if (best === -1) break;
+    a.empty = false;
+    a.slideIdx = best;
+    taken.add(best);
+    delivered++;
+  }
+  return true;
 }
 
 export async function newsToFullDeck(
@@ -93,6 +136,8 @@ export async function newsToFullDeck(
     slot: scaffold.slots[a.slotIdx],
     empty: !(typeof a.slideIdx === 'number' && a.slideIdx >= 0),
   }));
+
+  rescueEmptyMapping(assignments, slides, minPages);
 
   // Orphan rescue (Sprint 25): every unmapped outline slide's facts land in
   // the best-scoring filled slot as extra material.

--- a/sdf-js/src/present/scaffolds/registry.js
+++ b/sdf-js/src/present/scaffolds/registry.js
@@ -48,7 +48,19 @@ export const SCAFFOLDS = [
     label: 'VC Pitch Deck',
     description: 'Seed/Series A fundraise pitch (Sequoia / YC structure)',
     audience: 'vc, angel, partners',
-    keywords: ['pitch', 'fundraise', 'series', 'seed', 'investor', 'vc', 'ask', 'tam'],
+    keywords: [
+      'pitch',
+      'fundraise',
+      'series',
+      'seed',
+      'investor',
+      'vc',
+      'ask',
+      'tam',
+      '融资',
+      '路演',
+      '估值',
+    ],
     slots: [
       {
         name: 'cover',
@@ -224,7 +236,7 @@ export const SCAFFOLDS = [
     label: 'Product Launch',
     description: 'Announce a new product, feature, or release',
     audience: 'customer, press, internal',
-    keywords: ['launch', 'release', 'announcement', 'new', 'introducing'],
+    keywords: ['launch', 'release', 'announcement', 'new', 'introducing', '发布', '上线'],
     slots: [
       {
         name: 'cover',
@@ -293,7 +305,19 @@ export const SCAFFOLDS = [
     label: 'Quarterly Business Review',
     description: 'Internal Q review — KPIs, wins, challenges, outlook',
     audience: 'exec, board, manager, customer-success',
-    keywords: ['qbr', 'quarterly', 'review', 'q1', 'q2', 'q3', 'q4', 'business review'],
+    keywords: [
+      'qbr',
+      'quarterly',
+      'review',
+      'q1',
+      'q2',
+      'q3',
+      'q4',
+      'business review',
+      '季度',
+      '复盘',
+      '业务回顾',
+    ],
     slots: [
       {
         name: 'cover',
@@ -498,7 +522,19 @@ export const SCAFFOLDS = [
     label: 'Business Plan',
     description: 'Formal multi-section plan for bank / advisor / partner',
     audience: 'bank, advisor, partner, internal',
-    keywords: ['business plan', 'plan', 'strategy', 'roadmap', 'go-to-market'],
+    keywords: [
+      'business plan',
+      'plan',
+      'strategy',
+      'roadmap',
+      'go-to-market',
+      '商业计划',
+      '经济模型',
+      '设计文档',
+      '白皮书',
+      '产品设计',
+      '商业模式',
+    ],
     slots: [
       {
         name: 'cover',
@@ -575,7 +611,17 @@ export const SCAFFOLDS = [
     label: 'Vision & Mission',
     description: 'Company vision, mission, values, principles',
     audience: 'employee, prospect, partner',
-    keywords: ['vision', 'mission', 'values', 'principles', 'culture', 'manifesto'],
+    keywords: [
+      'vision',
+      'mission',
+      'values',
+      'principles',
+      'culture',
+      'manifesto',
+      '愿景',
+      '使命',
+      '价值观',
+    ],
     slots: [
       { name: 'cover', title: 'Title', purpose: 'Brand statement', recommended_atoms: ['cover'] },
       {
@@ -640,7 +686,18 @@ export const SCAFFOLDS = [
     label: 'Strategic Plan',
     description: 'Annual planning — SWOT + goals + initiatives + metrics',
     audience: 'exec, board, manager',
-    keywords: ['strategic', 'strategy', 'annual', 'planning', 'swot', 'goals', 'initiatives'],
+    keywords: [
+      'strategic',
+      'strategy',
+      'annual',
+      'planning',
+      'swot',
+      'goals',
+      'initiatives',
+      '战略',
+      '规划',
+      '路线图',
+    ],
     slots: [
       {
         name: 'cover',


### PR DESCRIPTION
## Summary

用户给了一份真实的 15.6K 字符中文产品设计文档 — 第一跑就打出两个连锁 bug, 当天修复并真机复验。

## 事故链

1. **ranker 零中文词汇**: 全表几乎 0 分, 'hr' 杂讯子串以 3 分"胜出" → 一份代币发射台设计文档被选了 **HR & People Update** 骨架
2. **错配骨架的连锁塌缩**: LLM mapper 面对不匹配的槽位正确地几乎不映射 → 孤儿救援明确排除 cover (设计如此), 只有 cover 被映射时无宿主 → 页地板无捐赠者 → **15.6K 文档产出 1 页 deck**

## 修复

- **CJK 词汇**: 6 个关键骨架补中文关键词; '发射' 因 crypto 多义 (发射台≠产品发布) 刻意不收 — 多义词宁缺勿滥
- **弱信号地板**: top score < 6 视为噪声 → 回退 news-briefing (14 槽通用骨架)。噪声定骨架比没有骨架更危险
- **塌缩救援** (`rescueEmptyMapping`, 纯函数): 映射塌缩到 only-cover 时, 按启发式评分把 outline slides 确定性补进空槽直到 minPages — deck 永不塌缩成一页

## 真机复验 (同一份文档)

| | 修复前 | 修复后 |
|---|---|---|
| 骨架 | HR & People Update (荒谬) | news-briefing (弱信号回退) |
| 页数 | **1** | **12** (0 失败) |
| 五轴 | n/a | fill 1.0 / 零幻觉 / 零视觉问题 / twin 1.0 |

facts recall 50% 如实反映 15.6K→12 页的压缩率 (损失的是长尾细节数字, 无捏造)。文档本体标注机密, deck 不入库, 仅提交引擎修复。测试 +5, npm test 136/136。

🤖 Generated with [Claude Code](https://claude.com/claude-code)