### PR TITLE
Sprint 85: 异源内页纹样 + 目录页完整画布 + 暗主题卡片修

### DIFF
--- a/sdf-js/apps/present/author-2d.js
+++ b/sdf-js/apps/present/author-2d.js
@@ -23,6 +23,7 @@ import {
   loadArtMount,
   fetchMintManifest,
   mountPaletteOverride,
+  mountUnderlayDecor,
 } from '../../src/present/art-mount.js';
 import { ATLAS_THEMES } from '../../src/present/themes.js';
 import { exportDeckToPPTX } from '../../src/present/exporters/pptx.js';
@@ -284,6 +285,8 @@ function slotRenderOpts(theme, deck, slot) {
     // Sprint 84: the deck speaks the artwork's colors — accents/numbers
     // across every atom come from the mount's extracted palette
     base.palette = mountPaletteOverride(base.palette, artMount);
+    // Sprint 85: 内页纹样 — 异源默认, 同源可选 (user: Naïve×drift-web 和谐)
+    base.decor = mountUnderlayDecor(base.decor, artMount, window.__underlayMode || 'hetero');
   }
   return base;
 }

--- a/sdf-js/src/present/art-mount.js
+++ b/sdf-js/src/present/art-mount.js
@@ -146,6 +146,86 @@ export async function loadArtMount(entry, base) {
   };
 }
 
+// ── Sprint 85: 内页纹样 — 异源为默认 (user A/B 裁定: 同源异源都好于无, 保留异源) ──
+// Each mount gets a DETERMINISTIC underlay family that is deliberately NOT
+// the family ported from the same artwork — the wall art and the wallpaper
+// speak the same palette but different forms. Stable per mount id.
+const MOUNT_FAMILY_OF = {
+  L01: 'meadow-streaks',
+  L02: 'banded-ribbons',
+  L03: 'block-mosaic',
+  L04: 'wash-flow',
+  L05: 'strata-lines',
+  L06: 'sediment-layers',
+  L07: 'ink-scribble',
+  L08: 'light-edges',
+  L10: 'hex-lattice',
+  L13: 'drift-web',
+  L17: 'cargo-dashes',
+  L19: 'folded-screens',
+  L21: 'scan-tides',
+  L22: 'paper-folds',
+  L26: 'growth-loops',
+  L28: 'street-grid',
+  L33: 'torn-paper',
+  L38: 'peg-wraps',
+  L41: 'river-courses',
+};
+const UNDERLAY_FAMILIES = [
+  'flow-streams',
+  'weave-dashes',
+  'circle-pack',
+  'shard-mesh',
+  'meadow-streaks',
+  'flow-ribbons',
+  'banded-ribbons',
+  'block-mosaic',
+  'wash-flow',
+  'strata-lines',
+  'sediment-layers',
+  'ink-scribble',
+  'light-edges',
+  'nib-flourish',
+  'hex-lattice',
+  'drift-web',
+  'cargo-dashes',
+  'folded-screens',
+  'halftone-fade',
+  'scan-tides',
+  'paper-folds',
+  'growth-loops',
+  'street-grid',
+  'torn-paper',
+  'peg-wraps',
+  'river-courses',
+];
+
+function fnv1a(str) {
+  let h = 2166136261;
+  for (let i = 0; i < str.length; i++) h = ((h ^ str.charCodeAt(i)) * 16777619) | 0;
+  return h >>> 0;
+}
+
+/** underlayFamilyFor(mountId) → a stable decor family ≠ the mount's own port. */
+export function underlayFamilyFor(mountId) {
+  const own = MOUNT_FAMILY_OF[mountId];
+  const pool = UNDERLAY_FAMILIES.filter((f) => f !== own);
+  return pool[fnv1a('underlay:' + mountId) % pool.length];
+}
+
+/**
+ * mountUnderlayDecor(baseDecor, mount, mode) → decor re-familied for this
+ * mount. mode 'hetero' (default — user A/B ruling) picks a stable family
+ * DIFFERENT from the mount's own port; 'homo' uses the same-artwork family
+ * where one exists (user: Naïve×drift-web 做到了颜色和设计的和谐).
+ */
+export function mountUnderlayDecor(baseDecor, mount, mode = 'hetero') {
+  if (!baseDecor || !mount?.id) return baseDecor;
+  const homo = MOUNT_FAMILY_OF[mount.id];
+  const family = mode === 'homo' && homo ? homo : underlayFamilyFor(mount.id);
+  return { ...baseDecor, family };
+}
+
 /** fetchMintManifest(base) → manifest array, or null when the cache is absent. */
 export async function fetchMintManifest(base) {
   try {

--- a/sdf-js/src/present/atoms-2d/charts/data/kpi-card.js
+++ b/sdf-js/src/present/atoms-2d/charts/data/kpi-card.js
@@ -208,7 +208,10 @@ function _drawLight(ctx, args, opts = {}) {
   const bg = palette.bg || [247, 244, 224];
   const accent = palette.colors?.[0] || palette.accent || [60, 100, 200];
   // Light card background — lighten the theme bg significantly
-  const cardBg = lighten(bg, 0.5);
+  // Sprint 85: on DARK themes lighten(bg) yields grey slabs that fight the
+  // accent numerals — light variants pin to paper instead
+  const bgLum = (0.2126 * bg[0] + 0.7152 * bg[1] + 0.0722 * bg[2]) / 255;
+  const cardBg = bgLum > 0.45 ? lighten(bg, 0.5) : [248, 246, 240];
 
   // ---- Drop shadow ----
   ctx.save();
@@ -307,7 +310,10 @@ function _drawAccentBorder(ctx, args, opts = {}) {
   const fg = palette.silhouetteColor || [30, 27, 30];
   const bg = palette.bg || [247, 244, 224];
   const accent = palette.colors?.[0] || palette.accent || [60, 100, 200];
-  const cardBg = lighten(bg, 0.5);
+  // Sprint 85: on DARK themes lighten(bg) yields grey slabs that fight the
+  // accent numerals — light variants pin to paper instead
+  const bgLum = (0.2126 * bg[0] + 0.7152 * bg[1] + 0.0722 * bg[2]) / 255;
+  const cardBg = bgLum > 0.45 ? lighten(bg, 0.5) : [248, 246, 240];
 
   const borderW = Math.max(8, Math.min(12, w * 0.035));
   const cardRadius = Math.min(w, h) * 0.06;

--- a/sdf-js/src/present/atoms-2d/renderer.js
+++ b/sdf-js/src/present/atoms-2d/renderer.js
@@ -189,7 +189,12 @@ export async function renderSceneDataToCanvas(canvas, sceneData, opts = {}) {
       ctx.beginPath();
       ctx.rect(bx, by, bw, bh);
       ctx.clip();
-      if (decorArtStrip) {
+      if (decorArt && role === 'agenda') {
+        // Sprint 85 (user: 目录页抬头小画布换完整画布) — the agenda banner
+        // shows the LARGE piece as a full-bleed band crop; sparse smalls
+        // stay on section/content banners
+        drawArtCover(decorArt, bx, by, bw, bh);
+      } else if (decorArtStrip) {
         drawArtStrip(bx, by, bw, bh);
       } else if (decorArt) {
         drawArtCover(decorArt, bx, by, bw, bh);

--- a/sdf-js/src/present/exporters/pdf.js
+++ b/sdf-js/src/present/exporters/pdf.js
@@ -11,7 +11,7 @@
 
 import { renderSceneDataToCanvas } from '../atoms-2d/renderer.js';
 import { slotPalette, slotRoleOf } from '../retheme.js';
-import { artMountOpts, mountPaletteOverride } from '../art-mount.js';
+import { artMountOpts, mountPaletteOverride, mountUnderlayDecor } from '../art-mount.js';
 
 const JSPDF_CDN = 'https://esm.sh/jspdf@2.5.2';
 let jsPDF = null;
@@ -74,7 +74,10 @@ export async function exportDeckToPDF(deck, opts = {}) {
           : slotPalette(deck.theme, slot),
         decorRole: slotRoleOf(slot),
         decor: deck.decor
-          ? { ...deck.decor, seed: (deck.decor.seed ?? 1) + slot.slotIdx }
+          ? (opts.artMount ? mountUnderlayDecor : (d) => d)(
+              { ...deck.decor, seed: (deck.decor.seed ?? 1) + slot.slotIdx },
+              opts.artMount,
+            )
           : undefined,
         // Sprint 82: 真迹装裱 — screen and file must show the same mount
         ...(artMountOpts(opts.artMount, slot, slotRoleOf(slot)) || {}),

--- a/sdf-js/src/present/exporters/pptx.js
+++ b/sdf-js/src/present/exporters/pptx.js
@@ -19,7 +19,7 @@
 
 import { renderSceneDataToCanvas } from '../atoms-2d/renderer.js';
 import { slotPalette, slotRoleOf } from '../retheme.js';
-import { artMountOpts, mountPaletteOverride } from '../art-mount.js';
+import { artMountOpts, mountPaletteOverride, mountUnderlayDecor } from '../art-mount.js';
 
 // pptxgenjs loaded from esm.sh on first call (matches pdfjs CDN pattern in
 // src/parser/pdf.js — no build step / bundler required).
@@ -90,7 +90,10 @@ export async function exportDeckToPPTX(deck, opts = {}) {
           : slotPalette(deck.theme, slot),
         decorRole: slotRoleOf(slot),
         decor: deck.decor
-          ? { ...deck.decor, seed: (deck.decor.seed ?? 1) + slot.slotIdx }
+          ? (opts.artMount ? mountUnderlayDecor : (d) => d)(
+              { ...deck.decor, seed: (deck.decor.seed ?? 1) + slot.slotIdx },
+              opts.artMount,
+            )
           : undefined,
         // Sprint 82: 真迹装裱 — screen and file must show the same mount
         ...(artMountOpts(opts.artMount, slot, slotRoleOf(slot)) || {}),


### PR DESCRIPTION
user 裁定: ①同源异源都好于无, 保留异源为默认 (mountUnderlayDecor mode 保留同源可选 — Naïve×drift-web 和谐案例) ②目录页抬头小画布→完整画布 (agenda banner 全幅裁条, 其余页保持稀疏小品) ③附带修暗主题 KPI 灰板问题 (卡底钉纸白)。测试 142/142。

🤖 Generated with [Claude Code](https://claude.com/claude-code)