### PR TITLE
Sprint 82: 真迹装裱产品面 + GL 铸造线 (41/50)

### DIFF
--- a/sdf-js/apps/present/author-2d.html
+++ b/sdf-js/apps/present/author-2d.html
@@ -70,7 +70,10 @@
         border: 1px solid rgba(255, 255, 255, 0.18);
         background: rgba(20, 22, 28, 0.9);
         color: #fff;
-        font: 600 12px -apple-system, Inter, sans-serif;
+        font:
+          600 12px -apple-system,
+          Inter,
+          sans-serif;
         cursor: pointer;
       }
       #prompt {
@@ -82,7 +85,10 @@
         border: 1px solid rgba(255, 255, 255, 0.16);
         background: rgba(20, 22, 28, 0.92);
         color: #fff;
-        font: 500 14px -apple-system, Inter, sans-serif;
+        font:
+          500 14px -apple-system,
+          Inter,
+          sans-serif;
         outline: none;
       }
       #prompt:focus {
@@ -94,7 +100,10 @@
         border: 0;
         background: #2d6fd6;
         color: #fff;
-        font: 700 14px -apple-system, Inter, sans-serif;
+        font:
+          700 14px -apple-system,
+          Inter,
+          sans-serif;
         cursor: pointer;
       }
       #go:disabled {
@@ -111,7 +120,10 @@
         border: 1px solid rgba(255, 255, 255, 0.18);
         background: rgba(255, 255, 255, 0.06);
         color: #fff;
-        font: 600 13px -apple-system, Inter, sans-serif;
+        font:
+          600 13px -apple-system,
+          Inter,
+          sans-serif;
         cursor: pointer;
       }
       #exportRow select {
@@ -119,7 +131,10 @@
         border: 1px solid rgba(255, 255, 255, 0.18);
         background: rgba(20, 22, 28, 0.9);
         color: #fff;
-        font: 600 12px -apple-system, Inter, sans-serif;
+        font:
+          600 12px -apple-system,
+          Inter,
+          sans-serif;
         padding: 0 6px;
         cursor: pointer;
       }
@@ -136,7 +151,10 @@
         left: 50%;
         bottom: 84px;
         transform: translateX(-50%);
-        font: 500 12px -apple-system, Inter, sans-serif;
+        font:
+          500 12px -apple-system,
+          Inter,
+          sans-serif;
         color: rgba(255, 255, 255, 0.6);
         z-index: 20;
         max-width: min(820px, calc(100vw - 40px));
@@ -157,7 +175,10 @@
         padding: 4px 12px;
         background: rgba(20, 22, 28, 0.9);
         color: rgba(255, 255, 255, 0.55);
-        font: 500 11px ui-monospace, Menlo, monospace;
+        font:
+          500 11px ui-monospace,
+          Menlo,
+          monospace;
         cursor: pointer;
       }
       #prov:hover {
@@ -219,7 +240,10 @@
         border: 1px solid rgba(255, 255, 255, 0.2);
         background: rgba(20, 22, 28, 0.92);
         color: #fff;
-        font: 500 13px -apple-system, Inter, sans-serif;
+        font:
+          500 13px -apple-system,
+          Inter,
+          sans-serif;
         outline: none;
       }
       .slide-edit-row button {
@@ -237,7 +261,10 @@
         inset: 0;
         background: rgba(10, 12, 16, 0.55);
         color: #fff;
-        font: 600 14px -apple-system, Inter, sans-serif;
+        font:
+          600 14px -apple-system,
+          Inter,
+          sans-serif;
         align-items: center;
         justify-content: center;
         z-index: 4;
@@ -276,7 +303,10 @@
         padding: 8px 14px;
         background: #2d6fd6;
         color: #fff;
-        font: 600 13px -apple-system, Inter, sans-serif;
+        font:
+          600 13px -apple-system,
+          Inter,
+          sans-serif;
         cursor: pointer;
       }
       .slide-card.failed .retry:disabled {
@@ -325,12 +355,20 @@
       </p>
       <div id="slides"></div>
     </div>
-    <div id="keyrow"><input id="key" type="password" placeholder="Anthropic API key (BYOK, stays local)" /></div>
+    <div id="keyrow">
+      <input id="key" type="password" placeholder="Anthropic API key (BYOK, stays local)" />
+    </div>
     <button id="prov" hidden title="点击复制这件作品的复现链接 — 持链接永久复现同一修饰"></button>
     <div id="status">describe what you want to present — Atlas builds the deck</div>
     <div id="bar">
-      <textarea id="prompt" placeholder="e.g. our Q3: revenue by region (Americas leads at 890), the sales funnel from 1200 leads to 45 closed, and the new org under the CEO"></textarea>
-      <select id="mode" title="快速 = 1 次 LLM 调用, 3-5 张结构图. 整本 = 新闻/文章 → 整本简报 (~16 次调用, ~$0.5, ~90s)">
+      <textarea
+        id="prompt"
+        placeholder="e.g. our Q3: revenue by region (Americas leads at 890), the sales funnel from 1200 leads to 45 closed, and the new org under the CEO"
+      ></textarea>
+      <select
+        id="mode"
+        title="快速 = 1 次 LLM 调用, 3-5 张结构图. 整本 = 新闻/文章 → 整本简报 (~16 次调用, ~$0.5, ~90s)"
+      >
         <option value="quick">快速 · 3-5 页</option>
         <option value="full">整本 · 10-20 页</option>
       </select>
@@ -338,10 +376,19 @@
       <button id="go">Generate</button>
       <div id="exportRow">
         <select id="theme" disabled title="换主题 (零成本, 即时重渲染)"></select>
-        <button id="save" disabled title="保存 deck.json — 机器契约文件, 可重新打开/交给 3D 端">💾</button>
+        <button id="save" disabled title="保存 deck.json — 机器契约文件, 可重新打开/交给 3D 端">
+          💾
+        </button>
         <button id="open" title="打开 deck.json">📂</button>
         <input id="openfile" type="file" accept=".json,application/json" hidden />
         <button id="redress" disabled title="换装 — 重铸修饰纹理 (内容不动, 零成本)">🎨</button>
+        <select
+          id="artmount"
+          hidden
+          title="真迹装裱 — 用原版生成艺术 mint 替换修饰引擎 (封面全幅 + 标题栏胶片条, 非商用)"
+        >
+          <option value="">装裱 · 生成引擎</option>
+        </select>
         <select id="decorvis" disabled title="修饰纹理显示">
           <option value="on">修饰 · 开</option>
           <option value="off">修饰 · 关</option>

--- a/sdf-js/apps/present/author-2d.js
+++ b/sdf-js/apps/present/author-2d.js
@@ -18,6 +18,7 @@ import {
   slotRoleOf,
 } from '../../src/present/retheme.js';
 import { decorFromHash, mintDecorHash } from '../../src/present/decor/registry.js';
+import { artMountOpts, loadArtMount, fetchMintManifest } from '../../src/present/art-mount.js';
 import { ATLAS_THEMES } from '../../src/present/themes.js';
 import { exportDeckToPPTX } from '../../src/present/exporters/pptx.js';
 import { exportDeckToPDF } from '../../src/present/exporters/pdf.js';
@@ -259,6 +260,71 @@ function slotDecor(deck, slot) {
   return { ...deck.decor, seed: (deck.decor.seed ?? 1) + (slot.slotIdx ?? 0) };
 }
 
+// ── Sprint 82: 真迹装裱 — authentic original mints as the deck's art layer.
+// The mount replaces the decor engine on art surfaces (cover full-bleed +
+// banner filmstrip); the decor toggle doubles as the mount's view switch.
+// Degrades to nothing when the local mint cache is absent (gitignored).
+const MINT_BASE = '../../examples/original-mints/cache/';
+const artMountEl = document.getElementById('artmount');
+let artMount = null;
+
+function slotRenderOpts(theme, deck, slot) {
+  const base = {
+    palette: slotPalette(theme, slot),
+    decor: slotDecor(deck, slot),
+    decorRole: slotRoleOf(slot),
+  };
+  if (artMount && decorVisEl.value !== 'off') {
+    Object.assign(base, artMountOpts(artMount, slot, slotRoleOf(slot)) || {});
+  }
+  return base;
+}
+
+(async () => {
+  const manifest = await fetchMintManifest(MINT_BASE);
+  const oks = (manifest || []).filter((m) => m.status === 'ok');
+  if (!oks.length) return; // no local cache — feature stays hidden
+  for (const m of oks) {
+    const o = document.createElement('option');
+    o.value = m.id;
+    o.textContent = `装裱 · ${m.name}${m.artist ? ' · ' + m.artist : ''}`;
+    o.title = `${m.license || ''} — 原版脚本非商用运行`;
+    artMountEl.appendChild(o);
+  }
+  artMountEl.hidden = false;
+  artMountEl.addEventListener('change', async () => {
+    const id = artMountEl.value;
+    try {
+      artMount = id
+        ? await loadArtMount(
+            oks.find((m) => m.id === id),
+            MINT_BASE,
+          )
+        : null;
+    } catch (e) {
+      artMount = null;
+      artMountEl.value = '';
+      return setStatus(`装裱加载失败: ${e.message}`, true);
+    }
+    const qs = new URLSearchParams(location.search);
+    if (id) qs.set('art', id);
+    else qs.delete('art');
+    history.replaceState(null, '', `?${qs.toString()}`);
+    if (currentDeck) await renderDeck(currentDeck);
+    syncProvenance();
+    setStatus(
+      artMount
+        ? `已装裱 — ${artMount.name} 真迹 (封面全幅 + 标题栏胶片条, 非商用)`
+        : '已卸下装裱 — 回到生成引擎',
+    );
+  });
+  const want = new URLSearchParams(location.search).get('art');
+  if (want && oks.some((m) => m.id === want)) {
+    artMountEl.value = want;
+    artMountEl.dispatchEvent(new Event('change'));
+  }
+})();
+
 function reopenUrl(hash, v, serial) {
   return `${location.origin}${location.pathname}?hash=${hash}${v ? `&v=${v}` : ''}${serial != null ? `&n=${serial}` : ''}`;
 }
@@ -274,7 +340,7 @@ function syncProvenance() {
   provEl.hidden = false;
   redressEl.disabled = false;
   decorVisEl.disabled = false;
-  provEl.textContent = `作品 #${String(d.hash).slice(0, 8)}${d.serial != null ? ` · Nº ${d.serial}` : ''} · ${d.family} · ${d.personality} · v${d.v ?? 1}${d.rare ? ' · ✨稀有' : ''}`;
+  provEl.textContent = `${artMount && decorVisEl.value !== 'off' ? `装裱 ${artMount.name} 真迹 · ` : ''}作品 #${String(d.hash).slice(0, 8)}${d.serial != null ? ` · Nº ${d.serial}` : ''} · ${d.family} · ${d.personality} · v${d.v ?? 1}${d.rare ? ' · ✨稀有' : ''}`;
   // the address bar IS the provenance link (safe: ?hash is consume-once);
   // preserve other params (?demo=1 etc.) — only the hash slot is ours
   const qs = new URLSearchParams(location.search);
@@ -376,11 +442,7 @@ async function renderDeck(deck) {
     card.appendChild(cap);
     attachSlideControls(card, canvas, deck, slot);
     slidesEl.appendChild(card);
-    await renderSceneDataToCanvas(canvas, slot.sceneData, {
-      palette: slotPalette(deck.theme, slot),
-      decor: slotDecor(deck, slot),
-      decorRole: slotRoleOf(slot),
-    });
+    await renderSceneDataToCanvas(canvas, slot.sceneData, slotRenderOpts(deck.theme, deck, slot));
   }
   // Sprint 68: failed slots surface as retryable cards, not console lines —
   // a dropped page you can SEE is a page you can rescue
@@ -493,11 +555,7 @@ function attachSlideControls(card, canvas, deck, slot) {
     rollBtn.disabled = editGo.disabled = true;
     try {
       const sceneData = await reliftSlot(currentDeck, slot.slotIdx, { apiKey, revision });
-      await renderSceneDataToCanvas(canvas, sceneData, {
-        palette: slotPalette(deck.theme, slot),
-        decor: slotDecor(deck, slot),
-        decorRole: slotRoleOf(slot),
-      });
+      await renderSceneDataToCanvas(canvas, sceneData, slotRenderOpts(deck.theme, deck, slot));
       editRow.classList.remove('open');
       editInput.value = '';
       autosave();
@@ -602,11 +660,11 @@ async function generate() {
           const entry = streamCards.get(slot.slotIdx);
           if (!entry) return;
           try {
-            await renderSceneDataToCanvas(entry.canvas, slot.sceneData, {
-              palette: slotPalette(streamTheme, slot),
-              decor: slotDecor({ decor: streamDecor }, slot),
-              decorRole: slotRoleOf(slot),
-            });
+            await renderSceneDataToCanvas(
+              entry.canvas,
+              slot.sceneData,
+              slotRenderOpts(streamTheme, { decor: streamDecor }, slot),
+            );
           } finally {
             entry.card.classList.remove('busy');
           }
@@ -670,6 +728,8 @@ async function doExport(format) {
       decorVisEl.value === 'off' ? { ...currentDeck, decor: undefined } : currentDeck;
     const result = await fn(deckForExport, {
       onProgress: (msg, pct) => setStatus(`${msg} (${Math.round(pct)}%)`),
+      // 真迹装裱跟随视图开关 — 屏幕与文件一致
+      ...(artMount && decorVisEl.value !== 'off' ? { artMount } : {}),
     });
     setStatus(`downloaded: ${result.filename}`);
   } catch (e) {

--- a/sdf-js/examples/original-mints/README.md
+++ b/sdf-js/examples/original-mints/README.md
@@ -10,10 +10,13 @@
 > 含 ND/SA/NFT License 个例)。仅限**非商用**演示; 任何商用前须逐项目
 > 重新核对 license。ND 项目注意: 裁切/平铺可能构成改编, 使用完整原图。
 >
-> 铸造管线: 每项目独立 iframe 会话 (防动画泄漏), 双尺寸 —
-> `<Lxx>-small.*` (高 240, banner 平铺用 — 小画布让整幅构图进标题栏) /
-> `<Lxx>-large.*` (长边 1280/1400, 封面全幅用)。svg 型走 XMLSerializer
-> 栅格化 fallback。
+> 铸造管线 (两代): ① browse iframe 会话 (无 WebGL, 适合 2D/setup 同步型);
+> ② **playwright + 系统 Chrome (WebGL 1+2 全通, 主力)** — 判稳捕获 +
+> 元素级截图 (绕开 preserveDrawingBuffer)。产物命名: `<Lxx>-large.*`
+> (长边 1280/1400, 封面全幅) / `<Lxx>-small-0..2.png` (高 240 三变体,
+> banner 胶片条 — 小画布让整幅构图进标题栏) / 旧代 `<Lxx>-small.*` 作
+> fallback。已知个案: 少数多层纹理/重型作品两代运行器都空白 (manifest
+> 标 blocked:runtime)。
 >
 > `cache/` 整目录 gitignore (产物不入库, 本地重铸即得)。
 

--- a/sdf-js/examples/original-mints/index.html
+++ b/sdf-js/examples/original-mints/index.html
@@ -1,0 +1,211 @@
+<!doctype html>
+<html lang="zh">
+  <head>
+    <meta charset="utf-8" />
+    <title>Original Mints — 链上原版真迹画廊</title>
+    <style>
+      :root {
+        color-scheme: dark;
+      }
+      body {
+        margin: 0;
+        background: #101116;
+        color: #e8e6e0;
+        font:
+          14px/1.5 Inter,
+          system-ui,
+          sans-serif;
+      }
+      header {
+        padding: 22px 28px 8px;
+      }
+      h1 {
+        margin: 0 0 4px;
+        font-size: 20px;
+      }
+      .sub {
+        color: #9a97a0;
+        font-size: 12.5px;
+        max-width: 72em;
+      }
+      #grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+        gap: 14px;
+        padding: 20px 28px 48px;
+      }
+      .card {
+        background: #191a21;
+        border-radius: 10px;
+        overflow: hidden;
+        cursor: pointer;
+        transition: transform 0.12s;
+        border: 1px solid #24252d;
+      }
+      .card:hover {
+        transform: translateY(-2px);
+        border-color: #3a3b45;
+      }
+      .thumb {
+        width: 100%;
+        aspect-ratio: 1;
+        object-fit: contain;
+        background: #0c0d11;
+        display: block;
+      }
+      .meta {
+        padding: 9px 11px 11px;
+      }
+      .name {
+        font-weight: 600;
+        font-size: 13px;
+      }
+      .artist {
+        color: #9a97a0;
+        font-size: 12px;
+      }
+      .badges {
+        margin-top: 6px;
+        display: flex;
+        gap: 5px;
+        flex-wrap: wrap;
+      }
+      .badge {
+        font-size: 10px;
+        padding: 1.5px 7px;
+        border-radius: 99px;
+        background: #24252d;
+        color: #b9b6c0;
+      }
+      .badge.nc {
+        background: #1d2b22;
+        color: #8fd0a5;
+      }
+      .badge.nd {
+        background: #2e2419;
+        color: #e0b070;
+      }
+      .badge.other {
+        background: #2c1d24;
+        color: #d792ab;
+      }
+      .card.blocked {
+        opacity: 0.35;
+        cursor: default;
+      }
+      .card.blocked:hover {
+        transform: none;
+      }
+      #viewer {
+        position: fixed;
+        inset: 0;
+        background: rgba(8, 8, 12, 0.92);
+        display: none;
+        align-items: center;
+        justify-content: center;
+        flex-direction: column;
+        gap: 14px;
+        z-index: 9;
+      }
+      #viewer.open {
+        display: flex;
+      }
+      #viewer img {
+        max-width: 88vw;
+        max-height: 78vh;
+        box-shadow: 0 18px 70px rgba(0, 0, 0, 0.6);
+      }
+      #viewer .vmeta {
+        color: #cfccd6;
+        font-size: 13px;
+        text-align: center;
+      }
+      #viewer a {
+        color: #8fb8e8;
+      }
+      .strip-row {
+        display: flex;
+        gap: 8px;
+      }
+      .strip-row img {
+        height: 74px;
+        max-width: none;
+        box-shadow: 0 4px 18px rgba(0, 0, 0, 0.5);
+      }
+    </style>
+  </head>
+  <body>
+    <header>
+      <h1>Original Mints — 链上原版真迹画廊</h1>
+      <div class="sub">
+        ArtBlocks 链上原始脚本逐字运行的产物 (固定 hash, 永久复现)。仅限非商用演示 — license
+        逐项目标注, 使用前核对。点击卡片看大图与胶片条; 「装裱」跳转 author-2d 直接给 deck
+        穿上这件真迹。
+      </div>
+    </header>
+    <div id="grid"></div>
+    <div id="viewer">
+      <img id="vimg" alt="" />
+      <div class="strip-row" id="vstrip"></div>
+      <div class="vmeta" id="vmeta"></div>
+    </div>
+    <script type="module">
+      const BASE = './cache/';
+      const grid = document.getElementById('grid');
+      const viewer = document.getElementById('viewer');
+      const vimg = document.getElementById('vimg');
+      const vstrip = document.getElementById('vstrip');
+      const vmeta = document.getElementById('vmeta');
+      viewer.addEventListener('click', () => viewer.classList.remove('open'));
+
+      function badgeClass(license) {
+        const l = String(license || '');
+        if (l.includes('ND')) return 'nd';
+        if (l.includes('NC')) return 'nc';
+        if (l.includes('CC')) return 'nc';
+        return 'other';
+      }
+
+      const manifest = await fetch(BASE + 'manifest.json')
+        .then((r) => (r.ok ? r.json() : null))
+        .catch(() => null);
+      if (!manifest) {
+        grid.innerHTML =
+          '<div style="grid-column:1/-1;color:#9a97a0">本地 mint 缓存不存在 — 先跑铸造 sweep (见 README)。</div>';
+      } else {
+        for (const m of manifest) {
+          const ok = m.status === 'ok';
+          const card = document.createElement('div');
+          card.className = 'card' + (ok ? '' : ' blocked');
+          const thumbFile = ok ? `${m.id}-small-0.png` : null;
+          card.innerHTML = `
+            ${ok ? `<img class="thumb" loading="lazy" src="${BASE}${thumbFile}" onerror="this.src='${BASE}${m.files?.small || m.files?.large || ''}'">` : '<div class="thumb" style="display:grid;place-items:center;color:#5a5b66">WebGL 待补</div>'}
+            <div class="meta">
+              <div class="name">${m.id} · ${m.name}</div>
+              <div class="artist">${m.artist || ''}</div>
+              <div class="badges">
+                <span class="badge ${badgeClass(m.license)}">${m.license || '?'}</span>
+                <span class="badge">${m.type || ''}</span>
+              </div>
+            </div>`;
+          if (ok) {
+            card.addEventListener('click', () => {
+              vimg.src = BASE + (m.files?.large || thumbFile);
+              vstrip.innerHTML = '';
+              for (let k = 0; k < 3; k++) {
+                const im = new Image();
+                im.src = `${BASE}${m.id}-small-${k}.png`;
+                im.onerror = () => im.remove();
+                vstrip.appendChild(im);
+              }
+              vmeta.innerHTML = `<b>${m.name}</b> · ${m.artist || ''} · ${m.license || ''} · hash ${String(m.hash).slice(0, 12)}…<br>
+                <a href="../../apps/present/author-2d.html?art=${m.id}" onclick="event.stopPropagation()">→ 在 author-2d 里装裱这件真迹</a>`;
+              viewer.classList.add('open');
+            });
+          }
+          grid.appendChild(card);
+        }
+      }
+    </script>
+  </body>
+</html>

--- a/sdf-js/src/present/art-mount.js
+++ b/sdf-js/src/present/art-mount.js
@@ -1,0 +1,80 @@
+// =============================================================================
+// art-mount.js — Sprint 82: 真迹装裱 (authentic-artwork mount) as a product
+// surface.
+//
+// A "mount" is an externally rendered generative artwork set (one large
+// cover piece + a strip of SMALL-canvas mints) that takes the decor
+// engine's place on a deck's art surfaces — cover full-bleed, title
+// banners as a gallery filmstrip (renderer opts decorArt / decorArtStrip,
+// Sprint 80-81). Mints come from running the ORIGINAL on-chain scripts
+// verbatim (non-commercial; see examples/original-mints/README.md) and
+// live in examples/original-mints/cache/ (gitignored) with a manifest.
+//
+// This module is the single place that turns a mount into render opts, so
+// author-2d, the exporters and any future surface stay in lockstep.
+// =============================================================================
+
+/**
+ * artMountOpts(mount, slot, baseRole) → partial renderSceneDataToCanvas opts.
+ * Content pages are promoted to 'section' so EVERY page carries the banner
+ * filmstrip (the mount is the deck's visual identity, not a per-page whim);
+ * the strip rotates by slotIdx so no two banners start on the same mint.
+ */
+export function artMountOpts(mount, slot, baseRole) {
+  if (!mount || !mount.cover) return null;
+  const role = baseRole === 'cover' || baseRole === 'agenda' ? baseRole : 'section';
+  const out = { decorRole: role, decorArt: mount.cover };
+  if (Array.isArray(mount.strip) && mount.strip.length) {
+    const k = (slot.slotIdx ?? 0) % mount.strip.length;
+    out.decorArtStrip = mount.strip.slice(k).concat(mount.strip.slice(0, k));
+  }
+  return out;
+}
+
+const loadImage = (url) =>
+  new Promise((resolve, reject) => {
+    const im = new Image();
+    im.onload = () => resolve(im);
+    im.onerror = () => reject(new Error(`art-mount: failed to load ${url}`));
+    im.src = url;
+  });
+
+/**
+ * loadArtMount(entry, base) — load a manifest entry's images.
+ * `base` is the URL prefix of the cache dir (trailing slash). Prefers the
+ * GL-sweep triple smalls (<id>-small-0/1/2.png), falls back to the single
+ * legacy small, then to the cover itself.
+ */
+export async function loadArtMount(entry, base) {
+  if (!entry || entry.status !== 'ok' || !entry.files?.large) {
+    throw new Error(`art-mount: ${entry?.id || '?'} has no usable large mint`);
+  }
+  const cover = await loadImage(base + entry.files.large);
+  const strip = [];
+  for (let k = 0; k < 3; k++) {
+    try {
+      strip.push(await loadImage(`${base}${entry.id}-small-${k}.png`));
+    } catch {
+      /* variant absent — fine */
+    }
+  }
+  if (!strip.length && entry.files.small) {
+    try {
+      strip.push(await loadImage(base + entry.files.small));
+    } catch {
+      /* fall through to cover-only mount */
+    }
+  }
+  return { id: entry.id, name: entry.name, artist: entry.artist, cover, strip };
+}
+
+/** fetchMintManifest(base) → manifest array, or null when the cache is absent. */
+export async function fetchMintManifest(base) {
+  try {
+    const res = await fetch(base + 'manifest.json');
+    if (!res.ok) return null;
+    return await res.json();
+  } catch {
+    return null;
+  }
+}

--- a/sdf-js/src/present/exporters/pdf.js
+++ b/sdf-js/src/present/exporters/pdf.js
@@ -11,6 +11,7 @@
 
 import { renderSceneDataToCanvas } from '../atoms-2d/renderer.js';
 import { slotPalette, slotRoleOf } from '../retheme.js';
+import { artMountOpts } from '../art-mount.js';
 
 const JSPDF_CDN = 'https://esm.sh/jspdf@2.5.2';
 let jsPDF = null;
@@ -73,6 +74,8 @@ export async function exportDeckToPDF(deck, opts = {}) {
         decor: deck.decor
           ? { ...deck.decor, seed: (deck.decor.seed ?? 1) + slot.slotIdx }
           : undefined,
+        // Sprint 82: 真迹装裱 — screen and file must show the same mount
+        ...(artMountOpts(opts.artMount, slot, slotRoleOf(slot)) || {}),
       });
     } catch (e) {
       console.error(`[pdf] slide render failed:`, e);

--- a/sdf-js/src/present/exporters/pptx.js
+++ b/sdf-js/src/present/exporters/pptx.js
@@ -19,6 +19,7 @@
 
 import { renderSceneDataToCanvas } from '../atoms-2d/renderer.js';
 import { slotPalette, slotRoleOf } from '../retheme.js';
+import { artMountOpts } from '../art-mount.js';
 
 // pptxgenjs loaded from esm.sh on first call (matches pdfjs CDN pattern in
 // src/parser/pdf.js — no build step / bundler required).
@@ -89,6 +90,8 @@ export async function exportDeckToPPTX(deck, opts = {}) {
         decor: deck.decor
           ? { ...deck.decor, seed: (deck.decor.seed ?? 1) + slot.slotIdx }
           : undefined,
+        // Sprint 82: 真迹装裱 — screen and file must show the same mount
+        ...(artMountOpts(opts.artMount, slot, slotRoleOf(slot)) || {}),
       });
     } catch (e) {
       console.error(`[pptx] slide render failed:`, e);


### PR DESCRIPTION
CAB 三线的 A+B (C=#310 已并)。

**A — GL 铸造线**: browse headless 无 WebGL → playwright+系统 Chrome (WebGL 1+2 全通)。全量重 sweep (large + 3×小画布/项目, 并发+判稳+元素截图), 真迹覆盖 **32→41/50**: Watercolor Dreams / INK / Box Light / Naïve / Växt / Proscenium / phase / CENTURY / 720 Minutes / Skulptuur 全部破墙。9 项两代运行器都失败, manifest 标 blocked:runtime。教训记档: 并发饥饿会产出空白捕获 (跳过检查必须含质量阈值 + 扩展名双查)。

**B — 产品面**: art-mount.js 单一装配点; author-2d 「装裱」选择器 (?art= 参数, provenance 徽章并报, decorvis 兼作开关); 导出 PPTX/PDF 同装裱; 真迹画廊页 (license 徽章 + 胶片条预览 + 一键装裱)。

测试 142/142; 语料墙 v2 已交 Downloads。

🤖 Generated with [Claude Code](https://claude.com/claude-code)