### PR TITLE
Sprint 74: 五修 — Fidenza 封面 / 山体 / 末页 / 字图比 (user 目检驱动)

### DIFF
--- a/sdf-js/examples/scaffold-pipeline/antfun-launchpad-v1/deck.json
+++ b/sdf-js/examples/scaffold-pipeline/antfun-launchpad-v1/deck.json
@@ -493,13 +493,13 @@
  },
  "colorProgram": "sections",
  "decor": {
-  "family": "river-courses",
+  "family": "flow-ribbons",
   "rare": false,
   "janky": false,
   "grain": 0,
-  "seed": 359318729,
+  "seed": 1668563515,
   "personality": "balanced",
-  "hash": "497bdd03fa27a6f7",
+  "hash": "f8e2a5b411c7c37c",
   "v": 3
  }
 }

--- a/sdf-js/src/present/atoms-2d/charts/data/kpi-card.js
+++ b/sdf-js/src/present/atoms-2d/charts/data/kpi-card.js
@@ -143,7 +143,7 @@ function _drawDark(ctx, args, opts = {}) {
 
   // ---- Icon (top-left) ----
   if (args.icon) {
-    drawIconStub(ctx, args.icon, x + 22, y + 26, 22, rgbCss(bg));
+    drawIconStub(ctx, args.icon, x + 26, y + 30, 32, rgbCss(bg));
   }
 
   // ---- Hero value ----
@@ -152,7 +152,7 @@ function _drawDark(ctx, args, opts = {}) {
   ctx.textBaseline = 'alphabetic';
   const availW = w - 44;
   const valueText = String(args.value ?? '');
-  let valueSize = Math.round(h * 0.34);
+  let valueSize = Math.round(h * 0.29); // Sprint 74: 字体偏大, 图标偏小 (user 目检)
   const minValueSize = Math.round(h * 0.14);
   ctx.font = `900 ${valueSize}px "Inter Display", Inter, system-ui, sans-serif`;
   while (ctx.measureText(valueText).width > availW && valueSize > minValueSize) {
@@ -242,7 +242,7 @@ function _drawLight(ctx, args, opts = {}) {
 
   // ---- Icon (top-left) ----
   if (args.icon) {
-    drawIconStub(ctx, args.icon, x + 22, y + 26, 22, rgbCss(accent));
+    drawIconStub(ctx, args.icon, x + 26, y + 30, 32, rgbCss(accent));
   }
 
   // ---- Hero value (dark text) ----
@@ -251,7 +251,7 @@ function _drawLight(ctx, args, opts = {}) {
   ctx.textBaseline = 'alphabetic';
   const availW = w - 44;
   const valueText = String(args.value ?? '');
-  let valueSize = Math.round(h * 0.34);
+  let valueSize = Math.round(h * 0.29); // Sprint 74: 字体偏大, 图标偏小 (user 目检)
   const minValueSize = Math.round(h * 0.14);
   ctx.font = `900 ${valueSize}px "Inter Display", Inter, system-ui, sans-serif`;
   while (ctx.measureText(valueText).width > availW && valueSize > minValueSize) {
@@ -345,7 +345,7 @@ function _drawAccentBorder(ctx, args, opts = {}) {
   // ---- Icon (top-left, after border) ----
   const textLeft = x + borderW + 14;
   if (args.icon) {
-    drawIconStub(ctx, args.icon, textLeft + 11, y + 26, 22, rgbCss(accent));
+    drawIconStub(ctx, args.icon, textLeft + 15, y + 30, 32, rgbCss(accent));
   }
 
   // ---- Hero value (dark text, offset past border) ----
@@ -354,7 +354,7 @@ function _drawAccentBorder(ctx, args, opts = {}) {
   ctx.textBaseline = 'alphabetic';
   const availW = w - borderW - 28;
   const valueText = String(args.value ?? '');
-  let valueSize = Math.round(h * 0.34);
+  let valueSize = Math.round(h * 0.29); // Sprint 74: 字体偏大, 图标偏小 (user 目检)
   const minValueSize = Math.round(h * 0.14);
   ctx.font = `900 ${valueSize}px "Inter Display", Inter, system-ui, sans-serif`;
   while (ctx.measureText(valueText).width > availW && valueSize > minValueSize) {

--- a/sdf-js/src/present/atoms-2d/charts/diagrams/mountain-path.js
+++ b/sdf-js/src/present/atoms-2d/charts/diagrams/mountain-path.js
@@ -83,75 +83,107 @@ export function drawPseudo3D(ctx, args, opts = {}) {
 
   const plotH = y + h - plotTop - PAD;
   const cx = x + w / 2;
-  const peakY = plotTop + plotH * 0.08;
+  const peakY = plotTop + plotH * 0.1;
   const baseY = plotTop + plotH * 0.95;
-  const baseLeft = x + w * 0.08;
-  const baseRight = x + w * 0.92;
+  const baseLeft = x + w * 0.06;
+  const baseRight = x + w * 0.94;
+  const hues = (palette.colors || []).filter(Array.isArray);
 
-  // Mountain silhouette
-  const gradient = ctx.createLinearGradient(cx, peakY, cx, baseY);
-  gradient.addColorStop(0, rgbCss(lighten(accent, 0.1)));
-  gradient.addColorStop(1, rgbCss(lighten(accent, 0.45)));
-  ctx.fillStyle = gradient;
+  // ── Sprint 74 redesign (user: 三角形不够美观) ──
+  // Depth from layered ridges; the peak is a CURVED profile, not a triangle;
+  // the trail is a smooth switchback; the summit carries a pennant.
+
+  // Back ridges — two soft distant silhouettes in faint hue tints
+  const ridge = (px, py, spread, tint) => {
+    ctx.fillStyle = rgbaCss(tint, 0.16);
+    ctx.beginPath();
+    ctx.moveTo(px - spread, baseY);
+    ctx.quadraticCurveTo(px - spread * 0.35, py + (baseY - py) * 0.25, px, py);
+    ctx.quadraticCurveTo(px + spread * 0.4, py + (baseY - py) * 0.35, px + spread, baseY);
+    ctx.closePath();
+    ctx.fill();
+  };
+  ridge(cx - w * 0.26, peakY + plotH * 0.3, w * 0.34, hues[1] || accent);
+  ridge(cx + w * 0.3, peakY + plotH * 0.22, w * 0.38, hues[2] || accent);
+
+  // Main peak — curved concave flanks (a mountain, not a triangle)
+  const grad = ctx.createLinearGradient(cx, peakY, cx, baseY);
+  grad.addColorStop(0, rgbCss(lighten(accent, 0.05)));
+  grad.addColorStop(0.55, rgbCss(lighten(accent, 0.3)));
+  grad.addColorStop(1, rgbCss(lighten(accent, 0.55)));
+  ctx.fillStyle = grad;
   ctx.beginPath();
   ctx.moveTo(baseLeft, baseY);
-  ctx.lineTo(cx - w * 0.12, peakY + plotH * 0.28);
-  ctx.lineTo(cx, peakY);
-  ctx.lineTo(cx + w * 0.12, peakY + plotH * 0.25);
-  ctx.lineTo(baseRight, baseY);
+  ctx.quadraticCurveTo(cx - w * 0.16, peakY + plotH * 0.42, cx - w * 0.025, peakY + plotH * 0.02);
+  ctx.quadraticCurveTo(cx, peakY - plotH * 0.015, cx + w * 0.03, peakY + plotH * 0.03);
+  ctx.quadraticCurveTo(cx + w * 0.18, peakY + plotH * 0.48, baseRight, baseY);
   ctx.closePath();
   ctx.fill();
 
-  // Mountain border
-  ctx.strokeStyle = rgbaCss(accent, 0.5);
+  // Face ridge-line — a subtle lit edge falling from the summit
+  ctx.strokeStyle = rgbaCss([255, 255, 255], 0.35);
   ctx.lineWidth = 1.5;
+  ctx.beginPath();
+  ctx.moveTo(cx, peakY);
+  ctx.quadraticCurveTo(cx - w * 0.03, peakY + plotH * 0.35, cx - w * 0.09, baseY);
   ctx.stroke();
 
-  // Build switchback waypoints from base to summit
+  // Switchback waypoints
   const N = milestones.length;
   const waypoints = [];
   for (let i = 0; i < N; i++) {
-    const t = (i + 0.5) / N; // 0..1 from base to peak
-    const wy = baseY - t * (baseY - peakY);
-    const xOffset = (i % 2 === 0 ? 1 : -1) * w * 0.16 * (1 - t * 0.6);
+    const t = (i + 0.5) / N;
+    const wy = baseY - t * (baseY - peakY) * 0.92;
+    const xOffset = (i % 2 === 0 ? 1 : -1) * w * 0.15 * (1 - t * 0.55);
     waypoints.push({ wx: cx + xOffset, wy });
   }
 
-  // Path line
-  ctx.beginPath();
-  ctx.moveTo(cx, baseY);
-  if (waypoints.length) {
+  // Trail — one smooth curve through the switchbacks, soft glow underneath
+  const trail = () => {
+    ctx.beginPath();
+    ctx.moveTo(cx - w * 0.02, baseY);
+    let prev = { wx: cx - w * 0.02, wy: baseY };
     for (const wp of waypoints) {
-      ctx.lineTo(wp.wx, wp.wy);
+      ctx.quadraticCurveTo(prev.wx, (prev.wy + wp.wy) / 2, wp.wx, wp.wy);
+      prev = wp;
     }
-    ctx.lineTo(cx, peakY + 4);
-  }
-  ctx.strokeStyle = rgbCss([255, 255, 255]);
-  ctx.lineWidth = 2.5;
-  ctx.setLineDash([6, 4]);
+    ctx.quadraticCurveTo(prev.wx, (prev.wy + peakY) / 2 + 6, cx, peakY + 6);
+  };
+  ctx.save();
+  ctx.strokeStyle = rgbaCss([255, 255, 255], 0.25);
+  ctx.lineWidth = 5;
   ctx.lineCap = 'round';
+  trail();
+  ctx.stroke();
+  ctx.strokeStyle = rgbCss([255, 255, 255]);
+  ctx.lineWidth = 2.2;
+  ctx.setLineDash([7, 5]);
+  trail();
   ctx.stroke();
   ctx.setLineDash([]);
+  ctx.restore();
 
-  // Milestone markers + labels
+  // Milestone markers — hue-rotated dots with white ring + halo, labels as before
   for (let i = 0; i < waypoints.length; i++) {
     const { wx, wy } = waypoints[i];
     const m = milestones[i];
     if (!m) continue;
     const onRight = i % 2 === 0;
+    const hue = hues.length > 1 ? hues[(i + 1) % hues.length] : accent;
 
-    // Circle marker
     ctx.save();
+    ctx.shadowColor = rgbaCss([0, 0, 0], 0.22);
+    ctx.shadowBlur = 6;
     ctx.fillStyle = rgbCss([255, 255, 255]);
-    ctx.strokeStyle = rgbCss(accent);
-    ctx.lineWidth = 2;
     ctx.beginPath();
-    ctx.arc(wx, wy, 8, 0, Math.PI * 2);
+    ctx.arc(wx, wy, 9, 0, Math.PI * 2);
     ctx.fill();
-    ctx.stroke();
     ctx.restore();
+    ctx.fillStyle = rgbCss(hue);
+    ctx.beginPath();
+    ctx.arc(wx, wy, 5.5, 0, Math.PI * 2);
+    ctx.fill();
 
-    // Label
     const labelMaxW = w * 0.22;
     const labelFs = fitFontSize(
       ctx,
@@ -165,7 +197,7 @@ export function drawPseudo3D(ctx, args, opts = {}) {
     ctx.fillStyle = rgbCss(fg);
     ctx.textAlign = onRight ? 'left' : 'right';
     ctx.textBaseline = 'middle';
-    const labelX = onRight ? wx + 12 : wx - 12;
+    const labelX = onRight ? wx + 14 : wx - 14;
     ctx.fillText(m.label ?? '', labelX, wy - (m.sublabel ? labelFs * 0.5 : 0));
 
     if (m.sublabel) {
@@ -176,14 +208,21 @@ export function drawPseudo3D(ctx, args, opts = {}) {
     }
   }
 
-  // Summit marker
-  const summitR = 12;
+  // Summit pennant — pole + flag, the climb has a destination
   ctx.save();
-  ctx.fillStyle = rgbCss(accent);
-  ctx.shadowColor = rgbaCss([0, 0, 0], 0.3);
-  ctx.shadowBlur = 8;
+  ctx.strokeStyle = rgbCss(fg);
+  ctx.lineWidth = 2;
   ctx.beginPath();
-  ctx.arc(cx, peakY, summitR, 0, Math.PI * 2);
+  ctx.moveTo(cx, peakY + 4);
+  ctx.lineTo(cx, peakY - plotH * 0.09);
+  ctx.stroke();
+  const flagH = plotH * 0.05;
+  ctx.fillStyle = rgbCss(hues[1] || accent);
+  ctx.beginPath();
+  ctx.moveTo(cx, peakY - plotH * 0.09);
+  ctx.lineTo(cx + w * 0.05, peakY - plotH * 0.09 + flagH / 2);
+  ctx.lineTo(cx, peakY - plotH * 0.09 + flagH);
+  ctx.closePath();
   ctx.fill();
   ctx.restore();
 
@@ -200,5 +239,5 @@ export function drawPseudo3D(ctx, args, opts = {}) {
   ctx.fillStyle = rgbCss(fg);
   ctx.textAlign = 'center';
   ctx.textBaseline = 'bottom';
-  ctx.fillText(summit, cx, peakY - summitR - 4);
+  ctx.fillText(summit, cx, peakY - plotH * 0.09 - 6);
 }

--- a/sdf-js/src/present/atoms-2d/charts/lists/bullet-list.js
+++ b/sdf-js/src/present/atoms-2d/charts/lists/bullet-list.js
@@ -80,7 +80,7 @@ export function drawPseudo3D(ctx, args, opts = {}) {
   const rowH = (plotH / N) * 0.85;
   const blockH = rowH * N;
   const blockTop = plotTop + (plotH - blockH) / 2;
-  const bulletR = Math.min(rowH * 0.18, 14);
+  const bulletR = Math.min(rowH * 0.22, 18); // Sprint 74: 图标偏小 (user 目检)
   const bulletX = x + PAD + bulletR + 4;
   const textX = bulletX + bulletR + 16;
 
@@ -111,7 +111,7 @@ export function drawPseudo3D(ctx, args, opts = {}) {
       // done = accent darkened 20%, highlight = full accent
       const badgeColor =
         status === 'todo' ? lighten(accent, 0.4) : status === 'done' ? darken(accent, 0.2) : accent;
-      const badgeR = Math.min(bulletR * 1.3, 14); // ~22-28px diameter
+      const badgeR = Math.min(bulletR * 1.3, 19); // Sprint 74: ~28-38px diameter
       // Drop shadow
       ctx.shadowColor = 'rgba(0,0,0,0.18)';
       ctx.shadowBlur = 5;
@@ -205,7 +205,7 @@ export function drawPseudo3D(ctx, args, opts = {}) {
       const labelColor = status === 'todo' ? rgbaCss(fg, 0.55) : rgbCss(fg);
       const labelWeight = status === 'highlight' ? '700' : '600';
       const labelFontSize = Math.min(
-        Math.round(rowH * 0.34),
+        Math.round(rowH * 0.3), // Sprint 74: 字体偏大
         // Cap font: long text in narrow containers shouldn't dominate row height
         Math.round((x + w - textX - PAD) / Math.max(8, String(it.label).length * 0.45)),
       );

--- a/sdf-js/src/present/atoms-2d/charts/lists/numbered-grid.js
+++ b/sdf-js/src/present/atoms-2d/charts/lists/numbered-grid.js
@@ -95,11 +95,20 @@ export function drawPseudo3D(ctx, args, opts = {}) {
   const availH = h - (plotTop - y) - PAD;
   const rowH = availH / rows;
 
+  // Sprint 74 redesign (user: 末页不够美观, 颜色也不好): cards rotate
+  // through the theme hues — tinted wash + hue top-bar + hue number chip —
+  // and an incomplete last row centres itself instead of leaving a hole.
+  const hues = (palette.colors || []).filter(Array.isArray);
+  const hueOf = (i) => (hues.length > 1 ? hues[i % hues.length] : numColor);
+
   for (let i = 0; i < items.length; i++) {
     const item = items[i];
     const col = i % cols;
     const row = Math.floor(i / cols);
-    const cellX = x + PAD + col * colW;
+    const inLastRow = row === rows - 1;
+    const lastRowCount = items.length - (rows - 1) * cols;
+    const rowShift = inLastRow && lastRowCount < cols ? ((cols - lastRowCount) * colW) / 2 : 0;
+    const cellX = x + PAD + col * colW + rowShift;
     const cellY = plotTop + row * rowH;
     const cellPad = 12;
     const cardMargin = 6;
@@ -108,20 +117,28 @@ export function drawPseudo3D(ctx, args, opts = {}) {
     const cardW = colW - cardMargin * 2;
     const cardH = rowH - cardMargin * 2;
     const numLabel = String(i + 1);
+    const hue = hueOf(i);
 
-    // Card background
-    ctx.fillStyle = rgbaCss(fg, 0.04);
+    // Card: soft hue-tinted wash + hairline + hue top-bar
+    ctx.fillStyle = rgbaCss(hue, 0.07);
     ctx.beginPath();
-    ctx.roundRect(cardX, cardY, cardW, cardH, 6);
+    ctx.roundRect(cardX, cardY, cardW, cardH, 8);
     ctx.fill();
-    ctx.strokeStyle = rgbaCss(fg, 0.08);
+    ctx.strokeStyle = rgbaCss(hue, 0.22);
     ctx.lineWidth = 1;
     ctx.stroke();
+    ctx.save();
+    ctx.beginPath();
+    ctx.roundRect(cardX, cardY, cardW, cardH, 8);
+    ctx.clip();
+    ctx.fillStyle = rgbaCss(hue, 0.85);
+    ctx.fillRect(cardX, cardY, cardW, 4);
+    ctx.restore();
 
     if (numberStyle === 'huge') {
       const numFontSize = Math.min(Math.round(rowH * 0.45), 72);
       ctx.font = `900 ${numFontSize}px "Inter Display", Inter, system-ui`;
-      ctx.fillStyle = rgbCss(numColor);
+      ctx.fillStyle = rgbaCss(hue, 0.9);
       ctx.textAlign = 'left';
       ctx.textBaseline = 'top';
       const numX = cellX + cellPad + numFontSize * 0.05;
@@ -168,7 +185,7 @@ export function drawPseudo3D(ctx, args, opts = {}) {
       const circleR = Math.min(rowH * 0.2, colW * 0.14, 28);
       const circleCX = cellX + cellPad + circleR;
       const circleCY = cellY + cellPad + circleR;
-      ctx.fillStyle = rgbCss(numColor);
+      ctx.fillStyle = rgbCss(hue);
       ctx.beginPath();
       ctx.arc(circleCX, circleCY, circleR, 0, Math.PI * 2);
       ctx.fill();

--- a/sdf-js/src/present/atoms-2d/presentation/cover.js
+++ b/sdf-js/src/present/atoms-2d/presentation/cover.js
@@ -65,8 +65,19 @@ export function drawPseudo3D(ctx, args, opts = {}) {
   const version = args.version;
   const style = args.style || 'gradient';
 
-  // ---- Backdrop: gradient (default) or section (deep accent + accent box behind title) ----
-  if (style === 'section') {
+  // ---- Backdrop: gradient (default) / section / overlay ----
+  // 'overlay' (Sprint 74): NO backdrop — the renderer has already painted an
+  // ink canvas + artwork-grade decoration underneath; this pass draws only a
+  // legibility scrim behind the title block + the type itself.
+  if (style === 'overlay') {
+    const scrim = ctx.createLinearGradient(x, y, x, y + h);
+    scrim.addColorStop(0, 'rgba(8, 10, 16, 0.06)');
+    scrim.addColorStop(0.42, 'rgba(8, 10, 16, 0.5)');
+    scrim.addColorStop(0.75, 'rgba(8, 10, 16, 0.5)');
+    scrim.addColorStop(1, 'rgba(8, 10, 16, 0.14)');
+    ctx.fillStyle = scrim;
+    ctx.fillRect(x, y, w, h);
+  } else if (style === 'section') {
     // Deep solid backdrop + decorative title-box behind text (PL D3180/031 pattern)
     ctx.fillStyle = rgbCss(darken(accent, 0.32));
     ctx.fillRect(x, y, w, h);

--- a/sdf-js/src/present/atoms-2d/renderer.js
+++ b/sdf-js/src/present/atoms-2d/renderer.js
@@ -63,6 +63,24 @@ export async function renderSceneDataToCanvas(canvas, sceneData, opts = {}) {
   // pure covers resolve to 'cover' on their own.
   const role = opts.decorRole || (isPureCover ? 'cover' : 'content');
   const UNDER_INTENSITY = { agenda: 'bold', section: 'bold', content: 'subtle' };
+  // Sprint 74 cover-canvas pipeline (user: 封面还是大部分蓝色, 美感不足):
+  // ink ground → ArtBlocks-grade painting → the cover atom re-enters as an
+  // 'overlay' (scrim + type only). The artwork gets the FULL palette on a
+  // near-black canvas — the hues finally pop — and the title sits above it.
+  const coverCanvas = !!(decor && isPureCover);
+  if (coverCanvas) {
+    const ink = (palette.silhouetteColor || [30, 27, 30]).map((c) => Math.round(c * 0.3));
+    ctx.fillStyle = `rgb(${ink[0]}, ${ink[1]}, ${ink[2]})`;
+    ctx.fillRect(0, 0, canvas.width, canvas.height);
+    drawDecor(ctx, decor, {
+      palette,
+      x: 0,
+      y: 0,
+      w: canvas.width,
+      h: canvas.height,
+      intensity: decor.intensity || 'artwork',
+    });
+  }
   if (decor && !isPureCover) {
     drawDecor(ctx, decor, {
       palette,
@@ -88,7 +106,7 @@ export async function renderSceneDataToCanvas(canvas, sceneData, opts = {}) {
       skipped++;
       continue;
     }
-    const args = s.args || {};
+    const args = coverCanvas && s.type === 'cover' ? { ...s.args, style: 'overlay' } : s.args || {};
     const style = deckStyle || s.style || 'pseudo3d';
     const subjectOpts = {
       x: s.x ?? 0,
@@ -108,17 +126,8 @@ export async function renderSceneDataToCanvas(canvas, sceneData, opts = {}) {
     }
   }
 
-  // Pure-cover slides: decoration goes on top of the gradient.
-  if (decor && isPureCover) {
-    drawDecor(ctx, decor, {
-      palette,
-      x: 0,
-      y: 0,
-      w: canvas.width,
-      h: canvas.height,
-      intensity: decor.intensity || 'hero',
-    });
-  }
+  // (cover decoration now painted BEFORE the cover atom — see the
+  // cover-canvas pipeline above; the atom re-enters as scrim + type)
 
   return { rendered, skipped, errors };
 }

--- a/sdf-js/src/present/decor/registry.js
+++ b/sdf-js/src/present/decor/registry.js
@@ -71,6 +71,10 @@ const INTENSITY = {
   // becomes the ARTWORK. Covers / agenda / section openers only; big white
   // 900-weight titles stay legible over it, body text would not.
   hero: { alpha: 0.42, alphaFill: 0.3, lineWidth: 2.2 },
+  // Sprint 74 (user: 封面美感不足, 还是大部分蓝色): artwork — ArtBlocks-
+  // grade opacity for the COVER CANVAS pipeline only (ink ground + painting
+  // + overlay-style title with its own scrim; never over body text).
+  artwork: { alpha: 0.9, alphaFill: 0.8, lineWidth: 2.6 },
 };
 
 // --- families ---------------------------------------------------------------


### PR DESCRIPTION
## Summary

user 逐页目检 PDF 提出五条, 全部落地。**Fidenza 版 PDF: ~/Downloads/ANTFUN-发射台V1-Atlas-20页-Fidenza版.pdf**

1. **封面成画** — 纯封面新管线: ink 画布 → `INTENSITY.artwork` (α0.9) 全色板作画 → cover atom 以 `style:'overlay'` 回场 (仅 scrim+排版)。ANTFUN 换铸 flow-ribbons — Fidenza 彩带在墨底上终于炸开
2. **目录页** (获表扬) 保持
3. **内页字图比**: kpi-card / bullet-list 图标 +45%, 值与标签字号 −12%
4. **mountain-path 重设计**: 曲面山体+渐变棱线+粉彩远山+发光平滑路径+色相里程碑+峰顶旗 — 不再是三角形
5. **numbered-grid 重设计**: 色相轮转卡 (tint 底/顶栏/数字章) + 末行居中

npm test 141/141, 对抗目检两轮通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)