### PR TITLE
Sprint 84: 装裱色调贯穿全 deck (提色+数字着色+内页艺术回归)

### DIFF
--- a/sdf-js/apps/present/author-2d.js
+++ b/sdf-js/apps/present/author-2d.js
@@ -18,7 +18,12 @@ import {
   slotRoleOf,
 } from '../../src/present/retheme.js';
 import { decorFromHash, mintDecorHash } from '../../src/present/decor/registry.js';
-import { artMountOpts, loadArtMount, fetchMintManifest } from '../../src/present/art-mount.js';
+import {
+  artMountOpts,
+  loadArtMount,
+  fetchMintManifest,
+  mountPaletteOverride,
+} from '../../src/present/art-mount.js';
 import { ATLAS_THEMES } from '../../src/present/themes.js';
 import { exportDeckToPPTX } from '../../src/present/exporters/pptx.js';
 import { exportDeckToPDF } from '../../src/present/exporters/pdf.js';
@@ -276,6 +281,9 @@ function slotRenderOpts(theme, deck, slot) {
   };
   if (artMount && decorVisEl.value !== 'off') {
     Object.assign(base, artMountOpts(artMount, slot, slotRoleOf(slot)) || {});
+    // Sprint 84: the deck speaks the artwork's colors — accents/numbers
+    // across every atom come from the mount's extracted palette
+    base.palette = mountPaletteOverride(base.palette, artMount);
   }
   return base;
 }

--- a/sdf-js/src/present/art-mount.js
+++ b/sdf-js/src/present/art-mount.js
@@ -19,16 +19,87 @@
  * Content pages are promoted to 'section' so EVERY page carries the banner
  * filmstrip (the mount is the deck's visual identity, not a per-page whim);
  * the strip rotates by slotIdx so no two banners start on the same mint.
+ * Sprint 84 (user: 内页丢了生成艺术是负优化): every promoted page also asks
+ * the renderer for the SUBTLE decor underlay (decorUnder) — the decor
+ * engine keeps painting the body, in the MOUNT's palette, so the artwork's
+ * voice runs through every page instead of stopping at the banner.
  */
 export function artMountOpts(mount, slot, baseRole) {
   if (!mount || !mount.cover) return null;
   const role = baseRole === 'cover' || baseRole === 'agenda' ? baseRole : 'section';
   const out = { decorRole: role, decorArt: mount.cover };
+  if (role === 'section') out.decorUnder = true;
   if (Array.isArray(mount.strip) && mount.strip.length) {
     const k = (slot.slotIdx ?? 0) % mount.strip.length;
     out.decorArtStrip = mount.strip.slice(k).concat(mount.strip.slice(0, k));
   }
   return out;
+}
+
+/**
+ * extractMountPalette(img) → {accent, colors[]} — the artwork's dominant
+ * voice, quantized from a downsampled read of the piece. Near-white and
+ * near-black pixels are skipped (paper/ink grounds would always win);
+ * candidates are ranked by frequency × saturation and deduped by RGB
+ * distance, and the most saturated survivor becomes the accent (Sprint 84,
+ * user: 数字应统一用彩色, 从生成艺术中提取主色调).
+ */
+export function extractMountPalette(img, { maxColors = 6 } = {}) {
+  try {
+    const S = 48;
+    const c = document.createElement('canvas');
+    c.width = S;
+    c.height = S;
+    const g = c.getContext('2d');
+    g.drawImage(img, 0, 0, S, S);
+    const d = g.getImageData(0, 0, S, S).data;
+    const buckets = new Map();
+    for (let i = 0; i < d.length; i += 4) {
+      const r = d[i];
+      const gg = d[i + 1];
+      const b = d[i + 2];
+      const lum = 0.2126 * r + 0.7152 * gg + 0.0722 * b;
+      if (lum > 235 || lum < 18) continue;
+      const key = ((r >> 4) << 8) | ((gg >> 4) << 4) | (b >> 4);
+      const e = buckets.get(key) || { n: 0, r: 0, g: 0, b: 0, sat: 0 };
+      e.n++;
+      e.r += r;
+      e.g += gg;
+      e.b += b;
+      e.sat += Math.max(r, gg, b) - Math.min(r, gg, b);
+      buckets.set(key, e);
+    }
+    const cands = [...buckets.values()]
+      .map((e) => ({
+        rgb: [Math.round(e.r / e.n), Math.round(e.g / e.n), Math.round(e.b / e.n)],
+        score: e.n * (1 + e.sat / e.n / 128),
+      }))
+      .sort((a, b) => b.score - a.score);
+    const dist = (a, b) => Math.hypot(a[0] - b[0], a[1] - b[1], a[2] - b[2]);
+    const picked = [];
+    for (const cnd of cands) {
+      if (picked.every((p) => dist(p, cnd.rgb) > 60)) picked.push(cnd.rgb);
+      if (picked.length >= maxColors) break;
+    }
+    if (!picked.length) return null;
+    const satOf = ([r, g, b]) => Math.max(r, g, b) - Math.min(r, g, b);
+    // accent: most saturated pick with enough presence (top half of ranking)
+    const top = picked.slice(0, Math.max(2, Math.ceil(picked.length / 2) + 1));
+    const accent = [...top].sort((a, b) => satOf(b) - satOf(a))[0];
+    return { accent, colors: [accent, ...picked.filter((p) => p !== accent)] };
+  } catch {
+    return null; // tainted canvas / no DOM — mount still works, without a palette
+  }
+}
+
+/**
+ * mountPaletteOverride(basePalette, mount) → the deck palette re-voiced in
+ * the artwork's colors. Accent AND colors[] are replaced (atoms read either);
+ * ink/bg/silhouette stay with the theme so text contrast is untouched.
+ */
+export function mountPaletteOverride(basePalette, mount) {
+  if (!mount?.palette?.accent) return basePalette;
+  return { ...basePalette, accent: mount.palette.accent, colors: mount.palette.colors };
 }
 
 const loadImage = (url) =>
@@ -65,7 +136,14 @@ export async function loadArtMount(entry, base) {
       /* fall through to cover-only mount */
     }
   }
-  return { id: entry.id, name: entry.name, artist: entry.artist, cover, strip };
+  return {
+    id: entry.id,
+    name: entry.name,
+    artist: entry.artist,
+    cover,
+    strip,
+    palette: extractMountPalette(cover),
+  };
 }
 
 /** fetchMintManifest(base) → manifest array, or null when the cache is absent. */

--- a/sdf-js/src/present/atoms-2d/charts/agenda/agenda-list.js
+++ b/sdf-js/src/present/atoms-2d/charts/agenda/agenda-list.js
@@ -253,7 +253,9 @@ function drawShowcase(
 
     // Big number (PL signature)
     if (numbered) {
-      ctx.fillStyle = isHi ? rgbCss(accent) : rgbaCss(fg, 0.18);
+      // Sprint 84 (user: 数字灰色对比奇怪显脏, 统一用彩色): the showcase
+      // numerals speak the accent — full for the highlight, airy for rest
+      ctx.fillStyle = isHi ? rgbCss(accent) : rgbaCss(accent, 0.45);
       ctx.font = `900 ${Math.round(numSize)}px "Inter Display", Inter, system-ui, sans-serif`;
       ctx.textAlign = 'left';
       ctx.textBaseline = 'top';

--- a/sdf-js/src/present/atoms-2d/charts/data/kpi-card.js
+++ b/sdf-js/src/present/atoms-2d/charts/data/kpi-card.js
@@ -245,8 +245,9 @@ function _drawLight(ctx, args, opts = {}) {
     drawIconStub(ctx, args.icon, x + 26, y + 30, 32, rgbCss(accent));
   }
 
-  // ---- Hero value (dark text) ----
-  ctx.fillStyle = rgbCss(fg);
+  // ---- Hero value — Sprint 84: numbers wear the accent (user: 数字应使用
+  // 彩色, 从生成艺术提取主色调; ink numerals read grey-dirty next to labels)
+  ctx.fillStyle = rgbCss(accent);
   ctx.textAlign = 'left';
   ctx.textBaseline = 'alphabetic';
   const availW = w - 44;
@@ -275,7 +276,7 @@ function _drawLight(ctx, args, opts = {}) {
 
   // ---- Sublabel ----
   if (args.sublabel) {
-    ctx.fillStyle = rgbaCss(fg, 0.45);
+    ctx.fillStyle = rgbaCss(accent, 0.7);
     const subFs = fitFontSize(
       ctx,
       String(args.sublabel),
@@ -348,8 +349,8 @@ function _drawAccentBorder(ctx, args, opts = {}) {
     drawIconStub(ctx, args.icon, textLeft + 15, y + 30, 32, rgbCss(accent));
   }
 
-  // ---- Hero value (dark text, offset past border) ----
-  ctx.fillStyle = rgbCss(fg);
+  // ---- Hero value — accent numerals (Sprint 84), offset past border ----
+  ctx.fillStyle = rgbCss(accent);
   ctx.textAlign = 'left';
   ctx.textBaseline = 'alphabetic';
   const availW = w - borderW - 28;
@@ -378,7 +379,7 @@ function _drawAccentBorder(ctx, args, opts = {}) {
 
   // ---- Sublabel ----
   if (args.sublabel) {
-    ctx.fillStyle = rgbaCss(fg, 0.45);
+    ctx.fillStyle = rgbaCss(accent, 0.7);
     const subFs = fitFontSize(
       ctx,
       String(args.sublabel),

--- a/sdf-js/src/present/atoms-2d/charts/diagrams/comparison-table.js
+++ b/sdf-js/src/present/atoms-2d/charts/diagrams/comparison-table.js
@@ -81,8 +81,19 @@ export function drawPseudo3D(ctx, args, opts = {}) {
   const colW = (w - colLabelW) / cols.length;
   const headerH = Math.round(tableH * 0.14);
   const rowH = (tableH - headerH) / rows.length;
-  const fontSize = Math.max(9, Math.min(13, Math.round(rowH * 0.38)));
-  const headerFontSize = Math.max(9, Math.min(13, Math.round(headerH * 0.35)));
+  // Sprint 84 (user: 表格字太小看不清): the 13px cap starved tall rows —
+  // let type grow with the row up to 19px; per-cell shrink guards width.
+  const fontSize = Math.max(12, Math.min(19, Math.round(rowH * 0.38)));
+  const headerFontSize = Math.max(12, Math.min(19, Math.round(headerH * 0.4)));
+  const fitWidth = (text, maxW, weight, fs) => {
+    let f = fs;
+    ctx.font = `${weight} ${f}px Inter, system-ui, sans-serif`;
+    while (f > 10 && ctx.measureText(text).width > maxW) {
+      f--;
+      ctx.font = `${weight} ${f}px Inter, system-ui, sans-serif`;
+    }
+    return f;
+  };
 
   // Column headers
   for (let c = 0; c < cols.length; c++) {
@@ -98,7 +109,7 @@ export function drawPseudo3D(ctx, args, opts = {}) {
     // Header text
     ctx.save();
     ctx.fillStyle = col.highlight ? 'rgba(255,255,255,0.97)' : rgbCss(fg);
-    ctx.font = `700 ${headerFontSize}px Inter, system-ui, sans-serif`;
+    fitWidth(String(col.label || ''), colW - 12, '700', headerFontSize);
     ctx.textAlign = 'center';
     ctx.textBaseline = 'middle';
     ctx.fillText(String(col.label || ''), cx2 + colW / 2, tableY + headerH / 2);
@@ -120,7 +131,7 @@ export function drawPseudo3D(ctx, args, opts = {}) {
     // Feature label
     ctx.save();
     ctx.fillStyle = rgbCss(fg);
-    ctx.font = `500 ${fontSize}px Inter, system-ui, sans-serif`;
+    fitWidth(String(row.label || ''), colLabelW - PAD * 1.5, '500', fontSize);
     ctx.textAlign = 'left';
     ctx.textBaseline = 'middle';
     ctx.fillText(String(row.label || ''), x + PAD, rowY + rowH / 2);
@@ -146,7 +157,7 @@ export function drawPseudo3D(ctx, args, opts = {}) {
         // Text value
         ctx.save();
         ctx.fillStyle = isHighlight ? rgbCss(accent) : rgbCss(fg);
-        ctx.font = `600 ${fontSize}px Inter, system-ui, sans-serif`;
+        fitWidth(String(val), colW - 10, '600', fontSize);
         ctx.textAlign = 'center';
         ctx.textBaseline = 'middle';
         ctx.fillText(String(val), cellCX, cellCY);

--- a/sdf-js/src/present/atoms-2d/charts/lists/feature-card-grid.js
+++ b/sdf-js/src/present/atoms-2d/charts/lists/feature-card-grid.js
@@ -239,15 +239,23 @@ export function drawPseudo3D(ctx, args, opts = {}) {
       curY += titleFs + 6;
     }
 
-    // Body — word-wrap up to 4 lines; ellipsis (never mid-word) on the last
-    // line if the text doesn't fit.
-    const bodyFs = Math.round(rowH * 0.09);
+    // Body — word-wrap capped by the space actually LEFT in the card
+    // (Sprint 84, user: 右侧字体过大超出范围 — a 4-line budget ignored the
+    // card bottom and let dense CJK bodies spill past the rounded rect).
+    let bodyFs = Math.round(rowH * 0.09);
+    const cardBottom = cardY + cardH - cardPad;
+    let fitLines = Math.floor((cardBottom - curY) / (bodyFs + 2));
+    if (fitLines < 2 && bodyFs > 10) {
+      bodyFs = Math.max(10, Math.round(bodyFs * 0.82)); // one shrink step buys a line
+      fitLines = Math.floor((cardBottom - curY) / (bodyFs + 2));
+    }
+    const maxLines = Math.max(1, Math.min(4, fitLines));
     ctx.font = `500 ${bodyFs}px Inter, system-ui`;
     ctx.fillStyle = rgbaCss(fg, 0.55);
     ctx.textAlign = 'center';
     ctx.textBaseline = 'top';
-    if (f.body) {
-      const lines = wrapText(ctx, f.body, textMaxW, 4);
+    if (f.body && maxLines > 0) {
+      const lines = wrapText(ctx, f.body, textMaxW, maxLines);
       for (const line of lines) {
         ctx.fillText(line, iconCX, curY);
         curY += bodyFs + 2;

--- a/sdf-js/src/present/atoms-2d/renderer.js
+++ b/sdf-js/src/present/atoms-2d/renderer.js
@@ -149,7 +149,11 @@ export async function renderSceneDataToCanvas(canvas, sceneData, opts = {}) {
       });
     }
   }
-  if (decor && !coverArt && !isPureCover && !bannerCanvas) {
+  // Sprint 84: mounted pages can ask for the subtle body underlay TOO
+  // (opts.decorUnder) — banner art + body elements in the mount's palette,
+  // instead of clean-but-voiceless content pages.
+  const wantUnder = bannerCanvas ? opts.decorUnder === true : !coverArt && !bannerCanvas;
+  if (decor && !isPureCover && wantUnder) {
     drawDecor(ctx, decor, {
       palette,
       x: 0,

--- a/sdf-js/src/present/exporters/pdf.js
+++ b/sdf-js/src/present/exporters/pdf.js
@@ -11,7 +11,7 @@
 
 import { renderSceneDataToCanvas } from '../atoms-2d/renderer.js';
 import { slotPalette, slotRoleOf } from '../retheme.js';
-import { artMountOpts } from '../art-mount.js';
+import { artMountOpts, mountPaletteOverride } from '../art-mount.js';
 
 const JSPDF_CDN = 'https://esm.sh/jspdf@2.5.2';
 let jsPDF = null;
@@ -69,7 +69,9 @@ export async function exportDeckToPDF(deck, opts = {}) {
     // preview — decoration layer included, per-atom errors non-fatal.
     try {
       await renderSceneDataToCanvas(canvas, slot.sceneData || { subjects: [] }, {
-        palette: slotPalette(deck.theme, slot),
+        palette: opts.artMount
+          ? mountPaletteOverride(slotPalette(deck.theme, slot), opts.artMount)
+          : slotPalette(deck.theme, slot),
         decorRole: slotRoleOf(slot),
         decor: deck.decor
           ? { ...deck.decor, seed: (deck.decor.seed ?? 1) + slot.slotIdx }

--- a/sdf-js/src/present/exporters/pptx.js
+++ b/sdf-js/src/present/exporters/pptx.js
@@ -19,7 +19,7 @@
 
 import { renderSceneDataToCanvas } from '../atoms-2d/renderer.js';
 import { slotPalette, slotRoleOf } from '../retheme.js';
-import { artMountOpts } from '../art-mount.js';
+import { artMountOpts, mountPaletteOverride } from '../art-mount.js';
 
 // pptxgenjs loaded from esm.sh on first call (matches pdfjs CDN pattern in
 // src/parser/pdf.js — no build step / bundler required).
@@ -85,7 +85,9 @@ export async function exportDeckToPPTX(deck, opts = {}) {
     // preview — decoration layer included, per-atom errors non-fatal.
     try {
       await renderSceneDataToCanvas(canvas, slot.sceneData || { subjects: [] }, {
-        palette: slotPalette(deck.theme, slot),
+        palette: opts.artMount
+          ? mountPaletteOverride(slotPalette(deck.theme, slot), opts.artMount)
+          : slotPalette(deck.theme, slot),
         decorRole: slotRoleOf(slot),
         decor: deck.decor
           ? { ...deck.decor, seed: (deck.decor.seed ?? 1) + slot.slotIdx }


### PR DESCRIPTION
user 四点现场反馈 (Naïve 装裱版):

1. **从生成艺术提主色调**: extractMountPalette 量化提取 (Naïve → 朱红 accent + 青/奶油/棕), mountPaletteOverride 注入 — 全 deck 说作品的颜色
2. **数字着色**: agenda 大编号灰→accent; kpi value/sublabel→accent
3. **内页生成艺术回归** (最关键): mounted 内页 decorUnder → decor 引擎以作品色继续画 body, 主题感贯穿
4. **第四页字号两端**: feature-card-grid 按剩余空间截行; comparison-table 12-19px + 逐格宽度收缩

测试 142/142; 三页目检通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)