### PR TITLE
feat: 屏幕字幕层(3D 不载文字) + 黑色岩石母题 — 标题 3 倍大字

### DIFF
--- a/sdf-js/apps/present/author.html
+++ b/sdf-js/apps/present/author.html
@@ -40,23 +40,58 @@
         background: rgba(40, 116, 196, 0.92);
         font-weight: 700;
       }
-      .lbl.title {
-        font-weight: 900;
-        background: none;
-        text-shadow: 0 2px 14px rgba(0, 0, 0, 0.65);
-      }
-      /* Jumbotron text: the glowing 3D screen face behind it IS the chip, so
-         no background — just big type with enough shadow to sit on the glow. */
-      .lbl.screen {
-        font-weight: 800;
-        background: none;
+      /* Stage layer — screen-space narrative typography. The 3D world tells
+         the story; sentences live on THIS canvas: a huge composed title and a
+         bullet column, never projected onto geometry. */
+      .stage-title {
+        position: fixed;
+        top: 6vh;
+        left: 50%;
+        transform: translate(-50%, -14px);
+        font:
+          900 clamp(44px, 7.2vh, 96px) / 1.12 -apple-system,
+          Inter,
+          sans-serif;
+        letter-spacing: 0.04em;
+        color: #fff;
         text-shadow:
-          0 1px 3px rgba(0, 0, 0, 0.8),
-          0 3px 16px rgba(0, 0, 0, 0.5);
-        max-width: 340px;
-        white-space: normal;
-        text-align: center;
-        line-height: 1.25;
+          0 1px 3px rgba(0, 0, 0, 0.9),
+          0 6px 30px rgba(0, 0, 0, 0.65);
+        opacity: 0;
+        transition:
+          opacity 0.5s,
+          transform 0.5s;
+        pointer-events: none;
+        white-space: nowrap;
+        z-index: 30;
+      }
+      .stage-title.on {
+        opacity: 1;
+        transform: translate(-50%, 0);
+      }
+      .stage-bullet {
+        position: fixed;
+        left: 6.5vw;
+        font:
+          700 clamp(20px, 3.5vh, 42px) / 1.3 -apple-system,
+          Inter,
+          sans-serif;
+        color: rgba(255, 255, 255, 0.96);
+        text-shadow:
+          0 1px 3px rgba(0, 0, 0, 0.85),
+          0 3px 18px rgba(0, 0, 0, 0.6);
+        opacity: 0;
+        transform: translateX(-18px);
+        transition:
+          opacity 0.45s,
+          transform 0.45s;
+        pointer-events: none;
+        max-width: 44vw;
+        z-index: 30;
+      }
+      .stage-bullet.on {
+        opacity: 1;
+        transform: translateX(0);
       }
       /* author bar — the one input that turns words into a world */
       #bar {

--- a/sdf-js/apps/present/figure-core.js
+++ b/sdf-js/apps/present/figure-core.js
@@ -96,6 +96,8 @@ export function createFigure({ outdoor = false, stage = false, present = false }
 
   let items = [];
   let els = [];
+  let stageItems = []; // narrative layer: titles + bullets, screen-space
+  let stageEls = [];
   let detachDeckWindows = null;
   let deckWarming = false; // keep the boot loader up while window shaders warm
   const loading = document.getElementById('loading');
@@ -105,21 +107,46 @@ export function createFigure({ outdoor = false, stage = false, present = false }
       if (el._lead) el._lead.remove();
       el.remove();
     }
-    // Reveal-timed overlay: labels fade in as the sequence clock passes each
-    // item's revealAt (makeOverlay isn't reused — it has no reveal timing).
-    items = (scene.overlay || []).filter((o) => o.anchor && o.text);
+    for (const el of stageEls) el.remove();
+    stageEls = [];
+    // Two text layers, HARD split (user-locked 2026-07-11):
+    //   • narrative (title / screen bullets) → the STAGE LAYER: pure screen-
+    //     space typography on its own canvas — big, composed, never projected.
+    //     The 3D world tells the story; it does not carry sentences.
+    //   • data labels (value / card) → the ANCHOR LAYER: projected onto the
+    //     geometry they measure, depth-scaled. Numbers live with their shapes.
+    const all = (scene.overlay || []).filter((o) => o.text);
+    items = all.filter((o) => o.anchor && (o.role === 'value' || o.role === 'card'));
     els = items.map((o) => {
       const d = document.createElement('div');
-      d.className =
-        'lbl' +
-        (o.role === 'value' ? ' value' : '') +
-        (o.role === 'screen' ? ' screen' : '') +
-        (o.role === 'title' ? ' title' : '');
+      d.className = 'lbl' + (o.role === 'value' ? ' value' : '');
       // Numeric value chips COUNT UP over ~0.8s after their reveal — numbers
       // that arrive read as data landing, not captions appearing.
       if (o.role === 'value' && /^[\d,]+$/.test(o.text)) {
         o._countTarget = Number(o.text.replace(/,/g, ''));
       }
+      d.textContent = o.text;
+      document.body.appendChild(d);
+      return d;
+    });
+    stageItems = all
+      .filter((o) => o.role === 'title' || o.role === 'screen')
+      .map((o) => ({ ...o, revealAt: o.revealAt ?? 0 }))
+      .sort((a, b) => a.revealAt - b.revealAt);
+    // Chapters: each title OWNS the stage until the next title (in a deck,
+    // titles arrive at their station's start — assembleDeck shifts revealAt).
+    // Bullets show inside their chapter only, so a station's list clears the
+    // stage when the camera slings away.
+    {
+      let ch = -1;
+      for (const o of stageItems) {
+        if (o.role === 'title') ch++;
+        o._ch = ch;
+      }
+    }
+    stageEls = stageItems.map((o) => {
+      const d = document.createElement('div');
+      d.className = o.role === 'title' ? 'stage-title' : 'stage-bullet';
       d.textContent = o.text;
       document.body.appendChild(d);
       return d;
@@ -175,6 +202,24 @@ export function createFigure({ outdoor = false, stage = false, present = false }
       loading.classList.add('done');
     }
     const t = studio.getSequenceTime ? studio.getSequenceTime() : 1e9;
+    // Stage layer (screen-space narrative): show the current chapter's title
+    // big and composed, and slide its bullets in as their beats pass. Pure 2D
+    // typography — never projected, never fighting the 3D frame.
+    {
+      let curCh = -1;
+      for (const o of stageItems)
+        if (o.role === 'title' && o.revealAt <= t + 0.02 && o._ch > curCh) curCh = o._ch;
+      let slot = 0;
+      for (let i = 0; i < stageItems.length; i++) {
+        const o = stageItems[i];
+        const on = o._ch === curCh && o.revealAt <= t + 0.02;
+        if (o.role === 'screen' && on) {
+          stageEls[i].style.top = `calc(26vh + ${slot} * 9.5vh)`;
+          slot++;
+        }
+        stageEls[i].classList.toggle('on', on);
+      }
+    }
     // Pass 1: project + opacity/count-up; collect visible labels for layout.
     const placedRects = []; // near labels claim space first
     const visible = [];
@@ -195,14 +240,11 @@ export function createFigure({ outdoor = false, stage = false, present = false }
         p.depth == null ? 1 : Math.max(0, Math.min(1, (reach - p.depth) / (reach * 0.45)));
       const opacity = (o.revealAt == null || t >= o.revealAt ? 1 : 0) * depthFade;
       el.style.opacity = opacity;
-      // Depth-scaled type: labels grow as the camera approaches their anchor,
-      // so text reads as living IN the world instead of a fixed-size HUD chip.
-      // 'screen' labels (jumbotron faces) get the largest base — the glowing
-      // 3D face behind them is their chip. Quantized + write-on-change so the
-      // per-frame style churn stays near zero.
+      // Depth-scaled type: data labels grow as the camera approaches the
+      // geometry they measure — numbers live WITH their shapes. Quantized +
+      // write-on-change so the per-frame style churn stays near zero.
       if (p.depth != null) {
-        const base =
-          o.role === 'title' ? 30 : o.role === 'screen' ? 21 : o.role === 'value' ? 13 : 13;
+        const base = 13;
         const fs =
           Math.round(Math.max(9, Math.min(base * (6.2 / Math.max(p.depth, 0.6)), base * 2.1)) * 2) /
           2;
@@ -234,12 +276,8 @@ export function createFigure({ outdoor = false, stage = false, present = false }
         placedRects.some(
           (r) => Math.abs(x - r.x) * 2 < w + r.w + 6 && Math.abs(yy - r.y) * 2 < h + r.h + 4,
         );
-      // Jumbotron/title text is PINNED to its screen geometry — displacing it
-      // off the glowing face it belongs to is worse than any overlap. It still
-      // claims its rect so free-floating cards route around it.
-      const pinned = v.o.role === 'screen' || v.o.role === 'title';
       let shift = 0;
-      while (!pinned && shift < 4 && collides(y)) {
+      while (shift < 4 && collides(y)) {
         y += 30;
         shift++;
       }

--- a/sdf-js/apps/present/figure.html
+++ b/sdf-js/apps/present/figure.html
@@ -40,23 +40,58 @@
         background: rgba(40, 116, 196, 0.92);
         font-weight: 700;
       }
-      .lbl.title {
-        font-weight: 900;
-        background: none;
-        text-shadow: 0 2px 14px rgba(0, 0, 0, 0.65);
-      }
-      /* Jumbotron text: the glowing 3D screen face behind it IS the chip, so
-         no background — just big type with enough shadow to sit on the glow. */
-      .lbl.screen {
-        font-weight: 800;
-        background: none;
+      /* Stage layer — screen-space narrative typography. The 3D world tells
+         the story; sentences live on THIS canvas: a huge composed title and a
+         bullet column, never projected onto geometry. */
+      .stage-title {
+        position: fixed;
+        top: 6vh;
+        left: 50%;
+        transform: translate(-50%, -14px);
+        font:
+          900 clamp(44px, 7.2vh, 96px) / 1.12 -apple-system,
+          Inter,
+          sans-serif;
+        letter-spacing: 0.04em;
+        color: #fff;
         text-shadow:
-          0 1px 3px rgba(0, 0, 0, 0.8),
-          0 3px 16px rgba(0, 0, 0, 0.5);
-        max-width: 340px;
-        white-space: normal;
-        text-align: center;
-        line-height: 1.25;
+          0 1px 3px rgba(0, 0, 0, 0.9),
+          0 6px 30px rgba(0, 0, 0, 0.65);
+        opacity: 0;
+        transition:
+          opacity 0.5s,
+          transform 0.5s;
+        pointer-events: none;
+        white-space: nowrap;
+        z-index: 30;
+      }
+      .stage-title.on {
+        opacity: 1;
+        transform: translate(-50%, 0);
+      }
+      .stage-bullet {
+        position: fixed;
+        left: 6.5vw;
+        font:
+          700 clamp(20px, 3.5vh, 42px) / 1.3 -apple-system,
+          Inter,
+          sans-serif;
+        color: rgba(255, 255, 255, 0.96);
+        text-shadow:
+          0 1px 3px rgba(0, 0, 0, 0.85),
+          0 3px 18px rgba(0, 0, 0, 0.6);
+        opacity: 0;
+        transform: translateX(-18px);
+        transition:
+          opacity 0.45s,
+          transform 0.45s;
+        pointer-events: none;
+        max-width: 44vw;
+        z-index: 30;
+      }
+      .stage-bullet.on {
+        opacity: 1;
+        transform: translateX(0);
       }
       /* Boot loader — visible until the first frame is drawn. Pure CSS-transform
          animation so it keeps moving even if the main thread hiccups. */

--- a/sdf-js/scripts/test-render-hold.mjs
+++ b/sdf-js/scripts/test-render-hold.mjs
@@ -30,14 +30,18 @@ ok(
 {
   const s = renderHold({ structure: 'hold', title: '最懂你的头条', nodes: [] });
   ok(
-    s.subjects.length === 2 && s.subjects.every((x) => x.id.startsWith('title-')),
-    'cover renders the master screen (volumetric shell + glowing face)',
+    s.subjects.some((x) => x.id === 'mono-title'),
+    'cover renders the black title monolith',
+  );
+  ok(
+    s.subjects.filter((x) => x.id.startsWith('floater-')).length >= 4,
+    'distant black rocks float behind the stage (the deck motif)',
   );
   ok(s.overlay.length === 1 && s.overlay[0].role === 'title', 'cover overlay is the title only');
   ok(s.cameraSequence.shots.length === 3, 'three quiet beats');
   ok(
-    s.subjects.every((x) => !x.animation),
-    'cover has no animations (nothing to reveal)',
+    s.subjects.filter((x) => x.id.startsWith('stone-')).length === 0,
+    'no bullet stones on a bare cover',
   );
 }
 
@@ -50,16 +54,15 @@ const IR = {
 };
 {
   const s = renderHold(IR);
-  const shells = s.subjects.filter((x) => /^b\d+-shell$/.test(x.id));
-  const faces = s.subjects.filter((x) => /^b\d+-face$/.test(x.id));
-  ok(shells.length === 6 && faces.length === 6, 'one volumetric screen per bullet (shell+face)');
+  const stones = s.subjects.filter((x) => /^stone-\d+$/.test(x.id));
+  ok(stones.length === 6, 'one black stone per bullet (the COUNT is geometry)');
   ok(
-    shells.every((x) => x.args.dims[2] >= 0.15),
-    'screen shells have real thickness (3D bodies, not flat cards)',
+    stones.every((x) => x.args.dims[2] >= 0.3),
+    'stones are real bodies with depth, not plaques',
   );
   ok(
     s.overlay.filter((o) => o.role === 'screen').length === 6,
-    'one jumbotron text per bullet (big depth-scaled DOM type)',
+    'one stage-layer bullet per point (screen-space typography)',
   );
   const reveals = s.overlay.filter((o) => o.role === 'screen').map((o) => o.revealAt);
   ok(
@@ -67,19 +70,22 @@ const IR = {
     'bullet reveals are staggered',
   );
   ok(
-    JSON.stringify(faces[5].material) !== JSON.stringify(faces[0].material),
-    'emphasized bullet screen gets the gold face',
+    JSON.stringify(stones[5].material) !== JSON.stringify(stones[0].material),
+    'emphasized bullet stone is gold',
   );
-  // deck-transplant safety: every build-in expr must parse under the STRICT shifter
+  // deck-transplant safety: every build-in expr (drop + idle bob tails on the
+  // floaters) must parse under the STRICT shifter
   let allShift = true;
-  for (const p of [...shells, ...faces]) {
+  const animated = s.subjects.filter((x) => x.animation);
+  ok(animated.length >= 10, 'stones drop in and floaters bob (animated bodies)');
+  for (const p of animated) {
     try {
       shiftBuildInExpr(p.animation[0].expr, 2.5, 10);
     } catch (e) {
       allShift = false;
     }
   }
-  ok(allShift, 'screen build-in exprs survive assembleDeck expr shifting');
+  ok(allShift, 'all build-in exprs survive assembleDeck expr shifting');
 }
 
 // ---- renderIR seam -----------------------------------------------------------------

--- a/sdf-js/src/scene/render-hold.js
+++ b/sdf-js/src/scene/render-hold.js
@@ -1,85 +1,57 @@
 // sdf-js/src/scene/render-hold.js
-// Structure renderer #6: hold → FLOAT-SCREEN WALL. Reads the IR ONLY.
+// Structure renderer #6: hold → BLACK MONOLITH FIELD. Reads the IR ONLY.
 //
 // A hold page has no chartable structure — a cover, a narration beat, a product
-// tour. The 3D form for "just words" is the JUMBOTRON: big volumetric screens
-// floating in the arena (a beveled shell + an inset glowing face — real bodies
-// with thickness, never flat cards), one per bullet, staggered in depth so the
-// wall has parallax. The words themselves ride the DOM overlay, but sized to
-// the screen via the depth-scaled font pass in figure-core (two-text-systems
-// rule intact: geometry carries the SCREEN, the DOM carries the TEXT).
+// tour. Division of labour (user-locked 2026-07-11): the 3D world TELLS THE
+// STORY and never carries sentences — narrative text lives on the screen-space
+// stage layer (figure-core renders `title`/`screen` overlay roles as big 2D
+// typography). What the world contributes here is PRESENCE: a black rock
+// monolith as the title's backdrop, one smaller black stone per bullet (the
+// COUNT is geometry even when the words are not), and a loose field of the
+// same black rocks floating in the distance — the visual motif of the deck.
 //
 // Fighting-game grammar, hold variation — the INTERLUDE:
-//   1. slow push-in on the master title screen
-//   2. drift along the screen wall while bullet screens swing in one per beat
-//   3. payoff pull-back framing the whole wall (auto-tagged 'station')
+//   1. slow push-in on the title monolith (the breath between rounds)
+//   2. drift as the bullet stones drop in one per beat
+//   3. payoff pull-back (auto-tagged 'station' by the renderIR seam)
 // No super — hold pages never punch; they set up the next station's hit.
 import { validateIR } from './ir.js';
 import { getEnvironment } from './environments.js';
 
 const label = (n) => (typeof n === 'string' ? n : (n && (n.label ?? n.name)) || '');
 
-const SHELL_MAT = {
+// Black rock: near-black, matte-leaning, cracked stone grain. The gold variant
+// marks the emphasized bullet's stone.
+const ROCK_MAT = {
   hue: 0.62,
-  sat: 0.4,
-  value: 0.3,
+  sat: 0.25,
+  value: 0.17,
   kind: 'normal',
-  roughness: 0.24,
+  roughness: 0.42,
+  clearcoat: 0.5,
+};
+const GOLD_MAT = {
+  hue: 0.11,
+  sat: 0.78,
+  value: 0.95,
+  glow: 0.22,
+  kind: 'normal',
+  roughness: 0.22,
   clearcoat: 0.6,
 };
-const faceMat = (emphasized) =>
-  emphasized
-    ? {
-        hue: 0.11,
-        sat: 0.72,
-        value: 0.95,
-        glow: 0.3,
-        kind: 'normal',
-        roughness: 0.3,
-        clearcoat: 0.4,
-      }
-    : {
-        hue: 0.58,
-        sat: 0.45,
-        value: 0.62,
-        glow: 0.18,
-        kind: 'normal',
-        roughness: 0.32,
-        clearcoat: 0.4,
-      };
 
-// One volumetric screen: beveled shell + glowing face inset just proud of the
-// front plane. Two subjects — thickness reads from every angle, and the lit
-// face gives the "screen" read without any texture machinery.
-function screen(id, [x, y, z], [w, h], yaw, emphasized, anim) {
-  const shell = {
-    id: `${id}-shell`,
+const rock = (id, [x, y, z], [w, h, d], material, extra = {}) => {
+  const s = {
+    id,
     type: 'rounded_box',
-    args: { dims: [w, h, 0.22], cornerR: 0.07 },
-    transform: { translate: [x, y, z], ...(yaw ? { rotate: [0, yaw, 0] } : {}) },
-    material: SHELL_MAT,
+    args: { dims: [w, h, d], cornerR: 0.06 },
+    transform: { translate: [x, y, z], ...(extra.rotate ? { rotate: extra.rotate } : {}) },
+    material,
   };
-  const face = {
-    id: `${id}-face`,
-    type: 'rounded_box',
-    args: { dims: [w - 0.22, h - 0.22, 0.05], cornerR: 0.05 },
-    // face sits proud of the shell front (+z toward the default camera)
-    transform: {
-      translate: [
-        x + (yaw ? -Math.sin(yaw) * 0.1 : 0),
-        y,
-        z + (yaw ? Math.cos(yaw) * 0.1 : 0.1),
-      ],
-      ...(yaw ? { rotate: [0, yaw, 0] } : {}),
-    },
-    material: faceMat(emphasized),
-  };
-  if (anim) {
-    shell.animation = [{ channel: 'transform.translate.y', expr: anim(y) }];
-    face.animation = [{ channel: 'transform.translate.y', expr: anim(y) }];
-  }
-  return [shell, face];
-}
+  if (material !== GOLD_MAT) s.pattern = 'cracked'; // stone grain; gold stays polished
+  if (extra.animation) s.animation = extra.animation;
+  return s;
+};
 
 export function renderHold(ir, opts = {}) {
   const v = validateIR(ir);
@@ -94,97 +66,112 @@ export function renderHold(ir, opts = {}) {
   const introLead = 2.2;
   const holdEach = 1.0;
 
-  // Drop-in build: screens settle from above as their beat arrives. The shape
-  // is the assembleDeck-transplant-safe smoothstep drop.
-  const dropExpr = (k) => (yFinal) => {
+  // ---- geometry ------------------------------------------------------------------
+  // Title monolith: the big black rock the title reads against. Offset right —
+  // the stage layer's bullet column owns the LEFT of the screen (+x renders
+  // screen-left, so the rock sits at negative x... the studio's +x→screen-left
+  // mirror strikes again; -x is screen-RIGHT).
+  const mx = N > 0 ? -2.3 : 0;
+  const subjects = [rock('mono-title', [mx, 2.1, -1.2], [4.4, 2.6, 0.6], ROCK_MAT)];
+
+  // Bullet stones: one black stone per bullet, a rising diagonal past the title
+  // monolith — the COUNT of points is world-geometry even though the words are
+  // screen typography. Each drops in on its beat (transplant-safe smoothstep)
+  // and hangs with a slow idle bob (the "floating rocks" read).
+  bullets.forEach((_, k) => {
+    const x = mx - 1.7 - k * 0.85; // -x is screen-RIGHT: the stone line rises away from the monolith
+    const y = 1.3 + k * 0.45;
+    const z = 0.2 - k * 0.7;
     const drop = 0.7;
     const t0 = introLead + k * holdEach - 0.35;
     const t1 = t0 + 0.55;
-    return `${(yFinal + drop).toFixed(3)} - ${drop.toFixed(3)} * smoothstep(${t0.toFixed(2)}, ${t1.toFixed(2)}, t)`;
-  };
-
-  // ---- geometry: the jumbotron wall ---------------------------------------------
-  // Master title screen high centre; bullet screens in two columns fanned
-  // around it, staggered in z so the wall reads as a hovering fleet, each
-  // yawed a few degrees toward the centre line.
-  const titleW = Math.max(4.2, 2.6 + (String(ir.title || '').length > 8 ? 1.8 : 0));
-  const subjects = [
-    ...screen('title', [0, N > 0 ? 3.35 : 1.9, N > 0 ? -0.8 : 0], [titleW, 1.3], 0, false, null),
-  ];
-  // One layout, two consumers: the screen geometry AND the overlay text anchors
-  // read the same positions, so they can never drift apart. Three-row walls
-  // tighten the row step and raise the base so the bottom row's screens clear
-  // the platform (screen half-height 0.46 + margin).
-  const rows = Math.ceil(N / 2);
-  const rowStep = rows > 2 ? 1.08 : 1.15;
-  const baseY = rows > 2 ? 2.85 : 2.35;
-  const bulletPos = bullets.map((_, k) => {
-    const col = k % 2 === 0 ? -1 : 1; // left, right, left, right…
-    const row = Math.floor(k / 2);
-    return {
-      col,
-      x: col * 2.05,
-      y: baseY - row * rowStep,
-      z: -0.3 + row * 0.55 + (col < 0 ? 0 : 0.25), // stagger depth → parallax
-    };
-  });
-  bulletPos.forEach((p, k) => {
-    const yaw = p.col * -0.16; // angled inward, facing the aisle
+    const phase = (k * 1.7) % 6.28;
     subjects.push(
-      ...screen(`b${k}`, [p.x, p.y, p.z], [3.0, 0.92], yaw, emphasis.has(k), dropExpr(k)),
+      rock(`stone-${k}`, [x, y, z], [0.62, 0.42, 0.5], emphasis.has(k) ? GOLD_MAT : ROCK_MAT, {
+        rotate: [0, 0.22 * (k % 2 === 0 ? 1 : -1), 0],
+        animation: [
+          {
+            channel: 'transform.translate.y',
+            expr: `${(y + drop).toFixed(3)} - ${drop.toFixed(3)} * smoothstep(${t0.toFixed(2)}, ${t1.toFixed(2)}, t) + 0.05 * sin(0.6 * t + ${phase.toFixed(2)})`,
+          },
+        ],
+      }),
     );
   });
 
-  // ---- camera: three quiet beats down the aisle -----------------------------------
+  // Distant floaters: the same black rock, scattered mid-air far behind and
+  // beside the stage — the motif that makes the world read as one place. All
+  // share the slow bob; deterministic layout from index math (no randomness).
+  const FLOATERS = [
+    [-6.5, 3.4, -6, 1.6, 0.9],
+    [4.8, 2.6, -7.5, 1.2, 0.7],
+    [-3.2, 4.6, -9, 2.2, 1.1],
+    [7.2, 4.0, -5, 0.9, 0.55],
+    [1.5, 5.2, -11, 1.8, 0.95],
+  ];
+  FLOATERS.forEach(([x, y, z, w, h], i) => {
+    subjects.push(
+      rock(`floater-${i}`, [x, y, z], [w, h, w * 0.55], ROCK_MAT, {
+        rotate: [0, 0.5 * i - 1, 0],
+        animation: [
+          {
+            channel: 'transform.translate.y',
+            expr: `${y.toFixed(3)} - 0.000 * smoothstep(0.00, 1.00, t) + ${(0.07 + 0.02 * i).toFixed(2)} * sin(${(0.35 + 0.08 * i).toFixed(2)} * t + ${((i * 2.1) % 6.28).toFixed(2)})`,
+          },
+        ],
+      }),
+    );
+  });
+
+  // ---- camera: three quiet beats ---------------------------------------------------
   const driftDur = Math.max(2.2, N * holdEach + 0.8);
-  const wallTop = N > 0 ? 3.35 : 1.9;
   const shots = [
     {
       duration: introLead,
-      pos: [0, wallTop - 0.15, 6.2],
-      target: [0, wallTop - 0.35, 0],
-      fov: 42,
+      pos: [mx + 0.6, 2.0, 5.8],
+      target: [mx, 2.1, 0],
+      fov: 44,
       aperture: 0.35,
-      focalDistance: 6.0,
+      focalDistance: 6.4,
       ease: 'out',
     },
     {
       duration: driftDur,
-      pos: [-1.5, 2.0, 5.4],
-      target: [0.3, N > 0 ? 2.0 : 1.8, 0],
+      pos: [mx - 1.8, 2.3, 5.2],
+      target: [mx + (N > 0 ? 1.0 : 0), 1.9, 0],
       fov: 46,
       transition: 'blend',
-      aperture: 0.28,
-      focalDistance: 5.4,
+      aperture: 0.26,
+      focalDistance: 5.6,
       ease: 'smooth',
     },
     {
       duration: 2.0,
-      pos: [0.6, 2.6, 7.6 * (env ? env.payoffZoom : 1)],
-      target: [0, N > 0 ? 2.2 : 1.8, 0],
+      pos: [mx + 0.8, 2.8, 8.2 * (env ? env.payoffZoom : 1)],
+      target: [mx, 2.2, -1],
       fov: 46,
       transition: 'blend',
       aperture: 0.12,
-      focalDistance: 7.6,
+      focalDistance: 8.6,
       ease: 'out',
     },
   ];
 
-  // ---- overlay: text mapped onto the screens --------------------------------------
-  // role 'screen' → figure-core renders it as big depth-scaled type with no
-  // chip background (the glowing face IS the background).
+  // ---- overlay: narrative → the stage layer ------------------------------------------
+  // title/screen roles are STAGE items — figure-core renders them as pure 2D
+  // typography (huge title, bullet column). anchor is kept only as a fallback
+  // for hosts without the stage layer.
   const overlay = [
     {
       text: String(ir.title || bullets[0] || ''),
-      anchor: [0, N > 0 ? 3.35 : 1.9, N > 0 ? -0.7 : 0.15],
+      anchor: [mx, 3.6, -1.2],
       role: 'title',
     },
   ];
   bullets.forEach((b, k) => {
-    const p = bulletPos[k];
     overlay.push({
       text: b,
-      anchor: [p.x, p.y, p.z + 0.16],
+      anchor: [mx - 1.7 - k * 0.85, 1.3 + k * 0.45, 0.2 - k * 0.7],
       role: 'screen',
       revealAt: introLead + k * holdEach + 0.25,
     });
@@ -196,6 +183,6 @@ export function renderHold(ir, opts = {}) {
     subjects: env ? [...subjects, ...env.subjects] : subjects,
     overlay,
     cameraSequence: { loop: false, shots },
-    defaults: env ? env.defaults : { stage: { size: [14, 10, 10] } },
+    defaults: env ? env.defaults : { stage: { size: [16, 12, 12] } },
   };
 }


### PR DESCRIPTION
## 方向(user 口述,已锁定)

> 3D 世界只负责讲故事和演示,没必要和 2D 的文字进行互动。除了数量标签以外,文本直接浮在屏幕上。标题字要大 2-3 倍,有气势。统一用黑色岩石质感的长方体作为字的背景,远处也有同样的黑石飘在空中。

## 实现

### 1. 字幕层(figure-core)— 两层文字硬分离

- **叙事层(title / screen)**:纯屏幕排版,永不投影。标题 `clamp(44px, 7.2vh, 96px)` 顶部居中(≈原来 3 倍),要点大字左列逐条滑入(`clamp(20px, 3.5vh, 42px)`)。**章节制**:每个 title 拥有到下一个 title 的时间窗,换站时上一站的字幕整体退场——deck 里每站 title 的 revealAt 就是站的开始(assembleDeck 时移天然给的)。
- **数据层(value / card)**:保持 3D 锚定 + 深度缩放——数字跟着它度量的几何走。
- 上一轮「字贴浮屏」的 depth-scale title/screen 路径全部退役。

### 2. render-hold 重写:黑色石碑场(BLACK MONOLITH FIELD)

- 标题背后一块大黑岩(4.4×2.6×0.6,cracked 石纹 + clearcoat 边缘反光)
- 每条要点一块黑石(**数量仍然是世界几何**,金石 = 强调条),沿对角线爬升,按拍落位 + 慢速悬浮 bob(idle tail 走 EXPR_RE 兼容形状,deck 移植安全)
- 远景 5 块同质感黑石悬空——全 deck 的视觉母题
- 文字零贴附:全部走字幕层

### 3. 全结构受益

magnitude/matrix/network/sequence/hierarchy 的站标题自动升级为屏幕大字(figure-core 层面统一),各站数据标签不变。

## 验证

- 141/141(hold 断言更新为黑石场不变量:石头数=要点数、浮石≥4、gold 强调、含 idle-tail 的 expr 全部过 strict shifter)
- 截图:封面 = 大字 + 悬空黑石碑 + 远景浮石(99fps);投资亮点 = 巨型标题 + 六条大字左列 + 石碑 + 金石强调(27fps@0.75×)
- presenter 回归:span 1/21 正常,stage title 与提词条不打架

## 注

#291 已被 merge,本 PR 基于其上;#291 中被否的「字贴屏」路径在本 PR 中移除。

🤖 Generated with [Claude Code](https://claude.com/claude-code)