### PR TITLE
feat(3d-first): 两轮视觉迭代 — hold 浮屏墙 + 深度缩放文字 + matrix 体积化

### DIFF
--- a/sdf-js/apps/present/author.html
+++ b/sdf-js/apps/present/author.html
@@ -40,6 +40,24 @@
         background: rgba(40, 116, 196, 0.92);
         font-weight: 700;
       }
+      .lbl.title {
+        font-weight: 900;
+        background: none;
+        text-shadow: 0 2px 14px rgba(0, 0, 0, 0.65);
+      }
+      /* Jumbotron text: the glowing 3D screen face behind it IS the chip, so
+         no background — just big type with enough shadow to sit on the glow. */
+      .lbl.screen {
+        font-weight: 800;
+        background: none;
+        text-shadow:
+          0 1px 3px rgba(0, 0, 0, 0.8),
+          0 3px 16px rgba(0, 0, 0, 0.5);
+        max-width: 340px;
+        white-space: normal;
+        text-align: center;
+        line-height: 1.25;
+      }
       /* author bar — the one input that turns words into a world */
       #bar {
         position: fixed;

--- a/sdf-js/apps/present/figure-core.js
+++ b/sdf-js/apps/present/figure-core.js
@@ -110,18 +110,17 @@ export function createFigure({ outdoor = false, stage = false, present = false }
     items = (scene.overlay || []).filter((o) => o.anchor && o.text);
     els = items.map((o) => {
       const d = document.createElement('div');
-      d.className = 'lbl' + (o.role === 'value' ? ' value' : '');
+      d.className =
+        'lbl' +
+        (o.role === 'value' ? ' value' : '') +
+        (o.role === 'screen' ? ' screen' : '') +
+        (o.role === 'title' ? ' title' : '');
       // Numeric value chips COUNT UP over ~0.8s after their reveal — numbers
       // that arrive read as data landing, not captions appearing.
       if (o.role === 'value' && /^[\d,]+$/.test(o.text)) {
         o._countTarget = Number(o.text.replace(/,/g, ''));
       }
       d.textContent = o.text;
-      if (o.role === 'title') {
-        d.style.fontSize = '20px';
-        d.style.fontWeight = '900';
-        d.style.background = 'none';
-      }
       document.body.appendChild(d);
       return d;
     });
@@ -188,6 +187,22 @@ export function createFigure({ outdoor = false, stage = false, present = false }
         p.depth == null ? 1 : Math.max(0, Math.min(1, (reach - p.depth) / (reach * 0.45)));
       const opacity = (o.revealAt == null || t >= o.revealAt ? 1 : 0) * depthFade;
       el.style.opacity = opacity;
+      // Depth-scaled type: labels grow as the camera approaches their anchor,
+      // so text reads as living IN the world instead of a fixed-size HUD chip.
+      // 'screen' labels (jumbotron faces) get the largest base — the glowing
+      // 3D face behind them is their chip. Quantized + write-on-change so the
+      // per-frame style churn stays near zero.
+      if (p.depth != null) {
+        const base =
+          o.role === 'title' ? 30 : o.role === 'screen' ? 21 : o.role === 'value' ? 13 : 13;
+        const fs =
+          Math.round(Math.max(9, Math.min(base * (6.2 / Math.max(p.depth, 0.6)), base * 2.1)) * 2) /
+          2;
+        if (el._fs !== fs) {
+          el._fs = fs;
+          el.style.fontSize = `${fs}px`;
+        }
+      }
       if (o._countTarget != null && o.revealAt != null) {
         const k = Math.max(0, Math.min(1, (t - o.revealAt) / 0.8));
         const eased = 1 - (1 - k) * (1 - k); // ease-out: fast start, settle on the number
@@ -211,8 +226,12 @@ export function createFigure({ outdoor = false, stage = false, present = false }
         placedRects.some(
           (r) => Math.abs(x - r.x) * 2 < w + r.w + 6 && Math.abs(yy - r.y) * 2 < h + r.h + 4,
         );
+      // Jumbotron/title text is PINNED to its screen geometry — displacing it
+      // off the glowing face it belongs to is worse than any overlap. It still
+      // claims its rect so free-floating cards route around it.
+      const pinned = v.o.role === 'screen' || v.o.role === 'title';
       let shift = 0;
-      while (shift < 4 && collides(y)) {
+      while (!pinned && shift < 4 && collides(y)) {
         y += 30;
         shift++;
       }

--- a/sdf-js/apps/present/figure-core.js
+++ b/sdf-js/apps/present/figure-core.js
@@ -139,7 +139,15 @@ export function createFigure({ outdoor = false, stage = false, present = false }
     adaptAfter = performance.now() + ADAPT_GRACE_MS;
     lowStreak = 0;
     highStreak = 0;
-    const dw = attachDeckWindows(studio, scene, { holdDuringWarmup: !present });
+    const dw = attachDeckWindows(studio, scene, {
+      holdDuringWarmup: !present,
+      // boundary swaps can stall the driver briefly — those samples are not a
+      // render-cost signal, so the adaptive scaler sits out a grace window
+      onSwap: () => {
+        adaptAfter = Math.max(adaptAfter, performance.now() + 2500);
+        lowStreak = 0;
+      },
+    });
     if (dw) {
       detachDeckWindows = dw.detach;
       deckWarming = true;

--- a/sdf-js/apps/present/figure.html
+++ b/sdf-js/apps/present/figure.html
@@ -40,6 +40,24 @@
         background: rgba(40, 116, 196, 0.92);
         font-weight: 700;
       }
+      .lbl.title {
+        font-weight: 900;
+        background: none;
+        text-shadow: 0 2px 14px rgba(0, 0, 0, 0.65);
+      }
+      /* Jumbotron text: the glowing 3D screen face behind it IS the chip, so
+         no background — just big type with enough shadow to sit on the glow. */
+      .lbl.screen {
+        font-weight: 800;
+        background: none;
+        text-shadow:
+          0 1px 3px rgba(0, 0, 0, 0.8),
+          0 3px 16px rgba(0, 0, 0, 0.5);
+        max-width: 340px;
+        white-space: normal;
+        text-align: center;
+        line-height: 1.25;
+      }
       /* Boot loader — visible until the first frame is drawn. Pure CSS-transform
          animation so it keeps moving even if the main thread hiccups. */
       #loading {

--- a/sdf-js/scripts/test-render-hold.mjs
+++ b/sdf-js/scripts/test-render-hold.mjs
@@ -29,7 +29,10 @@ ok(
 // ---- bare cover ------------------------------------------------------------------
 {
   const s = renderHold({ structure: 'hold', title: '最懂你的头条', nodes: [] });
-  ok(s.subjects.length >= 3, 'cover renders stele + plinth + band');
+  ok(
+    s.subjects.length === 2 && s.subjects.every((x) => x.id.startsWith('title-')),
+    'cover renders the master screen (volumetric shell + glowing face)',
+  );
   ok(s.overlay.length === 1 && s.overlay[0].role === 'title', 'cover overlay is the title only');
   ok(s.cameraSequence.shots.length === 3, 'three quiet beats');
   ok(
@@ -47,31 +50,36 @@ const IR = {
 };
 {
   const s = renderHold(IR);
-  const pips = s.subjects.filter((x) => x.id.startsWith('pip-'));
-  ok(pips.length === 6, 'one pip per bullet');
+  const shells = s.subjects.filter((x) => /^b\d+-shell$/.test(x.id));
+  const faces = s.subjects.filter((x) => /^b\d+-face$/.test(x.id));
+  ok(shells.length === 6 && faces.length === 6, 'one volumetric screen per bullet (shell+face)');
   ok(
-    s.overlay.filter((o) => o.role === 'card').length === 6,
-    'one overlay card per bullet (text stays in the DOM layer)',
+    shells.every((x) => x.args.dims[2] >= 0.15),
+    'screen shells have real thickness (3D bodies, not flat cards)',
   );
-  const reveals = s.overlay.filter((o) => o.role === 'card').map((o) => o.revealAt);
+  ok(
+    s.overlay.filter((o) => o.role === 'screen').length === 6,
+    'one jumbotron text per bullet (big depth-scaled DOM type)',
+  );
+  const reveals = s.overlay.filter((o) => o.role === 'screen').map((o) => o.revealAt);
   ok(
     reveals.every((t, i) => i === 0 || t > reveals[i - 1]),
     'bullet reveals are staggered',
   );
   ok(
-    JSON.stringify(pips[5].material) !== JSON.stringify(pips[0].material),
-    'emphasized bullet pip gets the gold material',
+    JSON.stringify(faces[5].material) !== JSON.stringify(faces[0].material),
+    'emphasized bullet screen gets the gold face',
   );
   // deck-transplant safety: every build-in expr must parse under the STRICT shifter
   let allShift = true;
-  for (const p of pips) {
+  for (const p of [...shells, ...faces]) {
     try {
       shiftBuildInExpr(p.animation[0].expr, 2.5, 10);
     } catch (e) {
       allShift = false;
     }
   }
-  ok(allShift, 'pip build-in exprs survive assembleDeck expr shifting');
+  ok(allShift, 'screen build-in exprs survive assembleDeck expr shifting');
 }
 
 // ---- renderIR seam -----------------------------------------------------------------

--- a/sdf-js/scripts/test-render-magnitude.mjs
+++ b/sdf-js/scripts/test-render-magnitude.mjs
@@ -70,7 +70,10 @@ ok(
   );
   ok((shots[shots.length - 1].focalDistance || 0) > 5, 'ends on a wide payoff frame');
 
-  // labels: 5 name cards + 5 value chips, reveal-tagged
+  // labels: 5 name cards + 5 value chips, reveal-tagged. (3D extruded digits
+  // above the champion were tried and REVERTED: a glyph label is one leaf but
+  // a huge expression — register pressure tanked magnitude stations to 1-16fps
+  // on M3. Bring back only with a cheap glyph representation.)
   const cards = scene.overlay.filter((o) => o.role === 'card');
   const values = scene.overlay.filter((o) => o.role === 'value');
   ok(cards.length === 5 && values.length === 5, '5 cards + 5 values');

--- a/sdf-js/src/runtime/deck-shader-windows.js
+++ b/sdf-js/src/runtime/deck-shader-windows.js
@@ -33,8 +33,13 @@ export function windowIndexAt(windows, t) {
  *   frame that's invisible; mid-playback it would freeze the show. Pass
  *   false when something else already owns the clock (presenter mode opens
  *   HELD at t≈0, which hides the same stalls for free).
+ * @param opts.onSwap  called at every boundary program swap. The host's
+ *   adaptive-resolution loop uses this to grant a grace window: the driver
+ *   still stalls briefly on some first draws (deferred specialization we
+ *   can't force), and those stall samples must not read as "render is slow,
+ *   downshift" — they'd park a fast deck at 0.5× for nothing.
  */
-export function attachDeckWindows(studio, scene, { holdDuringWarmup = true } = {}) {
+export function attachDeckWindows(studio, scene, { holdDuringWarmup = true, onSwap = null } = {}) {
   const windows = scene.deckWindows;
   if (!Array.isArray(windows) || windows.length < 2 || !studio.swapSDF) return null;
 
@@ -101,6 +106,7 @@ export function attachDeckWindows(studio, scene, { holdDuringWarmup = true } = {
     if (idx !== cur) {
       cur = idx;
       studio.swapSDF(sdfFor(idx));
+      if (onSwap) onSwap(idx);
     }
     requestAnimationFrame(tick);
   };

--- a/sdf-js/src/scene/render-hold.js
+++ b/sdf-js/src/scene/render-hold.js
@@ -1,43 +1,85 @@
 // sdf-js/src/scene/render-hold.js
-// Structure renderer #6: hold → TITLE CARD. Reads the IR ONLY (never 2D x/y).
+// Structure renderer #6: hold → FLOAT-SCREEN WALL. Reads the IR ONLY.
 //
 // A hold page has no chartable structure — a cover, a narration beat, a product
-// tour. In a deck it is the interlude between arenas: the world quiets down,
-// one monument holds the frame, and the SPEAKER carries the content. So the
-// geometry is deliberately minimal (a stele + one gold band + a pip per
-// bullet) and all narrative text rides the DOM overlay (two-text-systems rule:
-// only geometry-bound data labels ever go into the SDF).
+// tour. The 3D form for "just words" is the JUMBOTRON: big volumetric screens
+// floating in the arena (a beveled shell + an inset glowing face — real bodies
+// with thickness, never flat cards), one per bullet, staggered in depth so the
+// wall has parallax. The words themselves ride the DOM overlay, but sized to
+// the screen via the depth-scaled font pass in figure-core (two-text-systems
+// rule intact: geometry carries the SCREEN, the DOM carries the TEXT).
 //
 // Fighting-game grammar, hold variation — the INTERLUDE:
-//   1. slow push-in on the stele (the breath between rounds)
-//   2. lateral drift while bullet pips drop in one per beat
-//   3. payoff pull-back (auto-tagged 'station' by the renderIR seam)
+//   1. slow push-in on the master title screen
+//   2. drift along the screen wall while bullet screens swing in one per beat
+//   3. payoff pull-back framing the whole wall (auto-tagged 'station')
 // No super — hold pages never punch; they set up the next station's hit.
 import { validateIR } from './ir.js';
 import { getEnvironment } from './environments.js';
 
 const label = (n) => (typeof n === 'string' ? n : (n && (n.label ?? n.name)) || '');
 
-const pipMat = (emphasized) =>
+const SHELL_MAT = {
+  hue: 0.62,
+  sat: 0.4,
+  value: 0.3,
+  kind: 'normal',
+  roughness: 0.24,
+  clearcoat: 0.6,
+};
+const faceMat = (emphasized) =>
   emphasized
     ? {
         hue: 0.11,
-        sat: 0.78,
+        sat: 0.72,
         value: 0.95,
-        metal: 0,
-        glow: 0.22,
+        glow: 0.3,
         kind: 'normal',
-        roughness: 0.22,
-        clearcoat: 0.6,
+        roughness: 0.3,
+        clearcoat: 0.4,
       }
     : {
         hue: 0.58,
-        sat: 0.55,
-        value: 0.8,
+        sat: 0.45,
+        value: 0.62,
+        glow: 0.18,
         kind: 'normal',
-        roughness: 0.3,
-        clearcoat: 0.45,
+        roughness: 0.32,
+        clearcoat: 0.4,
       };
+
+// One volumetric screen: beveled shell + glowing face inset just proud of the
+// front plane. Two subjects — thickness reads from every angle, and the lit
+// face gives the "screen" read without any texture machinery.
+function screen(id, [x, y, z], [w, h], yaw, emphasized, anim) {
+  const shell = {
+    id: `${id}-shell`,
+    type: 'rounded_box',
+    args: { dims: [w, h, 0.22], cornerR: 0.07 },
+    transform: { translate: [x, y, z], ...(yaw ? { rotate: [0, yaw, 0] } : {}) },
+    material: SHELL_MAT,
+  };
+  const face = {
+    id: `${id}-face`,
+    type: 'rounded_box',
+    args: { dims: [w - 0.22, h - 0.22, 0.05], cornerR: 0.05 },
+    // face sits proud of the shell front (+z toward the default camera)
+    transform: {
+      translate: [
+        x + (yaw ? -Math.sin(yaw) * 0.1 : 0),
+        y,
+        z + (yaw ? Math.cos(yaw) * 0.1 : 0.1),
+      ],
+      ...(yaw ? { rotate: [0, yaw, 0] } : {}),
+    },
+    material: faceMat(emphasized),
+  };
+  if (anim) {
+    shell.animation = [{ channel: 'transform.translate.y', expr: anim(y) }];
+    face.animation = [{ channel: 'transform.translate.y', expr: anim(y) }];
+  }
+  return [shell, face];
+}
 
 export function renderHold(ir, opts = {}) {
   const v = validateIR(ir);
@@ -49,130 +91,101 @@ export function renderHold(ir, opts = {}) {
   const bullets = (ir.nodes || []).map(label).filter(Boolean);
   const N = bullets.length;
   const emphasis = new Set(ir.emphasis || []);
-
-  // ---- geometry: stele + gold band + bullet pips -------------------------------
-  // The stele stands left-of-centre so the bullet column (camera right) shares
-  // the frame instead of hiding behind it. Static on purpose — the anchor of a
-  // narration beat must not fidget.
-  const steleX = N > 0 ? -1.3 : 0;
-  const subjects = [
-    {
-      id: 'plinth',
-      type: 'box',
-      args: { dims: [2.6, 0.14, 1.1] },
-      transform: { translate: [steleX, 0.07, 0] },
-      material: { hue: 0.58, sat: 0.1, value: 0.55, kind: 'normal', roughness: 0.6 },
-    },
-    {
-      id: 'stele',
-      type: 'rounded_box',
-      args: { dims: [2.1, 2.5, 0.16], cornerR: 0.05 },
-      transform: { translate: [steleX, 1.39, 0] },
-      material: {
-        hue: 0.62,
-        sat: 0.45,
-        value: 0.34,
-        kind: 'normal',
-        roughness: 0.26,
-        clearcoat: 0.55,
-      },
-    },
-    {
-      // gold band near the stele's crown — the 3D "title underline"
-      id: 'band',
-      type: 'box',
-      args: { dims: [2.1, 0.07, 0.18] },
-      transform: { translate: [steleX, 2.28, 0] },
-      material: {
-        hue: 0.11,
-        sat: 0.78,
-        value: 0.95,
-        glow: 0.25,
-        kind: 'normal',
-        roughness: 0.2,
-        clearcoat: 0.6,
-      },
-    },
-  ];
-
-  // Bullet pips: a floating column beside the stele, one dropping in per beat.
-  // Drop (not erupt) — items arriving from above read as points being SET DOWN
-  // on the argument, and the drop shape is assembleDeck-transplant safe.
-  // The column is centred at stele mid-height and compresses its step for long
-  // lists so the last pip never sinks into the platform (6 bullets at a fixed
-  // 0.56 step put pip-5 at floor level).
-  const pipX = 0.9;
-  const pipStep = N > 1 ? Math.min(0.56, 2.3 / (N - 1)) : 0;
-  const pipTopY = 1.5 + ((N - 1) * pipStep) / 2;
-  const introLead = 2.2; // the hero push-in
+  const introLead = 2.2;
   const holdEach = 1.0;
-  bullets.forEach((_, k) => {
-    const y = pipTopY - k * pipStep;
-    const drop = 0.5;
+
+  // Drop-in build: screens settle from above as their beat arrives. The shape
+  // is the assembleDeck-transplant-safe smoothstep drop.
+  const dropExpr = (k) => (yFinal) => {
+    const drop = 0.7;
     const t0 = introLead + k * holdEach - 0.35;
-    const t1 = t0 + 0.5;
-    subjects.push({
-      id: `pip-${k}`,
-      type: 'rounded_box',
-      args: { dims: [0.3, 0.3, 0.3], cornerR: 0.09 },
-      transform: { translate: [pipX, y, 0] },
-      material: pipMat(emphasis.has(k)),
-      animation: [
-        {
-          channel: 'transform.translate.y',
-          expr: `${(y + drop).toFixed(3)} - ${drop.toFixed(3)} * smoothstep(${t0.toFixed(2)}, ${t1.toFixed(2)}, t)`,
-        },
-      ],
-    });
+    const t1 = t0 + 0.55;
+    return `${(yFinal + drop).toFixed(3)} - ${drop.toFixed(3)} * smoothstep(${t0.toFixed(2)}, ${t1.toFixed(2)}, t)`;
+  };
+
+  // ---- geometry: the jumbotron wall ---------------------------------------------
+  // Master title screen high centre; bullet screens in two columns fanned
+  // around it, staggered in z so the wall reads as a hovering fleet, each
+  // yawed a few degrees toward the centre line.
+  const titleW = Math.max(4.2, 2.6 + (String(ir.title || '').length > 8 ? 1.8 : 0));
+  const subjects = [
+    ...screen('title', [0, N > 0 ? 3.35 : 1.9, N > 0 ? -0.8 : 0], [titleW, 1.3], 0, false, null),
+  ];
+  // One layout, two consumers: the screen geometry AND the overlay text anchors
+  // read the same positions, so they can never drift apart. Three-row walls
+  // tighten the row step and raise the base so the bottom row's screens clear
+  // the platform (screen half-height 0.46 + margin).
+  const rows = Math.ceil(N / 2);
+  const rowStep = rows > 2 ? 1.08 : 1.15;
+  const baseY = rows > 2 ? 2.85 : 2.35;
+  const bulletPos = bullets.map((_, k) => {
+    const col = k % 2 === 0 ? -1 : 1; // left, right, left, right…
+    const row = Math.floor(k / 2);
+    return {
+      col,
+      x: col * 2.05,
+      y: baseY - row * rowStep,
+      z: -0.3 + row * 0.55 + (col < 0 ? 0 : 0.25), // stagger depth → parallax
+    };
+  });
+  bulletPos.forEach((p, k) => {
+    const yaw = p.col * -0.16; // angled inward, facing the aisle
+    subjects.push(
+      ...screen(`b${k}`, [p.x, p.y, p.z], [3.0, 0.92], yaw, emphasis.has(k), dropExpr(k)),
+    );
   });
 
-  // ---- camera: three quiet beats ------------------------------------------------
+  // ---- camera: three quiet beats down the aisle -----------------------------------
   const driftDur = Math.max(2.2, N * holdEach + 0.8);
+  const wallTop = N > 0 ? 3.35 : 1.9;
   const shots = [
     {
       duration: introLead,
-      pos: [steleX + 0.9, 1.5, 5.6],
-      target: [steleX + (N > 0 ? 0.7 : 0), 1.5, 0],
-      fov: 46,
-      aperture: 0.4,
-      focalDistance: 5.2,
+      pos: [0, wallTop - 0.15, 6.2],
+      target: [0, wallTop - 0.35, 0],
+      fov: 42,
+      aperture: 0.35,
+      focalDistance: 6.0,
       ease: 'out',
     },
     {
       duration: driftDur,
-      pos: [steleX - 1.4, 1.8, 5.0],
-      target: [N > 0 ? (steleX + pipX) / 2 + 0.4 : steleX, 1.5, 0],
-      fov: 44,
+      pos: [-1.5, 2.0, 5.4],
+      target: [0.3, N > 0 ? 2.0 : 1.8, 0],
+      fov: 46,
       transition: 'blend',
-      aperture: 0.3,
-      focalDistance: 5.0,
+      aperture: 0.28,
+      focalDistance: 5.4,
       ease: 'smooth',
     },
     {
       duration: 2.0,
-      pos: [steleX + 0.6, 2.1, 6.8 * (env ? env.payoffZoom : 1)],
-      target: [steleX + (N > 0 ? 0.8 : 0), 1.4, 0],
+      pos: [0.6, 2.6, 7.6 * (env ? env.payoffZoom : 1)],
+      target: [0, N > 0 ? 2.2 : 1.8, 0],
       fov: 46,
       transition: 'blend',
-      aperture: 0.14,
-      focalDistance: 6.8,
+      aperture: 0.12,
+      focalDistance: 7.6,
       ease: 'out',
     },
   ];
 
-  // ---- overlay: title on the stele, one card per bullet -------------------------
+  // ---- overlay: text mapped onto the screens --------------------------------------
+  // role 'screen' → figure-core renders it as big depth-scaled type with no
+  // chip background (the glowing face IS the background).
   const overlay = [
     {
       text: String(ir.title || bullets[0] || ''),
-      anchor: [steleX, 3.0, 0],
+      anchor: [0, N > 0 ? 3.35 : 1.9, N > 0 ? -0.7 : 0.15],
       role: 'title',
     },
   ];
   bullets.forEach((b, k) => {
+    const p = bulletPos[k];
     overlay.push({
       text: b,
-      anchor: [pipX + 0.35, pipTopY - k * pipStep, 0],
-      role: 'card',
+      anchor: [p.x, p.y, p.z + 0.16],
+      role: 'screen',
       revealAt: introLead + k * holdEach + 0.25,
     });
   });

--- a/sdf-js/src/scene/render-matrix.js
+++ b/sdf-js/src/scene/render-matrix.js
@@ -56,31 +56,42 @@ export function renderMatrix(ir, opts = {}) {
 
   const subjects = [];
 
-  // the board: one thin tile per cell (self-laid, so item positions match exactly)
+  // The backboard: one deep slab the whole grid mounts on — the wall reads as
+  // a MASS, not a floating plane (3D-first: every element carries thickness).
+  subjects.push({
+    id: 'backboard',
+    type: 'rounded_box',
+    args: { dims: [boardW + 0.5, boardH + 0.5, 0.28], cornerR: 0.08 },
+    transform: { translate: [0, cy, -0.34] },
+    material: { hue: 0.62, sat: 0.3, value: 0.22, kind: 'normal', roughness: 0.4, clearcoat: 0.3 },
+  });
+
+  // the board: one thick beveled block per cell, proud of the backboard
   for (let yi = 0; yi < Y; yi++)
     for (let xi = 0; xi < X; xi++)
       subjects.push({
         id: `cell-${xi}-${yi}`,
-        type: 'box',
-        args: { dims: [cellW, cellH, 0.1] },
+        type: 'rounded_box',
+        args: { dims: [cellW, cellH, 0.3], cornerR: 0.06 },
         transform: { translate: [cellX(xi), cellY(yi), 0] },
         material: { ...TILE_MAT },
       });
 
-  // items slam onto their cells one by one (drop along z from the camera side)
+  // items slam onto their cells one by one (drop along z from the camera side).
+  // Full cubes, not plaques — the slam lands a BODY on the board.
   const introLead = 1.6;
   const holdEach = 0.9;
-  const zFinal = 0.18; // proud of the board face
   const zStart = 2.4; // launched from the camera side
   order.forEach((i, k) => {
     const [xi, yi] = ir.cells[i];
-    const size = mag ? 0.22 + 0.3 * Math.sqrt((Number(mag[i]) || 0) / mMax) : 0.3;
+    const size = mag ? 0.24 + 0.32 * Math.sqrt((Number(mag[i]) || 0) / mMax) : 0.34;
+    const zFinal = 0.15 + size / 2 + 0.02; // clear the thick cell face
     const t0 = introLead + k * holdEach - 0.35;
     const t1 = t0 + 0.45;
     subjects.push({
       id: `item-${i}`,
       type: 'rounded_box',
-      args: { dims: [size, size, 0.14], cornerR: 0.03 },
+      args: { dims: [size, size, size], cornerR: 0.06 },
       transform: { translate: [cellX(xi), cellY(yi), zFinal] },
       material: itemMat(emphasis.has(i)),
       animation: [


### PR DESCRIPTION
## 背景

BP deck 50 分反馈的两条方向:**① 3D 世界尽量用三维物体不用面片;② 难以空间化的文本用大块浮屏表达**。按约定做两轮迭代。

## Round 1 — hold 浮屏墙 + 文字长进世界里

- **render-hold 重写**:石碑+小 pip 换成 **jumbotron 浮屏墙**——每条要点一块体积屏(倒角厚壳 + 内嵌发光屏面,双 subject),左右两列、深度错落(parallax)、向中线内倾;标题挂主屏。强调条金色屏面。布局单源(几何与文字 anchors 共用 positions 数组,不会漂移)。
- **DOM 文字随深度缩放**:figure-core 按 `project().depth` 缩放每个标签字号(量化 + 变化才写),文字近大远小,长在世界里而不是固定尺寸的 HUD 角标。新 `screen` 角色:大字、无底色(发光屏面就是它的底)、钉死在自己的屏上(碰撞布局不得推走)。

## Round 2 — matrix 体积化 + 边界降档宽限

- **matrix 象限墙有了质量**:深框 backboard 底板 + 厚倒角 cell 块 + **立方体** items 拍上墙(原来是 0.1 薄片 + 0.14 薄牌)。
- **swap 宽限**:`attachDeckWindows` 新 `onSwap` 钩子,边界换 shader 时给自适应降档 2.5s 宽限——驱动首绘卡顿的样本不再把快 deck 钉死在 0.5×(实测曲线:降档后能回升 0.75×→1.0×)。

## 尝试并回退:3D 立体金数字

给 emphasis 巨柱头顶加了 text-3d-extruded 的金色 "252.2"(视觉极佳,顺带发现并修了字形 +z 相机镜像问题)——但**字形是单 leaf 巨表达式,寄存器压力让 magnitude 站从 47-85fps 掉到 1-16fps**,回退。发现记录在测试注释里;等有便宜的字形表达(如 glyph 纹理)再上。这条与 #286 的「超线性静态成本」发现互为印证:**寄存器分配看表达式复杂度,「一条语句」骗不过它**。

## 实测(bytedance-bp 10 站,M3)

- 站内 33-125fps(浮屏站 120fps、产品/网络站 60-123fps、magnitude 站 47-123fps),自适应可自行回升
- 残留:边界处 2-4s 低谷(驱动延迟特化,#286 已知问题,10 站被放大),记 follow-up
- 141/141 测试(hold 断言更新为浮屏不变量;magnitude 断言恢复 + 回退原因入注)

## 截图要点(验证过)

封面 = 悬浮大标题屏;投资亮点 = 6 屏浮墙 + 金色强调屏,字全部印在屏上;2013 计划 = 厚框体积象限墙 + 立方体落格。

🤖 Generated with [Claude Code](https://claude.com/claude-code)