### PR TITLE
feat: 站级色谱编程 — 与 2D 端共享 spectrum 色板,四图四色

### DIFF
--- a/sdf-js/apps/present/author.js
+++ b/sdf-js/apps/present/author.js
@@ -3,6 +3,7 @@
 // world, and the camera flies it. The full thesis loop in one input box.
 import { textToIR } from '../../src/scene/text-to-ir.js';
 import { assembleDeck } from '../../src/scene/assemble-deck.js';
+import { getTheme } from '../../src/present/themes.js';
 import { createFigure } from './figure-core.js';
 import { attachPresenter } from './presenter.js';
 
@@ -13,6 +14,8 @@ const env = params.get('env') || 'studio';
 // Fighting-game stage ON by default for authored worlds (per-station platforms +
 // deck theatre layer) — it's the product face. ?stage=0 opts out.
 const stage = params.get('stage') !== '0';
+const __atlasTheme = getTheme('pitch-spectrum');
+const __atlasPalette = __atlasTheme ? { anchor: __atlasTheme.accent, colors: __atlasTheme.colors } : null;
 const { studio, show } = createFigure({ outdoor: env !== 'studio', stage, renderMode: ['rich', 'stone'].includes(new URLSearchParams(location.search).get('mode')) ? new URLSearchParams(location.search).get('mode') : 'analytic' });
 let presenter = null; // active presenter runtime (disposed on regenerate)
 
@@ -44,7 +47,7 @@ async function generate() {
       `building ${deck.slides.length} station${deck.slides.length > 1 ? 's' : ''}: ${deck.slides.map((s) => s.structure).join(' → ')}`,
     );
     loading.classList.remove('done'); // shader may recompile for a new shape
-    const scene = assembleDeck(deck, { env, stage });
+    const scene = assembleDeck(deck, { env, stage, palette: __atlasPalette });
     show(scene);
     // Full-speech input → the model returned script spans → presenter mode:
     // the world starts HELD; space walks the speech, teleprompter shows the

--- a/sdf-js/apps/present/figure-core.js
+++ b/sdf-js/apps/present/figure-core.js
@@ -131,6 +131,9 @@ export function createFigure({
       if (o.role === 'value' && /^[\d,]+$/.test(o.text)) {
         o._countTarget = Number(o.text.replace(/,/g, ''));
       }
+      // section color program: the value chip fills with its station's
+      // chapter color (falls back to the stylesheet blue)
+      if (o.role === 'value' && o.accentColor) d.style.background = o.accentColor;
       d.textContent = o.text;
       document.body.appendChild(d);
       return d;
@@ -241,8 +244,14 @@ export function createFigure({
       // reads at full strength, spoken-already lines fall back. (`cur` is the
       // latest revealed subtitle — reveal times are beat-synced by design.)
       for (let i = 0; i < stageItems.length; i++)
-        if (stageItems[i].role === 'screen')
-          stageEls[i].classList.toggle('cur', i === lastOn);
+        if (stageItems[i].role === 'screen') {
+          const isCur = i === lastOn;
+          stageEls[i].classList.toggle('cur', isCur);
+          // the CURRENT line reads in the station's chapter color — the
+          // subtitle column and the geometry share one palette
+          stageEls[i].style.color =
+            isCur && stageItems[i].accentColor ? stageItems[i].accentColor : '';
+        }
     }
     // Pass 1: project + opacity/count-up; collect visible labels for layout.
     const placedRects = []; // near labels claim space first

--- a/sdf-js/apps/present/figure.js
+++ b/sdf-js/apps/present/figure.js
@@ -5,6 +5,7 @@
 // (shared with the author page).
 import { renderIR } from '../../src/scene/render-ir.js';
 import { assembleDeck } from '../../src/scene/assemble-deck.js';
+import { getTheme } from '../../src/present/themes.js';
 import { createFigure } from './figure-core.js';
 import { attachPresenter } from './presenter.js';
 
@@ -21,7 +22,15 @@ const deckName = params.get('deck');
 const layout = params.get('layout') || undefined; // line | radial | grid
 const name = params.get('ir') || 'funnel-sales';
 const ir = await (await fetch(`../../scenes/ir/${deckName || name}.json`)).json();
-const scene = deckName ? assembleDeck(ir, { env, layout, stage }) : renderIR(ir, { env, stage });
+// Section color program: the SAME palette the 2D end ships (pitch-spectrum,
+// chromotome kov_06 — ink ground + vermilion anchor). One content, two
+// mediums, one visual system. ?palette=<theme-id> to swap, ?palette=0 off.
+const paletteId = params.get('palette');
+const theme = paletteId === '0' ? null : getTheme(paletteId || 'pitch-spectrum');
+const palette = theme ? { anchor: theme.accent, colors: theme.colors } : null;
+const scene = deckName
+  ? assembleDeck(ir, { env, layout, stage, palette })
+  : renderIR(ir, { env, stage });
 show(scene);
 // script spans may ride in the deck fixture (teleprompter); presenter uses them
 if (present) attachPresenter({ studio: window.__figStudio, scene, script: ir.script || null });

--- a/sdf-js/scripts/test-deck-windows.mjs
+++ b/sdf-js/scripts/test-deck-windows.mjs
@@ -67,9 +67,23 @@ ok(sliceOf(5).subjects.length === scene.subjects.length, 'finale slice is the fu
   const hills = (s) =>
     s.subjects.filter((x) => typeof x.id === 'string' && x.id.startsWith('horizon-'));
   const fullHills = hills(scene).length;
-  ok(fullHills > 6, `full deck rings ${fullHills} hills (needs trimming to matter)`);
-  ok(hills(sliceOf(0)).length === 6, 'station window keeps only the 6 nearest hills');
-  ok(hills(sliceOf(1)).length === 6, 'transit window keeps only the 6 nearest hills');
+  ok(fullHills > 7, `full deck rings ${fullHills} monoliths (needs trimming to matter)`);
+  // ambience tiers: data stations trim the skyline hard (focus on the data),
+  // transits keep a mid budget (no tier field → content default)
+  ok(hills(sliceOf(0)).length === 3, 'content station window trims to 3 skyline monoliths');
+  ok(hills(sliceOf(1)).length === 3, 'transit window trims to 3 skyline monoliths');
+  {
+    const heroScene = assembleDeck(
+      { title: 'h', slides: [{ structure: 'hold', title: 'c', nodes: [] }, ir('x')] },
+      { stage: true },
+    );
+    const hw = heroScene.deckWindows.find((w) => w.kind === 'station' && w.tier === 'hero');
+    ok(!!hw, 'hold stations are tier hero');
+    ok(
+      hills(sliceDeckWindow(heroScene, hw)).length === 7,
+      'hero windows keep the full skyline (7 monoliths)',
+    );
+  }
   ok(
     Array.isArray(wins[0].origin) && wins[0].origin.length === 3,
     'station window carries its origin (nearest-hill anchor)',
@@ -80,6 +94,7 @@ ok(sliceOf(5).subjects.length === scene.subjects.length, 'finale slice is the fu
     return (t[0] - o[0]) ** 2 + (t[2] - o[2]) ** 2;
   };
   const keptIds = new Set(hills(sliceOf(0)).map((x) => x.id));
+  // nearest-K invariant checked against the CONTENT budget below
   const kept = hills(scene).filter((x) => keptIds.has(x.id));
   const dropped = hills(scene).filter((x) => !keptIds.has(x.id));
   const maxKept = Math.max(...kept.map((x) => d2(x, wins[0].origin)));
@@ -96,6 +111,37 @@ for (let i = 0; i < wins.length; i++) {
     /* fall through */
   }
   ok(!!sdf, `window ${i} (${wins[i].kind}) slice compiles to an SDF`);
+}
+
+// ---- section color program -----------------------------------------------------
+{
+  const palette = {
+    anchor: [241, 70, 22],
+    colors: [[241, 70, 22], [43, 154, 233], [168, 124, 42], [1, 119, 86]],
+  };
+  const deck2 = {
+    title: 'c',
+    slides: [
+      { structure: 'hold', title: 'cover', nodes: [] },
+      ir('a'),
+      ir('b'),
+      { structure: 'hold', title: 'mid', nodes: ['x'] },
+      ir('c'),
+    ],
+  };
+  const sc = assembleDeck(deck2, { stage: true, palette });
+  const chips = sc.overlay.filter((o) => o.role === 'value' && o.accentColor);
+  ok(chips.length > 0, 'value chips carry the station accent color');
+  const stationHues = new Set();
+  for (const sub of sc.subjects) {
+    const m = /^s(\d+)-mono-1$/.exec(sub.id || '');
+    if (m) stationHues.add(`${m[1]}:${sub.material.hue.toFixed(3)}`);
+  }
+  const hues = [...stationHues].map((x) => x.split(':')[1]);
+  ok(new Set(hues).size >= 2, `content stations rotate hues (${[...stationHues].join(' ')})`);
+  const noPal = assembleDeck(deck2, { stage: true });
+  const blue = noPal.subjects.find((x) => /^s1-mono-1$/.test(x.id));
+  ok(Math.abs(blue.material.hue - 0.595) < 0.02, 'no palette → classic blue family (back-compat)');
 }
 
 // ---- windowIndexAt ------------------------------------------------------------

--- a/sdf-js/src/scene/assemble-deck.js
+++ b/sdf-js/src/scene/assemble-deck.js
@@ -38,6 +38,45 @@ export function shiftBuildInExpr(expr, dy, dt) {
 }
 
 const addV = (a, b) => [a[0] + b[0], a[1] + b[1], a[2] + b[2]];
+
+// rgb [0-255] triple → {h,s,v} in 0..1 (scene materials speak HSV)
+export function rgbToHsv([r, g, b]) {
+  const rn = r / 255,
+    gn = g / 255,
+    bn = b / 255;
+  const max = Math.max(rn, gn, bn),
+    min = Math.min(rn, gn, bn);
+  const d = max - min;
+  let h = 0;
+  if (d > 0) {
+    if (max === rn) h = ((gn - bn) / d + 6) % 6;
+    else if (max === gn) h = (bn - rn) / d + 2;
+    else h = (rn - gn) / d + 4;
+    h /= 6;
+  }
+  return { h, s: max === 0 ? 0 : d / max, v: max };
+}
+
+// Section color programming (the 2D end's applySectionAccents, spatialized):
+// a long deck in one accent reads monotone. hold pages (cover / contents /
+// interludes) keep the ANCHOR hue; every content station takes the next hue
+// from the palette. Deterministic rotation, no LLM.
+function assignAccents(slides, palette) {
+  if (!palette || !Array.isArray(palette.colors) || !palette.colors.length) return slides.map(() => null);
+  const anchor = rgbToHsv(palette.anchor || palette.colors[0]);
+  const GOLD_H = 0.11; // the deck-wide champion mark — accents must not impersonate it
+  const pool = palette.colors
+    .filter((c) => !palette.anchor || c.join(',') !== palette.anchor.join(','))
+    .map(rgbToHsv)
+    .filter((a) => Math.min(Math.abs(a.h - GOLD_H), 1 - Math.abs(a.h - GOLD_H)) > 0.06);
+  let next = 0;
+  return slides.map((ir) => {
+    if (ir.structure === 'hold') return anchor;
+    const a = pool.length ? pool[next % pool.length] : anchor;
+    next++;
+    return a;
+  });
+}
 const seqDuration = (shots) => shots.reduce((s, sh) => s + (sh.duration || 0), 0);
 
 // ---- Deck archetypes ---------------------------------------------------------
@@ -78,6 +117,7 @@ export function assembleDeck(deck, opts = {}) {
   if (!deck || !Array.isArray(deck.slides) || deck.slides.length === 0)
     throw new Error('assembleDeck: deck.slides must be a non-empty array of IRs');
   const env = getEnvironment(opts.env);
+  const accents = assignAccents(deck.slides, opts.palette);
   const stride = opts.stride ?? 16;
   const layout = DECK_LAYOUTS.includes(opts.layout ?? deck.layout)
     ? (opts.layout ?? deck.layout)
@@ -105,7 +145,10 @@ export function assembleDeck(deck, opts = {}) {
     // postFx / room shell) are discarded here on purpose — the deck owns the
     // world and applies ONE theatre layer below (walls would slice the deck
     // axis, and MAX_EXTRA_LIGHTS=4 can't do per-station rigs).
-    const st = renderIR(ir, opts.stage ? { stage: true } : {});
+    const st = renderIR(ir, {
+      ...(opts.stage ? { stage: true } : {}),
+      ...(accents[k] ? { accent: accents[k] } : {}),
+    });
     const origin = origins[k];
 
     // Transit shot: whip from the previous station's payoff toward this one's
@@ -166,12 +209,21 @@ export function assembleDeck(deck, opts = {}) {
     // outgoing station's words must clear the screen — the next title landing
     // WITH its arena is what makes the cut read intentional.
     const stationEnd = clock + seqDuration(st.cameraSequence.shots);
+    const accCss = accents[k]
+      ? (() => {
+          const { h, s: sat, v } = accents[k];
+          return `hsl(${(h * 360).toFixed(0)} ${(sat * 100).toFixed(0)}% ${(v * 58).toFixed(0)}%)`;
+        })()
+      : null;
     for (const o of st.overlay || []) {
       overlay.push({
         ...o,
         anchor: addV(o.anchor, origin),
         revealAt: (o.revealAt ?? 0) + clock,
         ...(o.role === 'title' || o.role === 'screen' ? { hideAt: stationEnd } : {}),
+        // the DOM layer paints in the station's chapter color too: the value
+        // chip's fill and the CURRENT subtitle line pick it up
+        ...(accCss ? { accentColor: accCss } : {}),
       });
     }
 
@@ -196,6 +248,9 @@ export function assembleDeck(deck, opts = {}) {
       start: clock,
       end: clock + stationDur,
       origin: [...origin],
+      // ambience tier (2D's page-tier system, spatialized): hold pages are
+      // HERO — full skyline; data stations trim ambience to keep focus
+      tier: ir.structure === 'hold' ? 'hero' : 'content',
     });
     clock += stationDur;
     const last = st.cameraSequence.shots[st.cameraSequence.shots.length - 1];
@@ -328,7 +383,8 @@ export function assembleDeck(deck, opts = {}) {
 // invisible while the statement count halves. Env terrains (alpine etc.) are
 // NOT trimmed: their pieces are large and continuous, and cutting one leaves
 // a hole in the world.
-const HILLS_PER_WINDOW = 6;
+const HILLS_HERO = 7;
+const HILLS_CONTENT = 3;
 export function sliceDeckWindow(scene, win) {
   if (!win || win.kind === 'finale') return scene;
   const wanted = new Set(win.stations);
@@ -349,15 +405,14 @@ export function sliceDeckWindow(scene, win) {
   };
   let subjects = scene.subjects.filter(keep);
   if (Array.isArray(win.origin)) {
+    const hillBudget = win.tier === 'hero' ? HILLS_HERO : HILLS_CONTENT;
     const hills = subjects.filter((s) => typeof s.id === 'string' && s.id.startsWith('horizon-'));
-    if (hills.length > HILLS_PER_WINDOW) {
+    if (hills.length > hillBudget) {
       const distSq = (s) => {
         const t = (s.transform && s.transform.translate) || [0, 0, 0];
         return (t[0] - win.origin[0]) ** 2 + (t[2] - win.origin[2]) ** 2;
       };
-      const near = new Set(
-        [...hills].sort((a, b) => distSq(a) - distSq(b)).slice(0, HILLS_PER_WINDOW),
-      );
+      const near = new Set([...hills].sort((a, b) => distSq(a) - distSq(b)).slice(0, hillBudget));
       subjects = subjects.filter((s) => !s.id || !s.id.startsWith('horizon-') || near.has(s));
     }
   }

--- a/sdf-js/src/scene/render-magnitude.js
+++ b/sdf-js/src/scene/render-magnitude.js
@@ -22,7 +22,10 @@ import { getEnvironment } from './environments.js';
 
 const label = (n) => (typeof n === 'string' ? n : (n && (n.label ?? n.name)) || '');
 
-const monoMat = (i, N, emphasized) => {
+// Section color programming: the station's chapter accent drives the family
+// hue (deck-level color program, shared palette with the 2D end); gold stays
+// the deck-wide CHAMPION mark. No accent → the classic blue family.
+const monoMat = (i, N, emphasized, accent) => {
   if (emphasized)
     return {
       hue: 0.11,
@@ -35,6 +38,15 @@ const monoMat = (i, N, emphasized) => {
       clearcoat: 0.6,
     };
   const k = N > 1 ? i / (N - 1) : 0;
+  if (accent)
+    return {
+      hue: accent.h,
+      sat: Math.min(1, accent.s * (0.8 + 0.25 * k)),
+      value: Math.max(0.28, accent.v * (1.0 - 0.3 * k)),
+      kind: 'normal',
+      roughness: 0.3,
+      clearcoat: 0.45,
+    };
   return {
     hue: 0.55 + 0.09 * k,
     sat: 0.62 + 0.14 * k,
@@ -103,7 +115,7 @@ export function renderMagnitude(ir, opts = {}) {
       type: 'rounded_box', // beveled edges — a hewn stone, not a raw prim
       args: { dims: [W, H, W], cornerR: 0.045 },
       transform: { translate: [xOf(i), yFinal, 0] },
-      material: monoMat(i, N, emphasis.has(i)),
+      material: monoMat(i, N, emphasis.has(i), opts.accent),
       animation: [
         {
           channel: 'transform.translate.y',

--- a/sdf-js/src/scene/render-matrix.js
+++ b/sdf-js/src/scene/render-matrix.js
@@ -19,10 +19,12 @@ import { getEnvironment } from './environments.js';
 const label = (n) => (typeof n === 'string' ? n : (n && (n.label ?? n.name)) || '');
 
 const TILE_MAT = { hue: 0.6, sat: 0.1, value: 0.3, kind: 'normal', roughness: 0.7, clearcoat: 0.1 };
-const itemMat = (emphasized) =>
+const itemMat = (emphasized, accent) =>
   emphasized
     ? { hue: 0.11, sat: 0.78, value: 0.95, glow: 0.22, kind: 'normal', roughness: 0.22, clearcoat: 0.6 }
-    : { hue: 0.57, sat: 0.55, value: 0.72, kind: 'normal', roughness: 0.3, clearcoat: 0.45 };
+    : accent
+      ? { hue: accent.h, sat: accent.s, value: Math.max(0.32, accent.v * 0.85), kind: 'normal', roughness: 0.3, clearcoat: 0.45 }
+      : { hue: 0.57, sat: 0.55, value: 0.72, kind: 'normal', roughness: 0.3, clearcoat: 0.45 };
 
 // ---- evolution form ------------------------------------------------------------
 // A matrix whose X axis is a two-state TIME axis (past → present) reads better
@@ -259,7 +261,7 @@ export function renderMatrix(ir, opts = {}) {
       type: 'rounded_box',
       args: { dims: [size, size, size], cornerR: 0.06 },
       transform: { translate: [cellX(xi), cellY(yi), zFinal] },
-      material: itemMat(emphasis.has(i)),
+      material: itemMat(emphasis.has(i), opts.accent),
       animation: [
         {
           channel: 'transform.translate.z',

--- a/sdf-js/src/scene/render-network.js
+++ b/sdf-js/src/scene/render-network.js
@@ -94,7 +94,7 @@ export function constellationLayout(ir, opts = {}) {
   return { pos, degree, hub };
 }
 
-const nodeMatN = (deg, maxDeg, emphasized) => {
+const nodeMatN = (deg, maxDeg, emphasized, accent) => {
   if (emphasized)
     return {
       hue: 0.11,
@@ -107,6 +107,15 @@ const nodeMatN = (deg, maxDeg, emphasized) => {
       clearcoat: 0.6,
     };
   const k = maxDeg > 0 ? deg / maxDeg : 0; // hubs lighter, leaves deeper
+  if (accent)
+    return {
+      hue: accent.h,
+      sat: Math.min(1, accent.s * (0.95 - 0.2 * k)),
+      value: Math.max(0.3, accent.v * (0.72 + 0.28 * k)),
+      kind: 'normal',
+      roughness: 0.55,
+      clearcoat: 0.2,
+    };
   return {
     hue: 0.64 - 0.09 * k,
     sat: 0.78 - 0.16 * k,
@@ -162,7 +171,7 @@ export function renderNetwork(ir, opts = {}) {
       type: 'sphere',
       args: { radius: nodeR(i) },
       transform: { translate: p },
-      material: nodeMatN(degree[i], maxDeg, emphasis.has(i)),
+      material: nodeMatN(degree[i], maxDeg, emphasis.has(i), opts.accent),
       animation: [
         {
           channel: 'transform.translate.y',

--- a/sdf-js/src/scene/render-sequence.js
+++ b/sdf-js/src/scene/render-sequence.js
@@ -22,7 +22,7 @@ export function magnitudeToRadii(magnitude, maxR = 1.8, tipR = 0.14) {
 // stage in warm gold so the outcome pops against the cool family. Warm coral on
 // every stage rendered muddy-brown under the studio's key light; the blue family
 // is proven legible there (sphere-fill gauge).
-const stageMat = (i, N, emphasized) => {
+const stageMat = (i, N, emphasized, accent) => {
   if (emphasized)
     return {
       hue: 0.11,
@@ -35,6 +35,15 @@ const stageMat = (i, N, emphasized) => {
       clearcoat: 0.6,
     };
   const k = N > 1 ? i / (N - 1) : 0;
+  if (accent)
+    return {
+      hue: accent.h,
+      sat: Math.min(1, accent.s * (0.8 + 0.25 * k)),
+      value: Math.max(0.26, accent.v * (1.0 - 0.35 * k)),
+      kind: 'normal',
+      roughness: 0.3,
+      clearcoat: 0.45,
+    };
   return {
     hue: 0.55 + 0.09 * k, // cyan-blue → indigo
     sat: 0.62 + 0.16 * k,
@@ -86,7 +95,7 @@ export function renderSequence(ir, opts = {}) {
       type: 'funnel-3d',
       args: { stages: 1, radii: [radii[i], radii[i + 1]], stageHeight, gap: 0 },
       transform: { translate: [0, yc, 0] },
-      material: stageMat(i, N, emphasis.has(i)),
+      material: stageMat(i, N, emphasis.has(i), opts.accent),
       animation: [
         {
           channel: 'transform.translate.y',


### PR DESCRIPTION
## 源头

2D 端用 applySectionAccents + chromotome spectrum 主题解决了长 deck 单色单调的问题。本 PR 把**同一套思想 + 同一份色板数据**搬进 3D:一份内容、两种媒介、一个视觉系统。

## 实现

- **色板共享**:app 层 import 2D 的 `pitch-spectrum`(kov_06:墨底 + 朱红锚 + 天蓝/赭金/深绿/绯粉/灰绿)传入 assembleDeck——墨底≈黑石、朱红锚≈头条红,天然同族。`?palette=<id>` 换主题,`?palette=0` 关闭
- **站级轮转**:hold 页(封面/目录)持锚色,内容站依次轮转色板;市场四图从四站同蓝变成**四个色相分明的章节**
- **金色卫冕**:金保留为全 deck 恒定的"冠军"符号;accent 池过滤与金相近的色相(赭金撞色实测发现并修复——绿柱阵中金色 252.2 跳出来的样片见测试截图)
- **文字入谱**:数值 chip 底色 = 站色,字幕**当前行** = 站色——几何与文字同一调色板
- **氛围两档**(2D 三级页面体系的空间版):hero 页(hold)保留 7 座天际碑,数据站裁到 3 座——注意力跟随页面等级
- 向后兼容:无色板 → 经典蓝系,单页(?ir=)不受影响

## 验证

- 120fps 门 @1.0×:market2/market3/network/funnel 全部 121
- 142/142(色相轮转 / chip 注入 / 分档预算 / 无色板回退断言)
- 目检:市场之二整站深绿 + 金柱冠军 + chip/字幕同染

🤖 Generated with [Claude Code](https://claude.com/claude-code)