### PR TITLE
fix: 预热不再假死 + 字幕逐拍同步 + 黑石开销修剪

### DIFF
--- a/sdf-js/apps/present/author.html
+++ b/sdf-js/apps/present/author.html
@@ -90,8 +90,12 @@
         z-index: 30;
       }
       .stage-bullet.on {
-        opacity: 1;
+        opacity: 0.52;
         transform: translateX(0);
+      }
+      /* the beat the camera is visiting reads at full strength */
+      .stage-bullet.on.cur {
+        opacity: 1;
       }
       /* author bar — the one input that turns words into a world */
       #bar {

--- a/sdf-js/apps/present/figure-core.js
+++ b/sdf-js/apps/present/figure-core.js
@@ -166,6 +166,7 @@ export function createFigure({ outdoor = false, stage = false, present = false }
     adaptAfter = performance.now() + ADAPT_GRACE_MS;
     lowStreak = 0;
     highStreak = 0;
+    const loadingMsg = loading && loading.querySelector('.msg');
     const dw = attachDeckWindows(studio, scene, {
       holdDuringWarmup: !present,
       // boundary swaps can stall the driver briefly — those samples are not a
@@ -173,6 +174,11 @@ export function createFigure({ outdoor = false, stage = false, present = false }
       onSwap: () => {
         adaptAfter = Math.max(adaptAfter, performance.now() + 2500);
         lowStreak = 0;
+      },
+      // A 10-station deck warms ~20s behind the boot overlay. Without visible
+      // progress that reads as a hang — the counter is what makes it a load.
+      onProgress: (done, total) => {
+        if (loadingMsg) loadingMsg.textContent = `warming shaders ${done}/${total}`;
       },
     });
     if (dw) {
@@ -210,15 +216,27 @@ export function createFigure({ outdoor = false, stage = false, present = false }
       for (const o of stageItems)
         if (o.role === 'title' && o.revealAt <= t + 0.02 && o._ch > curCh) curCh = o._ch;
       let slot = 0;
+      let lastOn = -1;
       for (let i = 0; i < stageItems.length; i++) {
         const o = stageItems[i];
-        const on = o._ch === curCh && o.revealAt <= t + 0.02;
+        // hideAt (set by assembleDeck = the station's end) clears the outgoing
+        // station's words during the transit flight; the chapter test keeps
+        // seeks honest in both directions.
+        const on =
+          o._ch === curCh && o.revealAt <= t + 0.02 && (o.hideAt == null || t < o.hideAt);
         if (o.role === 'screen' && on) {
           stageEls[i].style.top = `calc(26vh + ${slot} * 9.5vh)`;
           slot++;
+          lastOn = i;
         }
         stageEls[i].classList.toggle('on', on);
       }
+      // The camera and the words move as ONE: the beat the camera is visiting
+      // reads at full strength, spoken-already lines fall back. (`cur` is the
+      // latest revealed subtitle — reveal times are beat-synced by design.)
+      for (let i = 0; i < stageItems.length; i++)
+        if (stageItems[i].role === 'screen')
+          stageEls[i].classList.toggle('cur', i === lastOn);
     }
     // Pass 1: project + opacity/count-up; collect visible labels for layout.
     const placedRects = []; // near labels claim space first

--- a/sdf-js/apps/present/figure.html
+++ b/sdf-js/apps/present/figure.html
@@ -90,8 +90,12 @@
         z-index: 30;
       }
       .stage-bullet.on {
-        opacity: 1;
+        opacity: 0.52;
         transform: translateX(0);
+      }
+      /* the beat the camera is visiting reads at full strength */
+      .stage-bullet.on.cur {
+        opacity: 1;
       }
       /* Boot loader — visible until the first frame is drawn. Pure CSS-transform
          animation so it keeps moving even if the main thread hiccups. */

--- a/sdf-js/src/runtime/deck-shader-windows.js
+++ b/sdf-js/src/runtime/deck-shader-windows.js
@@ -39,7 +39,11 @@ export function windowIndexAt(windows, t) {
  *   can't force), and those stall samples must not read as "render is slow,
  *   downshift" — they'd park a fast deck at 0.5× for nothing.
  */
-export function attachDeckWindows(studio, scene, { holdDuringWarmup = true, onSwap = null } = {}) {
+export function attachDeckWindows(
+  studio,
+  scene,
+  { holdDuringWarmup = true, onSwap = null, onProgress = null } = {},
+) {
   const windows = scene.deckWindows;
   if (!Array.isArray(windows) || windows.length < 2 || !studio.swapSDF) return null;
 
@@ -65,6 +69,13 @@ export function attachDeckWindows(studio, scene, { holdDuringWarmup = true, onSw
       const step = (k) => (k <= 0 ? r() : requestAnimationFrame(() => step(k - 1)));
       step(n);
     });
+  // A REAL idle gap between warm steps. Each warm draw can block the main
+  // thread for 0.5-2s inside the driver (pipeline specialization happens
+  // synchronously at draw submit — no JS API can defer it); back-to-back
+  // blocks starve input handling and Chrome flags the page unresponsive.
+  // A macrotask pause between them lets queued events drain, so the page
+  // stays interactive even though the total warm time is the same.
+  const breathe = () => new Promise((r) => setTimeout(r, 60));
 
   // Warm the remaining windows in playback order — TWO passes, both hidden
   // behind the boot overlay (figure-core keeps it up until `warmed` resolves):
@@ -77,16 +88,21 @@ export function attachDeckWindows(studio, scene, { holdDuringWarmup = true, onSw
   //      BOUNDARY paid a 0.7-2s first-draw stall mid-presentation.
   const warmed = (async () => {
     const t0 = performance.now();
+    const total = (windows.length - 1) * 2;
     for (let i = 1; i < windows.length && !stopped; i++) {
       try {
         await studio.precompile(sdfFor(i));
       } catch (e) {
         console.warn('[deck-windows] precompile failed for window', i, e);
       }
+      if (onProgress) onProgress(i, total);
+      await breathe();
     }
     for (let i = 1; i < windows.length && !stopped; i++) {
       studio.swapSDF(sdfFor(i));
       await frames(3); // wake() renders settle frames — one real draw lands
+      if (onProgress) onProgress(windows.length - 1 + i, total);
+      await breathe();
     }
     if (stopped) return;
     studio.swapSDF(sdfFor(0)); // back to the opening window

--- a/sdf-js/src/scene/assemble-deck.js
+++ b/sdf-js/src/scene/assemble-deck.js
@@ -160,12 +160,18 @@ export function assembleDeck(deck, opts = {}) {
       subjects.push(moved);
     }
 
-    // Overlay: shift anchors + reveal times; station titles reveal with their slide.
+    // Overlay: shift anchors + reveal times; station titles reveal with their
+    // slide. Narrative roles (stage-layer subtitles) also get hideAt = the
+    // station's end: during the transit sling the frame is IN FLIGHT and the
+    // outgoing station's words must clear the screen — the next title landing
+    // WITH its arena is what makes the cut read intentional.
+    const stationEnd = clock + seqDuration(st.cameraSequence.shots);
     for (const o of st.overlay || []) {
       overlay.push({
         ...o,
         anchor: addV(o.anchor, origin),
         revealAt: (o.revealAt ?? 0) + clock,
+        ...(o.role === 'title' || o.role === 'screen' ? { hideAt: stationEnd } : {}),
       });
     }
 

--- a/sdf-js/src/scene/render-hold.js
+++ b/sdf-js/src/scene/render-hold.js
@@ -48,7 +48,9 @@ const rock = (id, [x, y, z], [w, h, d], material, extra = {}) => {
     transform: { translate: [x, y, z], ...(extra.rotate ? { rotate: extra.rotate } : {}) },
     material,
   };
-  if (material !== GOLD_MAT) s.pattern = 'cracked'; // stone grain; gold stays polished
+  // NOTE: no 'cracked' pattern — on near-black rock the grain is invisible
+  // but applyPattern still burns per-pixel ALU on every leaf. Texture comes
+  // from roughness/clearcoat under the rig instead.
   if (extra.animation) s.animation = extra.animation;
   return s;
 };
@@ -107,7 +109,6 @@ export function renderHold(ir, opts = {}) {
     [4.8, 2.6, -7.5, 1.2, 0.7],
     [-3.2, 4.6, -9, 2.2, 1.1],
     [7.2, 4.0, -5, 0.9, 0.55],
-    [1.5, 5.2, -11, 1.8, 0.95],
   ];
   FLOATERS.forEach(([x, y, z, w, h], i) => {
     subjects.push(


### PR DESCRIPTION
## 对应三条反馈

### 1. 编译期页面停止响应

根因:warm 阶段每个窗口的真实预热 draw 会在驱动内部同步做 pipeline 特化(0.5-2s 主线程阻塞),20 个窗口背靠背 → 输入事件饿死 → Chrome 判定页面无响应。

- warm 每步之间插入宏任务喘息(60ms),排队的输入事件得以处理——总时长不变,但页面全程可交互
- boot 遮罩显示进度「warming shaders N/38」——20s 的预热读作加载,而不是假死

### 2. 文本与画面同步精细化

- **hideAt 退场**:assembleDeck 给叙事 overlay 盖上 `hideAt = 站结束`,transit 飞行中屏幕清场,下一站标题随场景一起落地(实测 t=43s transit 时 T:- / cur:-)
- **当前拍高亮**:字幕列跟着镜头走——镜头正拜访的条目全亮,讲过的降到 52%(实测 cur 逐拍推进:2012e→2014e→2015e;1周后→…→7周后)

### 3. 性能

- 黑石去掉 cracked 石纹:近黑色上纹理不可见,但 applyPattern 每像素白烧 ALU
- 远景浮石 5→4
- 播放曲线:站内 33-121fps(此前多站被降档钉死);已知余项:network 站穿梭镜头 march 深(8-17fps@0.5×,结构渲染器专项)、边界单点 2-4s 特化卡顿(driver 层,追不动)

141/141 测试。

🤖 Generated with [Claude Code](https://claude.com/claude-code)