### PR TITLE
Sprint 87: 图标放大 + 色板预烘 + 装裱推荐 + 白卡钉墨

### DIFF
--- a/sdf-js/apps/present/author-2d.js
+++ b/sdf-js/apps/present/author-2d.js
@@ -24,6 +24,7 @@ import {
   fetchMintManifest,
   mountPaletteOverride,
   mountUnderlayDecor,
+  rankMounts,
 } from '../../src/present/art-mount.js';
 import { ATLAS_THEMES } from '../../src/present/themes.js';
 import { exportDeckToPPTX } from '../../src/present/exporters/pptx.js';
@@ -295,13 +296,24 @@ function slotRenderOpts(theme, deck, slot) {
   const manifest = await fetchMintManifest(MINT_BASE);
   const oks = (manifest || []).filter((m) => m.status === 'ok');
   if (!oks.length) return; // no local cache — feature stays hidden
-  for (const m of oks) {
-    const o = document.createElement('option');
-    o.value = m.id;
-    o.textContent = `装裱 · ${m.name}${m.artist ? ' · ' + m.artist : ''}`;
-    o.title = `${m.license || ''} — 原版脚本非商用运行`;
-    artMountEl.appendChild(o);
-  }
+  // Sprint 87: 推荐排序 — dropdown best-first for the CURRENT theme, ⭐ top-3
+  const themeAccentOf = () =>
+    (ATLAS_THEMES.find((t) => t.id === themeEl.value) || ATLAS_THEMES[0])?.accent;
+  const rebuildMountOptions = () => {
+    const keep = artMountEl.value;
+    while (artMountEl.options.length > 1) artMountEl.remove(1);
+    const ranked = rankMounts(oks, themeAccentOf());
+    ranked.forEach((m, i) => {
+      const o = document.createElement('option');
+      o.value = m.id;
+      o.textContent = `${i < 3 ? '⭐ ' : ''}装裱 · ${m.name}${m.artist ? ' · ' + m.artist : ''}`;
+      o.title = `${m.license || ''} — 原版脚本非商用运行 · 匹配分 ${m._score.toFixed(2)}`;
+      artMountEl.appendChild(o);
+    });
+    artMountEl.value = keep;
+  };
+  rebuildMountOptions();
+  themeEl.addEventListener('change', rebuildMountOptions);
   artMountEl.hidden = false;
   artMountEl.addEventListener('change', async () => {
     const id = artMountEl.value;

--- a/sdf-js/examples/original-mints/index.html
+++ b/sdf-js/examples/original-mints/index.html
@@ -127,6 +127,16 @@
         display: flex;
         gap: 8px;
       }
+      .swatches {
+        display: flex;
+        height: 10px;
+        border-radius: 5px;
+        overflow: hidden;
+        margin-top: 7px;
+      }
+      .swatches span {
+        flex: 1;
+      }
       .strip-row img {
         height: 74px;
         max-width: none;
@@ -183,6 +193,14 @@
             <div class="meta">
               <div class="name">${m.id} · ${m.name}</div>
               <div class="artist">${m.artist || ''}</div>
+              ${
+                m.palette
+                  ? `<div class="swatches">${m.palette.colors
+                      .slice(0, 6)
+                      .map((c) => `<span style="background:rgb(${c.join(',')})"></span>`)
+                      .join('')}</div>`
+                  : ''
+              }
               <div class="badges">
                 <span class="badge ${badgeClass(m.license)}">${m.license || '?'}</span>
                 <span class="badge">${m.type || ''}</span>

--- a/sdf-js/src/present/art-mount.js
+++ b/sdf-js/src/present/art-mount.js
@@ -142,7 +142,9 @@ export async function loadArtMount(entry, base) {
     artist: entry.artist,
     cover,
     strip,
-    palette: extractMountPalette(cover),
+    // Sprint 87: prebaked palette from the manifest wins (bake once, render
+    // anywhere — the gallery shows the same swatches the deck will wear)
+    palette: entry.palette || extractMountPalette(cover),
   };
 }
 
@@ -224,6 +226,46 @@ export function mountUnderlayDecor(baseDecor, mount, mode = 'hetero') {
   const homo = MOUNT_FAMILY_OF[mount.id];
   const family = mode === 'homo' && homo ? homo : underlayFamilyFor(mount.id);
   return { ...baseDecor, family };
+}
+
+// ── Sprint 87: 装裱推荐 — score mounts against the deck theme ───────────────
+function hueOf([r, g, b]) {
+  const mx = Math.max(r, g, b);
+  const mn = Math.min(r, g, b);
+  if (mx === mn) return 0;
+  let h;
+  if (mx === r) h = ((g - b) / (mx - mn)) % 6;
+  else if (mx === g) h = (b - r) / (mx - mn) + 2;
+  else h = (r - g) / (mx - mn) + 4;
+  return (h * 60 + 360) % 360;
+}
+
+/**
+ * rankMounts(entries, themeAccent) → entries sorted best-first with _score.
+ * Scoring, all heuristics: hue RELATIONSHIP to the theme accent (analogous /
+ * complementary / triadic read as designed, arbitrary angles as noise),
+ * accent saturation (vivid accents carry the numerals), palette richness,
+ * curation tier. Needs prebaked entry.palette (bake step) — unbaked entries
+ * sink to the bottom rather than erroring.
+ */
+export function rankMounts(entries, themeAccent) {
+  const themeHue = hueOf(themeAccent || [60, 100, 200]);
+  const scored = entries.map((m) => {
+    if (m.status !== 'ok' || !m.palette?.accent) return { ...m, _score: -1 };
+    const [r, g, b] = m.palette.accent;
+    const sat = (Math.max(r, g, b) - Math.min(r, g, b)) / 255;
+    const dh = Math.abs(((hueOf(m.palette.accent) - themeHue + 540) % 360) - 180); // 0..180
+    const rel = Math.min(
+      Math.abs(180 - dh), // analogous (dh≈180 means same hue after the fold above)
+      Math.abs(dh), // complementary
+      Math.abs(60 - dh), // triadic-ish
+    );
+    const harmony = Math.exp(-(rel * rel) / (2 * 28 * 28)); // σ 28°
+    const richness = Math.min(1, (m.palette.colors?.length || 0) / 5);
+    const tier = m.curation === 'curated' ? 1 : m.curation === 'playground' ? 0.6 : 0.4;
+    return { ...m, _score: harmony * 2 + sat * 1.4 + richness * 0.6 + tier * 0.5 };
+  });
+  return scored.sort((a2, b2) => b2._score - a2._score);
 }
 
 /** fetchMintManifest(base) → manifest array, or null when the cache is absent. */

--- a/sdf-js/src/present/atoms-2d/charts/data/kpi-card.js
+++ b/sdf-js/src/present/atoms-2d/charts/data/kpi-card.js
@@ -143,7 +143,14 @@ function _drawDark(ctx, args, opts = {}) {
 
   // ---- Icon (top-left) ----
   if (args.icon) {
-    drawIconStub(ctx, args.icon, x + 26, y + 30, 32, rgbCss(bg));
+    drawIconStub(
+      ctx,
+      args.icon,
+      x + 26,
+      y + 26,
+      Math.max(36, Math.min(56, Math.round(h * 0.24))),
+      rgbCss(bg),
+    );
   }
 
   // ---- Hero value ----
@@ -249,7 +256,14 @@ function _drawLight(ctx, args, opts = {}) {
 
   // ---- Icon (top-left) ----
   if (args.icon) {
-    drawIconStub(ctx, args.icon, x + 26, y + 30, 32, rgbCss(accent));
+    drawIconStub(
+      ctx,
+      args.icon,
+      x + 26,
+      y + 26,
+      Math.max(36, Math.min(56, Math.round(h * 0.24))),
+      rgbCss(accent),
+    );
   }
 
   // ---- Hero value — Sprint 84: numbers wear the accent (user: 数字应使用
@@ -360,7 +374,14 @@ function _drawAccentBorder(ctx, args, opts = {}) {
   // ---- Icon (top-left, after border) ----
   const textLeft = x + borderW + 14;
   if (args.icon) {
-    drawIconStub(ctx, args.icon, textLeft + 15, y + 30, 32, rgbCss(accent));
+    drawIconStub(
+      ctx,
+      args.icon,
+      textLeft + 15,
+      y + 26,
+      Math.max(36, Math.min(56, Math.round(h * 0.24))),
+      rgbCss(accent),
+    );
   }
 
   // ---- Hero value — accent numerals (Sprint 84), offset past border ----

--- a/sdf-js/src/present/atoms-2d/charts/data/stat-with-icon.js
+++ b/sdf-js/src/present/atoms-2d/charts/data/stat-with-icon.js
@@ -69,7 +69,10 @@ export function drawPseudo3D(ctx, args, opts = {}) {
   const h = opts.h ?? 480;
   const palette = opts.palette || {};
   const accent = palette.accent ?? [30, 80, 180];
-  const fg = palette.silhouetteColor ?? [20, 28, 50];
+  const themeFg = palette.silhouetteColor ?? [20, 28, 50];
+  const fgLum = (0.2126 * themeFg[0] + 0.7152 * themeFg[1] + 0.0722 * themeFg[2]) / 255;
+  const fg = fgLum > 0.55 ? [42, 44, 50] : themeFg; // Sprint 87: 白卡钉深墨
+
   const bgColor = palette.bg ?? [248, 246, 240];
   const iconColor = Array.isArray(args.iconColor) ? args.iconColor : accent;
 
@@ -82,7 +85,7 @@ export function drawPseudo3D(ctx, args, opts = {}) {
   const hasTrend = !!args.trend;
   const hasSublabel = !!args.sublabel;
 
-  const iconSize = h * 0.18;
+  const iconSize = h * 0.24; // Sprint 87 (user: 图标做大)
   const iconBadgeR = iconSize / 2 + 8;
 
   // Auto-shrink value font

--- a/sdf-js/src/present/atoms-2d/charts/lists/feature-card-grid.js
+++ b/sdf-js/src/present/atoms-2d/charts/lists/feature-card-grid.js
@@ -144,7 +144,11 @@ export function drawPseudo3D(ctx, args, opts = {}) {
   const features = Array.isArray(args.features) ? args.features : [];
   const bg = args.bg ?? 'cards';
   const accent = palette.accent ?? [30, 80, 180];
-  const fg = palette.silhouetteColor ?? [20, 28, 50];
+  const themeFg = palette.silhouetteColor ?? [20, 28, 50];
+  // Sprint 87: cards are WHITE — text ink must be dark regardless of theme
+  // (dark themes carry a light fg that ghosts on paper; the kpi lesson)
+  const fgLum = (0.2126 * themeFg[0] + 0.7152 * themeFg[1] + 0.0722 * themeFg[2]) / 255;
+  const fg = args.bg === 'plain' ? themeFg : fgLum > 0.55 ? [42, 44, 50] : themeFg;
   const bgColor = palette.bg ?? [248, 246, 240];
 
   // Background
@@ -201,7 +205,8 @@ export function drawPseudo3D(ctx, args, opts = {}) {
     }
 
     // Icon
-    const iconR = Math.min(rowH * 0.15, colW * 0.12, 40);
+    // Sprint 87 (user: 图标做大): anchor, not footnote
+    const iconR = Math.min(rowH * 0.19, colW * 0.15, 52);
     const iconCX = cellX + colW / 2;
     const iconCY = cardY + cardPad + iconR;
 

--- a/sdf-js/src/present/atoms-2d/charts/lists/numbered-grid.js
+++ b/sdf-js/src/present/atoms-2d/charts/lists/numbered-grid.js
@@ -64,7 +64,10 @@ export function drawPseudo3D(ctx, args, opts = {}) {
   const palette = opts.palette || {};
   const items = Array.isArray(args.items) ? args.items : [];
   const accent = palette.accent ?? [30, 80, 180];
-  const fg = palette.silhouetteColor ?? [20, 28, 50];
+  const themeFg = palette.silhouetteColor ?? [20, 28, 50];
+  const fgLum = (0.2126 * themeFg[0] + 0.7152 * themeFg[1] + 0.0722 * themeFg[2]) / 255;
+  const fg = fgLum > 0.55 ? [42, 44, 50] : themeFg; // Sprint 87: 白卡钉深墨
+
   const bgColor = palette.bg ?? [248, 246, 240];
   const numberStyle = args.numberStyle ?? 'huge';
   const numColor = Array.isArray(args.numberColor) ? args.numberColor : accent;

--- a/sdf-js/src/present/atoms-2d/charts/lists/pillar-3up.js
+++ b/sdf-js/src/present/atoms-2d/charts/lists/pillar-3up.js
@@ -95,7 +95,10 @@ export function drawPseudo3D(ctx, args, opts = {}) {
   const w = opts.w ?? 720;
   const h = opts.h ?? 480;
   const palette = opts.palette || {};
-  const fg = palette.silhouetteColor ?? [20, 28, 50];
+  const themeFg = palette.silhouetteColor ?? [20, 28, 50];
+  const fgLum = (0.2126 * themeFg[0] + 0.7152 * themeFg[1] + 0.0722 * themeFg[2]) / 255;
+  const fg = fgLum > 0.55 ? [42, 44, 50] : themeFg; // Sprint 87: 白卡钉深墨
+
   const bgColor = palette.bg ?? [248, 246, 240];
   const accent = palette.accent ?? [30, 80, 180];
   const colors = palette.colors ?? [

--- a/sdf-js/src/present/atoms-2d/charts/lists/testimonial-wall.js
+++ b/sdf-js/src/present/atoms-2d/charts/lists/testimonial-wall.js
@@ -67,7 +67,10 @@ export function drawPseudo3D(ctx, args, opts = {}) {
   const w = opts.w ?? 720;
   const h = opts.h ?? 480;
   const palette = opts.palette || {};
-  const fg = palette.silhouetteColor ?? [20, 28, 50];
+  const themeFg = palette.silhouetteColor ?? [20, 28, 50];
+  const fgLum = (0.2126 * themeFg[0] + 0.7152 * themeFg[1] + 0.0722 * themeFg[2]) / 255;
+  const fg = fgLum > 0.55 ? [42, 44, 50] : themeFg; // Sprint 87: 白卡钉深墨
+
   const bgColor = palette.bg ?? [248, 246, 240];
   const accent = palette.accent ?? [30, 80, 180];
   const colors = palette.colors ?? [

--- a/sdf-js/src/present/atoms-2d/icons/icon-grid.js
+++ b/sdf-js/src/present/atoms-2d/icons/icon-grid.js
@@ -95,7 +95,7 @@ export function drawPseudo3D(ctx, args, opts = {}) {
   // what the label text actually needed, so row-2 icons overlapped row-1
   // labels (e.g. 4 items wrapping 3+1: "Security" hidden behind "Care").
   const heroBoost = h >= 360 ? 1.3 : 1.0; // Auto-boost on large hero slots (h ≥ 360 = BIG slot)
-  const baseIconR = Math.min(colW * 0.22, 48);
+  const baseIconR = Math.min(colW * 0.27, 58); // Sprint 87 图标做大
   let iconR = baseIconR * iconSizeMultiplier * heroBoost;
   let labelFsTarget = Math.max(11, Math.min(18, Math.round(colW * 0.085)));
   const labelFsMin = 9;

--- a/sdf-js/src/present/atoms-2d/icons/icon-row.js
+++ b/sdf-js/src/present/atoms-2d/icons/icon-row.js
@@ -102,7 +102,7 @@ export function drawPseudo3D(ctx, args, opts = {}) {
   const rows = useTwoRows ? 2 : 1;
   const colW = (w - PAD * 2) / cols;
   const rowH = (y + h - plotTop - PAD) / rows;
-  const baseIconR = Math.min(rowH * 0.32, colW * 0.32, 64);
+  const baseIconR = Math.min(rowH * 0.38, colW * 0.36, 76); // Sprint 87 图标做大
   // Auto-boost on large hero slots (h ≥ 360 = BIG slot)
   const heroBoost = h >= 360 ? 1.3 : 1.0;
   const iconR = baseIconR * iconSizeMultiplier * heroBoost;


### PR DESCRIPTION
全做四件套的 1/2/4 (three.js 扩容在后台铸造中):

1. **图标放大**: kpi 卡 32px 固定 → 随卡高 (最大 56), feature-grid/stat-with-icon/icon-row/icon-grid 全线 +25-40%
2. **色板预烘**: 63 件提取色烘进 manifest, 画廊卡片带色板条
3. **装裱推荐**: rankMounts 色轮关系评分, author-2d 下拉 ⭐ 前三 + 随主题重排
4. **白卡幽灵字歼灭**: 5 个白卡 atom 亮 fg 全部钉深墨

注: test-assemble-deck-golden 0/3 为 3D 端 golden 漂移, 干净 main 复现, 与本 PR 无关。

🤖 Generated with [Claude Code](https://claude.com/claude-code)