### PR TITLE
fix: 演出时钟完整性 — presenter 空格乱序修复(两个时钟 bug)

### DIFF
--- a/sdf-js/src/render/studio.js
+++ b/sdf-js/src/render/studio.js
@@ -2027,7 +2027,7 @@ export function createStudioRenderer({
   // (N station windows + N-1 transit pairs + the finale full-world program).
   // 24 covers a 12-station deck; each cached FS is ~1MB of driver bytecode,
   // well worth not recompiling a 200-500ms shader mid-presentation.
-  const PROGRAM_CACHE_MAX = 24;
+  const PROGRAM_CACHE_MAX = 48; // 2N windows for a deck: 13 stations = 26 programs — leave headroom
   // KHR_parallel_shader_compile: lets the driver compile+link on background
   // threads. We link WITHOUT querying LINK_STATUS (that query forces a
   // synchronous compile of the whole ~150KB+ shader — the multi-second
@@ -2250,7 +2250,7 @@ export function createStudioRenderer({
   // count) but defer GPU shader upload to next rAF (so cleared canvas paints
   // before the 200-500ms compile blocks the main thread).
   // `result` carries leafMaterials + leafPatterns + glsl for LUT upload.
-  function uploadCompiledFrag(fragSource, result) {
+  function uploadCompiledFrag(fragSource, result, { resetClocks = true } = {}) {
     // Program cache: hit avoids the GLSL compile+link that dominates scene-swap
     // perceived latency.
     // 2026-05-24: cache entry now carries the FS too. WebGL deleteProgram does
@@ -2280,7 +2280,7 @@ export function createStudioRenderer({
       // Async path: poll completion on rAF; swap the program in when ready.
       // Until then the previous program (or nothing, on first load) keeps
       // rendering and the main thread stays free (loading UIs can animate).
-      const mine = { entry, fragSource, result };
+      const mine = { entry, fragSource, result, resetClocks };
       pendingProgram = mine;
       const poll = () => {
         if (pendingProgram !== mine) {
@@ -2303,7 +2303,10 @@ export function createStudioRenderer({
           return;
         }
         finishProgramSetup(entry, result);
-        _debugFirstDraw = true; // first frame of THIS program resets the clocks
+        // Clock reset is a SCENE-LOAD semantic. A mid-play window swap that
+        // missed the cache must NOT restart the presentation (it used to
+        // zero the sequence mid-station whenever the LRU thrashed).
+        if (mine.resetClocks) _debugFirstDraw = true;
         wake();
       };
       requestAnimationFrame(poll);
@@ -2820,7 +2823,21 @@ export function createStudioRenderer({
       // run on wall time, so without this reset a 6s cameraSequence + its build-in
       // animations can be over before the audience sees frame one.
       timeStart = performance.now();
-      if (activeSequence) sequenceStartTime = performance.now();
+      // Sequence clock starts at the first visible frame — but if a presenter
+      // already HELD the clock (pause before this frame ever drew), re-anchor
+      // the frozen interval instead of stamping start=now: otherwise the held
+      // time becomes pausedAt−now ≈ −(compile seconds) and every subsequent
+      // playTo() first crawls through negative time (the "space bar plays
+      // from nowhere" bug on big decks whose first frame lands late).
+      if (activeSequence) {
+        if (sequencePaused) {
+          const heldRaw = (sequencePausedAt - sequenceStartTime) / 1000;
+          sequenceStartTime = performance.now() - heldRaw * 1000;
+          sequencePausedAt = performance.now();
+        } else {
+          sequenceStartTime = performance.now();
+        }
+      }
       const err = gl.getError();
       const errName =
         err === gl.NO_ERROR
@@ -3002,7 +3019,7 @@ export function createStudioRenderer({
      */
     swapSDF(sdf) {
       const { fragSource, result } = compileStudioFrag(sdf, renderMode);
-      uploadCompiledFrag(fragSource, result);
+      uploadCompiledFrag(fragSource, result, { resetClocks: false });
       wake();
       return { bytes: fragSource.length };
     },


### PR DESCRIPTION
## 症状

13 站 deck 上按空格播放乱掉:每次按键先"从莫名位置"播放几秒,节拍完全错位。

## 两个根因(都是老 bug,被 13 站规模放大)

1. **held 时钟被首帧重置打翻**:「时钟从第一可见帧起算」的重置逻辑在 presenter 已经 HOLD 的情况下照样把 `sequenceStartTime` 拨到"现在"。13 站 deck 的首帧因 26 个 shader 预热晚到 ~5 秒,冻结位置变成 `pausedAt − now ≈ −4.9s`——之后每次 playTo 都要先爬过 4.9 秒的负时间。修复:paused 状态下**重锚定冻结区间两端**,held 位置原样保留。
2. **播放中换窗把时钟归零**:cache miss 的窗口 swap 完成时设了 `_debugFirstDraw` → 下一帧把演出时钟归零(站中间!)。26 窗 > 24 缓存上限,LRU 必然抖动、必然触发。修复:`swapSDF` 传 `resetClocks:false`(时钟重置是"场景加载"语义,不是"换窗"语义)+ 缓存 24→48。

## 诊断线索链(记录在案)

t=-4.94 且冻结 → API 三入口拦截零调用 → 排除 hitstops/warp → holdAt 探针证明冻结时刻正确 → 锁定非 API 写者 `_debugFirstDraw` → 第一修后暴露第二个 bug(t 半路归 2.0)→ LRU 抖动。

## 验证

10 次空格严格单调精确落拍:0.02 → 6.4 → 18.6 → hold(原地)→ 28.5 → 42.8 → 56.1 → 69.4 → 77.9 → 78.9 → 88.2。142/142 测试。

🤖 Generated with [Claude Code](https://claude.com/claude-code)