### PR TITLE
Sprint 83: 稀疏 banner + 布局卫生 pass

### DIFF
--- a/sdf-js/scripts/test-align.mjs
+++ b/sdf-js/scripts/test-align.mjs
@@ -1,0 +1,69 @@
+// test-align.mjs — Sprint 83: layout-hygiene pass (edge clustering + grid snap)
+import { alignSceneData } from '../src/present/align.js';
+
+let passed = 0;
+let failed = 0;
+function ok(cond, msg) {
+  if (cond) {
+    passed++;
+    console.log(`  ✓ ${msg}`);
+  } else {
+    failed++;
+    console.log(`  ✗ ${msg}`);
+  }
+}
+
+// 1. near-miss left edges collapse to one column
+{
+  const scene = {
+    subjects: [
+      { type: 'kpi-card', x: 40, y: 160, w: 380, h: 200 },
+      { type: 'kpi-card', x: 43, y: 400, w: 377, h: 200 },
+      { type: 'kpi-card', x: 38, y: 640, w: 382, h: 200 },
+    ],
+  };
+  const out = alignSceneData(scene);
+  const xs = new Set(out.subjects.map((s) => s.x));
+  ok(xs.size === 1, `near-miss lefts unify (${[...xs].join(',')})`);
+  const rights = new Set(out.subjects.map((s) => s.x + s.w));
+  ok(rights.size === 1, 'near-miss rights unify');
+  ok([...xs][0] % 8 === 0, 'unified edge sits on the 8px grid');
+}
+
+// 2. genuinely different columns stay apart
+{
+  const scene = {
+    subjects: [
+      { type: 'kpi-card', x: 40, y: 160, w: 300, h: 200 },
+      { type: 'kpi-card', x: 640, y: 160, w: 300, h: 200 },
+    ],
+  };
+  const out = alignSceneData(scene);
+  ok(out.subjects[1].x - out.subjects[0].x > 500, 'distinct columns are not merged');
+  ok(out.subjects[0].y === out.subjects[1].y, 'shared row tops align');
+}
+
+// 3. banner cover atoms and typeless subjects are untouched
+{
+  const scene = {
+    subjects: [
+      { type: 'cover', x: 0, y: 0, w: 1280, h: 121 },
+      { type: 'bullet-list', x: 41, y: 163, w: 1199, h: 500 },
+      null,
+    ],
+  };
+  const out = alignSceneData(scene);
+  ok(out.subjects[0].h === 121, 'banner cover keeps its raw geometry');
+  ok(out.subjects[1].x % 8 === 0 && out.subjects[1].y % 8 === 0, 'content snaps to grid');
+  ok(out.subjects[2] === null, 'null subjects pass through');
+}
+
+// 4. pure function — input untouched
+{
+  const scene = { subjects: [{ type: 'kpi-card', x: 41, y: 163, w: 300, h: 200 }] };
+  alignSceneData(scene);
+  ok(scene.subjects[0].x === 41, 'input sceneData is never mutated');
+}
+
+console.log(`\n${passed} passed, ${failed} failed`);
+if (failed) process.exit(1);

--- a/sdf-js/src/present/align.js
+++ b/sdf-js/src/present/align.js
@@ -1,0 +1,90 @@
+// =============================================================================
+// align.js — Sprint 83: deterministic layout hygiene (user: 页面元素对齐
+// 再优化一下, 现在画面有一点脏).
+//
+// LLM-lifted slots carry near-miss geometry: three cards at x=40/43/38, a
+// column edge that wanders 6px, gaps of 22/26/23. Individually invisible,
+// together they read as dirt. This pass cleans a slot's subjects without
+// any aesthetic opinion:
+//   1. EDGE CLUSTERING — left / right / top / bottom edges within `tol`
+//      of each other collapse to their cluster median (things that were
+//      meant to align, align);
+//   2. GRID SNAP — every resulting edge lands on an `grid`-px lattice
+//      (margins and gaps become multiples of one rhythm).
+//
+// View-level: the renderer applies it at paint time; deck.json (the
+// machine contract, twin source for the 3D end) keeps the raw lift
+// geometry. Banner 'cover' atoms are exempt — they own full-width bands.
+// =============================================================================
+
+function clusterMedians(values, tol) {
+  const idx = values.map((v, i) => [v, i]).sort((a, b) => a[0] - b[0]);
+  const out = new Array(values.length);
+  let group = [];
+  const flush = () => {
+    if (!group.length) return;
+    const median = group[Math.floor(group.length / 2)][0];
+    for (const [, i] of group) out[i] = median;
+    group = [];
+  };
+  for (const pair of idx) {
+    if (group.length && pair[0] - group[group.length - 1][0] > tol) flush();
+    group.push(pair);
+  }
+  flush();
+  return out;
+}
+
+/**
+ * alignSceneData(sceneData, {grid, tol}) → a NEW sceneData with cleaned
+ * subject geometry. Pure; the input is never mutated.
+ */
+export function alignSceneData(sceneData, { grid = 8, tol = 14 } = {}) {
+  const subjects = Array.isArray(sceneData?.subjects) ? sceneData.subjects : [];
+  const snap = (v) => Math.round(v / grid) * grid;
+  const movable = [];
+  for (let i = 0; i < subjects.length; i++) {
+    const s = subjects[i];
+    if (
+      s &&
+      s.type !== 'cover' &&
+      typeof s.x === 'number' &&
+      typeof s.y === 'number' &&
+      typeof s.w === 'number' &&
+      typeof s.h === 'number'
+    ) {
+      movable.push(i);
+    }
+  }
+  if (!movable.length) return sceneData;
+  const lefts = clusterMedians(
+    movable.map((i) => subjects[i].x),
+    tol,
+  );
+  const rights = clusterMedians(
+    movable.map((i) => subjects[i].x + subjects[i].w),
+    tol,
+  );
+  const tops = clusterMedians(
+    movable.map((i) => subjects[i].y),
+    tol,
+  );
+  const bottoms = clusterMedians(
+    movable.map((i) => subjects[i].y + subjects[i].h),
+    tol,
+  );
+  const next = subjects.slice();
+  for (let k = 0; k < movable.length; k++) {
+    const s = subjects[movable[k]];
+    const x = snap(lefts[k]);
+    const y = snap(tops[k]);
+    next[movable[k]] = {
+      ...s,
+      x,
+      y,
+      w: Math.max(16, snap(rights[k]) - x),
+      h: Math.max(16, snap(bottoms[k]) - y),
+    };
+  }
+  return { ...sceneData, subjects: next };
+}

--- a/sdf-js/src/present/atoms-2d/renderer.js
+++ b/sdf-js/src/present/atoms-2d/renderer.js
@@ -17,6 +17,7 @@
 
 import { renderAtom, isAtom2DType } from './registry.js';
 import { drawDecor } from '../decor/registry.js';
+import { alignSceneData } from '../align.js';
 
 const DEFAULT_PALETTE = {
   bg: [247, 244, 224],
@@ -48,7 +49,11 @@ export async function renderSceneDataToCanvas(canvas, sceneData, opts = {}) {
     ctx.fillRect(0, 0, canvas.width, canvas.height);
   }
 
-  const subjects = Array.isArray(sceneData?.subjects) ? sceneData.subjects : [];
+  // Sprint 83: layout hygiene — near-miss edges cluster + snap to an 8px
+  // lattice at paint time (deck.json keeps raw lift geometry). opts.align
+  // === false opts out (visual-audit replays raw coordinates).
+  const aligned = opts.align === false ? sceneData : alignSceneData(sceneData);
+  const subjects = Array.isArray(aligned?.subjects) ? aligned.subjects : [];
 
   // Decoration layer (Sprint 41): generative backdrop, theme-constrained +
   // seeded. Content slides get it UNDER the atoms ('subtle'); pure-cover
@@ -74,8 +79,11 @@ export async function renderSceneDataToCanvas(canvas, sceneData, opts = {}) {
   // decorArt is present.
   // Sprint 81: opts.decorArtStrip — an ARRAY of SMALL-canvas mints for the
   // title banner (user: 标题上的作品小画布更好 — a small canvas lets the
-  // whole composition sit inside the band instead of a zoomed crop). The
-  // strip tiles fit-height across the band like a gallery filmstrip.
+  // whole composition sit inside the band instead of a zoomed crop).
+  // Sprint 83 (user: 小画布不要排满, 目录页标题上放 1-2 个就好): the strip
+  // is SPARSE by default — an ink ground with 1-2 framed pieces on the
+  // right, breathing room instead of a wall-to-wall filmstrip. Callers can
+  // widen via opts.decorArtStripMax.
   const decorArt = opts.decorArt || null;
   const decorArtStrip =
     Array.isArray(opts.decorArtStrip) && opts.decorArtStrip.length ? opts.decorArtStrip : null;
@@ -98,18 +106,30 @@ export async function renderSceneDataToCanvas(canvas, sceneData, opts = {}) {
     const sh = dh / sc;
     ctx.drawImage(img, (iw - sw) / 2, (ih - sh) / 2, sw, sh, dx, dy, dw, dh);
   };
-  // gallery filmstrip: whole small mints at band height, butt-joined
+  // sparse gallery: ink ground + 1-2 whole small mints, right-aligned and
+  // framed with breathing room — the label owns the left, art owns the right
   const drawArtStrip = (dx, dy, dw, dh) => {
-    let cx2 = dx;
-    let k = 0;
-    while (cx2 < dx + dw) {
-      const img = decorArtStrip[k % decorArtStrip.length];
+    const ink = (palette.silhouetteColor || [30, 27, 30]).map((c) => Math.round(c * 0.3));
+    ctx.fillStyle = `rgb(${ink[0]}, ${ink[1]}, ${ink[2]})`;
+    ctx.fillRect(dx, dy, dw, dh);
+    const pad = Math.max(8, dh * 0.12);
+    const tileH = dh - pad * 2;
+    const maxN = Math.max(1, opts.decorArtStripMax ?? 2);
+    let right = dx + dw - pad * 1.5;
+    for (let k = 0; k < Math.min(maxN, decorArtStrip.length); k++) {
+      const img = decorArtStrip[k];
       const iw = img.width || 1;
       const ih = img.height || 1;
-      const tileW = Math.max(8, (dh * iw) / ih);
-      ctx.drawImage(img, cx2, dy, tileW, dh);
-      cx2 += tileW;
-      k++;
+      const tileW = (tileH * iw) / ih;
+      const left = right - tileW;
+      if (left < dx + dw * 0.42) break; // the label zone stays clear
+      ctx.save();
+      ctx.shadowColor = 'rgba(0, 0, 0, 0.45)';
+      ctx.shadowBlur = Math.max(6, dh * 0.08);
+      ctx.shadowOffsetY = 2;
+      ctx.drawImage(img, left, dy + pad, tileW, tileH);
+      ctx.restore();
+      right = left - pad * 1.5;
     }
   };
   if (coverCanvas) {


### PR DESCRIPTION
user 反馈 ③小画布不要排满 (目录页 1-2 个) ④对齐优化 (画面有点脏)。

- **稀疏 banner**: 排满胶片条 → 墨底 + 右侧 1-2 件 framed 带阴影小品, 标签区规定留白
- **布局卫生**: align.js 边缘聚类 (近失 14px 内归中位) + 8px 网格吸附, 渲染时视图层应用, 机器契约不动
- 测试 143/143 (新增 test-align 9 项); ANTFUN 四页目检通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)