### PR TITLE
Sprint 73: 三级页面体系 (hero 封面/目录/扉页) + quick 分节 + spectrum 主题×2

### DIFF
--- a/sdf-js/apps/present/author-2d.js
+++ b/sdf-js/apps/present/author-2d.js
@@ -11,7 +11,12 @@ import { textToIR } from '../../src/scene/text-to-ir.js';
 import { irDeckTo2DDeck } from '../../src/scene/ir-to-2d.js';
 import { newsToFullDeck, reliftSlot, retryFailedSlot } from '../../src/present/news/full-deck.js';
 import { renderSceneDataToCanvas } from '../../src/present/atoms-2d/renderer.js';
-import { rethemeDeck } from '../../src/present/retheme.js';
+import {
+  rethemeDeck,
+  applySectionAccents,
+  slotPalette,
+  slotRoleOf,
+} from '../../src/present/retheme.js';
 import { decorFromHash, mintDecorHash } from '../../src/present/decor/registry.js';
 import { ATLAS_THEMES } from '../../src/present/themes.js';
 import { exportDeckToPPTX } from '../../src/present/exporters/pptx.js';
@@ -372,8 +377,9 @@ async function renderDeck(deck) {
     attachSlideControls(card, canvas, deck, slot);
     slidesEl.appendChild(card);
     await renderSceneDataToCanvas(canvas, slot.sceneData, {
-      palette: deck.theme,
+      palette: slotPalette(deck.theme, slot),
       decor: slotDecor(deck, slot),
+      decorRole: slotRoleOf(slot),
     });
   }
   // Sprint 68: failed slots surface as retryable cards, not console lines —
@@ -488,8 +494,9 @@ function attachSlideControls(card, canvas, deck, slot) {
     try {
       const sceneData = await reliftSlot(currentDeck, slot.slotIdx, { apiKey, revision });
       await renderSceneDataToCanvas(canvas, sceneData, {
-        palette: deck.theme,
+        palette: slotPalette(deck.theme, slot),
         decor: slotDecor(deck, slot),
+        decorRole: slotRoleOf(slot),
       });
       editRow.classList.remove('open');
       editInput.value = '';
@@ -596,8 +603,9 @@ async function generate() {
           if (!entry) return;
           try {
             await renderSceneDataToCanvas(entry.canvas, slot.sceneData, {
-              palette: streamTheme,
+              palette: slotPalette(streamTheme, slot),
               decor: slotDecor({ decor: streamDecor }, slot),
+              decorRole: slotRoleOf(slot),
             });
           } finally {
             entry.card.classList.remove('busy');
@@ -630,6 +638,9 @@ async function generate() {
       `rendering ${irDeck.slides.length} slide${irDeck.slides.length > 1 ? 's' : ''}: ${irDeck.slides.map((s) => s.structure).join(' → ')}`,
     );
     currentDeck = irDeckTo2DDeck(irDeck);
+    // Sprint 73: quick decks get section colors too — every content page
+    // holds its own hue (slot names are unique → one section per page)
+    applySectionAccents(currentDeck);
     // demo default is a fixed hash (deterministic screenshots), but an
     // explicit ?hash= re-open wins even in demo — provenance is testable
     currentDeck.decor = mintDecor(

--- a/sdf-js/src/present/atoms-2d/renderer.js
+++ b/sdf-js/src/present/atoms-2d/renderer.js
@@ -56,6 +56,13 @@ export async function renderSceneDataToCanvas(canvas, sceneData, opts = {}) {
   // and would bury an underlay).
   const decor = opts.decor;
   const isPureCover = subjects.length > 0 && subjects.every((s) => s?.type === 'cover');
+  // Sprint 73 (三级页面体系): the deck breathes in three registers —
+  //   cover/agenda/section openers = generative ARTWORK pages (hero/bold),
+  //   content pages = generative ELEMENTS (subtle underlay, unchanged).
+  // Callers pass opts.decorRole ('cover'|'agenda'|'section'|'content');
+  // pure covers resolve to 'cover' on their own.
+  const role = opts.decorRole || (isPureCover ? 'cover' : 'content');
+  const UNDER_INTENSITY = { agenda: 'bold', section: 'bold', content: 'subtle' };
   if (decor && !isPureCover) {
     drawDecor(ctx, decor, {
       palette,
@@ -63,7 +70,7 @@ export async function renderSceneDataToCanvas(canvas, sceneData, opts = {}) {
       y: 0,
       w: canvas.width,
       h: canvas.height,
-      intensity: decor.intensity || 'subtle',
+      intensity: decor.intensity || UNDER_INTENSITY[role] || 'subtle',
     });
   }
   let rendered = 0;
@@ -109,7 +116,7 @@ export async function renderSceneDataToCanvas(canvas, sceneData, opts = {}) {
       y: 0,
       w: canvas.width,
       h: canvas.height,
-      intensity: decor.intensity || 'bold',
+      intensity: decor.intensity || 'hero',
     });
   }
 

--- a/sdf-js/src/present/decor/registry.js
+++ b/sdf-js/src/present/decor/registry.js
@@ -67,6 +67,10 @@ const INTENSITY = {
   subtle: { alpha: 0.07, alphaFill: 0.05, lineWidth: 1 },
   medium: { alpha: 0.14, alphaFill: 0.1, lineWidth: 1.2 },
   bold: { alpha: 0.26, alphaFill: 0.18, lineWidth: 1.6 },
+  // Sprint 73 (三级页面体系): hero — the family stops being a wash and
+  // becomes the ARTWORK. Covers / agenda / section openers only; big white
+  // 900-weight titles stay legible over it, body text would not.
+  hero: { alpha: 0.42, alphaFill: 0.3, lineWidth: 2.2 },
 };
 
 // --- families ---------------------------------------------------------------

--- a/sdf-js/src/present/exporters/pdf.js
+++ b/sdf-js/src/present/exporters/pdf.js
@@ -10,6 +10,7 @@
 // =============================================================================
 
 import { renderSceneDataToCanvas } from '../atoms-2d/renderer.js';
+import { slotPalette, slotRoleOf } from '../retheme.js';
 
 const JSPDF_CDN = 'https://esm.sh/jspdf@2.5.2';
 let jsPDF = null;
@@ -67,7 +68,8 @@ export async function exportDeckToPDF(deck, opts = {}) {
     // preview — decoration layer included, per-atom errors non-fatal.
     try {
       await renderSceneDataToCanvas(canvas, slot.sceneData || { subjects: [] }, {
-        palette: deck.theme,
+        palette: slotPalette(deck.theme, slot),
+        decorRole: slotRoleOf(slot),
         decor: deck.decor
           ? { ...deck.decor, seed: (deck.decor.seed ?? 1) + slot.slotIdx }
           : undefined,

--- a/sdf-js/src/present/exporters/pptx.js
+++ b/sdf-js/src/present/exporters/pptx.js
@@ -18,6 +18,7 @@
 // =============================================================================
 
 import { renderSceneDataToCanvas } from '../atoms-2d/renderer.js';
+import { slotPalette, slotRoleOf } from '../retheme.js';
 
 // pptxgenjs loaded from esm.sh on first call (matches pdfjs CDN pattern in
 // src/parser/pdf.js — no build step / bundler required).
@@ -83,7 +84,8 @@ export async function exportDeckToPPTX(deck, opts = {}) {
     // preview — decoration layer included, per-atom errors non-fatal.
     try {
       await renderSceneDataToCanvas(canvas, slot.sceneData || { subjects: [] }, {
-        palette: deck.theme,
+        palette: slotPalette(deck.theme, slot),
+        decorRole: slotRoleOf(slot),
         decor: deck.decor
           ? { ...deck.decor, seed: (deck.decor.seed ?? 1) + slot.slotIdx }
           : undefined,

--- a/sdf-js/src/present/retheme.js
+++ b/sdf-js/src/present/retheme.js
@@ -150,6 +150,19 @@ export function applySectionAccents(deck, { minHues = 3 } = {}) {
  * sectionAccent must also render under a palette variant, or only the
  * lift-baked colors would shift.
  */
+/**
+ * slotRoleOf(slot) — Sprint 73: which register a page plays in the
+ * three-tier system (cover / agenda / section opener / content). Derived
+ * from slot names (news-briefing convention); unknown names are content.
+ */
+export function slotRoleOf(slot) {
+  const name = String(slot?.slotName || '');
+  if (name === 'cover') return 'cover';
+  if (name === 'agenda') return 'agenda';
+  if (/-lead$/.test(name)) return 'section';
+  return 'content';
+}
+
 export function slotPalette(theme, slot) {
   if (!slot?.sectionAccent) return theme;
   const hue = [...slot.sectionAccent];

--- a/sdf-js/src/present/themes.js
+++ b/sdf-js/src/present/themes.js
@@ -181,6 +181,56 @@ export const ATLAS_THEMES = [
   // ORGANIC / NATURE — rounded sans + soft gradients + nature palette
   // ============================================================================
   {
+    id: 'pitch-spectrum',
+    label: 'Pitch · Spectrum',
+    macroCluster: 'pitch',
+    // Sprint 73: multi-hue on ink — vivid editorial energy for pitch decks.
+    // Palette: chromotome kov_06 (the repo's established palette corpus),
+    // the Fidenza-on-dark register: vermilion anchor + azure / ochre /
+    // green / blush over deep ink. Built for section-accent programming.
+    bg: [14, 22, 30],
+    silhouetteColor: [238, 236, 228],
+    accent: [241, 70, 22], // vermilion anchor
+    colors: [
+      [241, 70, 22], // vermilion (anchor)
+      [43, 154, 233], // azure
+      [168, 124, 42], // gold ochre
+      [1, 119, 86], // deep green (lifted from kov_06 green toward teal for dark-bg contrast)
+      [236, 191, 175], // blush
+      [189, 201, 177], // sage grey
+    ],
+    font: {
+      heading: '"Inter Display", Inter, system-ui, sans-serif',
+      body: 'Inter, system-ui, sans-serif',
+    },
+    featured: true,
+  },
+  {
+    id: 'organic-spectrum',
+    label: 'Organic · Spectrum',
+    macroCluster: 'organic',
+    // Sprint 73: the Fidenza warm-naturals register — sand canvas,
+    // vermilion / amber / deep green / sage (chromotome kov_05 + hilda
+    // family, the repo's palette corpus). Flow-ribbons on this palette IS
+    // the Fidenza feel our L2 recipe port was born from.
+    bg: [246, 240, 228],
+    silhouetteColor: [56, 44, 36],
+    accent: [200, 66, 34], // vermilion, earthed
+    colors: [
+      [200, 66, 34], // vermilion (anchor)
+      [222, 146, 50], // amber
+      [0, 113, 88], // deep green
+      [134, 150, 121], // sage
+      [140, 75, 71], // clay
+      [86, 118, 140], // river blue
+    ],
+    font: {
+      heading: 'Georgia, "Source Serif Pro", serif',
+      body: 'Inter, system-ui, sans-serif',
+    },
+    featured: true,
+  },
+  {
     id: 'organic-teal',
     label: 'Organic · Teal',
     macroCluster: 'organic',


### PR DESCRIPTION
## Summary

user 指示三连: quick 模式接分节配色、pitch/organic 各配多色相主题、封面/目录/子标题页生成艺术化 ("现在中规中矩, 生成艺术是给你加灵性的")。

## 三级页面体系

deck 三个呼吸段位:
- **封面 / 目录 / 章节扉页 = 生成艺术主场** — `INTENSITY.hero` (α0.42) 让家族从水印变成画: ANTFUN 封面上 Hodgin 河曲带牛轭湖在 navy 上流成真正的作品, 目录页曲线在 01-06 条目间穿行
- **内页 = 生成艺术元素** — subtle 底纹不变
- 实现: renderer `decorRole` (cover→over+hero, agenda/section-lead→under+bold, content→subtle) + `slotRoleOf` 共享判角; author-2d 三渲染路径 + pptx/pdf 导出器全部接线 (屏幕/导出一致)

## quick 分节 + 主题扩容

- quick 模式 `applySectionAccents` — 3-5 页 deck 每页各持一色相
- **pitch-spectrum**: 墨底 + 朱红锚 + 天蓝/赭金/深绿/绯粉 (chromotome kov_06, repo 既有色板语料)
- **organic-spectrum**: Fidenza 暖色本味 — 砂底 + 朱红/琥珀/深绿/鼠尾草/陶土/河蓝 (kov_05+hilda 系); flow-ribbons 在这块色板上就是 L2 recipe port 的出生地气质

## 交付

- Hero 版 PDF: `~/Downloads/ANTFUN-发射台V1-Atlas-20页-Hero版.pdf`
- npm test 141/141; demo e2e quick 分节 ✓ 零 console 错误

🤖 Generated with [Claude Code](https://claude.com/claude-code)