### PR TITLE
Sprint 77: 全语料二读审计 — 50 课 vs 链上原文

### DIFF
--- a/docs/superpowers/artblocks-study/76-corpus-second-reading-audit.md
+++ b/docs/superpowers/artblocks-study/76-corpus-second-reading-audit.md
@@ -1,0 +1,89 @@
+# 76 — 全语料二读审计: 50 课 vs 链上原文
+
+> 2026-07-11。方法 = Fidenza 二读 (75) 的推广: 从 ArtBlocks 公开 GraphQL
+> (`data.artblocks.io`) 拉取全部 50 课对应项目的**链上原始脚本** (共 ~2MB, 含
+> Cytographia 288KB / BUSY 252KB 两个巨兽), 7 个并行审计员逐课把笔记的事实性
+> claim 与原文对照, 有 decor 家族的课再对照 registry.js 的渲染层实现。
+> 逐 claim 证据表见 [`audit/`](audit/) 下 batch-A..G 七份报告。
+> 判定尺度: 刻意简化不算错; 只标 **笔记事实错误** / **VOICE MISS** (丢原作签名
+> 特征) / **INVENTED DETAIL** (原作没有、我们发明的细节)。
+
+## 总量
+
+| 判定 | 课数 | 说明 |
+|---|---|---|
+| HIGH | 10 | 笔记核心机制讲错, 或家族丢签名/建立在发明机制上 |
+| MED | ~20 | 机制不精确 / 家族有一处 voice 级偏差 |
+| LOW / CLEAN | ~20 | claim 全坐实 (多课到变量名/常量级逐字命中) |
+
+笔记的 attribution (项目号/作者/license) 50/50 全对。可核对 claim 总体命中率
+高 (大多数课 80%+ 逐字坐实), 错误集中在**渲染层机制**——和 Fidenza 二读的教训
+完全同构。
+
+## HIGH 级清单 (10 课)
+
+| 课 | 错在哪 | 下游影响 |
+|---|---|---|
+| L19 Screens | "WebGL 仅 blit、艺术全在 CPU" 讲反 — 每层有动态拼装的 riso 合成 shader (纸纹/边缘扰动/网屏化/套印偏移); "半透明干涉 moiré" 机制不存在 (实为不透明套印 + BSP 深度树 + 交点剪段编织空隙) | folded-screens 的"干涉"叙述是错误下游 |
+| L20 RASTER | 原作是逐通道 3 级色阶噪声 dither + 像素块化, **没有变径圆点** | halftone-fade 的"点径=field^gamma"圆点网屏是 INVENTED — 装饰效果成立, 但归因需改 (那是传统印刷网屏, 不是 RASTER) |
+| L22 ORI | 3 条机制全是发明: 原作折线预生成后作用于全部 facet (无"贪心剖最大"); 折轴全随机 (非轴对齐±jitter); 着色是随机明度偏移 (非深度渐变) | paper-folds 把 3 条发明当"ORI 规则"实现了 |
+| L33 Qilin | 原作是 Verlet 软体, `detectJagged` **主动拒绝**尖锐边; "双尺度噪声撕口"不存在, 纸感来自纹理/泼溅/颗粒 | torn-paper 的整套撕边 recipe 属 INVENTED, 且丢图案纸片签名 |
+| L37 Blocks of Art | 原作是 hex 格上的**等距立方体** (shear 三张脸), 不是平面面板网格 | 笔记 idiom 需重写 |
+| L38 Ringers | pAlg 指认错 (是布点非缠绕); shrinkConcavePegs 方向反; 真缠绕 = 洗牌子集 × 绕质心角排序的**闭合环** | peg-wraps 丢闭合环+缠绕带两签名, 发明了"逐钉交替侧别" |
+| L42 Trossets | "邻格约束传播"不存在 (全局子集 + 每格独立均匀抽签, 衔接靠 Truchet 端点约定); "端点±抖动"不存在 (图元全精确几何) | idiom 结论建立在不存在的机制上 |
+| L44 FAKE IT | 头牌 idiom "textBoundingBoxes 增量放置+重叠检测" 是 write-only 死代码; 真避让 = 按文本长度降字号/关贴纸 | idiom 需换头牌 |
+| L50 720 Minutes | 机制讲反: 每 token 是**固定专属一分钟** (tokenId 末 4 位经 seed 42 洗牌分配), 不是"收藏一天" | 与 L27 的时钟流派表联动错 |
+| L16 Proscenium | "fragment 一行直通/颜色全在 CPU" 以偏概全 — 另有完整 GPU 光照 shader (fresnel + 9 灯) | 笔记结论需限定范围 |
+
+另 3 处 MED 级但性质相同的"观感反推成机制": L47 (Squiggle 的 y 是 hash 字节
+Catmull-Rom, 非正弦), L26 (Spaghetti Bones 生长是密度门控出芽, 非"过长重采样"),
+L08 (Box Light 的 distShader 与双色渐变 shader 是**死代码**, 真柔光 = 8 射线
+× 250 帧 raymarch 累积)。
+
+## 家族对照 (21 个受审家族)
+
+**忠实 / 干净 (9)**: strata-lines (全维度同构, 最佳), ink-scribble, drift-web,
+cargo-dashes, scan-tides (ND 合规), hex-lattice, street-grid (仅车道直线 vs
+原作蜿蜒, LOW), 以及 flow-ribbons / banded-ribbons 的二读修正部分 (luxe 色池
+16 色权重逐项精确、平端、碰撞、离散档位全验证)。
+
+**VOICE MISS / INVENTED (12, 按修复价值排序)**:
+
+| # | 家族 | 差距 | 级 |
+|---|---|---|---|
+| 1 | peg-wraps | 丢**闭合环** + **缠绕带** (原作: 洗牌子集绕质心角排序闭合); 发明"逐钉交替侧别"。修法已写进 batch-D 报告 (角排序/闭合/单钉高亮三条) | HIGH |
+| 2 | torn-paper | 撕边 recipe 整套 INVENTED; 原作签名 = 图案纸片 (纹理+泼溅+颗粒) | HIGH |
+| 3 | paper-folds | 3 条发明机制当规则; 丢"剖+镜像翻折"签名 | HIGH |
+| 4 | banded-ribbons | 残留一处: 原版分段色只画在带**两端** (加权段数, 20% 零段), 带身单一底色; 我们全身分段。另: 段长应加权抽取, z 档 8 非 7 | MED |
+| 5 | river-courses | 双细岸线 vs 原作**变宽填充带**; 古河道应 5 色轮换非单色淡出 | MED |
+| 6 | growth-loops | 细描线丢原作**点彩累积**骨质 (盖点+taper+多色) | MED |
+| 7 | meadow-streaks | 空心 stroke 椭圆 vs 原作**实心叶片** (fill+反差 stroke) | MED |
+| 8 | wash-flow | 线段 vs 原作连续色幕 (TRIANGLE_STRIP+SUBTRACT 减色); 发明 5→1 taper 与 π/4 角度偏置 | MED |
+| 9 | sediment-layers | 丢竖直 hatch 沉积纹理 (作品名的来源); 但笔记本身是有意重读为山峦剪影 — 待裁决 | MED |
+| 10 | block-mosaic | 逐 cell strokeRect 产生均匀网格感, 原作整块矩形无内隔线 | MED |
+| 11 | folded-screens | 每 facet 随机 tone vs 原作沿链**连续明暗坡** | MED |
+| 12 | halftone-fade | 圆点网屏是发明 (效果成立); 至少改归因 | LOW-MED |
+| — | light-edges | "双色棱"踩在原作死代码上 — 效果自立, 归因限定 | LOW |
+
+## 系统性 lesson (跨课)
+
+1. **体量感靠填充/累积, 不靠描线** — Fidenza fat ribbon / Fragments 实心叶 /
+   Qilin 图案纸片 / Spaghetti Bones 点彩 / Ancient Courses 填充带 / Watercolor
+   连续色幕: 6 个独立证据指向同一习惯 — decor 引擎默认用细 stroke 画一切。
+   这是修复清单里最高杠杆的一条: 引擎级补一组 fill/accumulate 习语, 12 处
+   voice miss 里 6 处同源。
+2. **"把观感反推成机制"是一读的主要失误模式** — L42 约束传播、L22 折叠规则、
+   L44 重叠检测、L33 撕口、L20 圆点、L47 正弦: 看效果脑补实现。二读铁律:
+   **机制 claim 必须在原文里找到对应行**, 找不到就标 unverifiable。
+3. **正向确认也有含金量** — 双 sfc32+1e6 预热+交替消费在 4 作里逐字出现
+   ("社区标配" idiom 从推测升级为实锤); BUSY 脚本里发现零权重 `"busiest"`
+   档直接证明姊妹作同引擎; luxe 色池 16 色权重逐项命中。
+
+## 下一步 (待用户排序)
+
+- A. 家族修复 sprint: 按上表 #1-#8 逐个二修 (peg-wraps / torn-paper /
+  paper-folds 三个 HIGH 优先; banded-ribbons 端部分段是 Fidenza 收官)
+- B. 引擎级 fill/accumulate 习语 (系统性 lesson #1, 一次修六处同源)
+- C. 笔记勘误 wave: 10 HIGH + ~20 MED 的事实修正 (含 L27↔L50 联动)
+- D. 冻结影响: 家族二修会动指纹 — 沿用"同日修正例外"不适用, 需按 DECOR_V
+  纪律走新 lane 或 v4 版本位

--- a/docs/superpowers/artblocks-study/audit/batch-A.md
+++ b/docs/superpowers/artblocks-study/audit/batch-A.md
@@ -1,0 +1,201 @@
+# 二读审计 batch-A
+
+课程: L01 / L03 / L04 / L05 / L32 / L36 / L47 / L49。
+方法: 笔记 claim ↔ 链上脚本逐条核对; 4 个衍生家族对照 registry.js。
+判定尺度按 brief: 刻意简化不算错, 只标 VOICE MISS / INVENTED DETAIL / 笔记事实错误。
+
+---
+
+## L01 Fragments of an Infinite Field (Rizzolli, #159) — 笔记 ✅ 为主, 家族 MED
+
+### claim 核对
+
+| claim | 判定 | 证据 (L01-159.js) |
+|---|---|---|
+| hash → 32 决策位, 每 2 hex 字符 mod 10 | ✅ | `semente()`: `slice(i+2, i+4)` ×32, `parseInt(x,16) % 10` (L23-32) |
+| 网格 93-107 × 20-39 | ⚠️ | `linha=map(s[0],0,9,93,107)`, `col=map(s[1],0,9,20,39)` 存在, 但它们是**格子尺寸除数** (`larg=DIM/linha`, `alt=DIM/col`); 实际循环 `i≤DIM, j≤1.5·DIM` (L301-302), 纵向 translate 是 `j*alt/fy` (fy=10) → 画布上有效网格 ≈ linha 列 × **10·col (200-390) 行**, 不是 20-39 行 |
+| 噪声系数 fn 0.0325-0.07 | ✅ | L42 |
+| fx=1, fy=10 各向异性椭圆 | ✅ | L44-46; `ellipse(0,0, this.fx*larg, fy*alt*a)` (L332) |
+| 噪声门控密度 `if (a2 < chance)` | ✅ | L316; 注意 a2 = 同一噪声场**转置坐标** `noise(fn*j, fn*i)` (L304), 非独立噪声 |
+| 噪声索引色板 `cor[floor(a*cor.length)]` | ✅ | `fill(novaCor[floor(a*corFolhas.length)])` (L331), `stroke(corFlor[floor(a*corFlor.length)])` (L329) |
+| 四季 + 每季 2 变体叶色/花色 5 色板 | ✅ | estacao 四分支 (L61-209); corFolhas 变体由 `random(1)<0.5`, corFlor 变体由 digit 23/25/14/22 |
+| 夏雨/冬雪叠加 | ✅ | `if(inverno) neve(); if(verao && chuvaChance<0.9) chuva()` (L287-292) |
+| 草叶场画两遍 花前浓/花后疏 | ✅ | `folhas(random(.35,.6)); play(); folhas(random(.2,.35))` (L284-286) |
+| flor 四层 petalaPlot/petalaOut/corona/stamen | ✅ | L383-645; petalaOut 仅秋季用 (L713) |
+| "按季节决定花朵绘制顺序" | ⚠️ 轻微 | 实际只有秋季不同 (85% 概率多画一层 petalaOut, L707-717); 春夏冬顺序完全相同 |
+
+### 家族对照 meadow-streaks (registry.js L239-266, CODE PORT CC BY, attribution L2994 ✅)
+
+| 维度 | 判定 |
+|---|---|
+| 各向异性椭圆 + 噪声旋转 | 对上: `ctx.ellipse(0,0,bladeW=3, cellH*(0.5+a))` + `rotate((a-0.5)*π*1.6)` (L256-260)。旋转范围 ±0.8π vs 原作 `a*TAU` 全周 — 尺度级简化, 可接受 |
+| **形状构造 fill vs stroke** | **偏差 (MED, VOICE)**: 原作草叶是**实心 fill 椭圆** (叶色) + 反差色 stroke 描边 (L329-332); 我们 stroke-only 空心轮廓 (L257-261, 无 fill)。原作质感 = 密集实心色叶片; 空心轮廓在 bladeW=3 下勉强读作笔画, 但"实心叶片场"这一签名丢了。Fidenza 先例同型 (细描线代替实心形) |
+| 颜色来源 | 对上: 噪声索引 `colors[floor(a*colors.length)]` (L253) — 正确继承核心 idiom |
+| 分布随机性/门控 | 对上: `gate>0.46 continue` (L252)。差异: 门控用独立噪声 (seed+7919), 原作是同场转置 — recipe 级, LOW |
+| 双层纵深 (花前/花后两遍) | 未做 — decor 无主体, 合理省略 |
+
+**严重度: MED** (家族 fill→stroke; 笔记本身仅 1 处网格行数 ⚠️ LOW)
+
+---
+
+## L03 Archetype (Golid, #23) — 全部 ✅, 家族 MED
+
+### claim 核对
+
+| claim | 判定 | 证据 (L03-23.js) |
+|---|---|---|
+| xorshift32 `<<13 >>17 <<5` | ✅ | `function rnd(){seed^=seed<<13,seed^=seed>>17,...seed<<5...}` |
+| w_pick 累计和加权 | ✅ | `w_pick(e,t)`: `t.reduce((e,t)=>[...e, e[len-1]+t],[0])` + findIndex |
+| chaos/balance/pattern 三人格包, 权重 [1,4,2] | ✅ | `layout=w_pick([chaos_layout,balance_layout,pattern_layout],[1,4,2])`; 各包含 outerSize/minGridSize/innerSize/nonempty |
+| Apparatus next_block 延伸水平/垂直/开新块 | ✅ | `next_block(e,t,n,a)`: n.in&&n.h 续水平, a.in&&a.v 续垂直, 否则 `i()` 开新块, `chance_extend` 概率驱动 |
+| linegrid → NW 角点 → 矩形 | ✅ | `linegrid_to_rects` → `get_nw_corners` (h&&v&&in) → `corners_to_rects` |
+| group 颜色继承 + group_size | ✅ | `i()` group 分支: `t = rng()>.5 ? n.col : a.col; main_color = rng()>group_size ? random : t`; atomAppOpts group_size=0.4; colorModes 权重 [4,2,1,2] |
+| 嵌套网格: 外层分区 → 内层原子块 | ✅ | reset(): 三个 section Apparatus → createGrid → createApparatus (内层) |
+| 量化深度 depthSteps=8 | ✅ | `z1:.1+Math.floor(rng()*depthSteps)/depthSteps`, `depthSteps=8` |
+| 等轴测 xu/yu/zu 三面 + 面透明度组合 | ✅ | xr=-π/6, yr=3π/6, zr=π/6; shades 6 组 `[[1,1],[1,0],[0,1],[0,0],[.15,0],[0,.15]]` 权重 [5,1,1,.5,1,1]; shadeOpacityTop=0 恒定 |
+| painter toposort | ✅ | `get_overlap_graph` + `toposort1(...).reverse()` |
+| 42 套色板 {c,s,b,w}, 按 w 抽 | ✅ | get_palette 数组逐一数 = **42 条**; `w_pick(e, e.map(e=>e.w))` |
+
+### 家族对照 block-mosaic (registry.js L437-488, recipe-only, attribution L3005 ✅)
+
+| 维度 | 判定 |
+|---|---|
+| 生长而非切分 | 对上 (recipe 级): 逐格扫描, 延左 p=.42 / 延上 p=.30 / 开新块 (L452-466) — 状态机生长, 非递归切分 ✅ |
+| 邻块颜色继承 | 对上: `inheritFrom = rand()<0.55 ? (left!==-1?left:up) : -1` (L463)。差异: 原作 50/50 随机选 n.col/a.col, 我们恒优先 left — LOW |
+| **块轮廓构造** | **偏差 (MED, VOICE)**: 原作经 NW 角点把每个生长块画成**一个完整矩形** (块内无内隔线); 我们对**每个 cell** 都 `strokeRect` (L482-484) → 画面呈均匀 16×9 网格线, 块只靠同色分组隐约可见。"不规则矩形紧密填充"这一 Archetype 签名被均匀格线稀释。同色描边减轻但未消除 |
+| 稀疏填充 34% (id-hash 门控) | 我们发明 (L477-478), 但属 decor 减重设计决定, 不算 INVENTED DETAIL 违例 — 记录备查 |
+| 等轴测三面 | 未做 — 笔记明说 "v1 不做 (平面块更安全)", 已声明的设计决定 ✅ |
+
+**严重度: MED** (家族逐 cell 描边 → 网格感; 笔记零错误)
+
+---
+
+## L04 Watercolor Dreams (NumbersInMotion, #59) — 笔记 MED ×1 ⚠️×1, 家族 MED
+
+### claim 核对
+
+| claim | 判定 | 证据 (L04-59.js) |
+|---|---|---|
+| pwa(list) {p} 字段加权选择 | ✅ | `function pwa(s){let e=random(1)...if(e<=s[o].p+t)...}` |
+| pal = IQ 余弦 a+b·cos(2π(c·t+d)) | ✅ | `pal(s,e,t,o,r)`: `255*(e[i]+t[i]*cos(2*PI*(o[i]*s+r[i])))` |
+| **"颜色引擎是连续函数而非离散色卡"** | **⚠️ (MED)** | pal 只服务 `isv:true` 的 6/36 个 colorScheme (p 合计 ≈0.075); 其余 **30 个 scheme 是离散 3 色 RGB 色卡** (drawGraded 用 `palette[colorIndex%len]`, 每条 Flow 一色)。余弦板是稀有 variegated 模式, 不是主颜色引擎 |
+| mc/ml/mr/mlt 圆/线/矩形/字母轮廓采样 | ✅ | 四函数俱在; mlt 用 letterData A-Z 多边形 |
+| rlbs 弧长等距重采样 | ✅ | 逐段累计 dist + 线性插值 |
+| FlowNode 噪声平流 | ✅ | `update(): currPos += flowField(currPos)` ×stepsPerUpdate(4) |
+| **"每步画低透明度线段"** | **⚠️ (LOW-MED)** | 实际是 `beginShape(TRIANGLE_STRIP)` — prev/curr 两排节点织成**连续色带**, alpha 随 age `map(age,0,lifespan,255,0)` 从全不透明衰减, 且 `pg.blendMode(SUBTRACT)` + 暖纸底 `background(242,224,201)` — 减色混合是水彩暗部的来源, 笔记漏了这层签名 |
+| 人格布尔梯 20/15/10/5/1% | ✅ | `isMirrored=random(1)<.2, isRotated<.15, isStriped<.1, isInverted<.05, isWavey<.01` 逐字吻合 |
+| 镜像折叠 abs(x-0.5·ss) 喂噪声 | ✅ | `abs(s.x-.5*ss)/(noiseScales...s*ss)+offset` |
+
+### 家族对照 wash-flow (registry.js L520-563, recipe-only, attribution L3006 ✅)
+
+| 维度 | 判定 |
+|---|---|
+| 形状锚定 + 噪声平流 | 对上 (recipe 级): 斜色带上采样 NODES 节点, 逐步平流 (L535-559)。源形状只有 band (无圆环) — 笔记 port 判定写"色带/圆环", 圆环未做, LOW |
+| **连续拖痕的画法** | **偏差 (MED, VOICE)**: 原作相邻节点连成 TRIANGLE_STRIP **连续色幕**被整体拖走; 我们每节点独立 moveTo/lineTo 短线段 (L553-556) → 纤维束感, 非"整幅软色雾"。与 Fidenza"细描线代替 fat ribbon"同型 |
+| **笔宽 5→1 递减 ("thick→thin as it dries")** | **INVENTED DETAIL**: `lineWidth = P.lineWidth*(5-4s/STEPS)` (L552) — 原作无笔宽渐变 (宽度由 min/maxDist 节点密度维持), 干燥变细是我们发明的 |
+| 角度场 | 偏差 LOW: 我们 `noise*2π + π/4` 恒加 45° 偏置 (L546) — 原作 `angleAmp(2-6)*π*noise` 无常数偏置; 小号 INVENTED |
+| 颜色 | 对上: `continuousPalette(colors, n.t)` 沿节点参数 t 连续插值 (L550) — 笔记设计的 recipe 适配, 成立 |
+| alpha 层次 | 对上: 恒定低 alpha 累积 (L543) — 对原作 age-fade 的合理简化; SUBTRACT 混合未仿 (Canvas 下合理) |
+
+**严重度: MED** (笔记: 余弦板以偏概全; 家族: 线段代色幕 + 2 处 invented)
+
+---
+
+## L05 Apparitions (Penne, #28) — 笔记全 ✅, 家族 LOW (最佳对照)
+
+### claim 核对
+
+| claim | 判定 | 证据 (L05-28.js) |
+|---|---|---|
+| hti: 32 × 0-255 全字节 | ✅ | `hti`: 32 × slice(2+2e,4+2e) → parseInt 16 |
+| mv(i,min,max) = map(byte,0,255,…) | ✅ | `mv=(e,v=0,c=1)=>map(rv[e],0,255,v,c)` |
+| 色板链 ~30 区间; 白 0.5%/黑 0.5%/HSB 1% | ✅ | mv(1) 三元链共 **29 个分支**: `<.005→[cw]`, `<.01→[cb]+dk`, `<.02→HSB 特殊 colorMode(HSB,360,...)`, `<.1→黑白`, … else ew 大杂烩 |
+| gg(xd,yd) 网格; xd 列 × yd 行 | ✅ | `v.xd=mv(2,100,300)` 列 / `v.yd=mv(3,600,700)` 行 |
+| dal: 每行 curveVertex, x/y 各自噪声位移 (xa/ya × xo/yo) | ✅ | `x_=...map(noise(c*xo, j*yo),0,1,-xa,xa)`, `y_=...±ya`; xa/ya=0.1-0.3×width, xo=.002-.005, yo=.005-.03 |
+| sxn/syn 开关 → 2×2 性格 | ✅ | mv(16): <.6 both false / <.7 both true / <.8 (F,T) / else (T,F); sxn→noise(c·xo) 仅按行, syn→noise(j·yo) 仅按列 |
+| 色带分块: 每 bd 行重选 tic/tac, 行内 lerp | ✅ | `i%v.bd==0 && (tic=…,tac=…)`; `stroke(lerpColor(tic,tac,i%bd/bd))`; bd=int(mv(8,10,200)) |
+| 影线 #1111 微偏移先画 | ✅ | `v.sw&&(…stroke("#1111"), dal(gd,i,.004*height)…)`; dk 模式用 "#EEE1" |
+| 蒙版底 rect/ellipse | ✅ | `v.bk = mv(9)<.5?"r":"e"` |
+| 4.7KB | ✅ | 4659 bytes |
+
+### 家族对照 strata-lines (registry.js L574-616, recipe-only, attribution L3011 ✅)
+
+| 维度 | 判定 |
+|---|---|
+| 平行线束 + 噪声垂直位移 | 对上: 34 行, `dy=(noise(px*FREQ, r*0.09)-0.5)*2*AMP` (L599) — 即原作 sxn/syn=false 主模式 |
+| 色带分块渐变 | **精确对上**: `r%BAND===0 重选 c1/c2` + `lerpColor3(c1,c2,(r%BAND)/BAND)` (L589-594) — 与原作机制逐字同构 |
+| 影线 | 对上: 深色 understroke 先画、+2.5 偏移、低 alpha (L603-605)。差异: 主线 1.4× 粗于影线 (原作同宽), 影线色用 silhouetteColor 非纯黑 — LOW |
+| 未仿项 | x 向位移 / curveVertex 平滑 / 蒙版底形 — 均为尺度级简化, 不涉签名 |
+
+**严重度: LOW** (batch 内最忠实的一组)
+
+---
+
+## L32 Dreams (Bagley, #89) — 笔记 MED ×1
+
+| claim | 判定 | 证据 (L32-89.js) |
+|---|---|---|
+| **视觉 "抖动渐变填充的梦境色块"** | **❌ (MED)** | 脚本里没有任何抖动/渐变填充机制: draw() 两遍 — 先 `noFill()+stroke(r.c)` 描轮廓、再 `fill(r.c)+noStroke()` 平涂, 每个四边形**单色 flat fill**。渐变感只来自 `c1=c[d%c.length]` 深度轮换的相邻色块。"抖动渐变"疑与 Bagley 其他作品混淆 |
+| max-run 受限随机序列 | ✅ | `u==p?t++:t=0, t>2&&(u=0==p?1:0,t=0), L.push(u)` — 逐字吻合 |
+| 嵌套稀有度 `cs = 5==ri(0,150)?9:ch([5,15,10])` | ✅ | 逐字吻合; ri(0,150) 均匀 151 值 → 1/151; cs=9 → `C=shp(C)` + `c=C[cv]` 全板混色 |
+| 全 13 板 | ✅ | C 数组数得 13 组色板 |
+| 扭曲四边形递归 (四角点传参) | ✅ | `sd(p1,p2,p3,p4,…)` 任意四边形; 分割点 `a1=.5+mn(p1.x,p1.y,A)` 噪声扰动, 整树继承 |
+| "13 组**具名**调色板" | 🔍 | minified 里色板是匿名数组, 名字读不出 (可能存在于未混淆源) — 不判错 |
+
+**严重度: MED** (视觉机制描述与代码不符; 三个 idiom 全部精确)
+
+---
+
+## L36 Frammenti (Contiero, #72) — 笔记 ✅ 为主, LOW ×1
+
+| claim | 判定 | 证据 (L36-72.js) |
+|---|---|---|
+| Z() = WCAG 相对亮度 (0.2126/0.7152/0.0722 + sRGB 线性化) | ✅ | `v<=.03928?v/12.92:((v+.055)/1.055)^2.4` + `.2126a[0]+.7152a[1]+.0722a[2]` — 教科书级吻合; 且用 WCAG 对比率 `(max+.05)/(min+.05)`, `while(n<3)` 换色 — 笔记 "亮度差校验低于阈值自动换" 完全成立 |
+| 32 槽位: a[4]<64, a[8]→板 | ✅ | `f={a:a[4]<64, b:q(a[8],0,P.length),…}` |
+| "a[11]→密度" | ⚠️ LOW | `f.d=z(a[11],.03,.16)` 实为**边距比例** (`w=t-t*f.d*2` 画幅内缩); 密度类参数在 f.g/f.i/f.k/f.l |
+| 4.7KB 全功能 | ✅ | 4704 bytes |
+
+**严重度: LOW**
+
+---
+
+## L47 Chromie Squiggle (Snowfro, #0) — 笔记 MED ×1
+
+| claim | 判定 | 证据 (L47-0.js) |
+|---|---|---|
+| tokenData.hashes 复数, 32 槽位 × N hashes 入池 | ✅ | L1-10: `numHashes=tokenData.hashes.length`, 双层循环全部入 decPairs。⚠️ 微: 实际消费只有 decPairs[0..31] (首个 hash), 其余入池未用 |
+| HSB 步进 | ✅ | `colorMode(HSB,255)`; `hue=((color/spread)+startColor+index)%255` 逐点步进 |
+| **"正弦 y 偏移"** | **❌ (MED)** | y 不是正弦: `y = curvePoint(map(decPairs[j],…), map(decPairs[j+1],…), …, t)` (L55) — **Catmull-Rom 样条穿过 hash 字节映射的控制点**。波形本身就是 hash 的可视化 (decPairs[j] 直接当振幅), 这比"正弦"更强地支撑笔记自己的 provenance 论点, 写错反而亏了 |
+| spread trait | ✅ | `spread = decPairs[28]<3 ? 0.5 : map(…,5,50)` (1.2% 超密彩虹) |
+| "槽位即 trait" | ✅ | reverse/slinky/pipe/bold/segmented 全部 decPairs[22..31] 阈值 (L24-30) |
+
+**严重度: MED** (机制讲错; 谱系/历史 claim 与脚本一致)
+
+---
+
+## L49 Elevated Deconstructions (luxpris, #7) — 笔记 ✅ 为主, LOW
+
+| claim | 判定 | 证据 (L49-7.js) |
+|---|---|---|
+| 32 槽位 | ✅ | L3-5 循环 32 (实际消费 decPairs[0..20]) |
+| multiplier = width/2400 分辨率无关 | ✅ | `multiplier = width/2400` (L19), 全部尺寸乘 multiplier |
+| 3.1KB 全语料最小 | ✅ | 3072 bytes |
+| "三五个形块的悬浮平衡 / 少量形块放置=全部" | ⚠️ LOW | 实际内容: 4 束平行线 (5-15 次重复偏移) + 同心圆簇 + **一个 `drawingContext.shadowBlur=40` 软阴影大圆** + **7500×multiplier 条粉色发丝线纹理**。"形块"是不准确的; shadowBlur (原生 canvas API 入 p5) 与发丝纹理是值得记的细节, 笔记漏了 |
+| seed 取 hash.slice(48,64) (尾 16 字符) | — | 笔记未 claim; 记录: 与常见 slice(0,16) 不同 |
+
+**严重度: LOW**
+
+---
+
+## 汇总
+
+| 课 | 笔记 | 家族 | 总严重度 |
+|---|---|---|---|
+| L01 | ⚠️ 网格行数 (LOW) | meadow-streaks: fill→stroke (VOICE) | MED |
+| L03 | 全 ✅ | block-mosaic: 逐 cell 描边→网格感 (VOICE) | MED |
+| L04 | 余弦板以偏概全 + 画法描述不精确 | wash-flow: 线段代色幕 (VOICE) + 笔宽taper/角度偏置 (INVENTED) | MED |
+| L05 | 全 ✅ | strata-lines: 全维度对上 | LOW |
+| L32 | "抖动渐变填充"无代码依据 | — | MED |
+| L36 | a[11]=边距非密度 (LOW) | — | LOW |
+| L47 | "正弦 y 偏移"错, 实为 hash 字节 Catmull-Rom 样条 | — | MED |
+| L49 | 视觉 gloss 不准 + 漏 shadowBlur/发丝纹理 (LOW) | — | LOW |

--- a/docs/superpowers/artblocks-study/audit/batch-B.md
+++ b/docs/superpowers/artblocks-study/audit/batch-B.md
@@ -1,0 +1,182 @@
+# 二读审计 — batch-B (L02 / L14 / L19 / L20 / L21 / L24 / L39 / L40)
+
+审计员: batch-B agent · 对照物: `<scratchpad>/ab-scripts/*.js` 链上原文 (已 js-beautify, 行号引用 beautified 版)
+判定尺度按 audit-brief: ✅ confirmed / ❌ wrong / ⚠️ imprecise / 🔍 unverifiable; 家族只标 VOICE MISS / INVENTED DETAIL。
+
+---
+
+## L02 Fidenza (Tyler Hobbs, #78) — 严重度 MED
+
+链上脚本可读性极好 (压缩但未混淆, 函数名保留: `flwP/flwL/cSegs/cllsn/fat/fSeg/pcLx`)。
+注意: 笔记头部说 "curated 抓取的 #78 script.js 为空, 本课用手藏版" — 本次 scratchpad 的
+L02-78.js 是**真链上原文** (14.5KB, 含全部 palette 函数), 该待办可视为已补洞。
+
+### 笔记 claim 核对 (02-fidenza-hobbs.md)
+
+| claim | 判定 | 证据 |
+|---|---|---|
+| "flow field 噪声场 → 角度网格" | ❌ | `flwP` (L149-172) **不用任何噪声**: 基角是 8 方向加权抽签 `wc([pi(.5),.1, pi(0),.1, pi(.25),.2, …])` (L644) 铺满整格, 再叠 15/28/45 个随机扰动 — 70% 走 `adjFlw` (半径内高斯角度冲击, 线性衰减), 30% 走 `adjFlw2` (全场 `sqrt(dist)` 螺旋旋转, `od(.5)` 定向)。`noise()` 只在 Soft-Shapes 渲染 (`strokeSegment` L422) 出现。Fidenza 的"整幅单一主流向 + 局部扰动"气质正来自常量基角, 不是 Perlin 场 |
+| "可选角度量化 (90°/45° → collapsed 变体)" | ❌ ×2 | 量化是 `snp(j, pi(.2))` (L189) = **36° 步进**, 单一模式 (`u=od(.04)`, L670), 无 90°/45° 两档; 且 **collapsed 是另一个特征** (`o=od(.04)`, L667): 绕中心 `(w(.5),h(.4))` 的径向场 + 距离比例旋转 (L153), 与量化无关。量化对应的是 "Shape Angles: Sharp" 类 trait, collapsed 对应旋涡构图 |
+| 起点 = y 行 × x 步进, 双向高斯抖动, shuffle | ✅ | cSegs L289-297: 行距 `n=h(.017)×{0.5,1,2.5,5}` (highAF/high/med/low), x 步 `r=w(.01)` (low `w(.02)`/highAF `w(.007)`), 抖动 `gssn(a,w(.005))`+`gssn(y,q)` (q=`w(.03)`, low `w(.07)`); 行列表和点列表都 `shffl` |
+| 碰撞 = 距离 < r1+r2 且 curveId 不同; 每点注册 [x,y,r,curveId]; nScts² 网格 | ✅ | `cllsn` L262-274: `dist(a,b,e,h) <= c+i && f!==j`; `o[c][e].push([f,g,b,r])` L317; `nScts=10` L71 |
+| 碰撞/越界 → 结束段继续走线找下一段 (编织) | ✅ | cSegs L346-350: else 分支 push 段后 `u+=1` 继续遍历同一条曲线 |
+| look-ahead `max(2, r/ε)` 预检 | ✅ | L321 `Math.max(2, Math.floor(b / w(.001)))` — 探 margin/2px 个点 × 步长 `w(.007)`=14px ≈ 2×全宽 |
+| 粗细 = 概率加权谱 f(), 少量极粗+大量中细 | ⚠️ | pm2-pm6 (L453-471) 确是 `wc` 加权谱; 但 V1/V4 是**固定宽** (pm1≡z1, pm7≡z4), V6/V7 谱重心在粗端 (pm6: z5 .2/z6 .5/z7 .3) — "极粗稀有"只对中小 scale 变体成立 |
+| 密度档位 low/med/high/highAF = 间距+抖动参数组 | ✅ | 见上, L284-287 + L664 |
+
+### 家族对照 A: banded-ribbons (registry.js L2017-2171, 二读后当前实现)
+
+brief 专项: fat ribbon / 分段色 / luxe 数值 / 平端 / 碰撞 / 粗细 levels / turn bias / density / 碰撞半径。
+
+- **fat ribbon 构造** ✅ 对上: 脊线→逐点法向偏移 top/bot (L2131-2141) = 原版 `fatTop/fatBot` (原 L209-249); 闭合 fill, 非描边折线。
+- **平端** ✅ 对上: L2158-2168 直接 top→reversed bot 闭合 = 原版 `fat()` (L245-249) 的平切端; 半圆端帽发明已移除。
+- **luxe 色池数值** ✅ **逐项精确**: 我把原版 16 色 HSB(360,100,100) 全部手工转 RGB 与 registry L2060-2077 对照 — 16/16 颜色分毫不差 (例: dRed [358,64,86]→[219,79,84]; ppGrn [160,15,85]→[184,217,206]; ddBrwn [25,45,13]→[33,24,18]), 16/16 权重与 `pcLx` (原 L521) 完全一致 (.05/.03/.12/.02/.06/.06/.03/.04/.18/.02/.05/.05/.03/.17/.09/.03)。注: 原版权重和=1.03, `wc` 不归一; registry 用 poolTotal 归一 — 数学上等价。
+- **粗细 levels** ✅ 对上 (缩尺设计决定): 离散档 + 加权抽取 (L2087-2094) = 原版 z 档 + pm 谱。原版是 8 档 z0..z7=2..320 (75 笔记写"7 档" ⚠️, 见下)。
+- **分段色** ⚠️ **机制偏差 (MED)**: 原版**先整条 fat shape 填一个底色** (`pMnCl`, 且宽带避开背景色, L681+695), 然后只在**两端**各画 `pNStps` 段 — 段数加权 `wc([0,.2, 1,.1, 2,.15, 4,.4, 8,.12, 16,.03])` 上限 1/f (L483, 20% 概率零段=纯色带), 从两端向内推进 (L697-719 的 `[!0,!1]` 循环)。段长 `pSL` 也是加权 [4px .15 / 8px .4 / 16px .3 / 32px .15] × 变体倍率 0.5-2.5 (L477-480)。registry 是全身均匀切段 + 段长均匀抽 (L2145-2148)。**原版"纯色长带混着端部分段带"的混合质感被简化成全身分段**。不算丢签名 (分段色本身在), 但这是二读后仍存的最大机制差。
+- **碰撞** ⚠️ 两点: (1) 原版碰撞→当前段隐没、曲线继续走再现 (编织); banded-ribbons 碰撞→整条 break (L2120)。编织再现由 flow-ribbons 保有, banded 放弃 — 记 MED 设计权衡而非 miss。(2) 碰撞半径: 原版注册半径=margin (略大于绘制半宽, z4: 40 vs 37.6 → 自带留隙, 且判定是 r1+r2 双半径和); registry 用 `half*0.8` 查 14px cell 集合 (L2097-2106) — 允许轻微贴边。LOW。
+- **turn bias**: 原版**没有** per-ribbon turn bias — 曲率全部来自场扰动 (adjFlw/adjFlw2); banded 的 `baseAngle + (noise-.5)*2.6` (L2122) 保住了"单一主流向+摆动", 比 flow-ribbons 的纯噪声更接近原版气质。✅ 无遗漏。
+- **density**: 原版 行×步进+抖动+shuffle; banded 均匀随机撒 attempts 次 (L2114)。装饰尺度可接受, LOW。
+- **最小长度门** ✅ `spine.length*step < thick*2.2` (L2127) ≈ 原版 look-ahead 门。
+- **描边**: 原版深色描边是稀有模式 (`t`≈2.5%+blk/wOC 变体, L672; 默认段描边是自色 `w(5e-4)`, L432); registry 永远画深色发丝框 (L2161)。轻微 INVENTED (always-on), LOW。
+
+### 家族对照 B: flow-ribbons (registry.js L268-425, v1 冻结)
+
+分段可见性/网格碰撞+id 豁免/look-ahead/行+抖动+shuffle/加权粗细 5 个 idiom 全对上 (L332-338, 356-366, 393-411)。
+一个真差异: **场用 `noise()*4π` 全向** (L398/418) — 原版是常量主方向+扰动, 所以 flow-ribbons 是回旋纹而非 Fidenza 的定向编织。v1 已冻结不改, 但记录: **主方向感是 L02 笔记"噪声场"误读的下游** (MED, banded-ribbons 已实质修正)。
+
+### 75-fidenza-second-reading.md 补充核对
+
+- "7 档离散等级 z0=2…z7=320" ⚠️ — 是 **8 档** (z0..z7, 原 L84)。数值 2/5/10/20/40/80/160/320 @2000 ✅。
+- "厚带沿弧长切 4-32px 短段, 每段独立抽色" ⚠️ — 见上: 只有两端 pNStps 段重抽色, 带身保持底色; 4-32px 是 pSL 基值 ✅ 但有 0.5-2.5× 变体倍率。
+- "luxe 淡色/新闻纸占 ~55%" ✅ 大意 (newsprint .12 + ppGrn .18 + browns .29 ≈ .59 承重)。
+- "碰撞留隙…曲线相遇即止" ⚠️ — 原版是段隐没再现, 不是止; 该句与 L02 笔记 idiom 1 自相矛盾 (同段落却引"与 L2 结论一致")。
+- "产物: 色池 = 主题色×1 + OKLab tint×1.6 + 中性×2.2" — **文档漂移**: Sprint 76 已换成真 luxe 池 (registry L2053-2077), 75 笔记此节未更新。LOW (merge 在后, 建议下次 doc pass 补一行)。
+
+---
+
+## L14 Torrent (Steganon, #466) — 严重度 MED (无家族)
+
+| claim | 判定 | 证据 |
+|---|---|---|
+| "原生 WebGL" | ❌ | 是 **p5.js WEBGL 模式** (`new p5(...)` L191, `createCanvas(t,r,e.WEBGL)` L198, `createShader` L199), 非原生 WebGL |
+| "8.9KB (frag ~1.5KB)" | ✅ | 8864 bytes; frag 字符串 ~1.9KB, 近似可 |
+| "CPU 只准备一张源纹理" | ✅ | `oe(R)` (L155-175) 在 p5.Graphics 上画条纹 `Z`/斜杠 `te`/圆/矩形 + 三层 blendMode 洗线 `ee` (BURN/SOFT_LIGHT/OVERLAY, L173), shader 只吃 `u_imageInput` |
+| `uv.y = mod(f(uv) + mod(u_time,1000.)/u_speed, u_mod)` | ✅ | frag 原文逐字 (L199) |
+| fbm 场位移采样 | ✅ | `f()` = 7-octave value-noise fbm (a=0.9, gain .4, lacunarity `2.2+u_r3/4`); 且 `tt()` 把时间也馈入 hash 种子 |
+| 恒等 hash 颗粒 `fract(sin(dot(uv,…))*43758.5453)/u_noise` | ✅ | frag 末行逐字, 常数 43758.5453 ✅ |
+| "tile 化: u_tileoffset/u_tiledivisor 把一条流切成 N 条并排 — 单 shader 多窗格复用" | ❌ | 这两个 uniform 是 **print 导出机制**: `d`(?print=true) 时按 `U=20`px 横条逐条渲进大图 `T` 拼高分辨率输出 (L210: `T.image(e, 0, U*G, …)`); 实时模式恒为 `tileoffset=0, tiledivisor=1`。不是视觉多窗格 |
+| "静止一帧只是条纹, 运动才是作品 — 动画即本体" | ⚠️ | 链上**默认是静帧**: 非 `?animated=true` 且非 print 时 `ae(e)`=noLoop (L202)。动画是 opt-in 查看参数; 每 200 帧还会换 uniform 场景 (`re(r)`, L209)。"shader-core→3D 端"的分流判定仍成立, 但"动画即本体"与收藏者默认所见不符 |
+
+---
+
+## L19 Screens (Thomas Lin Pedersen, #255) — 严重度 HIGH
+
+| claim | 判定 | 证据 |
+|---|---|---|
+| "原生 js" · 14KB | ✅ | 无 p5, 手写 canvas2d + webgl; 13.7KB |
+| "WebGL 仅 blit; fragment shader 全文 `gl_FragColor=texture2D(u_t,v_t)`; 艺术在 CPU" | ❌ **核心机制讲错** | 那只是最终显示 program `X` (L166)。真正的**每层合成 shader 动态拼串** (L503-506): stegu simplex + `fbm8/fbm6/fbm1` (L162-165), 纸纹 `tex=fbm8((K*pos)*200*q+of)+fbm8(pos+of)/4`, 边缘扰动 `di=vec2(fbm1(pos*75),…)/2500`, 网屏化 `g=smoothstep(tex-0.15,tex,sc)` 把 CPU 灰度 mask 转成一层**riso 质感彩墨**, 还有 D 变体的斑点罩层与逐层套印偏移/旋转 (misregistration, L512-520 的 `d`)。CPU 画的是灰度渐变 mask, **一半的艺术在 GPU**。末行还有致谢彩蛋 "noise from github.com/stegu/webgl-noise with permission" |
+| "hash → 自实现 sfc32" | ❌ | 是 **xorshift128** (Marsaglia): `r^=r<<11; e[0]^=r^r>>>8^t>>>19` (L18)。sfc32 是 L21 Tide Predictor 的写法, 两者不同 |
+| "线段链表结构" | ✅ | `xe` 造 `{l,n}` 双向链 (L220-233), `_e` 数链长, `ge` 剪链 |
+| "y/z 轴旋转 (伪 3D 折叠)" | ⚠️ | 只有**一次全局绕 x 轴 -π/5 旋转** (L445-451, z 初始恒 0 → 实效 = y 向 cos 压缩/透视缩短); 折叠感真正来源: 链条转向 + 每段向下挤出高度 `i=[200,30,10,200][L]` 的四边幕布 (L525-526) + 沿链灰度渐变 + **BSP 二叉深度排序** (`ae/ie` front/back 树, L202-219 — painter's algorithm) 遮挡 |
+| "每段灰度 `rgb(255e,…)`" | ✅ | `De = e => rgb(${255*e},…)` (L467), 段的 p/p1 弧长位置作 gradient stops (L526) |
+| "2-3 屏半透明叠加, 交叠处密度拍频 (moiré)" | ❌ | 无 alpha 叠加: 层合成是 `mix(col,bg,g)` **不透明套印**; 交叠处理是几何的 — 相交处либо截断 (`I=false` 时把 s1 切在交点, L423-427) либо**剪掉交点周围 5 段造成穿插空隙** (`ge(r.n,5)`, L429-430 — 真正的"编织让位"), 不是光学干涉 |
+| (未入笔记的大 idiom) | — | 5 个形状生成器 `de[]` (同心圆/平行线/回字方/放射线/样条曲线, L274-376) 按 E 组合; 交点剪 5 段的 weave-gap; BSP 深度树 — 三者都是 Screens 的骨架, 笔记未捕获 |
+
+### 家族对照: folded-screens (registry.js L1169-1227)
+
+- 屏数 2-3 / 折痕切 facet / facet 斜率 ✅ recipe 级成立 (链条转向的合理缩写)。
+- **tone 偏差 (MED)**: 原版亮度是**沿整链连续的灰度渐变** (p→p1 单调推进, 映射两个 palette 色之间) — 折叠读成 3D 靠的是连续明暗坡; registry 每 facet 独立随机 `tone: 1 - toneSpread*rand()` (L1204), 相邻 facet 明暗无序 → 坡变成补丁。建议 (不改代码, 仅记录): tone 沿 facet 序单调渐变即可贴回原版。
+- **"半透明干涉" = INVENTED (LOW-MED)**: 承笔记 ❌ 而来; 原版是不透明套印+BSP 遮挡+套印偏移。装饰尺度低 alpha 叠加是合理简化, 但不宜再以"复刻了原作干涉"叙述。
+- 每屏单色 (L1192) vs 原版每链双色渐变 + 特殊层 W 黑底反白 (L510) — 刻意简化, 不标。
+
+---
+
+## L20 RASTER (itsgalo, #341) — 严重度 HIGH
+
+| claim | 判定 | 证据 |
+|---|---|---|
+| "p5 + 双 shader" · 10KB | ✅ | shA=`fsn`, shB=`fs` (L1-3, L43); 10496 bytes |
+| Gesture 类沿点对生成笔触路径 | ✅ | 5×4 网格点 shuffle 取 brushes 个 (initPts L97-104), 二次贝塞尔 + 每采样点 ±10 抖动 (qCurve L172-184), 逐帧沿路径推进 |
+| drawBrush 软径向印章 alpha=A·(1-d/R) | ✅ | L79-89: `alpha = r/255*(255-map(dist,0,w/2,0,255))`, A=15 极低; 印章以 texture+plane 盖进 buffA (L158) |
+| "drawNoise 撒噪声底" | ⚠️ | `npg` 是馈给 shB 4D simplex 的**噪声查找纹理** (`S.setUniform("h", npg)`, L59; frag 内 `A(a)=texture2D(h,…)` 采样), 不是可见的噪声底图 |
+| "shA 半调点阵显示 (uniform j = 点径)" | ❌ **机制讲错** | `fsn` 是**逐通道 3 级色阶 + 值噪声抖动的 dither**: `g(b,c,a)`: `d=2/a*m(b)+c-1/a; f=clamp(floor(a*d)/(a-1))` (a=3 → 电平 {0,.5,1}), 外加 `floor(c)/k` 像素块化。**没有圆点、没有可变点径**; `j`=dot 是像素块尺寸 (默认 ≈1px, 键盘 1/2/4/8 放大), 恒定值, 不由场值调制 |
+| shB 反馈 warp (自采样+偏移) | ✅ | `d=texture2D(G,(a+l)*0.986)` — simplex 位移 l + 0.986 缩放反馈, buffB→buffC 回灌 (L59) |
+| "场与屏分离" 架构读法 | ✅ | 成立 (笔刷 buffA/累积 buffC 为场, shA 为屏), 但"屏"的real form是 dither 而非 halftone |
+
+### 家族对照: halftone-fade (registry.js L1947-2015)
+
+- 软径向 blob 场 ✅ 对上 drawBrush 思想 (falloff 平方是无害微调)。
+- **"点径 = field^gamma" 的可变半径圆点网屏 + 错行 rosette (L2000-2010) = INVENTED DETAIL (MED-HIGH)**: RASTER 全程无变径圆点 — 它的印刷感来自 3 级噪声抖动色阶 + 像素块。家族把经典 halftone 视觉语言安在了 RASTER 名下; 注释 (L1947-1953) 与笔记都以"原作架构"叙述这一机制, 需在文档上更正归因 (视觉本身作为装饰家族没问题)。若想贴回原作 voice: 屏应是"粗像素 + 每通道少级色阶 + 噪声阈值抖动"。
+
+---
+
+## L21 Tide Predictor (LoVid, #376) — 严重度 LOW (ND 严格, 只读只对照)
+
+笔记全部 claim 与原文一致 (此处只写 recipe 级结论, 不复述代码):
+
+- 1000×1000 单一扫描索引折行 ✅; 无几何/噪声/对象 ✅ (全批最小 4.6KB ✅)
+- 三通道三角波 `255-|255-(i%p)·k|`, 周期互异 ✅ (周期 ∈ {1000,500,333,250,200} 铸造抽取)
+- 波谷处 0.01% 换周期 (±2 随机游走, 下限 10) / 1% 增益微调 ✅; 每帧掷 sync_probs [0.01/0.05/0.1/0.5] 全体归位 ✅
+- drawWait 1→5000→500ms ✅; PRNG 确为 sfc32 (源码自名) ✅ — L19 笔记的 "sfc32" 很可能是从这课串写
+- (审计员旁注, 不入笔记建议) 源码增益微调分支有一处真值判断笔误, 使微调恒走增益+方向 — 纯观察, ND 下不做任何利用
+
+### 家族对照: scan-tides (registry.js L1879-1945)
+
+ND 合规 ✅: 结构完全重写 (行式 gradient 段 vs 逐像素), 零代码搬运。idiom 对照: 1D 扫描游标跨行连续 ✅ (`scan += w`, L1936); 三角波 ✅; 周期随机游走+概率再同步 ✅ (静态适配为逐行, 笔记已声明); RGB 三通道→双主题色 OKLab + 失谐第二通道刻线 = 已文档化的调色板约束改写 ✅。无 VOICE MISS / 无 INVENTED。
+
+---
+
+## L24 WaVyScApE (Holger Lippmann, #406) — 严重度 MED (无家族)
+
+| claim | 判定 | 证据 |
+|---|---|---|
+| p5 纯 2D · 7.4KB | ✅ | 7426 bytes |
+| y 向每 60-140px 一带; 42% 显影 | ✅ | `S()` L91: `f += random(60,140)/1600*he`; `a<42 && v()` |
+| 15 控制点变形闭合 blob, 沿 x 每 1-5px 盖章, 控制点连续 update | ✅ | `D=15` (L11), `I` 类 noise 驱动 magnitude/omega (L110-117); `v()` L96: `f += random(1,5)/1e3*wi`; 每枚章实为两遍 (fill(0,3) 阴影 + 彩色, L100-108) |
+| "**17 组**手调调色板库" | ❌ | `k` 有 **34 组** (L17-58, 含重复组: 0≡12 等; 尾部两组几乎全随机槽)。17 疑是把阈值表 `y` (L15, 恰 17 元素) 数成了调色板 |
+| 逐带抽签 (per-band 调色板) | ✅ | `E = int(random(k.length))` 在 `v()` 内 = 每带重抽 (L95) |
+| 随机色槽 `[d(150,255),d(200),d(100,255)]` | ✅ | L18 逐字 |
+| 画布内签名条 (白框 + 日期_作品名/作者/网址) | ✅ | L74-87: 白边 rects + `text(F+"_WaVyScApE / holger lippmann / www.e-art.co")`, F=真实渲染日期 |
+| 自 xorshift `f^=f<<13…` | ✅ | `t()` L4-6 (种子 `parseInt(hash.slice(0,16))` 借 "0x" 前缀解析) |
+| (未捕获, 不扣分) | — | draw() 叠 6 遍 S() (L71, 随机 scale/密度), b<s 阈值走 `y[]` 表控制黑描边带比率 |
+
+---
+
+## L39 Endless Nameless (Rafaël Rozendaal, #120) — 严重度 LOW-MED (无家族)
+
+| claim | 判定 | 证据 |
+|---|---|---|
+| 原生 js · 3.0KB | ✅ | 2976 bytes, 无库 |
+| 色对目录: two-colors w3 (13 对) / white+color w1 / black+color w1 | ✅ | L12-55 逐字 (white+color 7 对, black+color 8 对); groupCount [1,2,3], pairCount [1,12] |
+| rects 阶梯 [1,2,3,3,3,5,5,5,5,5,9,9,9,9,13,16,36,72] | ✅ | L4 逐字; `Rnd.pck` 查表即抽签 ✅ |
+| 3KB 含动画 (speed/stops) | ✅ | speed 7e-4, stops [2,16], 60fps setInterval (L159) |
+| "**纯平色块**分割, Mondrian 血统" | ⚠️ | 分割是 ✅ (cmp: 每次取**最大面积**块二分, perp=.8 偏垂直切, variability 抖动切点, L94-112); 但每块填的是**滚动的双色线性 gradient** (奇数个 stops 交替色对两色, 相位 `p += s` 循环, L134-155) — 不是平色。"endless" 的流动感正在此; 笔记的视觉描述漏掉了核心渲染层 |
+
+---
+
+## L40 Skulptuur (Piter Pasma, #173) — 严重度 LOW (无家族; Bubble Blobby 脚本不在本批)
+
+| claim | 判定 | 证据 |
+|---|---|---|
+| 原生 js · 6.4KB | ✅ | 6370 bytes, webgl2, 零依赖 |
+| JS 拼装 GLSL 距离场源码 (dg 字符串累加) | ✅ | `dg += \`o=p+V(…);…F b${i}=${C};\`` (L30-41) 注入 `F D(V p){${dg}…}` (L93) |
+| `L(max(q,0))-` 即 box SDF | ✅ | `g = '),0)+L(max(q,0))-'` (L37) — 经典 `min(max(...),0)+length(max(q,0))-r` |
+| min/max/abs 高尔夫 | ✅ | `#define` 缩写表 (S/N/L/M/P/J/V/W/X/F, L70-72); 洋葱层 `abs(C)-h*e/40` (L38) |
+| xorshift + 场景组合器 | ✅ | R() = xorshift128 (L2); 组合器 = cf 循环 + 网格 repeat `o.xy-=M(floor(o.xy)+…)` |
+| 12 组行列比例 O[] 抽两组 | ✅ | O 12 项 (L10-23); `cf=[O.splice(R(12)|0,1)[0], O[R(11)|0]]` 不放回抽两组, 各带 shape(R8)/onion(R3) 参数 |
+| "元编程 SDF raymarch" | ⚠️ (从宽) | 实际是**渐进式路径追踪器**: 5-9 次弹射循环、反射/漫反射混合、逐帧 accumulation buffer、ACES 近似 tonemap + 抖动 (L93 尾段) — 比 "raymarch" 高一档; 另有 1/150 金料稀有位 `G=R(150)<1` (L68)。分流判定不受影响 |
+
+---
+
+## 总严重度速览
+
+| 课 | 严重度 | 一句话 |
+|---|---|---|
+| L02 | MED | 场≠噪声场 (常量基角+扰动)、量化 36° 非 90/45、collapsed≠量化; luxe 池 16/16 精确、平端/碰撞/档位 ✅; banded 全身分段 vs 原版端部分段 |
+| L14 | MED | p5 非原生 WebGL; tile uniform 是 print 分条导出非多窗格; 链上默认静帧 |
+| L19 | HIGH | "WebGL 仅 blit" 大错 (每层 fbm riso shader 占一半艺术); sfc32 实为 xorshift128; 家族 facet 随机 tone 丢连续明暗坡 |
+| L20 | HIGH | shA 是 3 级噪声 dither 非变径半调; halftone-fade 的"点径=场值"+rosette = INVENTED DETAIL |
+| L21 | LOW | 全部 claim 精确; scan-tides ND 合规、无发明 |
+| L24 | MED | 调色板 34 组非 17; 其余含随机色槽引文逐字 ✅ |
+| L39 | LOW-MED | 两个 idiom 引文逐字 ✅; "纯平色块"漏掉滚动双色 gradient 本体 |
+| L40 | LOW | 全部 ✅; 实为渐进 path tracer (超出笔记但不矛盾) |

--- a/docs/superpowers/artblocks-study/audit/batch-C.md
+++ b/docs/superpowers/artblocks-study/audit/batch-C.md
@@ -1,0 +1,163 @@
+# ArtBlocks 二读审计 — batch-C
+
+课程: L06 / L07 / L13 / L23 / L42 / L46 / L48
+方法: 笔记 claim 逐条对照链上原脚本 (scratchpad/ab-scripts/), 家族对照 registry.js。
+判定尺度按 audit-brief (刻意简化不算错; 只标 VOICE MISS / INVENTED DETAIL / 笔记事实错误)。
+
+---
+
+## L06 Neural Sediments (Eko33, #418) — 家族 sediment-layers
+
+### Claim 核对表
+
+| Claim | 判定 | 证据 (原脚本) |
+|---|---|---|
+| 双 sfc32, hash 前后两半各喂一个 | ✅ | `this.prngA=new sfc32(tokenData.hash.substr(2,32)); this.prngB=new sfc32(tokenData.hash.substr(34,32))` (byte ~40650) |
+| 交替取数 | ✅ | `random_dec(){this.useA=!this.useA; return this.useA?this.prngA():this.prngB()}` |
+| 1e6 次预热 | ✅ | `for(let i=0;i<1e6;i+=2){this.prngA();this.prngB()}` (总计 1e6 次取数, 每流 50 万) |
+| 自实现 Box-Muller Gaussian | ⚠️ 微 | 实为 Marsaglia polar 变体 (`do{x1=...;x2=...;w=x1²+x2²}while(w>=1)`), 即 p5 randomGaussian 的克隆; 习惯上归为 Box-Muller polar form, 表面不精确 |
+| 自实现 Perlin, 用自己 PRNG 填表 | ✅ | `this.perlin[i]=this.random_dec()` 填 4096 表; 算法为 p5 noise 克隆, `perlin_octaves=1, amp_falloff=.2` (非 p5 默认 4/0.5) |
+| token 0 特判固定 hash | ✅ | `if(mintNumber==0){tokenData.hash="0x8d20ecb9..."}` |
+| cliff() "噪声折线 top + 高度 → 面片" | ⚠️ | top 边不是 noise(x) 折线, 是**向量随机游走**: `setHeading(displacement, truncatedGaussian(0,maxAngle,...))`, 且有 `force_backward_cliff_number → setHeading(...,radians(120))` / 140° 上限 — 可以**倒走出悬垂 (overhang)**。Perlin 只用在渲染层 (线的 alpha/摆动) |
+| polygonClipping union/difference 背面剔除 + 层间遮挡 | ✅ | `cullBackfacesPoly` 用 `polygonClipping.difference(result,face)`; `fullContoursPoly` union; 背景区用 `xor(visibleContours, canvaspoly)` |
+| drawFrame1/2/3, 4 帧一轮, "重计算不卡浏览器" | ⚠️ | 结构 ✅ (`frameCount%4` switch case 1/2/3)。但三帧**各自 clear()+drawScene() 重画一版不同的场景** (rd 流续走), frame2 用 `pg.blendMode(DIFFERENCE)` 复合, frame3 用 BLEND 叠 grain+cracks 版 — 分帧是**多 pass 视觉复合**, 不只是性能分摊 |
+| massExport 换 hash → 重渲染 → 存图循环 | ✅ | `saveSketch(); setTimeout(()=>{tokenData.hash="0x"+Date.now()...; initInput(); redraw()},1e3)` |
+| grainGraphics 颗粒后处理 | ✅ | frame3: `tint(100,.3); image(grainGraphics,...)` |
+| 77KB 含 40KB polygonClipping | ✅ | 文件 77370B, 库结束于 byte ~40430 |
+
+### 家族对照 sediment-layers (registry.js 618-676)
+
+原版渲染层真相 (drawCliffs, byte ~72316): 悬崖面 = **白底 quad (DARKEST 混合) + 黑色波浪描边 (wrapLine) + 面内竖直黑色 hatch 线** (nLines 5-400, 直线段 10 段渐变 alpha 或 organic 逐点 point() 抖动画法); 彩色只来自**单一 watercolor 色**铺在背景区 (xor 出的非悬崖区) + 全局 grain。
+
+| 维度 | 判定 |
+|---|---|
+| 层叠地平线 back→front + 前遮后 | 对上 (recipe 声明的简化: painter 序 + 近不透明 wash 代替多边形布尔, brief 允许) |
+| 顶边形状 | **偏差**: 家族用平滑 Perlin `noise(px*0.0045, li*3.7)` (L657); 原版是 truncatedGaussian 随机游走折线, 棱角 + 竖直崖面 + 可倒走悬垂 — 剪影气质从"锯齿地质剖面"变成"平滑山峦" |
+| 面的质感 | **VOICE MISS (MED)**: 原版的签名 = 崖面上密集**竖直 hatch 细线** (作品名 "Sediments" 的沉积颗粒感即来自此) + organic 逐点画法; 家族是纯色 solid wash (L651 `rgba(fill,0.92)`), 无任何面内纹理 |
+| 顶边 hairline 描边 (L664-673) | 对上 — 原版有 `cliffBuffer.stroke("black"); strokeWeight(scl*1)` + wrapLine 波浪描边, 非发明 |
+| 颜色来源 | 设计决定 (允许): 原版近乎黑白 + 单一 watercolor accent (`watercolor_color=rd.random_choice(colors)`, 14 色池选 1); 家族每层轮换主题色 |
+| 分布随机性 | 对上: 层数 personality 化 (4-10 层) vs 原版 n_cliff 3-88, 缩小版合理 |
+
+**严重度: MED** — 笔记 2 处机制不精确 (cliff top 生成方式 / 分帧的真实目的), 家族丢了"竖直 hatch 沉积纹理 + 棱角崖面"这一签名组合 (Fidenza 尺度下算 voice miss, 但笔记 idiom-1 本身就是按"山峦剪影"重读的, 属于有意重定向 — 建议 parent 裁决)。
+
+---
+
+## L07 INK (Iskra Velitchkova, #497) — 家族 ink-scribble
+
+### Claim 核对表
+
+| Claim | 判定 | 证据 |
+|---|---|---|
+| 自带 sfc32 Random class | ✅ | minified `class Random` (byte 9684): 同款 sfc32 (substr(2,32)/(34,32)), 同款 1e6 预热, `d()` 交替 uA — 与 Eko33 同代差特征坐实 (grep 'sfc32' 0 命中只因函数名被压成 `e`) |
+| ~15 种西语命名笔法, hash 选用 | ✅ | drawMacarra/Carboncillo/CarboncilloMas/GridSuave/Ramonycajal/DomingoMercado(+Detalle)/Delicado(+Vertical)/Novia/Pelo/Maquinaria/LapizCorrido/LineasYcuadrados/... 由 `z.s` switch 分发 (`15==z.s` 等), 每笔法附 `z.f.song` 彩蛋 |
+| 噪声-利萨茹核心: noise(c+sin(e)·freq)·ampX / noise(c+cos(e)·freq)·ampY | ✅ | drawCarboncilloMas: `for(let e=0;e<=TWO_PI;e+=.001){var p=noise(o+sin(e)*l)*t, d=noise(o+3*cos(e)*l)*i; ...}` — o=中心 y, l=freq, t/i=amp |
+| 三遍复笔: "同一曲线画 3 遍, 每顶点独立偏移" | ⚠️ | 实现是**每步在同一 beginShape 里连发 3 个顶点** (基点 + 2 个抖动副本): `pg.vertex(a+4*p,o+4*d), pg.vertex(a+4*p+R.r(4),o+4*d-R.r(14)), pg.vertex(a+4*p+R.r(4),o+4*d-R.r(4))` — 是单笔画内的 zigzag 三重顶点, 不是整曲线描三遍; 之后常再来第二个 beginShape 全 pass (噪声相位不同)。视觉等效"复笔毛边", 机制描述不准 |
+| 抖动幅度 R.r(4)~R.r(44) | ✅ | R.r(4)/R.r(14)/R.r(11)/R.r(12) 遍布; R.r(44)×3 + R.r(41)×1 存在 |
+| 0.001 步进 ≈ 6283 顶点/遍 | ⚠️ 微 | 步进 0.001 ✅, 但部分循环走 `e<=2*TWO_PI` (两圈), 且每步 3 顶点 → 单 shape 实际 ~1.9-3.8 万顶点; "6283/遍"是按单顶点单圈算的下限 |
+| shader 后处理颗粒 | ✅ | 文件开头即 WebGL2 GLSL: `hash(vec2)` 颗粒 + erode/dilate 滤镜组, `aeGris/aeCartulina/aeWorsePerson` 等后处理链 |
+| 45KB / CC BY-NC-SA | ✅ | 45149B |
+
+### 家族对照 ink-scribble (registry.js 678-728)
+
+| 维度 | 判定 |
+|---|---|
+| 噪声-利萨茹闭环 | 对上: `rx=noise(phase+sin(e)*freq, phase)*ampX; ry=noise(phase, phase+cos(e)*freq)*ampY` (L714-715), 参数域闭合与原版同理 (原版 endShape 不 CLOSE, 靠 sin/cos 周期性闭合; 家族 closePath 显式闭合 — 等效, 非发明) |
+| 复笔毛边 | 对上 (声明的降密简化): 2 遍 × 每顶点 jitter 1.5/4px (L709-710) vs 原版每步 3 顶点 + 二次 pass; 递进 jitterAmp 是合理浓缩 |
+| 密度 | 对上: STEP=0.02 ≈ 314 顶点 — 笔记 idiom 4 明说 deck 降密 |
+| 颜色 | 设计决定: 原版黑墨 `stroke(0,s)` + 偶发 `fill(10)` 深色实心块 (p≈0.057); 家族主题色、无实心块 — 缩小版可接受 |
+| 分布 | 家族角落加权 (L698-701, 让开 slide 中心) — 原版全画布均匀 `R.r(-artW/4,artW)`; 功能性 deck 决定且笔记已声明"角落加权散布", 不算 invented |
+
+**严重度: MED** — 笔记"三遍复笔"机制描述不准 (单笔画内三重顶点 zigzag, 非整曲线三遍); 家族无 voice miss。
+
+---
+
+## L13 Naïve (Olga Fradina, #483) — 家族 drift-web
+
+### Claim 核对表
+
+| Claim | 判定 | 证据 |
+|---|---|---|
+| 2D-core, shader 只是后滤镜 | ✅ | 主体画进 `buff=createGraphics(576,1024)`; 最后 `shader(theShader); theShader.setUniform("u_tex0",buff)` |
+| 双相结构: 背景相沉积点 → 重新撒粒子 → 前景相连线 | ✅ | `iters<options.backIterations` 沉积 `thickDots`; `iters==options.backIterations && initParticles()`; 其后 `options.lines.enable && ... drawConnections(l)` |
+| 孪生噪声 nX=noise(x,y), nY=noise(y,x) | ✅ | `noiseProcessing`: `noise((o+3e3)/nF,(e+4e3)/nF)` 与坐标互换的 `noise((e+4e3)/nF,(o+3e3)/nF)` |
+| 算子动物园: round 量化 / sin-of-noise / 双尺度 max·min / addedNoise | ✅ | `options.rounded.enabled && ($=round($*v)/v)`; `sinOfNoise`; `maxOfNoises && ($=max($,t))` (t = nFactor/nDenom 第二尺度); 另有 subtracted/multiplied/moduloNoise (笔记未列全, 不算错) |
+| IQ easing 全套备用 (expImpulse/cubicPulse/gain/parabola/pcurve/sinc) | ✅ | 全部逐字在 (byte ~19100-19700), 另有 polyImpulse/expSustainedImpulse/expStep/falloff |
+| 距离带连线 minDist+maxDist + visiblePercent 概率 | ✅ | `s<options.lines.maxDist && s>options.lines.minDist`; `R.random_dec()<options.lines.visiblePercent && drawConnections(l)` |
+| 速度赋值非积分, 无惯性 | ✅(微注) | `e.vel.x=s*shiftSignDX; e.vel.y=t*shiftSignDY` 每帧覆写 — 无惯性成立; 但 wind/repeller 走 `applyForce→acc`, update() 里 `vel.add(acc)` 在赋值后仍会叠加 — 帧内扰动, 不推翻结论 |
+
+### 家族对照 drift-web (registry.js 960-1070)
+
+| 维度 | 判定 |
+|---|---|
+| 孪生互换噪声 | 对上 (L1017-1018) |
+| 算子人格化 calm 无算子 / balanced 双尺度 max / wild 加量化 | 对上 (WEB_PERSONALITIES L969-1003: quantize 0/0/5, maxOfNoises f/t/t — 与笔记宣称一致) |
+| 距离带 + visible 概率 | 对上 (L1051, L1055) |
+| 双相 | 简化 (允许): 家族相 2 直接在相 1 落点上一次性连线, 不重新撒粒子、不边漂边连 — 原版 `initParticles()` 重撒 + 逐帧连线。装饰尺度合理缩减, 无 voice miss |
+| 边界 | 对上: 家族 wrap (L1038-1041) ≈ 原版 edges() wrap |
+
+**严重度: LOW** — 全部 claim 坐实, 家族忠实。
+
+---
+
+## L23 Pre-Process (Casey Reas, #383) — 无家族
+
+| Claim | 判定 | 证据 |
+|---|---|---|
+| 100 cell | ✅ | `let numCells = 100` |
+| mintNumber 算术 trait %8/%3/%5 | ✅(微注) | `mintNumber += 1; surface = mintNumber % 8; origin = mintNumber % 3; growth = mintNumber % 5;` + 0→上限 remap (`if(surface==0) surface=8`) — 笔记省略了 +1 与 remap, 结论 ("#N 性格可预告") 不受影响 |
+| hash 与序号 trait 互补 | ✅ | 位置/角度来自 `r = new RND()` (hash 种子), trait 来自序号 |
+| 图层布尔开关组 drawCenter/drawPerimeter/drawAngle/fillCell/textOn | ✅ | `setParameters()` 按 surface 1-8 设置这 5 个布尔 + networkMode |
+| 相触连线 | ✅ | `distance < cellwidth/2 + other/2 - 1 → friends[]`, `displayNetwork()` 画 LINES; networkMode 1 为 alpha 渐积变体 |
+| 圆心点/周界圈/角度刻线 + globalSpin | ⚠️ 微 | drawCenter (圆心点) ✅, drawPerimeter (周界圈) ✅, `globalSpin=0.0125` ✅; 但 drawAngle 画的是周界上的**小圆点** (`ellipse(ax,ay,ds/2)`), 不是"刻线" |
+
+**严重度: LOW** — 仅表面用词 (角度刻线→角度点)。
+
+---
+
+## L42 Trossets (Anna Carreras, #147) — 无家族
+
+| Claim | 判定 | 证据 |
+|---|---|---|
+| 具名 trosset 画家字典按格抽签 | ✅ | 13 个画家函数经 `trosset(s)` 按 id 0-12 分发; `assignaTrosset()` 逐格赋 id |
+| "16 个具名画家" | ❌ | 实际 **13 个** (L/R/H/V/P/X/M/VV/XX/LL/PP/MN/MS), 分发表止于 `12==s && trossetMS()` |
+| 抽签按邻格已定画家过滤 possibles, "字典+约束传播 = 手写 WFC" | ❌ **INVENTED** | `assignaTrosset(){for(...) trossos[s].id = possibles[int(r.rb(0,len))]}` — possibles 是**全图一次性**按 `q=r.rb(0,195)` 从 p0..p30 选出的子集 (line 74 三元链), 每格**独立均匀抽取, 零邻格逻辑**。跨格观感靠的是 Truchet 式约定 (图元端点固定在 .25/.5/.75 分数位, 任意相邻都能接上) + 绘制时 `scale(2*w)` 超出格子一倍造成交叠 — 不存在约束传播 |
+| 字典键方向语义 (L/R/H/V) | ⚠️ | H/V 确实横线/竖线 (`liniaH: line(.25,.5,.75,.5)`); L/R 对应 arcsD/arcsE (加泰兰 dreta/esquerra 右/左弧) — 命名有语义, 但"邻格衔接靠方向命名约定成立"是过度引申 (见上, 无衔接机制) |
+| 地名调色板 cMontseny/cSalines/cIbiza/cAltafulla/cOlivos, 5 色一组 | ⚠️ | 5 个名字全部在 ✅, 每组 5 色 ✅ (`c1..c5 = cTots[numc][0..4]`), 共 19 组; 但命名不全是地名 — 还有 cPaella/cTortilla (食物)/cBarraca/cIndustria/cAlzines/cBuganvilea (物/植物), "加泰生活命名"更准 |
+| 松弛感来源: "缠线端点带 ±抖动, 笔触不严格" | ❌ **INVENTED** | 全脚本 `r.rb` 只出现在 setup/creaTrossos/assignaTrosset (格子细分与抽签); **所有绘制图元是精确几何** — `arc(.75,.25,.5,.5,90°,180°)`, `line(.25,.5,.75,.5)`, 端点零抖动。松弛感真实来源: ~7-11% 概率的格子四分细分 (`r.rb(0,1)>r.rb(pMin,pMax)` → 4 个半尺寸 trosset) + `scale(2*w)` 的相邻交叠 + 童趣图元词汇 |
+
+**严重度: HIGH** — 笔记两处核心机制是发明的 (约束传播式抽签、笔触端点抖动), 外加画家数量错 (16→13)。idiom 1 的"字典+约束传播"结论建立在不存在的机制上; 若 cargo-dashes v2 照此采纳需改写为 "Truchet 端点约定 + 全局子集抽签"。
+
+---
+
+## L46 Scribbled Boundaries (William Tan, #131) — 无家族 (NIFTY, 零 port)
+
+| Claim | 判定 | 证据 |
+|---|---|---|
+| hash 字节查表二段跳 | ✅ 逐字 | `sp=[40,40,70,120,150,75,100,150,170,200,220]; rp=hi.slice(0,9).map(v=>sp[parseInt(v*(sp.length-1)/255)])` — 与笔记引文一致 (含重复 40) |
+| graphics[] 多层离屏合成 | ✅ | createGraphic/endGraphic 按笔画预算切层 (`forcount>(grindex+1)*sPerLayer` 换层); draw() 里逐层 `image(graphics[i],...)`, 鼠标移动时各层按 `Math.abs(l/2-i)/(l/2)` 视差偏移 |
+| 边界折返加密, 密度即轮廓, 无需描边 | ✅ | `class scribble_gr.display()`: 随机游走 curveVertex 链, 候选点命中任一 mask 形状 (inCircle/isInside/inBlock/inParting/...) 时**跳过该顶点且 prevx/prevy 不动** — 笔停在边界原地重试, 密度在形状外缘堆积, 形状区留白成形。机制 = 拒绝采样式折返, 与笔记 recipe 描述相符 |
+| 23KB / NIFTY | ✅ | 22708B; 无家族, 合规 |
+
+**严重度: LOW** — 全部坐实, 引文精确。
+
+---
+
+## L48 CENTURY (Casey Reas, #100) — 无家族
+
+| Claim | 判定 | 证据 |
+|---|---|---|
+| `let janky = true` 具名布尔 trait | ✅ | line 4 逐字; 随后 hash 重抽 `r.rb(0,1)>0.7 → janky=true` (p=0.3) |
+| janky 统一控制切片边缘错位 | ✅(微注) | 唯一消费点 sliceBuffer: `janky==true && randomized==true → slices[which].display(x + slices[which].xoffset)` (首尾切片豁免) — 控制的是**切片 x 错位**一处机制, "抖动/错位"的"抖动"略宽 |
+| 双调色板配对 colorsA + lineColorsA 分池 | ✅ | 且共 4 对 (A/B/C/D) 按 rc 阈值 0.63/0.95/0.99 选; lineColorOptions 再限制线色池深度 `int(r.rb(2, lineColors.length+1))` |
+| maxSlices=50 + sliceOrder 洗牌 | ✅ | line 7 `let maxSlices = 50`; `randomSequence(): sliceOrder=scrambleArray(...)`, 另有 orderedSequence() 有序变体 (构图=排列 成立, 且排列/恒等二态) |
+| #100 编号即概念 | 🔍 | 平台元数据, 脚本内不可核 (合理的外部事实) |
+
+**严重度: LOW** — 全部坐实。
+
+---
+
+## 跨课观察
+
+1. L06/L07 的 sfc32 + 1e6 预热 + 交替双流是同一份社区样板 (变量名都同构), 笔记"后期标配"判断被两份脚本互证。
+2. batch-C 唯一系统性问题在 L42: 笔记把 Truchet 式"任意相邻皆可接"的静态约定, 误读成了动态"约束传播/WFC", 又给精确几何脑补了笔触抖动 — 两者都是把"观感"反推成"机制"的失误 (与 feedback_read_source_before_porting 同型教训)。
+3. 三个家族 (sediment-layers / ink-scribble / drift-web) 均无 invented detail; 唯一 voice 问题在 sediment-layers 的面内竖直 hatch 纹理缺失 (原作"沉积"质感的来源)。

--- a/docs/superpowers/artblocks-study/audit/batch-D.md
+++ b/docs/superpowers/artblocks-study/audit/batch-D.md
@@ -1,0 +1,185 @@
+# ArtBlocks 二读审计 — batch-D
+
+课程: L08 / L10 / L17 / L30 / L31 / L34 / L37 / L38
+方法: 笔记 claim 逐条对照链上原脚本 (prettier 展开后阅读, `<scratchpad>/ab-scripts/pretty/`)。
+家族对照: `sdf-js/src/present/decor/registry.js` (行号以当前 main 为准)。
+
+---
+
+## L08 Box Light Studies — Lieberman (#499) · 家族 light-edges · **MED**
+
+### Claim 核对
+
+| Claim (笔记 08-*.md) | 判定 | 证据 (L08-499.js pretty) |
+|---|---|---|
+| p5 WebGL, 41KB | ✅ | 41245 bytes; p5.RendererGL patch, createFramebuffer polyfill (L549-556) |
+| 盒体几何: rotateX/Y/Z 三函数 + 棱线投影, 每棱=(ptA,ptB,colorA,colorB) | ✅ | 函数 i/a/n = 三轴旋转 (L22-42); f() 8 顶点 + 24 indices=12 棱 (L133-150); s() setUniform ptA/ptB/colorA/colorB/lineId (L72-100) |
+| 多 pass fbo 链: initShader → iterShader (3×3 邻域 jump-flood) → voroShader (spiral 补洞 + 距离衰减) | ✅ | process(): fbo2/fbo3 乒乓, stepP 从 1024 逐半 11 轮 (L839-874); voroShader `spiral(int n)` 600 次搜索 + `d=mix(1.,d,dScale)` (L777) |
+| **distShader (距离→亮度) 作为管线一环** | ❌ | distShader 与 drawShader 仅 createShader (L779, 783), **全文无第二处引用 — 死代码**。真实柔光 = `_` 渲染器: trace() 沿距离场 100 步 2D raymarch × 每像素 8 方向随机射线 × 累积 250 帧 (`250 < c ||` L937) 的渐进式 2D 光传输, 不是"距离直接映射亮度" |
+| line shader: 沿线渐变双色 + 光晕 | ⚠️ | 双色渐变 shader D (`mix(mix(colorA,colorB,.4),…,pct)` L984) 是**弃用代码**: L152 `createShader(T,D)` 返回值未接, `z=createShader(T,C)`。活 shader C 的棱色 = 三通道 simplex noise 按 lineId 键控 + doubleExponentialSigmoid 整形 (L986); colorA/colorB uniform 永远传白/黑 (`d={a:[1,1,1,1],b:[0,0,0,1]}` L155) 且 C 不声明该 uniform |
+| 稀有度: colorMode / seethrough 等 hash 决策 | ⚠️ | settings 表 (L988-995): seethrough (float 0-1) 与 look (int 0-10) 是真 hash trait; **colorMode/drawMode/palette 均 min==max, 恒为常量 1** — 真正的形态开关是笔记未点名的 `look` (11 档, 直接字符串替换进 shader L909-913) |
+| 本质是 shader 作品, p5 只是宿主 | ✅ | 全部美学在 GLSL: JFA 场 + raymarch 光传输 + look 分支 BRDF; p5 只画种子线 |
+
+### 家族对照 (registry.js `drawLightEdges` L739-796)
+
+| 维度 | 对照 |
+|---|---|
+| 构图: 棱线即光源 | 对上 — 4-6 个盒, 每棱独立描 (递归写在注释里的分流判定成立) |
+| 盒构造 | 偏差 (可接受): 旋转正方形 + 固定 (dx,dy) 斜移 = 2.5D 伪盒 (L751-767); 原作真 3D 旋转 + 逐盒递增转角 + 网格/线性/吸附多种摆位 (m() L192-311)。装饰尺度简化, 不算错 |
+| 辉光 | 声明式近似 ✓: 宽×0.25α → 中×0.5α → 窄×全α 三层 (L780-784), 与笔记 idiom 2 一致 (笔记已声明这是 2D 近似而非原机制) |
+| **颜色: 双色棱 (两半各一色, L771-778)** | **INVENTED DETAIL (间接)**: 该机制源自原作的**死 shader D**; 链上实际渲染的棱色是 noise 场渐变 (彩虹微渐变), 从不出现"两端两色"的分段。家族忠实实现了笔记的 idiom 3, 但 idiom 3 本身读的是弃用代码 |
+| 碰撞/去重 | 原作有共线近距棱去重 (函数 l, 阈值 5/0.01, L117-132) + X 模式 3-7 段随机切分; 家族无 — 装饰尺度可接受 |
+
+**严重度 MED**: 笔记两处渲染层机制错误 (distShader 死代码当活 pass; 双色渐变 shader 死代码当活机制), 一处稀有度不精确 (colorMode 恒定, 漏掉真开关 look)。家族视觉方向 (棱=光, 分层 glow) 成立; "双色棱"是踩在死代码上的发明细节, 但装饰效果无害。
+
+---
+
+## L10 while true — Wander (#498) · 家族 hex-lattice · **LOW**
+
+### Claim 核对
+
+| Claim | 判定 | 证据 (L10-498.js pretty) |
+|---|---|---|
+| 原生 WebGL 23.7KB | ✅ | 23714 bytes; WebGL2 (`#version 300 es`) |
+| cubic→cartesian: x'=√3·(x+y/2), y'=1.5·y, RT3=√3 | ✅ | vertex shader `const float RT3 = sqrt(3.0)`; `cubic_to_cat: vec2(RT3*(o.x+0.5*o.y), 1.5*o.y)` (L841) — 逐字符合 |
+| vertex 只做实例化摆放 | ✅ | apply_tfm: axial→cubic (q,r,s=-q-r), w<0 翻转, rotate_k 绕 normalize(vec3(1)) 转 (L841); tfm/col 均 per-instance attribute + vertexAttribDivisor (L971-979) |
+| fragment 只做 OKLab→sRGB | ✅ | fragment 全文 = oklab2rgb + rgb2srgb (L842), 无其他逻辑 |
+| class G random tape: 预抽 I 个 float, float(t,min,max)→[下一游标,值] | ✅ | class G (L876-900): `values=Array(I).map(()=>l.float())`; `float(t,s,e)` 返回 `[this.step(t), i*(e-s)+s]` — 显式游标、引用透明, 完全符合 |
+| (补充发现) | — | 磁带长度 I = `[2048,2048,2048,2048,8][h.int(5)]` (L186): 4/5 概率 2048, **1/5 概率仅 8** — 短磁带循环复用是一个笔记未记的 trait 杠杆 |
+
+### 家族对照 (registry.js `drawHexLattice` L911-958)
+
+| 维度 | 对照 |
+|---|---|
+| hex 数学 | 对上: `RT3*R*(q + row%2*0.5), 1.5*R*rr` (L930-931) — odd-row offset 形式 ≡ 立方坐标规范式 |
+| OKLab lerp | 对上: rgbToOklab/oklabToRgb (L873-898) 常数与 Ottosson 参考及原作 shader 一致; lerpColorOklab 沿种子化方向打渐变 (L935-939) |
+| 分布 | 声明式: noise gate >0.52 稀疏留白 (L932-933) + (q+rr*3)%4 选择性填充 — 笔记 port 判定写明"六边形铺陈+OKLab 渐变+种子化稀疏填充", 家族=自己的 recipe, 成立 |
+| 形状构造 | 偏差 (可接受): 家族描 hex 轮廓线+偶尔填充; 原作从不描 hex 边框 — 它在格上实例化填充图案件 (三角形细分 subs)。recipe-only 下的自由发挥, 无签名丢失 (原作签名=感知均匀渐变+hex 织物, 家族保住了两者) |
+
+**严重度 LOW**: 全部 claim 被源码逐字证实 (含 RT3、游标返回形状)。
+
+---
+
+## L17 Cargo — Asendorf (#426) · 家族 cargo-dashes · **LOW-MED**
+
+### Claim 核对
+
+| Claim | 判定 | 证据 (L17-426.js pretty) |
+|---|---|---|
+| 管线三段 C2dImage → c2dMotion → gl.render | ✅ | L1 `const C2dImage`, L1742 `const C2dMotion`, L1625 `render = renderFeedback + renderDraw`; 主循环 L1874-75 |
+| 画家字典 dashed[0..7], 每个 (x,y,w,h)=>{} 闭包 | ✅/⚠️ | dashed[0..7] 确实存在 (L12-96: 4 横 + 4 竖)。但它只是 **8 本字典之一**: dashed/noise/grid/boxes/area/framed/rectangle/gradient 各 ~8 画家 (drawSymbol switch t=0..7, L904-938), 共 ~64 画家 + 8 种抽签策略 (case 0-7 含 rythm 计数器) + 9 种切块结构。笔记把"虚线字典"当唯一美学根基, 以偏概全 |
+| 2 的幂行距 yStep = 2^random_int(0,2) | ✅ | L14 `let yStep = pow(2, R.random_int(0, 2))` — 逐字 |
+| 整数 dash [1..8, 1..8] | ⚠️ | dashed[0]/[4] 逐字符合 (L15/57); 但 dashed[1]/[5] 用 [1..8,1..16] 四组轮换, dashed[2]/[6] 用 [1..4,1..16], dashed[3]/[7] 用 [1..2,1..16] — 参数空间比笔记写的大一倍 |
+| pixel-sorting 退为 GPU 运动层 | ✅ (recipe 级) | 运动 = cellular-noise 位移 (r 通道 8 bit 各控一档频率) + reset 图案 (g 通道) 的 feedback shader (L1592), 控制图由 C2dMotion 按 rect 涂 RGB (L1830-38)。不是字面 pixel-sorting, 笔记措辞"退为运动层"成立 |
+| 静态构图可 port, 运动层不 port | ✅ | 构图全在 Canvas2D (C2dImage.draw → getImageData L1403) |
+
+### 家族对照 (registry.js `drawCargoDashes` L1091-1167)
+
+| 维度 | 对照 |
+|---|---|
+| 画家 4 本: 横虚线/竖虚线/疏点线/淡实面+框 | 对上: 分别对应 dashed[0] / dashed[4] / dashed[3] (疏点 [1..2, 长 gap]) / framed·rectangle 族 (原作有实面+框画家, L450/594 验证) |
+| 2 的幂行距 | 对上 (放大 ×2 适配装饰尺度): `pow(2, 1+rand*3)*2` (L1099) |
+| 整数 dash | 对上: `[1+rand*8, 1+rand*8]` (L1100) — 取的是 dashed[0] 的字面参数空间 |
+| 切块 | 对上 (简化): 行 × 随机切点 (L1147-1158) ≈ 原作 drawStructureColumns/subdivRows 的行式结构 |
+| 人格 = 字典开放页数 calm2/balanced3/wild4 | 对上: CARGO_PERSONALITIES painters 2/3/4 + `.slice(0, B.painters)` (L1086-88, 1144) |
+
+**严重度 LOW-MED**: 家族维度全对上; 唯一实质不精确是笔记把 8 本字典 ~64 画家收窄成"一本 dashed 字典 8 画家" — recipe 结论 ("字典×抽签是复利资产") 反而被更强地支持, 但事实陈述以偏概全。
+
+---
+
+## L30 phase — Bednar (#143) · 无家族 · **CLEAN (LOW)**
+
+| Claim | 判定 | 证据 (L30-143.js pretty) |
+|---|---|---|
+| 管线署名 drawArt → blurArt → blendArt → compositeArt → renderFinal | ✅ | 五个函数逐名存在 (L458/479/501/526/547); 主循环按此顺序调用 (L888-908) |
+| 自带 compileShader 工具函数 | ✅ | L448 `function compileShader(e,t)` — 被 6 处 shader 编译复用 |
+| 零 p5 几何调用 (rect/line 均 0) | ✅ | 全文无 `rect(`/`line(` 绘图调用 (grep 0 hit); 条纹在 artFragmentShader 里算 |
+| blur-then-blend (模糊是混合前置件) | ✅ | phaseLevel switch: `blurArt(target, target2, 0..3)` 先行, `blendArt` 随后 (L890-906); phaseLevel=4 档直接 blend 不 blur |
+| hexToHSV / HSLtoHSV 双色彩空间桥 | ✅ | L391 `function hexToHSV`, L431 `function HSLtoHSV`, palette 处理 L367 |
+
+**严重度 LOW**: 五条全部逐字证实, 无家族。文档课判定 (条纹柔度住在 GPU pass 链, 不 port) 与源码一致。
+
+---
+
+## L31 Subscapes — DesLauriers (#53) · 无家族 · **CLEAN (LOW)**
+
+| Claim | 判定 | 证据 (L31-53.js pretty) |
+|---|---|---|
+| 内嵌完整 oklab→sRGB 矩阵 | ✅ | L21-42: l_/m_/s_ 系数 0.3963377774/0.2158037573… + 输出矩阵 4.0767245293/-3.3072168827/… (输入实为 OKLCH: L/100, C·cos(H°), C·sin(H°) — 比笔记说的还多一层 LCh 包装, 不矛盾) |
+| 2021 年即采用 (比 L10 早两年) | 🔍 | 脚本本身无日期; #53 项目号与公开铸造时间一致, 采信但源码不可证 |
+| BSP 切向由块的 o/c (宽高比) 加权 | ✅ | L74: 切向 = `((e=1,t=1)=>0.5>oe()/d(e,t))(o/c, f)` — **变量名就是 o/c** (o=宽 c=高, L53-54), 随机数除以 pow(宽高比, f) 决定横竖 — 高块竖切宽块横切, 逐字证实 |
+| min-size 停机在 filter 里 (s 谓词), 剖到极限的块静默丢弃 | ✅ | L78 `e.C = t.filter(s).map(…)`; s = `f>=n && o>=n` (L81-86) — 谓词名也是 s。子块不合格即整支丢弃 → 自动留白 |
+
+**严重度 LOW**: 三条可核 claim 全部到变量名级别证实。
+
+---
+
+## L34 Gazers — Kane (#215) · 无家族 · **LOW**
+
+| Claim | 判定 | 证据 (L34-215.js pretty) |
+|---|---|---|
+| 每帧 uD = new Date, 时/分/秒/月/日全入渲染参数 | ✅ | draw() 开头 L44-49: uD/hR/mI/sZ/mH/dY; 光位 lX/lY 由 时+分 映射 (L64-71) |
+| 真实月相驱动构图 (gMN=月相计算) | ✅/⚠️ | 月相真实: `lc = 2551443` 秒 = 朔望月 (L1791); gLP() = (距参考新月时间 mod lc)/86400 映射到 0-8 相位 (L1379-1390); gNP() = 距新月秒数/lc (L1044)。**但 gMN 是月亮绘制例程 (L145), 月相计算是 gLP/gNP** — 函数名张冠李戴, 机制本身对 |
+| 跨年夜彩蛋 `11==mH && 31==dY && 23==hR` 时 map 分钟做过渡 | ✅ | L57 逐字: `nY = 11==mH && 31==dY && 23==hR ? map(mI,0,60,0,0.2) : 0`; nY 驱动 frameRate+300·nY 加速 (L133) |
+| URL hash 参数覆盖 location.hash.split("\|"), 身份/视图两层分离 | ✅ | L53 `aR = window.location.hash.slice(1).split("|")`; aR[4] 显示模式, aR[9] mN, aR[10] 亮度 fR, aR[7]/[8] 光位覆盖 — 全是视图参数, tokenHash 身份不动 |
+| 午夜整点触发 sDY() 重算 | ✅ | L52 `1==sP && 0==hR && 0==mI && 0==sZ && sDY()`; sDY 按距参考日天数重放 seed 流 (L410-424) |
+| (笔记未记的 trait) | — | 参考"新月"日期 nM 按稀有度从 Kane 个人纪年里选 (theDream/firstSale/firstOnePersonShow…, L861-875 + L1650-58) — 传记日期作 trait, 有趣但不影响审计 |
+
+**严重度 LOW**: 唯一瑕疵是 gMN 函数名指认错位 (⚠️ 表面级)。三层时钟论点 (氛围/构图/事件) 被源码充分支撑。
+
+---
+
+## L37 The Blocks of Art — Shvembldr (#74) · 无家族 · **HIGH (笔记事实错误)**
+
+| Claim | 判定 | 证据 (L37-74.js pretty) |
+|---|---|---|
+| 95×110 固定面板 | ✅ | L17-18 `panelWidth = 95*M, panelHeight = 110*M` |
+| makeHex 六角点集工具: 60° 步进一圈 | ✅ | L10-13 `r += 60` (angleMode DEGREES); 起始角 30° |
+| 量产纪律: 同一 panel 引擎变造型库 (things) | ✅ | things = 从 f 数组 (thing0/thing1/… 多造型函数+参数包) 随机分配 (L323-325); 每帧 `things[t].thing(back, time, params)` (L335-337) — 且是**动画**的 |
+| **"面板网格, 每格一件带边框独立小作品; backs/things/images 三层结构"** | ❌ | **构图不是平面面板网格, 是错行 hex 格上的等距立方体 (isometric cubes)**。证据: makeHex 造 5×4 错行六角格 (L49-60); draw() 里每个 hex cell 画**三张剪切面**: `shearY(30)` 顶/左面、`shearY(-30)` 右面、`shearY(30)+shearX(-41)` 第三面, 各自 clip 后贴一张 95×110 面板 (L338-363)。**images 不是"层" — 是每块立方体的三张脸**: `images = backs 三张一组` (L327-330)。backs=离屏画布, things=画家, images=三面组。标题 "The Blocks of Art" 的 Blocks 是字面义: 积木块 |
+| 格内自治 + 格间秩序 | ⚠️ | 精神成立 (每面确实是独立动画小作品, 面有 stroke 边框 L340-341), 但"画廊挂画"读法漏掉了核心视觉身份: 挂的不是画, 是转印在立方体三面上的画 |
+
+**严重度 HIGH** (按判定尺度: 笔记讲错了原作机制): "三层结构"与"面板网格"是对构图的误读 — 原作是六角格等距立方体阵, images 是立方体的三张脸不是三个图层。无家族继承, 损害封闭在文档层; panel-as-mini-canvas 这条 idiom 本身仍然成立 (以"面"为单位)。建议笔记改写分流判定段。
+
+---
+
+## L38 Ringers — Cherniak (#13) · 家族 peg-wraps · **HIGH**
+
+### Claim 核对 (字符串数组混淆, 经查表解读)
+
+| Claim | 判定 | 证据 (L38-13.js pretty) |
+|---|---|---|
+| 骨架: pegs 网格 + getTangents + pAlg + shrinkConcavePegs + connects | ✅/❌ | 名字都在字符串表 (L1-64); **但 pAlg 不是"缠绕算法"** — `ps.pAlg = rp[7]<220 ? G_ALG : R_G_ALG` 选的是**钉子布点算法**: pOnGrid (规则网格 gridD 3-6, L237-249) vs pOnRGrid (递归细分网格, L250-262)。缠绕算法在 Ring.generate (L343) |
+| 构图即排列: 一个访问排列 + 每钉侧别 | ⚠️ | 不是自由排列: points = 全部钉洗牌后取 sampleRate (0.5-0.8) 的**子集** (sampleSize L296-300), 然后**按绕质心的极角排序** (`this.points.sort` 按 atan2 差, L355-368, forceCentroid 可移质心 L154) — 访问顺序是确定性的角排序, 组合空间的结构 = 子集 × 参数, 不是排列 × 侧别序列 |
+| 切线几何: 同半径圆外切线 = 圆心连线垂直偏移 ±R; 异侧走内切线出交叉 | ⚠️ | getTangents (N(171), L450-476) 是**完整的双圆 4 切线通解** (外 c=1 / 内 c=-1), 支持不等半径 — 且半径确实会变: vRad = BIGGER_NEAR_RAD/BIGGER_FAR_RAD 按离画布中心距离缩放钉半径 (L159-168), C_RAD 恒定只是常见档。切线选择由**凹凸性**驱动: isConcave 来自相邻钉叉积 (L369-386), wrapped 模式按两端凹凸组合选 l[0]/l[1]/l[2]/l[3] (L387-400) |
+| 绳是主角: 钉画静点, 绳 arc+tangent 交替一笔连续 | ✅ | Ring.draw: beginShape → 逐弧采样 vertex (100·width/800 步) → 切线端点 vertex → endShape (L312-342); strokeWeight 8 (参考宽 800) 粗绳 (L130, L144) |
+| **shrinkConcavePegs: 凹侧钉半径微缩, 绳贴得更紧** | ❌ | 收缩只发生在**绘制期**: `ps.shrinkConcavePegs && s.isConcave && s.r >= 2*strokeW && (a *= 0.4)` (L200) — 缩的是画出来的钉圆直径 (×0.4), **绳的路径用原始 r 计算, 完全不动**。视觉效果是绳松松地绕在变小的钉子外围 (更"ring"), 方向与"贴得更紧"相反 |
+| (笔记未记的签名) | — | ① 绳是**闭环**: 遍历 (t+1)%len 回到起点 — 项目名 Ringers 的 ring; ② 闭环可**填充** (ps.fill, 填 hlCol/secCol, L173-177); ③ **单个随机高亮钉** (g = rngFloor, 命中者用 hlCol #f2c945 等, L183-196) — Ringers 最有辨识度的 trait 之一; ④ 钉子可画同心环 (concentric, L199-221); ⑤ 32 字节 hash 逐字节直读作参数 (setupPs L263-269) |
+
+### 家族对照 (registry.js `drawPegWraps` L1386-1472)
+
+| 维度 | 对照 |
+|---|---|
+| 钉网格 + 静点 | 对上: 规则 cols×rows 网格 (L1402-1409), 钉画淡点 (L1424-1429) ≈ pOnGrid + C_RAD |
+| 同半径外切线 ±R 偏移 | 对上 (同半径特例数学正确, L1441-1450); 原作是 4 切线通解+变半径 — 装饰尺度简化可接受 |
+| 弯折处 ctx.arc 连续路径 | 对上: 上一切点→本切点绕钉 arc (L1451-1458), arc+tangent 交替 ✓ |
+| **访问顺序: 无重复随机游走** | **VOICE MISS**: 原作是洗牌子集 + **绕质心角排序** → 绳呈现为环绕钉云的整齐缠绕带, 交叉只出现在凹钉处; 家族的自由随机顺序让绳在钉阵里乱穿, 读作 scribble 而非 wrap |
+| **绳端: 开放折线 (i→i+1, 不闭合)** | **VOICE MISS**: 原作绳永远闭合成环 (Ringers 之 ring), 且可填充成实心色块 — 与 Fidenza 先例"细描线代替 fat closed ribbon"同类: 丢了闭合缠绕带这一签名形态 |
+| **侧别: 逐钉严格交替 (weave = i%2, L1444)** | **INVENTED DETAIL**: 原作从不交替 — 侧别由角排序多边形的凹凸性决定 (isConcave); 交替产生的规律性内切线交叉是我们发明的机制 (视觉上近似"编织", 但节奏与原作不同源) |
+| 高亮: 所有被访问钉都点亮 (L1464-1470) | 偏差: 原作只高亮**一个**随机钉 (孤点色彩是其辨识度来源); 全亮反而稀释。顺带丢了 fill/concentric 两个次级签名 (装饰尺度可谅解, 单高亮钉本可零成本保留) |
+| 颜色/alpha/粗细 | 设计决定 (主题色 + intensity), 不算错; 但原作 fat rope (strokeWeight 8/800) vs 家族 `P.lineWidth*1.1` 细线, 与"绳是主角"的权重分配相悖 — 记在 voice 项下 |
+
+**严重度 HIGH**: 笔记 2 处机制错误 (pAlg 指认错、shrinkConcavePegs 方向反) + 1 处结构不精确 (排列说), 家族丢 2 个签名特征 (闭合环 + 角排序缠绕带 → 开放随机 scribble) 并发明 1 个机制 (逐钉交替侧别)。根因链: 笔记把"排列+侧别"当参数结构 → 家族照笔记实现 → voice 漂移。修法 (recipe 级): 访问序改为绕质心角排序 + 闭合回起点 + 单钉高亮, 三改都不增加代码量级。
+
+---
+
+## 总结 (每课一行)
+
+- L08 Box Light Studies — MED: distShader/双色渐变 shader 均为死代码被当活机制 (真柔光=8 射线×250 帧 2D raymarch 累积; 真棱色=noise 场), 家族"双色棱"踩在死代码上
+- L10 while true — LOW: 全部 claim 到字面级证实 (RT3 公式/OKLab fragment/游标磁带); 补充: 磁带 1/5 概率仅 8 格
+- L17 Cargo — LOW-MED: 管线/2^k 行距/dash 参数逐字证实; 但"8 画家字典"实为 8 本字典 ~64 画家, 以偏概全
+- L30 phase — CLEAN: 五 pass 署名/compileShader/零几何调用/双色彩桥全部逐字证实
+- L31 Subscapes — CLEAN: OKLab 矩阵/o-c 宽高比加权/filter 谓词 s 全部到变量名级证实
+- L34 Gazers — LOW: 朔望月常数 2551443/跨年彩蛋/hash 视图层/午夜 sDY 逐字证实; 仅 gMN≠月相计算 (是绘制例程)
+- L37 The Blocks of Art — HIGH: 构图误读 — 原作是 hex 格等距立方体 (三张剪切面各贴一块 95×110 面板), "backs/things/images 三层结构"里 images 是立方体三面不是三图层
+- L38 Ringers — HIGH: 笔记 pAlg 指认错 + shrinkConcavePegs 方向反 + "排列"失准 (实为子集×角排序); 家族丢闭合环+缠绕带签名, 发明逐钉交替侧别

--- a/docs/superpowers/artblocks-study/audit/batch-E.md
+++ b/docs/superpowers/artblocks-study/audit/batch-E.md
@@ -1,0 +1,131 @@
+# 二读审计 — batch-E (L09 / L26 / L33 / L41)
+
+方法: 逐 claim 对照链上原文 (scratchpad/ab-scripts/) + registry.js 家族函数。
+判定尺度按 brief: 刻意简化不算错; 只标 VOICE MISS / INVENTED DETAIL / 笔记事实错误。
+
+---
+
+## L09 Cytographia — Golan Levin (#487) · 家族 nib-flourish · 总评 MED
+
+### Claim 核对表
+
+| # | 笔记 claim | 判定 | 证据 (L09-487.js) |
+|---|---|---|---|
+| 1 | shader 材质部门: frag_paper / frag_blur / frag_comp | ✅ | 三个变量均存在。frag_paper = 程序纸纹 (uNoiOff/uGLNoi/expSg/elW 噪声整形); frag_blur = 可分离 blur (uTexelSize/uBlur); frag_comp = overlay 混合合成, 含 `U sampler2D texRevTxt; U F uReverseTextAmount` = 背面文字透印 (笔记的"水印") |
+| 2 | 笔尖 vertex shader: 宽度 = 基宽 × nib(方向 vs nibAngle, nibStrength) × iqPerlinNoise6 | ✅ | vertex shader main: `F orientation=aPosition.z; ... F noise=iqPerlinNoise6(noiseFrequency*noiPos)-0.5; F th=zoom*thickness*(1.+noiseAmplitude*noise); F ns=nibStrength*0.5; th*=((1.-ns)+ns*cos(2.*(orientation+nibAngle))); px+=th*cos(orientation); py-=th*sin(orientation)` — 三因子乘法结构逐字吻合 |
+| 3 | iqPerlinNoise6 = 6 倍频噪声 | ✅ | `for(int o=0;o<6;o++){f+=iqNoi(uv)*ampl;ampl*=noiseFalloff;uv=m*uv;}` m=mat2(1.6,1.2,-1.2,1.6), 经典 IQ fbm |
+| 4 | StyledPolyline 是书法渲染载体 | ✅ | class StyledPolylineRenderer: `drawStyledPolyline(...)` setUniform("nibAngle",n)/("nibStrength",f) → `displayShaderTriangleStrip` — 填充三角带, 非描线 |
+| 5 | stamp corrupter | ✅ | `frag_corrupterb64`(base64 GLSL) → `shaderStampCorrupter=ogCorruptedStamp.createShader(...)` |
+| 6 | asemic 字形系统 | ✅ | `makeAsmSys()` + "asemic" ×3 |
+| 7 | 细胞/blob = "converge 增长算法 + 相交检测" | ⚠ | **converge() 不是增长算法** — 它是 marching-squares 等值线追踪器里的边二分收敛步: getFieldAtPix 四角位掩码 (i\|=1/2/4/8) 走格, converge 在 cell 边上二分逼近等值点, 失败信息 `"FAILURE: blob with "+d`。blob 来自隐式场取等值线, 不是 converge "长"出来的。checkIntersection (线段相交) ✅ 存在 |
+| 8 | CC BY-NC 4.0 | 🔍 | 脚本内无 license 文本 (来自 AB 元数据, 无法从脚本核) |
+
+细节 nuance (不扣分): shader 里 orientation 是每顶点的偏移法向角 (aPosition.z), 不是行进方向; cos(2θ) 周期 π, 与"行进方向 vs 笔尖角"表述只差 π/2 相位, recipe 级等价。噪声按空间位置采样 (noiPos), 不是沿路径参数。
+
+### 家族对照 nib-flourish (registry.js L805-859)
+
+| 维度 | 对照 |
+|---|---|
+| 形状构造 | ✅ 对上: 沿路径逐点算半宽 → 左右偏移成飘带多边形 **填充** (L836-856) = 原作三角带填充的 canvas 等价, 无 Fidenza 式细描线问题 |
+| nib 因子 | ✅ `0.25+0.75*|sin(qa-nibAngle)|` (L842) vs 原 `(1-ns)+ns*cos(2(θ+nib))` — 同为周期 π 的方向调制族, voice 保住 |
+| 噪声呼吸 | ✅ `0.6+0.4*noise(phase+k*0.3,...)` (L843) — 沿路径参数化 vs 原作空间场采样, recipe 级等价 |
+| 一支笔 | ✅/⚠ `nibAngle = rand()*π` 全画一支笔 (L811); 原作 nibAngle 是 drawStyledPolyline 的逐调用参数, 可以每类笔画不同。缩小版一支笔合理 |
+| **端点 taper** | **INVENTED DETAIL (LOW)**: `taper=sin(π·t)` 两端收尖 (L841) — 原 shader 无弧长 taper (顶点只知 orientation, 不知 t)。与 Fidenza 半圆端帽同类: 我们发明的收尾 |
+| 颜色/alpha | 设计决定: 主题色 + alpha≤0.22 (L850) vs 原作黑墨 `fill(0,0,0)` — 允许 |
+| Attribution | ✅ L3023: after Cytographia / Golan Levin / #487 recipe-only |
+
+**严重度: MED** — claim 7 "converge 增长算法" 讲错机制 (等值线追踪 ≠ 增长); 家族发明了端点 taper (轻)。核心 idiom (宽度=方向×呼吸的函数) 逐字核实成立, 笔记的"一句话学到的"站得住。
+
+---
+
+## L26 Spaghetti Bones — Joshua Bagley (#456) · 家族 growth-loops · 总评 MED
+
+### Claim 核对表
+
+| # | 笔记 claim | 判定 | 证据 (L26-456.js) |
+|---|---|---|---|
+| 1 | G.grw/G.org/G.mve/G.rsp 四方法 | ✅ | class DiffG 均有 |
+| 2 | cohesion: 点吸引邻居 | ✅ | org(): 相邻点弹簧 (`f=map(m,0,this.d,-this.dmod,0)`) + 向 prev/next 中点吸引 (`f=map(m,0,this.d,0,5*this.dmod)`) |
+| 3 | separation + quadtree 加速 | ✅ | org(): `this.dat.q(are,fnd)` 范围查询 → 逐个排斥 (`fr=constrain(map(m,0,this.d,this.dmod,0),...)`); class Q 内注 `"ty Daniel Shiffman"` |
+| 4 | "线段过长即中点重采样" 是生长规则 | ⚠→❌ | **原作生长不看线段长**: grw() 插中点的门槛是**局部密度** — `this.dat.q(a,f,8); f.length<7 && nP.push(中点)` + age<agx + 窗口内 + 轮转偏移 ofr。"过长即分裂"只存在于 ext()/exts() (初始化 + 显示平滑用)。笔记把**我们家族的机制**说成了原作的 |
+| 5 | rsp() = 重采样 | ⚠ | rsp() 实为**再激活**: 找低密度点 (`f.length<30`) 把一段 age 归零 (重新可生长), 不动几何。命名误导, 笔记跟着误读 |
+| 6 | spd 自调速 "快进无聊段慢放涌现段" | ⚠ | 机制是 **fps 自适应**: `f>58&&FS>25?spd++ : f<10?spd=1 : f<49&&spd--` — 渲染便宜就快, 重就慢。效果近似笔记说法, 但导演依据是帧率不是形态 |
+| 7 | ded 死亡重生 | ✅ | `(TT>20||ded)&&...G.gan()`; gan() 扫 400px 网格找空 cell → ini() 新环; 全满 `done=!0` |
+| 8 | NP 计数出芽 | ⚠ | NP 计生长 tick; `NP>50&&(CNT<10&&(ded=!0))` = **停滞检测**触发重生, 不是出芽计数 |
+| 9 | 15KB / p5 纯 2D | ✅ | 14.6KB, 无 shader; PRNG 是 xorshift128 `"ty Piter Pasma"` (未 claim, 记档) |
+
+### 家族对照 growth-loops (registry.js L1658-1766)
+
+| 维度 | 对照 |
+|---|---|
+| 三规则 | ✅ cohesion 0.12 (L1707-08) / 网格代 quadtree (L1692-98, cell=repelR, 3×3 邻域) / segMax 9 重采样 (L1674-89) — 与笔记 port 描述一致。注意: 家族的"过长分裂"其实更接近教科书 DiffG, 原作反而是密度门控出芽 — 差异已被 claim 4 的笔记错误掩盖 |
+| 快照年轮 | ✅ snapEvery 存轮廓淡描 (L1739-41, L1752-57) — 原作历史来自 PG 持久缓冲的自然累积 (从不清除), 快照是合理缩小 |
+| **渲染层** | **VOICE MISS (MED)**: 原作从不 stroke 轮廓 — dsp() 沿平滑片段**盖点** `PG.circle(p.x,p.y,cs)`, 尺寸两端 taper (swp/mxs), `R()<ran` 随机跳点淡出, 多帧累积成骨质/珊瑚的体积感; 颜色按片段长度映射进洗牌调色板 + cm() 色相偏移 + 多环多色。家族 = 单色细描线 + 淡填充 (L1759-64)。点彩累积质感是"Bones"的命名级签名, 细描线代之 ≈ Fidenza 细线代 fat ribbon 先例 |
+| 多环 | 允许的简化: 原作 gan() 不断重生填满画布, 家族单环 (元素更少 = 设计决定) |
+| Attribution | ✅ L3039-43 |
+
+**严重度: MED** — 笔记 claim 4/5/8 把生长调度机制讲得不准 (密度门控出芽被说成长度重采样; rsp/NP 语义错位); 家族渲染层丢了点彩累积签名 (VOICE MISS, 但 decor 尺度可辩护)。
+
+---
+
+## L33 Memories of Qilin — Emily Xie (#282) · 家族 torn-paper · 总评 HIGH
+
+### Claim 核对表
+
+| # | 笔记 claim | 判定 | 证据 (L33-282.js) |
+|---|---|---|---|
+| 1 | 加权 trait 表 `[["Sweep",68],["Focal",11],["Offset",12],["Vertical",6],["Flock",3]]` | ✅ | `const i=[["Sweep",68],["Focal",11],["Offset",12],["Vertical",6],["Flock",3]]` 逐字吻合 |
+| 2 | 每板每色 [hex,weight] 含 weight 0; 每板专属纹理色 | ✅ | 如 Sea Dune `clrs:[["#757575",10],["#4e5864",0],...]`; weight 0 无法被加权抽样 p() 选为主色 b=N(), 但 z() 均匀抽仍可选 → "偏置不禁止"成立; `textureClrs` 每板 {pattern:[{bg,stk},weight]} ✅ (笔记写"textureC", 实名 textureClrs) |
+| 3 | **撕纸边 = 双尺度噪声 (慢起伏+细毛刺) + 偶发尖锐内切 (撕口)** | ❌ | **原作没有这个机制**。纸片是 Verlet 软体 (te/re/ae 类, 内注 credit David Lu): 圆环粒子 + 弹簧约束 morph 松弛, warp() 用**单尺度**噪声场位移 (`noise(i+x*s,n+y*o)*TAU*a`), 且 `detectJagged()` (段长>0.15 判毛糙) **主动拒绝尖锐边** — 毛了就 `e-=30` 重试直到平滑。既无双尺度边缘噪声, 也无撕口内切; "撕纸感"实际来自: 图案纹理填充 + Z() 泼溅 (4 万个微三角/微矩形纤维) + $()/ee() 颗粒 + le() 噪声纸边框 |
+| 4 | 双 PRNG 交替 + 1e6 预热 + 100 空转 | ✅ | sfc32×2 (hash.substr(2,32)/(34,32)), `random_dec(){this.useA=!this.useA;...}` 交替; `for(let e=0;e<1e6;e+=2)this.prngA(),this.prngB()` = 1e6 次调用; `for(let e=0;e<=100;e++)_.random_dec()` ✅。另档: I() 里 `f=3e3-颜色数` 补齐 PRNG 调用次数到定额 (调用数归一化, 笔记未提, 值得记) |
+
+### 家族对照 torn-paper (registry.js L1488-1544)
+
+| 维度 | 对照 |
+|---|---|
+| **形状构造** | **INVENTED DETAIL (HIGH, 与 claim 3 同根)**: 46 点径向环 + 双尺度噪声半径 (L1509-20) + 撕口 `d<3 → r*=0.55+0.15d` (L1521-24) — 整套边缘 recipe 是我们发明的, 原作是 Verlet 软体且**拒绝**尖锐边。作为装饰 recipe 本身能看, 但笔记把它包装成"Xie 的机制的最小实现", 系谱错了 |
+| 颜色权重 | ✅ accent 三倍权重 `flatMap((c,i)=>i===0?[c,c,c]:[c])` (L1495) — 加权板的合理最小致敬 |
+| squash/旋转 | ✅ 有对应物: 原作 changeFormSize(1.4,1) 各向异性缩放; 家族 squash 0.55-1.25 + rot (L1503-04) |
+| 填充与描边 | ⚠ VOICE (MED): 原作 = 图案纹理 (waves/flowers/hexagons/vines... 8 种 pattern generator) mask 进片内 + 统一深色 lineColor 细描边; 家族 = 平涂 + 自身色描边。**图案纸片是 Qilin 的招牌** — decor 尺度弃纹理可辩护, 但应记档为已知 voice 损失 |
+| Attribution | ✅ L3049-53 |
+
+**严重度: HIGH** — claim 3 是笔记事实错误 (发明了原作明确拒绝的机制: detectJagged 反毛糙是铁证), 家族形状构造建在这个发明之上; 纹理填充签名未做 (MED)。权重双 claim (trait 表 + 调色板) 和 PRNG 考据全部逐字成立。
+
+---
+
+## L41 Ancient Courses of Fictional Rivers — Robert Hodgin (#284) · 家族 river-courses · 总评 MED
+
+### Claim 核对表
+
+| # | 笔记 claim | 判定 | 证据 (L41-284.js) |
+|---|---|---|---|
+| 1 | resampleLine / calcFlowBitangent 存在 | ✅ | 两函数均在; resample(e,r) 按 spacing 均匀重采样 |
+| 2 | 河曲 = "点沿法向逃离弦中点, 弯越急逃越快" | ⚠ | 方向 = bitangent (法向), 由 `p5.Vector.cross(p,s).z<0` 定侧 ✅; 速率 = `sqrt(1-dot(t_i,t_{i+1}))*riverSpeed` — **转角越大越快** ✅; 但"逃离弦中点"是**我们 port 的公式** (registry L1272-90 ±5 窗口弦中点), 不是原作的 tangent-dot 公式。recipe 同族, 表述把两者混了 |
+| 3 | 牛轭截弯: 索引远、空间近 → splice | ✅ | checkOxbows(): `for(t=e+riverCollSpacing; t<min(e+numPts/2,numPts)...) if(magSq<riverCollDistSqrd && t-e<numPts/2){ e+1..t-1 → new Oxbow; splice }` — 逐字吻合; Oxbow 对象还会 update/衰亡 (isDead → 移除) |
+| 4 | "(7 处)" | 🔍 | 含义不明 — 小写 "oxbow" 恰好出现 7 次, 若指此为琐碎; 若指机制处数则不成立 (机制一处)。建议删掉这个数字 |
+| 5 | HISTORY_TYPES 河道演化史 | ✅ | `HISTORY_TYPES=["SEQUENTIAL","STACKS","SHORTSTACKS","RANDOMIZED"]`; drawRiver 按类型选 cs[l] 5 色轮换 |
+| 6 | trait 分类学 BIOME×5/COMP×6/CITY×4/GRID×4 | ✅ | `BIOMES=["FARMLAND","SWAMP","DESERT","ARCTIC","MOUNTAINS"]`(5); `COMPS=[...]`(6); `CITY_TYPES=["REMOTE","HAMLET","SETTLEMENT","TOWN"]`(4); `GRID_TYPES=["NO GRID","JUST DOTS","PLUSSES","DOTTED LINES"]`(4) |
+| 7 | 装饰系统: 地块/建筑/宝藏图/铁路 | ✅ | plots/plotB/PLOT_TYPES, Building, TREASURE, HAS_RAILROAD/Railroad 均在 |
+| 8 | MAX_PTS=700 + 索引窗口 = port 亲历教训 | ✅ (自述) | registry L1266 `MAX_PTS=700`, L1317-18 窗口 i+8..i+90。注意原作牛轭扫描窗口是 numPts/2 (半条河), 小窗口是我们的工程发明 — 笔记正确地把它标为 port 教训而非原作机制 |
+| 9 | "淡出给时间: 古河道按年代淡出" | ⚠ | 原作史河道 = `lerpColor(bgColor, cs[l], riverFramePer*HISTORY_CONTRAST)` — **5 色轮换 + 向背景色 lerp**, 不是单色 alpha 淡出; 多色古河道是 Ancient Courses 的可识别特征之一 |
+
+### 家族对照 river-courses (registry.js L1245-1376)
+
+| 维度 | 对照 |
+|---|---|
+| 迁移+重采样 | ✅ 窗口弦中点变体 (L1272-95, 注释诚实记录了первая尝试的教训) + 均匀重采样 (L1306-14) + 3 点核扩散 (L1300-05, 我们加的平滑, 无害) |
+| 牛轭截弯 | ✅ 索引远(≥8)+空间近(<cutoff) splice → oxbows (L1317-28), 第二色描 (L1349-54) — recipe 对上 |
+| 史河道 | ⚠ MED: 单色 alpha 梯度 (L1342-47) vs 原作 5 色轮换×HISTORY_TYPE — 多色地质史签名丢失 (decor 尺度可辩护, 记档) |
+| **活河渲染** | **VOICE MISS (MED)**: 原作 buildRiverGeo = 左右岸按 bitangent 偏移**噪声调制的变宽度** (`map(getNoise(S,.01),0,1,.15R,.9R)`) 合成**闭合填充带** + 日照方向偏移的 highlight/shadow 双 pass; 家族 = ±2.2 常数偏移的两条细描岸线 (L1356-74)。河读作"水体"靠的是填充变宽带 — 细双线代 fat 填充带, Fidenza 先例直接适用 |
+| Attribution | ✅ L3055-59 |
+
+**严重度: MED** — 笔记机制方向全对, 两处表述把我们 port 的公式/渲染当原作描述 (claim 2 弦中点, claim 9 单色淡出); 家族活河用双细线代原作变宽填充带 = voice miss。
+
+---
+
+## 跨课观察
+
+1. **共同模式**: 三个家族 (growth-loops / torn-paper / river-courses) 的笔记都存在"用我们 port 的实现反向描述原作"的倾向 — L26 长度重采样、L33 双尺度噪声撕边、L41 弦中点逃离/单色淡出。写笔记时机制描述应先从原码取证再写 port。
+2. **共同 voice 缺口**: 三个原作的"体量感"都来自**填充/累积** (点彩累积 / 纹理填充 / 变宽填充带), 三个家族都退到了细描线 — 与 Fidenza 二读发现同构, 是系统性的 decor 渲染习惯, 不是单课失误。
+3. Attribution 四条全部正确 (#487/#456/#282/#284, 项目名/作者名无误)。
+4. L09 笔记质量最高: shader 三因子公式、6 倍频、triangle-strip 填充全部逐字核实成立。

--- a/docs/superpowers/artblocks-study/audit/batch-F.md
+++ b/docs/superpowers/artblocks-study/audit/batch-F.md
@@ -1,0 +1,148 @@
+# Batch-F 二读审计报告
+
+课程: L28 BUSY (家族 street-grid) / L22 ORI (家族 paper-folds) / L11 Gumbo / L12 Trichro-matic / L15 Växt / L25 Still Moving
+原脚本: scratchpad/ab-scripts/L{28-504, 22-379, 11-462, 12-482, 15-488, 25-433}.js
+家族源: sdf-js/src/present/decor/registry.js
+
+---
+
+## L22 ORI — James Merrill (#379) · 严重度 HIGH
+
+### Claim 核对表
+
+| # | 笔记 claim | 判定 | 证据 |
+|---|---|---|---|
+| 1 | 参数化线段相交 (t/s 双参数) | ✅ | 函数 `n(...)`: `let t={t:x,s:f,side:null,other:null,xy:null}` — 交点对象带 t 与 s 双参数, 且 `l.sort((r,e)=>r.t-e.t)` 按 t 排序 |
+| 2 | 点在多边形内测试 | ✅ | `const o=(r,e)=>{...l>o!=m>o&&n<(h-s)*(o-l)/(m-l)+s&&(i=!i)...}` — 标准 ray-cast |
+| 3 | 多边形沿折线剖分 | ✅ | 剖分机器: 交点带 `flag` 插入边表, 按到线首距离排序后配对切出子多边形 (`if(s.length<2)return[r.slice(0)]; s.sort(...S.dist(a,r)-S.dist(a,e)...)`) |
+| 4 | "折是平面拓扑操作, 没有 3D" | ✅ | 折 = 剖分 + 2D 镜像: `Ie` 里质心侧别测试后 `l=g(r,n,o).vertices`, `g` 沿折线法向 (`atan2(...)+PI/2`) 反射顶点; 另有 `x(l,n,t.distance)` 折翼平移。**注意: 笔记把折描述成"两侧各出一个子多边形"漏掉了镜像这一步** — 镜像才是"折"; 剖分只是"切" |
+| 5 | **永远剖最大 facet (贪心面积 = 构图均衡器)** | ❌ | 原作不存在。折线由 `T.d2/d3/d4/d5/foldOver/radial/smallSmallSheers` **预先批量生成** (每档 10~25 条), 然后 `for(let n=1;n<=se.length;n++){...r=Ie(r,i,o,a,t)}` 逐条**作用于所有被穿过的 facet** (`Ie` 内 `r.forEach`)。全脚本唯一按面积排序处 `ye=ye.sort(((r,e)=>c(e)-c(r)))` (函数 `Ye`) 只用于把预生成的 2500 个样式对象按面积序配给 facet + d6 z 序调整, 与剖分选择无关 |
+| 6 | **折轴偏爱轴对齐 (±jitter)** | ❌ | 折线生成器 `B=(r,e,n=!1)=>{const o=n\|\|random(2*-PI,2*PI);...}` — 折轴角**全随机**; `d4` 是平行族整体转一个随机角 `i=random(2*PI)`, `radial` 径向。轴对齐 ± 抖动确实存在但在**填充线方向 d9** 上: `case"down":o.d9=PI/2+random(-.1,.1)` / `"flippy":o.d9=PI/2*(±1)+random(-.1,.1)` — 笔记把 fill 方向的 idiom 错安到折轴上 |
+| 7 | **facet 按折叠深度渐变色调** | ❌ | 无折叠深度追踪 (`Ie` 不给 facet 计数)。实际着色: 每 facet 从调色板组随机取色 + 随机明度偏移 `z("b5",random(-15,10))` + `A(...,5)` 明度抖动, 再叠方向性纹理填充 (leaf/dots/evenLines/perspective, 沿 d9 方向 `lerpColor(...,r/h+randomGaussian(0,.1))`)。"色阶读成纸的朝向"的效果存在, 但机制是随机明度+方向纹理, 不是深度渐变 |
+| 8 | webpack 打包 | ✅ | 文件头 `var r={d:(e,n)=>{...Object.defineProperty...},o:...}` — webpack 5 runtime |
+| 9 | "原生 js" | ⚠️ | 实为 **p5.js** (createCanvas/beginShape/endShape/vertex/lerpColor/randomGaussian/createVector/noiseSeed/randomSeed/drawingContext 全在), webpack 只是打包层 |
+| 10 | 58KB / CC BY-NC | ✅/🔍 | 58198 B ✓; license 链上读不出 |
+
+### 家族对照: paper-folds (registry.js:1768-1877)
+
+| 维度 | 判定 | 说明 |
+|---|---|---|
+| 形状构造 (closed fill + crease stroke) | 对上 | 原作 facet 也是闭合多边形填色 + 描边 (`er(r,e)` outline); registry.js:1866-1874 fill+stroke ✓ |
+| 剖分机器 (splitPolyByLine, 侧别分类+插交点) | 对上 | registry.js:1785-1805 与原作机器等价 (实现路线不同但同构) |
+| **贪心剖最大 facet** (registry.js:1835-1846, 注释 "ORI's balance rule") | **INVENTED DETAIL** | 原作没有此规则 (见 claim 5)。整个循环选 max-area 是我们发明的, 却署名 ORI |
+| **折轴轴对齐基调** (registry.js:1849 `baseAng = rand()<0.5 ? 0 : PI/2`) | **INVENTED DETAIL** | 原作折轴全随机 (claim 6); 轴对齐属于原作的填充方向 |
+| **深度渐变着色** (registry.js:1832/1858 depth 计数, 1863-1864 `depth/splits → lerpColorOklab`) | **INVENTED DETAIL** | 原作按 facet 随机明度偏移, 无 depth 追踪 (claim 7) |
+| **折 = 剖 + 镜像翻转** | **VOICE MISS (偏 MED)** | 原作真正的"折"是把一侧沿折线**反射** (`g`) 并可平移 (`x`), 产生翻折错位感; 家族只剖不折 — 变成"矩形递归 BSP + 色调渐变", 几何上更接近 shard-mesh 的姊妹而非折纸引擎。装饰尺度下色调+折痕线仍能读出拼贴感, 故 MED 不 HIGH |
+| 颜色来源 (2 色 OKLab lerp 接主题) | 对上 (刻意简化) | 原作是调色板组+角色 (b5/c2 组) + 随机明度; 家族接 deck 主题双色 — 设计决定 |
+| 分布随机性 | 对上 (刻意简化) | 原作满地 weighted choice `P([...])`; 家族均匀 rand — 装饰尺度可接受 |
+
+**结论: HIGH** — 笔记 4 条解剖 recipe 里 3 条 (贪心最大/轴对齐折轴/深度着色) 是发明或错安, 且全部三条被家族当"ORI 的规则"实现并写进注释。家族视觉本身成立, 但 provenance 叙述失真: 它 port 的是笔记的想象, 不是 ORI 的机制。
+
+---
+
+## L28 BUSY — James Merrill (#504) · 严重度 MED
+
+### Claim 核对表
+
+| # | 笔记 claim | 判定 | 证据 |
+|---|---|---|---|
+| 1 | 251KB, BUSY #504 | ✅/🔍 | 251648 B ✓; `saveCanvas(\`BUSY-${tokenData.hash}.png\`)` 确认是 BUSY; 项目号链上读不出 |
+| 2 | "原生 js (webpack)" | ⚠️ | 双错: 打包器是 **Vite/Rollup** (文件头 modulepreload polyfill 是 Vite 签名, 无 webpack runtime), 且是 **p5.js** 应用 (`window.setup=()=>`, createCanvas×3, beginShape×215, saveCanvas, HALF_PI, 含 p5-svg: `createCanvas(1e3,1e3*e,SVG)`)。252KB 大头之一是打包进来的多边形布尔运算库 (martinez 型 sweep-line) |
+| 3 | trait 类型学: straight/corner/corner-XL/…/pathFromCache "道路是带类型目录的词汇表" | ⚠️ | 词汇表**核心成立但清单混层**: `straight/corner/corner-XL/start/end` = 路径段类型 (`case"corner":t=w3(i,t,o,"normal")`), `singleLine,3/megaSingle,1/ghost,4/railroad/highway` = 道路 genus 加权目录 (`Y1([...])`), 交叉口目录是 `["intersection",1,"furball",5,"splitter",4,"three-way",2]`, `pathFromCache` = 形状缓存类型。但 **diagonal-left/right 是调色板空间分布模式** (`rndFromList(["random",10,"top-to-bottom",10,"diagonal-left",5,...])` 决定按位置取 ink), **circular 是 turbulence 场模式** (`case"circular":i=1-dist(...)`) — 这两个不是路型。另有笔记漏的 genus: electricPole |
+| 4 | "沿路行驶的 agent 轨迹 / agent 沿网行驶留痕" | ⚠️ | **静态作品, 无 agent 模拟**: 全文 0 个 requestAnimationFrame/draw()/frameCount, 有 noLoop。车是精灵多边形 (`"car-1-side"…"car-5-side"/"train-front-1"/"train-car-1"`) 按 `carDensity` 沿路**摆放**, 行人是 `walkerPositions` 过街点。"网络先于显影"的洞察本身 ✅ (路网 = 作品本体), 但"行驶留痕"是想象出来的机制 |
+| 5 | 转弯 = 固定半径四分之一圆弧 | ✅ | `w3` 按 e6/e7 方向对以 PI/2 整数倍旋转放角件; 铁路弯 `y3` 用 24 段顶点扫 PI/2 圆弧 (`c*PI/4/(o/2)`, c≤24 → 总角 PI/2), 半径绑格距 (`.5±t/2`) |
+| 6 | pathFromCache = 昂贵路径算一次显影 N 次 | ✅ | shape type `"!"` → `{type:"pathFromCache",attributes:{x,y,refID}}`, 渲染时 `o=k1(l[i.refID],{x:i.x,y:i.y},!1)` — 按 refID 取缓存路径带偏移重印 |
+| 7 | ghost = 幽灵重影 | 🔍/⚠️ | ghost 是道路 genus 之一, 与 singleLine 同路径: 单 ink (`l.genus==="singleLine"\|\|l.genus==="ghost"?t=[t[0]]`)、占格豁免 — 读起来更像"淡色幽灵路"而非重影; 混淆代码里读不出"重影"证据 |
+| 8 | 姊妹作同引擎两参数档 | ✅(旁证) | BUSY 自己的构图模式表里赫然有 `"busiest",0` 权重零档: `rndFromList(["cityNormal",20,"cityXL",16,"justPipes",5,"thinAir",5,"Detail",5,"busiest",0…])` — 同引擎内置 busiest 档, 姊妹发行 = 换权重, 笔记判断被链上代码直接支持 |
+
+### 家族对照: street-grid (registry.js:1546-1640)
+
+| 维度 | 判定 | 说明 |
+|---|---|---|
+| 车道 = 平行双轨 | 对上 | 原作路 = 带状两条边线 (`n.line(0,-h/2,…)` + `+h/2`, `a4:{height:.6}`); registry.js:1576-1590 法向偏移 ±gauge/2 双线 ✓ |
+| 宽路虚线中线 (gauge>7, registry.js:1603-1611) | 对上 (recipe 级) | 原作有 `dashesPerGrid:2,dashLength:.2` 路内虚线元素, highway 是加权升格 genus (`L.d9&&(n=l2(n,"highway"))`) — "宽路才有虚线"是合理归纳 |
+| 铁路垂直枕木 (registry.js:1591-1602) | 对上 (recipe 级) | 原作 railroad genus 双线 `c2:{height:.5,b8:2,a6:.15}` + 横向元素; 枕木间距 gauge*2.2 是我们的调音, 机制方向一致 |
+| 四分之一圆弧转角 | 对上/小偏差 | 弧本身 ✓ (claim 5)。偏差: 原作的弧长在**一条路自己转弯处** (路径 corner 段), 家族放在**两条直通车道的交叉口上** (registry.js:1622-1637) 且车道永远贯穿全区 — 原作道路是格上随机行走的蜿蜒路径 (起点随机+方向改变 `p=R3(a,u,p)`+占格碰撞 `A(a,u,1,1,t)`), 家族是全跨度直线。装饰尺度可接受, LOW |
+| 颜色来源 | 对上 (刻意简化) | 原作具名 ink 调色板 (`{name:"Robot",inks:[…]}`) 按 genus 切片 (ghost 1 色/highway 3 色); 家族接 deck 主题随机取 — 设计决定 |
+| 分布随机性 | 小偏差 | 原作 genus 是加权离散目录 (`["singleLine",3,"megaSingle",1,"ghost",4]`), 家族是连续均匀 gauge (3+rand*gaugeMax) + railChance 概率 — 丢了"离散档位"的工程感一半, 但人格档 (calm/balanced/wild) 补了档位感, LOW |
+| 无 agent 层 | 对上 | 笔记 port 判定"agent/车流层不 port"— 恰好躲过了 claim 4 的错误, 家族干净 |
+
+**结论: MED** — 家族本身干净 (LOW), 但笔记有三处失真: 技术栈双错 (p5+Vite ≠ 原生js+webpack)、类型清单把调色板分布模式 (diagonal-left/right) 和 turbulence 模式 (circular) 混进路型目录、"agent 行驶留痕"实为静态精灵摆放 (无动画循环)。"busiest 权重 0 档"是本次审计最漂亮的正向发现。
+
+---
+
+## L11 Gumbo — Mathias Isaksen (#462) · 严重度 LOW
+
+| # | 笔记 claim | 判定 | 证据 |
+|---|---|---|---|
+| 1 | 15KB, 绝大部分是打包成 JS 字符串的 GLSL | ✅ | 16171 B; 模板字符串 `e=\`#version 300 es…\`` 占全文一半以上 |
+| 2 | 伪装成 js 的 SDF raymarch | ✅ | `main()` 里 sphere-trace 循环: `for(I l=0;l<it;l++){F j=i(h);…d+=j;h=x+y*d;if(K(j)<1e-6)break;}` |
+| 3 | 值噪声 vn() | ✅ | `F vn(W v,F y,F f){…J(v),fract(v),s01(i)… 8 角 mix}` — 三线性值噪声, 名字就叫 vn |
+| 4 | fbm | ✅ | `F d(W v,I f,F y,F t){…d+=n*vn(…),n*=.5,v=e(2.*v,W(1),1.2)}` — 倍频+半幅+旋转 |
+| 5 | 盒体与圆柱 SDF (含圆角) / "圆角盒 rc()" | ⚠️ | 盒 `b()` = 精确盒 SDF (`K(v)-t/2`), **无圆角半径参数**; `rc()` = `b(e(v,f,y,d,1.),…)` 即**旋转盒** (r 更可能是 rotated), 也无圆角。"圆角感"实际来自 `o()`/`dc()` 的 tube 半径 (棱柱环 `t*=Y(PI/(h*tan(PI/h)))` + 截面半径 n) 与 smin 柔融 — 圆角安错了函数 |
+| 6 | mat3 旋转对齐 e(v,f,y) | ✅ | `W e(W v,W y,W f,F t,F i){…mat3(h,H(h,n),n)…}` — 轴对齐旋转 |
+| 7 | 角度量化棱柱 o() | ✅ | `x=2.*PI*round(h*x/(2.*PI))/h` — 极角量化成 h 边形 |
+| 8 | smooth-min 柔融 | ✅ | `F u(F v,F f){F t=22.…y-log(exp(-t*(v-y))+exp(-t*(f-y)))/t}` — 指数 smin k=22, 组合处 `d=u(d,M(…))` |
+| 9 | "原生 WebGL" | ⚠️ | `getContext("webgl2")` + `#version 300 es` — WebGL2 |
+
+无家族 (纯文档课)。旁注: Gumbo 也用双 sfc32 + 1e6 预热 + 交替消费 (`i=!i,i?e():f()`) — L25 那条"社区共识" idiom 的第三个目击, 笔记没提, 白捡的语料。
+
+---
+
+## L12 Trichro-matic — MacTuitui (#482) · 严重度 LOW (near-clean)
+
+| # | 笔记 claim | 判定 | 证据 |
+|---|---|---|---|
+| 1 | CPU 构图 + shader 视觉核, polyVertices[128] / paletteAccentArray[50] 作 uniform | ✅ | `uniform vec2 polyVertices[128]` + `uniform uvec2 polyIndices[128]` + `uniform vec3 paletteAccentArray[50]` (另有 altPaletteAccentArray[50]) |
+| 2 | UV warp / wave warp / spiralize / palette-swap / grid bleed-through 全是 uniform 开关 | ✅ | `uniform int waveWarpX / waveWarpY / uvSpiralizeEnabled / paletteSwapWarpEnabled / gridBleedThrough / warpLayer …` 全套开关 + 参数 (uvWarpScale/waveWarpDivisor/paletteSwapArmWidth 等) |
+| 3 | 具名调色板完整对象 `{name:"Chalks",theme:"Calm",bg/highlight/lowlight/line/stroke/base/accent[]}` | ✅ | 原文逐字命中: `{name:"Chalks",theme:g,bg:["#e9e1cc"],highlight:[…],lowlight:[…],line:[…],stroke:[…],base:[…],accent:[…5 色]}`, 其中 `g="Calm"` |
+| 4 | 性格标签 Calm/Assertive/Rich/Toasty/Chilled | ✅ | `"Calm",m="Assertive",v="Rich",b="Toasty",w="Chilled"` — 5 个全对, 15 个调色板各带 theme |
+| 5 | 48KB (JS 30KB + frag ~18KB) | ✅ | 49876 B, frag 是内嵌大字符串 |
+| 6 | "原生 WebGL" | ⚠️ | `getContext("webgl2")` + `#version 300 es` — WebGL2 (与 L11 同款小误) |
+
+无家族 (文档课)。
+
+---
+
+## L15 Växt — Santiago (#488) · 严重度 CLEAN
+
+| # | 笔记 claim | 判定 | 证据 |
+|---|---|---|---|
+| 1 | JS 侧 0 绘制调用, 生成器拼装 GLSL 源码 | ✅ | 无 ellipse/rect/vertex 绘制; 构图全部输出为 GLSL 表达式字符串 (`P(n)`/`H(n)` 生成 `sc(…)`/`sb(…)` SDF 调用文本), 最后 `e.createShader(35632)` + `compileShader` |
+| 2 | 逐项 `$n += "sh += SM(...)*step(...)"` | ✅ | **连变量名都对**: `$n+=\`sh += ${…\`SM(-${…},0.,-${r})*step(-${r},0.)\`…}\`` — 每个遮挡体一项软影, 累加进 sh; 高光侧同构累加进 d |
+| 3 | 内嵌自实现 simplex 噪声 | ✅ | `F pns(A x,F a,out A g){…A uv=A(x.x+x.y*0.5,x.y)…}` — 2D simplex (带解析梯度输出!) 手写在 frag 里 |
+| 4 | O(N) 项内联展开, 无循环无数组 | ✅ | 影子/高光累加全部是字符串拼出的加法链, shader 里无 shape 数组无循环 (palette 数组除外, 但那是 ES 3.00 合法用法, 不在该 claim 范围) |
+| 5 | `#define ro(a) mat2(…)` + 单字母别名 | ✅ | `#define ro(a) (mat2(cos(a),-sin(a),sin(a),cos(a)))` + `#define A vec2 / B vec3 / C vec4 / F float / I int / SM smoothstep` |
+| 6 | WebGL2 · 16KB | ✅ | `getContext("webgl2")` (这课笔记连版本都写对了), 15808 B |
+
+无家族 (移交 3D 端文档课)。旁注: 同款双 prngA/prngB + 1e6 预热 + 交替 rd() 也在 (class A) — 该 idiom 第四个目击。
+
+---
+
+## L25 Still Moving — Stern & Stiles (#433) · 严重度 CLEAN
+
+| # | 笔记 claim | 判定 | 证据 |
+|---|---|---|---|
+| 1 | p5 纯 2D, 24KB | ✅ | setup/draw/createCanvas/createGraphics/keyIsDown; 24241 B |
+| 2 | 诗行数据 `PO=["I don't know much about minds…"]` | ✅ | 首行原文逐字: `"I don't know much about minds, but I think"`, 共 72 行诗全部上链 |
+| 3 | 36×24 低清网格 + 阈值 thrsh=75 | ✅ | `VW=36,VH=VW/1.5` (=24), `thrsh=75`; 摄像头帧 `v.size(VW,VH)`, 帧差 `dist(a,l,…)>thrsh` 触发字符投放; 文字位图同用 36×24×BR 网格 + `BL.pixels[e]<130` 阈值 |
+| 4 | 双 PRNG 交替 + 1e6 预热, 各吃 hash 一半 | ✅ | `prngA=_(hash.substr(2,32)), prngB=_(hash.substr(34,32))`; `for($=0;$<1e6;$+=2)prngA(),prngB()`; `RD(){useA=!useA; return useA?prngA():prngB()}` — 与笔记描述逐字吻合, "与 Neural Sediments 同构"成立 |
+| 5 | 伪视频/监控质感 = 采样屏换皮 | ✅ (诠释) | 机制核对如上; thrsh 可用方向键 15~165 调 ("camera sensitivity"), 75 是初始值 — 笔记写法无误 |
+| 6 | CC BY-NC-SA | 🔍 | license 链上读不出 |
+
+无家族 (伦理线文档课, 判定正确: 文字语义内容确实是作品核心)。小遗漏 (非错误): 作品核心交互是**摄像头动作侦测**驱动文字投放 (createCapture(VIDEO)), 笔记只写了"伪视频处理"没点名 webcam — 不影响任何 recipe。
+
+---
+
+## 总裁定
+
+| 课 | 严重度 | 一句话 |
+|---|---|---|
+| L22 ORI | **HIGH** | 3 条机制 claim 为发明 (贪心最大/轴对齐折轴/深度着色), 全部进了 paper-folds 家族并署名 ORI; 家族另丢"剖+镜像"的折签名 |
+| L28 BUSY | **MED** | 词汇表混层 (diagonal/circular 非路型) + 静态精灵被写成 agent 行驶 + p5/Vite 误标 webpack/原生js; 家族干净, 且发现 "busiest",0 档实锤姊妹引擎 |
+| L11 Gumbo | LOW | 核心 SDF/raymarch/smin/fbm 全实锤; "圆角盒 rc()" 安错 (rc 是旋转盒, 圆角来自 o/dc tube + smin); WebGL2 误标 WebGL |
+| L12 Trichro-matic | LOW | 调色板对象/主题标签/uniform 开关逐字实锤; 仅 WebGL2 误标 |
+| L15 Växt | CLEAN | 元编程 shader claim 连 `$n` 变量名与 SM*step 累加式都逐字命中 |
+| L25 Still Moving | CLEAN | PO/36×24/thrsh=75/双 PRNG+1e6 全部逐字实锤 |
+
+横向发现: 双 sfc32 + 1e6 预热 + 交替消费在本批 4/6 作品出现 (L25/L15/L11/L28 的 Merrill 除外待查) — "社区共识"级判定进一步加强。

--- a/docs/superpowers/artblocks-study/audit/batch-G.md
+++ b/docs/superpowers/artblocks-study/audit/batch-G.md
@@ -1,0 +1,158 @@
+# 二读审计 — Batch G (L16 / L18 / L27 / L29 / L35 / L43 / L44 / L45 / L50)
+
+全部无 decor 家族, 只审"笔记 claim vs 链上原脚本"。方法: grep/perl 定位, 不通读。
+
+---
+
+## L16 Proscenium (Remnynt, #486) — 笔记: 16-proscenium.md · 脚本: L16-486.js
+
+| Claim | 判定 | 证据 |
+|---|---|---|
+| 原生 WebGL, 145KB | ✅ | 145110 bytes; 无 p5./THREE. 引用; 自建 shader 类 |
+| uModelMatrix/uViewMatrix/uProjectionMatrix 全套矩阵管线 | ✅ | 三个 uniform 各出现 9-11 次, vertex shader `gl_Position = uProjectionMatrix * uViewMatrix * uModelMatrix * ...` |
+| fragment shader 只有一行 `gl_FragColor = vColor` | ❌ **以偏概全** | 点/painter shader 确实是 passthrough: `fragmentShaderSource` = `gl_FragColor = vec4(vColor.rgb, vColor.a);` 一句。**但** 脚本另有 `TerrainViewShader` (两个 #version 300 es 变体, 主 view 里 `new TerrainViewShader(...)` 无条件实例化), 其 fragment 是完整光照: `const int MAX_LIGHTS = 9` + `uLightDirections/uLightColors` + `fresnelSchlick(...)` + `specular/diffuse` → `fragColor = vec4(finalColor, 1.0)` |
+| "几何、颜色、排序全在 CPU" | ⚠️ | 排序 ✅ CPU (见下行); 几何数据 CPU 生成 ✅; 但 terrain **光照着色在 GPU** (Fresnel-Schlick + 9 灯), "颜色全在 CPU" 不成立 |
+| SORT_CLOSEST_DISTANCE / SORT_REACH / SORT_EVENTS_* 多策略排序 | ✅ | SORT_CLOSEST_DISTANCE ×2, SORT_REACH ×2, SORT_EVENTS_TIME ×3, SORT_EVENTS_REACH ×2 |
+| SRGBtoRGB/RGBtoSRGB 显式转换函数对 | ✅ | 各 11/10 次 |
+
+**严重度: HIGH** — 笔记把整部作品描述成"直通 shader, 视觉全 CPU", 漏掉了带 Fresnel + 多灯的
+terrain 光照 fragment shader (机制讲错)。分流结论 (CPU-3D 归 3D 端参考, 非 shader-core raymarch)
+仍然成立, 但"第五形态: CPU-3D + 直通 shader"的表述需改为"CPU 几何/排序 + 混合 shader
+(painter passthrough + terrain 光栅光照)"。
+
+---
+
+## L18 Solar Transits (Hodgin, #423) — 笔记: 18-solar-transits-hodgin.md · 脚本: L18-423.js
+
+| Claim | 判定 | 证据 |
+|---|---|---|
+| 原生 WebGL2 多 pass | ✅ | `getContext("webgl2",{premultipliedAlpha:!1,alpha:!1,preserveDrawingBuffer:!0})`; createFramebuffer/framebufferTexture2D helper |
+| 18 处 precision 声明 | ✅ | `precision highp float;` ×16 + `precision highp int;` ×2 = 18 |
+| 几何只有全屏单三角 `Float32Array([-1,-1,3,-1,-1,3])` | ✅ | 该数组 (含配套 texcoord `[0,0,2,0,0,2]`) 出现 5 次, 唯一 drawArrays 路径 |
+| 曝光累积 (长曝光感) | ✅ | `exposure` / `exposureFrames` 参数; `or=168+an.exposureFrames` 帧数控制 |
+| 轨道/凌日参数化 | ✅ | planetDist/planetEdge/planetPer/corona/Transit 等词汇齐全 |
+
+**严重度: LOW** — 全部 claim 对上, 无发现。
+
+---
+
+## L27 because unless until (ixnayokay, #472) — 笔记: 27-because-unless-until-ixnayokay.md · 脚本: L27-472.js
+
+| Claim | 判定 | 证据 |
+|---|---|---|
+| 27 个 class | ✅ | `grep -o 'class [A-Za-z_$]*' \| sort -u` = 27 个唯一 class 名 |
+| 双 PRNG 交替 + 1e6 预热 | ✅ | `this.prngA=new e(t.hash.substr(2,32)), this.prngB=new e(t.hash.substr(34,32)); for(let t=0;t<1e6;t+=2)this.prngA(),this.prngB()`; `random_dec(){this.useA=!this.useA, ...}` 严格交替 (预热各 5e5 次, 合计 1e6, 表述无碍) |
+| hash 切 32 字节决策槽位 (Rizzolli 模式) | ✅ | `new Array(32).fill(null).map((e,i)=>parseInt(t.hash.slice(2+2*i,4+2*i),16))` — 与 PRNG 种子并存, "双纪律叠加"成立 |
+| 真实时钟层: 不同现实日期/时刻不同容貌 | ✅ | help 文案 "renders as if the current date was the Unix epoch -- January 1, 1970" + "Special Day behaviors"; `rt()` 返回 [getDay, getDate, getMonth, getFullYear], `lt()` 用 getSeconds; 十二月名数组 `A=["January",...]` |
+| "Golden Hour" / "Last Light" / "Blue Skies" 是时段氛围档 | ⚠️ **不精确** | 三者实际是 **Coloring Mode 调色板词条** (与 Scorch/Asiimov/Midnight/CMYK 并列的 CMYK 色值表, 如 `"Golden Hour":ye([0,0,0,100],[0,28,100,0],...)`) — 是 hash 抽的具名调色板, 不是时钟驱动的氛围状态。时钟层真实存在 (Special Day), 但笔记把调色板名当成了时钟证据 |
+| 命名 trait 面板 "Coloring Modes"/"Detail Levels" | ✅ | 字符串各出现 5+/12 次 |
+
+**严重度: MED** — 核心机制 (双纪律 PRNG、时钟反应) 全对; 唯"Golden Hour 等 = 时段氛围档"
+把调色板名误读为时钟档位。L50 笔记的对照表引用了这一误读 (见 L50 节)。
+
+---
+
+## L29 Quine (Larva Labs, #506) — 笔记: 29-quine-larvalabs.md · 脚本: L29-506.js
+
+| Claim | 判定 | 证据 |
+|---|---|---|
+| script 字段是一整份 HTML (ASCII art 签名头 + style + svg + 代码) | ✅ | 文件头: `<!DOCTYPE html>` + QQQ ASCII art "A generative code/art project by Larva Labs" + `<style>` + `<svg id="s" viewBox="0 0 1440 2560">` + `<script>` |
+| processBlocks/processSubstitutions 切块自身源码 | ✅ | L139 `function processBlocks(text, vars)` — 解析自身源码里的 `/*__var{*/ ... /*__}*/` 条件块; L194 `processSubstitutions` |
+| randomColorScheme/getSchemeByName 具名 scheme 目录 | ✅ | L93/L105; SCHEMES 表 `{name:"C", weight:100, colors:...}` 加权抽取 + 按名查找 (L448-452), 另有 ALT_HIGHLIGHT "BX" |
+| 37KB custom | ✅ | 36792 bytes, 无 p5 |
+| Curated 收官 / V3 合约 / NFT License | 🔍 | 链下元数据, 脚本内不可核 (tokenData.externalAssetDependencies 的存在与 V3 说法相容) |
+
+**严重度: LOW** — 可核 claim 全部对上。
+
+---
+
+## L35 Edifice (Kovach, #204) — 笔记: 35-edifice-kovach.md · 脚本: L35-204.js
+
+| Claim | 判定 | 证据 |
+|---|---|---|
+| 具名算子: Tear/Perspective/Sharp/Wave/Torus/Fold/Shift/Turn/Twist/Squish/Isometrize | ✅ | 全部字符串在场 (各 2-6 次), 且都有对应 `case"..."` 分支 |
+| MidpointWalkFill 具名填充器 | ✅ | ×3 + `case"MidpointWalkFill"` |
+| Manhattan / Chebyshev 距离度量可换 | ✅ | `case"Manhattan"` / `case"Chebyshev"` → 不同邻域集 + `fillGridDistToStart` |
+| Bismuth 材质 | ✅ | ×4, 在填充器抽签表 `[["Bismuth",2],["Manhattan",4],["Chebyshev",4],...]` |
+| "一个 mint = 网格 + [Fold, Twist, Isometrize] 算子**序列/链**" | ⚠️ **不精确** | 变换是**单次加权抽签**: `Mt=t([["Sharp",..],["Shift",10],["Wave",10],["Turn",10],["Twist",10],["V",10],["Perspective",5],["Squish",...],["NoShift",1],["Tear",6],["Isometrize",.2]])` — Mt 是标量 trait (`"Wave"==Mt||"Sharp"==Mt` 等值比较), switch 返回**一个**变换函数。正交轴是 变换×填充器×度量×轴向 各抽一次, 不是可组合的算子链 |
+| "Isometrize 作为末端算子: 最后一步推成等距" | ⚠️ | Isometrize 是上述同一张抽签表里的一个选项 (权重 0.2, `case"Isometrize": return t=>{...new tt(e+n,(n-e)/2)}` 确为等距投影), 不是叠加在其他算子之后的末端 stage |
+
+**严重度: MED** — 词汇表全部属实, 但"算子链/序列"与"末端算子"两处把 单抽正交轴 讲成了
+可组合管线, 生成器架构描述失准 (idiom 1 的"组合即 trait"依据不足)。
+
+---
+
+## L43 entretiempos (Soria-Rodriguez, #267) — 笔记: 43-entretiempos-soria.md · 脚本: L43-267.js
+
+| Claim | 判定 | 证据 |
+|---|---|---|
+| p5 + shader 后滤镜; CPU 侧 dC/dIi3/dRi 画构图 | ✅ | `function dC` + dIi3/dRi 在场; shader 是 `tex0` 后处理 |
+| fragment 只做 grain + 方向模糊 (u_dir) + 亮度/对比 (u_br/u_con) | ✅ | frag: `rd()` hash 噪声 + `gB(tex0, uv, tS*u_dir)` 高斯 9-tap 方向模糊 + `bC(v,b,c)=(v-0.5)*c+0.5+b` |
+| grain 是"恒等 hash" | ⚠️ | hash 函数确是经典 `fract(sin(dot(st,vec2(12.9898,78.233)))*43758.5453123)`; 但采样点是 `rd(uv*u_time)`, u_time=millis()/1e3 — **grain 逐帧动**, 不是 hash 冻结的静态颗粒 |
+| "u_g(rain)" — u_g 是 grain 强度 | ❌ | `u_g` 是 **gamma**: `vec3 g(vec3 v, float p){return pow(abs(v),p)}` → `cOut=g(cOut,u_g)`; CPU 侧 `shG=dP.sh.shBW?1.65:1.15` (典型 gamma 值)。grain 强度实际走 `u_pC` (`cOut=0.99*tI+tN*u_pC`) |
+| u_pA/u_pB/u_pC/u_g/u_br/u_con "全从 hash 铸造" | ⚠️ **不精确** | 多数是**常量**: `shBlEqA=.45, shBlEqB=.55, shK=1.05, shBr=.028, shCon=.925`; hash 只铸 `shBW=R.rd()<.075` (黑白 trait) 与模糊方向符号 `shBx/shBy=(-1)**R.rc([...])`, shG/shBlEqC 仅随 shBW 二选一。"冲印批次"实为 方向+BW 两根 lane, 不是六参数全 hash |
+| sigM (sigmoid) 开场即定义 | ✅ | `sigM(t){return 1/(1+Math.exp(-t))}` 定义于文件头部 (class Random 之前), 用于距离→透明度映射 `(...sigM(min(dist(...),dist(...))))**3` |
+
+**严重度: MED** — 结构判定正确, 但 u_g=gamma 误读为 grain, "参数全从 hash" 与实况
+(大半常量) 不符, grain 还是时间动画的。idiom 1 ("后滤镜参数也是 trait") 的证据被高估。
+
+---
+
+## L44 FAKE IT TILL YOU MAKE IT (Maya Man, #337) — 笔记: 44-fake-it-mayaman.md · 脚本: L44-337.js
+
+| Claim | 判定 | 证据 |
+|---|---|---|
+| sentenceStructure + interjection + punctuation 槽位拼句 | ✅ | `sentenceStructures=[["np","are part of the process"],["amx","ns","energy"],["I am","adv","amx"],...]` — 模板+词类槽 (np/ns/adj/adv/ving/amx/wp/ws); interjection ×3, punctuation ×4 |
+| textBoundingBoxes 做文字排布碰撞 (增量放置 + 重叠检测, 生成时避让) | ❌ **机制不存在** | `textBoundingBoxes` 全文件仅 2 处: 声明 `textBoundingBoxes=[]` 和 `textBoundingBoxes.push([-textWidth(i)/2, e*t-t/2, textWidth(i), t])` — **write-only, 从未被读取**; 无 overlap/intersect/collide 任何检测函数。实际防重叠机制是**按文本长度降字号/关贴纸**: `e.length>=7||numWords>=5?(txtsi=6,stickers=!1):...`, `e.length>=10&&(stickers=!1)` |
+| stickers 层叠贴纸 = 独立点缀词汇表 | ⚠️ | 有 sticker 词汇 (star/sparkle/cuteFace/drawCharacter...) 且 `stickerTypeIndex=R.r_i(0,..)` 抽类型, 但 `stickers` 是**布尔开关**, 贴纸按网格平铺 (`switch(stickerTypeIndex){case 0: 0==e&&0==l?...translate(...)}`), 非自由层叠拼贴 |
+| 39KB 原生 js | ✅ | 39032 bytes, p5 风格全局 API (textWidth/push/translate — 实为 p5, 笔记说"原生 js"存疑但 minor) |
+
+**严重度: HIGH** — idiom 2 是本课头牌带走项, 但"textBoundingBoxes 增量放置+重叠检测"
+在脚本里不存在 (变量是死积累), "生成侧避让"的真实手段是长度分档降字号。
+笔记的"一句话学到的"整句建立在这个不存在的机制上。
+
+---
+
+## L45 Fontana (Rayner, #367) — 笔记: 45-fontana-rayner.md · 脚本: L45-367.js
+
+| Claim | 判定 | 证据 |
+|---|---|---|
+| SVG 管线 | ✅ | `createElementNS(svgns,t)` / xlinkns; 元素词汇 "path"×13 / "line"×7 / "circle"×4 / "rect"×1 |
+| gen() 开场十余行把参数 clamp 进 (1e-5, 0.99999), 0.5 特判 0.49999 | ✅ | `function gen(){function a(a,t,e,r,...){ a=parseFloat(a.toFixed(5))<=0?1e-5:a, a=...>=1?.99999:a, ... a=.5==parseFloat(a.toFixed(5))?.49999:a, ...}` — 4 参数 × 3 种箝位 = 12 行, `1e-5`×4 / `.99999`×4 / `.49999`×4 全对上。(细节: 箝位在 gen 内部的辅助函数 a() 开场, 非 gen 顶层 — 表述可容) |
+| 0/0.5/1 处贝塞尔/除法退化 | ✅ 佐证 | 箝位后紧跟 `M=o/Math.cos(v)` / `Math.tan(k)` 等除法/正切, 0.5→tan(π/2) 奇点, 防御动机吻合 |
+| 19KB | ✅ | 18611 bytes |
+| "全语料仅二例 SVG" (与 Unigrids 并列) | 🔍 | 跨语料统计, 本课脚本内不可核 |
+
+**严重度: LOW** — 头牌 idiom (偏执级箝位) 逐字对上。
+
+---
+
+## L50 720 Minutes (Alexis André, #27) — 笔记: 50-720-minutes-andre.md · 脚本: L50-27.js
+
+| Claim | 判定 | 证据 |
+|---|---|---|
+| 自带 alea PRNG + simplex (Float32Array 梯度表 + Uint8Array perm) | ✅ | Baagøe alea (masher 模式) 全文; simplex: `const l=1/3,u=1/6` (F3/G3 常数) + `c=new Float32Array([1,1,0,-1,1,0,...])` 12 梯度 + `this.perm=new Uint8Array(512); this.p12=this.perm[t]%12` — 教科书 3D simplex |
+| "hash 定这一枚看哪 720 变体, **此刻几点决定你看到哪一件**; 收藏的是一天不是一帧; 每分钟一貌" | ❌ **机制讲反** | 分钟归属由 **tokenId** 定, 不是时钟也不是 hash: `v.init(42)` 固定种子洗牌 0..719 → `Ie=be[parseInt((tokenData.tokenId+"").substr(-4))%720], Ue=Ie%60, Ge=(Ie-Ue)/60` — 每枚 token 被固定分配**一个专属分钟**。视觉变体参数全部来自 hash (`v.init(tokenData.hash); he=v.r` → me/Ae/Fe/Ne/Se/Ce...), 与当前时间无关。当前时钟只做两件事: 画活动表针 (`i=Date.now(); ... l=p(f/60)%24; u=.5*d-l*d/6, c=.5*d-f*d/30`) + 当现实分钟命中本枚专属分钟时置激活旗 (`ze=f==Ue&&l%12==Ge, Oe=f==Ue`)。**收藏的是一分钟** (720 枚合起来才是一天), 到点作品"庆祝"自己 — 不是"此刻选帧" |
+| 720 循环 (12 小时表盘, 错过明天再来) | ✅ | `l%12==Ge` — 12 小时制, 专属分钟每天命中两次 |
+| 17KB 原生 js | ✅ | 17109 bytes; 原生 WebGL (`getContext("webgl",...)`), 无 p5 |
+
+**严重度: HIGH** — 本课头牌 claim ("时间=身份本体, 此刻决定见哪件") 把机制讲反:
+身份是 tokenId 分配的固定分钟, 时钟是活表针+到点庆祝。"时钟流派三样本"表格中本课行
+("身份本体: 一分钟=一件作品"倒是碰巧接近真相, 但正文解释是反的) 与 L27 行
+("氛围档 Golden Hour" — 已在 L27 节证伪) 都需修。
+
+---
+
+## 汇总
+
+| 课 | 严重度 | 核心发现 |
+|---|---|---|
+| L16 | HIGH | 漏了 TerrainViewShader GPU 光照 (Fresnel+9灯), "shader 只有一行"以偏概全 |
+| L18 | LOW | 全对 |
+| L27 | MED | Golden Hour 等是调色板名, 非时钟氛围档 |
+| L29 | LOW | 全对 |
+| L35 | MED | 变换是单抽 trait 轴, 非"算子链" |
+| L43 | MED | u_g=gamma 非 grain; "参数全从 hash"实为大半常量; grain 随 u_time 动 |
+| L44 | HIGH | textBoundingBoxes write-only, "碰撞避让"机制不存在 (真机制=长度分档降字号) |
+| L45 | LOW | 全对 |
+| L50 | HIGH | 分钟归属=tokenId 固定分配, 非"此刻选帧"; 收藏的是一分钟不是一天 |


### PR DESCRIPTION
user 指令: "把你学习的40个课程都跟原版代码对照一下先"。方法 = Fidenza 二读 (75) 推广到全语料。

- **覆盖**: 50/50 课, 链上原始脚本全部拉到 (含 Cytographia 288KB / BUSY 252KB), 7 个并行审计员逐 claim 对照
- **结果**: 10 HIGH (笔记核心机制讲错) / ~20 MED / ~20 LOW·CLEAN; 21 个受审家族里 9 个全维度忠实, 12 个有 voice miss 或 invented detail (已按修复价值排序)
- **系统性发现**: ①原作体量感来自填充/累积而我们一律细描线 (6 处同源, 引擎级修一次顶六处) ②"观感反推机制"是一读的主要失误模式 (6 例) ③双 sfc32+1e6 预热等社区 idiom 获逐字实锤
- 纯 docs PR, 不动任何源码/冻结; 修复排期见报告末节, 等 user 裁决

🤖 Generated with [Claude Code](https://claude.com/claude-code)