### PR TITLE
feat: stone 渲染模式 — 编译期极简白石着色,产品默认(性能优先)

### DIFF
--- a/sdf-js/apps/present/author.js
+++ b/sdf-js/apps/present/author.js
@@ -13,7 +13,7 @@ const env = params.get('env') || 'studio';
 // Fighting-game stage ON by default for authored worlds (per-station platforms +
 // deck theatre layer) — it's the product face. ?stage=0 opts out.
 const stage = params.get('stage') !== '0';
-const { studio, show } = createFigure({ outdoor: env !== 'studio', stage });
+const { studio, show } = createFigure({ outdoor: env !== 'studio', stage, renderMode: new URLSearchParams(location.search).get('mode') === 'rich' ? 'rich' : 'stone' });
 let presenter = null; // active presenter runtime (disposed on regenerate)
 
 const promptEl = document.getElementById('prompt');

--- a/sdf-js/apps/present/figure-core.js
+++ b/sdf-js/apps/present/figure-core.js
@@ -15,7 +15,12 @@ import { attachDeckWindows } from '../../src/runtime/deck-shader-windows.js';
  * `present`: a presenter owns the sequence clock (it opens HELD at t≈0) — the
  * deck warm-up must not pause/restart the clock underneath it.
  */
-export function createFigure({ outdoor = false, stage = false, present = false } = {}) {
+export function createFigure({
+  outdoor = false,
+  stage = false,
+  present = false,
+  renderMode = 'stone', // presentation product default: perf first, beauty later
+} = {}) {
   const wrap = document.getElementById('wrap');
   const canvas = document.getElementById('c');
   const size = () => {
@@ -85,6 +90,7 @@ export function createFigure({ outdoor = false, stage = false, present = false }
     }),
     onFps,
   });
+  if (studio.setRenderMode) studio.setRenderMode(renderMode);
   window.addEventListener('resize', () => {
     size();
     if (studio.requestRender) studio.requestRender();

--- a/sdf-js/apps/present/figure.js
+++ b/sdf-js/apps/present/figure.js
@@ -12,7 +12,8 @@ const params = new URLSearchParams(location.search);
 const env = params.get('env') || 'studio';
 const stage = params.get('stage') === '1'; // ?stage=1 → fighting-game stage preset
 const present = params.get('present') === '1'; // ?present=1 → space steps the beats
-const { show } = createFigure({ outdoor: env !== 'studio', stage, present });
+const renderMode = params.get('mode') === 'rich' ? 'rich' : 'stone'; // stone = perf-first default
+const { show } = createFigure({ outdoor: env !== 'studio', stage, present, renderMode });
 
 const deckName = params.get('deck');
 const layout = params.get('layout') || undefined; // line | radial | grid

--- a/sdf-js/scripts/test-feature-gates.mjs
+++ b/sdf-js/scripts/test-feature-gates.mjs
@@ -67,19 +67,33 @@ const braces = (s) => (s.match(/\{/g) || []).length - (s.match(/\}/g) || []).len
     ].every((f) => feats.includes(f)),
     'all 9 material-kind branches are marked',
   );
-  // each marked block must be the dangling-else form: starts with `if (` and
-  // its body ends with `} else` so any subset re-chains into valid GLSL
-  const blocks = [...src.matchAll(/\/\/#feature \w+\r?\n([\s\S]*?)\/\/#endfeature/g)].map(
-    (m) => m[1],
-  );
+  // MATERIAL-KIND blocks must be the dangling-else form: starts with `if (`
+  // and ends with `} else` so any subset re-chains into valid GLSL. The
+  // structural rich/stone gates (compile-time shading paths) are exempt —
+  // they are self-contained statement runs, checked separately below.
+  const KIND_SET = new Set([
+    'sea', 'emissive', 'translucent', 'glass', 'mountain', 'snowy', 'building',
+    'eroded', 'fill',
+  ]);
+  const marked = [...src.matchAll(/\/\/#feature (\w+)\r?\n([\s\S]*?)\/\/#endfeature/g)];
+  const kindBlocks = marked.filter((m) => KIND_SET.has(m[1])).map((m) => m[2]);
   ok(
-    blocks.every(
-      (b) =>
-        /^\s*if \(is\w+\) \{/.test(b) &&
-        /\} else\s*$/.test(b.trimEnd() + '\n' ? b.replace(/\s+$/, '') : b),
-    ),
-    'every block is `if (…) { … } else` (dangling-else form)',
+    kindBlocks.length >= 9 &&
+      kindBlocks.every(
+        (b) => /^\s*if \(is\w+\) \{/.test(b) && /\} else\s*$/.test(b.replace(/\s+$/, '')),
+      ),
+    'every material-kind block is `if (…) { … } else` (dangling-else form)',
   );
+  // rich/stone are mutually exclusive shading paths: EITHER selection must
+  // leave the shader with balanced braces (subset compiles structurally).
+  const names = marked.map((m) => m[1]);
+  ok(names.includes('rich') && names.includes('stone'), 'rich + stone gates present');
+  const balance = (glsl) => [...glsl].reduce((n, c) => n + (c === '{') - (c === '}'), 0);
+  const richOnly = applyFeatureGates(src, new Set([...KIND_SET, 'rich']));
+  const stoneOnly = applyFeatureGates(src, new Set([...KIND_SET, 'stone']));
+  ok(balance(richOnly) === balance(stoneOnly), 'rich and stone selections brace-balance equally');
+  ok(!stoneOnly.includes('softShadow(p + n * 0.002, toLight'), 'stone drops the main shadow march');
+  ok(stoneOnly.includes('STONE mode'), 'stone shading path survives gating');
 }
 
 console.log(`\n${pass} passed, ${fail} failed`);

--- a/sdf-js/src/render/studio.js
+++ b/sdf-js/src/render/studio.js
@@ -846,10 +846,13 @@ void main() {
     float bnc  = clamp(0.5 - 0.5 * n.y, 0.0, 1.0);                 // bounce light from ground
 
     float shadowK = 1.0;
+    //#feature rich
     if (u_shadowsOn > 0.5) {
       float lightDist = length(u_lightPos - p);
       shadowK = softShadow(p + n * 0.002, toLight, 0.02, lightDist, 8.0); // softer penumbra
     }
+    //#endfeature
+
 
     // Base albedo + material params:
     //   - object hits (matId=2): material LUT keyed by hit leaf index. If the
@@ -938,12 +941,15 @@ void main() {
     // Pattern uses surface normal for orientation-aware 2D projection (so
     // brick courses are horizontal regardless of which way the wall faces).
     // leafPat was already fetched above in the combined fetchLeafData call.
+    //#feature rich
     if (matId > 1.5 && !isSea && !isMountain && leafPat.x > 0.5) {
       // W12 pattern-AA: footprint at the hit (distance + grazing via dot(n,rd))
       // → ray-differential anti-aliasing inside applyPattern.
       float patFW = filterWidth(t, u_resolution.y, dot(n, rd), 1.5);
       base = applyPattern(base, p, n, leafPat, patFW);
     }
+    //#endfeature
+
 
     //#feature sea
     if (isSea) {
@@ -1580,6 +1586,7 @@ void main() {
     } else
     //#endfeature
     {
+      //#feature rich
       // Procedural surface texture (Hoskins fbm). Gated by "plasticness":
       // metals + emissives keep smooth uniform surfaces; matte diffuse gets
       // ±10% albedo variance to break up plastic-looking uniformity. The
@@ -1772,6 +1779,23 @@ void main() {
       // in atom showcases.)
       col = lin;
       col += base * glowK * 1.4;
+      //#endfeature
+      //#feature stone
+      // STONE mode — the IQ white-marble minimal shader (user-locked: solve
+      // performance first, beauty later; the 3D world's job is spatial
+      // visualization of intent, not material fidelity). One warm key,
+      // hemispheric sky fill, AO for grounding, exponential distance fade.
+      // No shadow march, no reflection retrace, no GGX/rim/kicker, no extra
+      // lights, no fbm, no patterns — the entire rich block above compiles
+      // OUT, so the win is both per-pixel ALU and register pressure.
+      // Albedo is kept (black-rock motif / gold emphasis still read) — the
+      // cost lives in the lighting path, not the palette.
+      vec3 lin = base * (0.38 + 0.72 * diff) * vec3(1.06, 1.01, 0.94);
+      lin += base * (0.6 + 0.4 * n.y) * ao * 0.55;
+      lin *= mix(1.0, ao, 0.55);
+      col = lin * exp(-0.03 * t);
+      col += base * glowK * 1.4;
+      //#endfeature
     }
   }
 
@@ -1860,7 +1884,7 @@ void main() {
 // materials → feature set; pass B emits the real shader with the library
 // DCE-pruned against the GATED template. Both passes walk the same tree, so
 // the u_sdfArgs slot order is identical (deterministic).
-function compileStudioFrag(sdf) {
+function compileStudioFrag(sdf, renderMode = 'rich') {
   const probe = compileSDF3ToGLSL(sdf, {
     sceneFnName: 'sceneSDF',
     includeLibrary: false,
@@ -1869,6 +1893,11 @@ function compileStudioFrag(sdf) {
   });
   if (probe.error) throw new Error(`compileSDF3ToGLSL: ${probe.error}`);
   const features = featuresFromLeafMaterials(probe.leafMaterials);
+  // 'rich' or 'stone': mutually exclusive compile-time shading paths. Stone
+  // (the presentation product default) compiles the whole PBR block out —
+  // less ALU per pixel AND less register pressure (the M3 giant-shader
+  // lesson: uniform branches don't give registers back).
+  features.add(renderMode === 'stone' ? 'stone' : 'rich');
   const result = compileSDF3ToGLSL(sdf, {
     sceneFnName: 'sceneSDF',
     includeLibrary: true,
@@ -1952,6 +1981,7 @@ export function createStudioRenderer({
   const defaultCam = { position: [...camState.position], yaw: 0, pitch: -0.25 };
 
   let program = null;
+  let renderMode = 'rich'; // setRenderMode('stone') — presentation product default
   let uniformsCache = {};
   let rafId = null;
   let contextLost = false; // set by webglcontextlost handler — pauses the loop
@@ -2874,7 +2904,7 @@ export function createStudioRenderer({
       // gating + data-as-uniforms + library DCE all happen inside
       // compileStudioFrag — the emitted source depends on the scene SHAPE and
       // feature set only, never on the data.
-      const { fragSource, result } = compileStudioFrag(sdf);
+      const { fragSource, result } = compileStudioFrag(sdf, renderMode);
       const bytes = fragSource.length;
 
       // ---- Step 2: Clear canvas to BLACK IMMEDIATELY ----
@@ -2940,6 +2970,15 @@ export function createStudioRenderer({
     },
 
     /**
+     * 'stone' | 'rich' shading for every SUBSEQUENT compile (program cache
+     * keys on the generated source, so both modes can coexist in cache).
+     * Call before render()/precompile(); does not retroactively swap.
+     */
+    setRenderMode(mode) {
+      renderMode = mode === 'stone' ? 'stone' : 'rich';
+    },
+
+    /**
      * Seamless SDF swap for deck window switching. Unlike render(): no canvas
      * clear (the old program keeps drawing until the new one is ready), no
      * presentation-clock reset (the camera sequence keeps playing through the
@@ -2947,7 +2986,7 @@ export function createStudioRenderer({
      * frame; a miss compiles async via KHR_parallel and swaps in when linked.
      */
     swapSDF(sdf) {
-      const { fragSource, result } = compileStudioFrag(sdf);
+      const { fragSource, result } = compileStudioFrag(sdf, renderMode);
       uploadCompiledFrag(fragSource, result);
       wake();
       return { bytes: fragSource.length };
@@ -2963,7 +3002,7 @@ export function createStudioRenderer({
     precompile(sdf) {
       let fragSource;
       try {
-        ({ fragSource } = compileStudioFrag(sdf));
+        ({ fragSource } = compileStudioFrag(sdf, renderMode));
       } catch (e) {
         console.error('[studio] precompile: GLSL generation failed:', e);
         return Promise.resolve(false);

--- a/sdf-js/src/scene/render-network.js
+++ b/sdf-js/src/scene/render-network.js
@@ -264,11 +264,12 @@ export function renderNetwork(ir, opts = {}) {
   const payoffDist = (cloudR * 2.6 + 1.5) * (env ? env.payoffZoom : 1);
   shots.push({
     duration: 2.4,
-    // payoff stays EYE-LEVEL: from above, the floor fills the frame and every
-    // floor pixel pays the wet-floor reflection retrace — measured 7fps vs
-    // 24fps. Sky pixels are cheap; floor pixels are not.
-    pos: [1.4, midY + 1.2 + (env ? 0.5 : 0), payoffDist],
-    target: [0, midY, 0],
+    // payoff at a MID crane angle (~25° down): eye-level rays run the length
+    // of the whole cloud (11fps even in stone mode); steep overhead fills the
+    // frame with floor (which in RICH mode pays the wet-floor retrace). The
+    // middle angle grounds most rays quickly without floor-filling the frame.
+    pos: [1.4, midY + payoffDist * 0.42 + (env ? 0.5 : 0), payoffDist * 0.92],
+    target: [0, midY - 0.1, 0],
     fov: 44,
     transition: 'blend',
     aperture: 0.12, // deep focus: the whole story stays sharp


### PR DESCRIPTION
## 方向(user 指定)

> 产品目的是文字表达意图的 3D 空间可视化,材质不是最重要的。先用最简单的白色石头材质解决性能,再解决画面好不好看。(附 IQ sphere-AO shadertoy 作为参照配方)

## 实现:rich / stone 编译期互斥 feature

关键决策:**编译期 gate 而不是 uniform 分支**——#286 的教训是 Apple GPU 寄存器按 shader 最坏路径分配,uniform 分支不还寄存器。stone 模式下整个 PBR 块从源码里剔除:

| 剔除(rich only) | 保留(stone 配方,即 IQ 白石) |
|---|---|
| 主光软阴影 march(32 步/像素) | 一盏暖 key(diffuse) |
| 反射 retrace(32 步/像素) | 半球天光(0.6+0.4·n.y) |
| GGX/rim/kicker/studio 高光 | AO(落地感,IQ 配方的灵魂) |
| 额外聚光灯循环(每灯 32 步影) | 距离雾 exp(-0.03t) |
| fbm 表面纹理 / Shane 图案 | **albedo 保留**(黑石母题/金强调仍成立) |

- `studio.setRenderMode('stone'|'rich')`,programCache 按生成源自动区分,两模式可共存缓存
- **Present 产品页默认 stone**,`?mode=rich` 换回全质感;compositor/gallery 不受影响(默认 rich)
- network payoff 改中俯角(平视 ray 纵穿整团云,stone 下也只有 11fps)

## 实测(M3,bytedance-bp,固定 0.75× 对比)

| 镜头 | rich | stone |
|---|---|---|
| network hero(云内) | 16 | **72** |
| network tour | 39 | **60** |
| hold / magnitude 站 | 98-121 | **121** |
| 金柱 super(1.0×) | 47-85 | **120** |

观感目检:白模干净、AO 接触影在、金柱 252.2 冲击力和 super 压暗全保留(截图验证)。141/141(feature-gate 测试扩展:rich/stone 括号平衡 + stone 无阴影 march 断言)。

## 已知余项

network payoff 全景(2.4s)stone 下仍 ~14fps——平视全景的 march 长度问题对着色模式免疫,需要下一级(解析求交渲染器,见下)。

## 下一步方向(user 的 shadertoy 例子暗示的终局)

例子的主角其实是 `sphIntersect`——**解析求交,零步进**。我们的场景 100% 由 box/sphere/capsule/ellipsoid 构成,全部有解析交。一个「解析白模渲染器」可以彻底告别 raymarch 的掠射坍缩(预计再一个数量级),这是架构级专项,建议下一轮立项。

🤖 Generated with [Claude Code](https://claude.com/claude-code)