### PR TITLE
feat(w1): hold 站发射 — 无结构页不再消失, slot→station 覆盖 48%→100%

### DIFF
--- a/sdf-js/scenes/ir/handoff-funding-round.json
+++ b/sdf-js/scenes/ir/handoff-funding-round.json
@@ -1,0 +1,52 @@
+{
+  "title": "eval-funding-round",
+  "slides": [
+    {
+      "structure": "hold",
+      "title": "Redo Announces $81 Million Series B to Support Commerce Technology Expansion",
+      "nodes": ["Series B financing announcement · Commerce technology platform"]
+    },
+    {
+      "structure": "hold",
+      "title": "TL;DR",
+      "nodes": ["Every merchant is fighting to own the relationship with their shoppers"]
+    },
+    {
+      "structure": "magnitude",
+      "nodes": ["Single Product · 2,350", "Multi-Product · 1,750"],
+      "magnitude": [2350, 1750],
+      "emphasis": [0],
+      "title": "Platform Adoption"
+    },
+    {
+      "structure": "hold",
+      "title": "Wins",
+      "nodes": ["ReturnBear Acquisition", "100+ Countries", "International Infrastructure"]
+    },
+    {
+      "structure": "hold",
+      "title": "Challenges",
+      "nodes": []
+    },
+    {
+      "structure": "sequence",
+      "nodes": ["", "", ""],
+      "magnitude": [2, 2, 2],
+      "order": [0, 1, 2],
+      "title": "Q4 Priorities"
+    },
+    {
+      "structure": "hold",
+      "title": "Ask",
+      "nodes": ["Strategic Intros", "Hiring Support", "Retention Expertise"]
+    },
+    {
+      "structure": "magnitude",
+      "nodes": ["Series B Financing", "Valuation"],
+      "magnitude": [81000000, 1250000000],
+      "display": ["$81M", "$1.25B"],
+      "emphasis": [1],
+      "title": "Financials"
+    }
+  ]
+}

--- a/sdf-js/scripts/test-assemble-deck-golden.mjs
+++ b/sdf-js/scripts/test-assemble-deck-golden.mjs
@@ -41,19 +41,25 @@ for (const layout of LAYOUTS) {
     ok(false, `${layout}: golden file missing — run with --update once`);
     continue;
   }
-  const want = readFileSync(file, 'utf8').replace(/\n$/, '');
-  if (got === want) {
+  // Compare CONTENT, not formatting: the pre-commit prettier hook re-indents
+  // fixture JSONs, so a raw string compare fails at char 1 on indentation
+  // alone. Normalizing through parse→stringify keeps the check exact on every
+  // value while ignoring whitespace style.
+  const norm = (s) => JSON.stringify(JSON.parse(s));
+  const want = norm(readFileSync(file, 'utf8'));
+  if (norm(got) === want) {
     ok(
       true,
       `${layout}: output matches golden (${scene.subjects.length} subjects, ${scene.cameraSequence.shots.length} shots, ${scene.deckWindows.length} windows)`,
     );
   } else {
+    const gotN = norm(got);
     let i = 0;
-    while (i < Math.min(got.length, want.length) && got[i] === want[i]) i++;
+    while (i < Math.min(gotN.length, want.length) && gotN[i] === want[i]) i++;
     const ctx = (s) => s.slice(Math.max(0, i - 80), i + 80).replace(/\n/g, '⏎');
-    ok(false, `${layout}: output diverges from golden at char ${i}`);
+    ok(false, `${layout}: output diverges from golden at char ${i} (normalized)`);
     console.log(`    golden: …${ctx(want)}…`);
-    console.log(`    got:    …${ctx(got)}…`);
+    console.log(`    got:    …${ctx(gotN)}…`);
     console.log(
       '    (intentional change? regenerate with --update and justify the diff in the PR)',
     );

--- a/sdf-js/scripts/test-atlas-deck-handoff.mjs
+++ b/sdf-js/scripts/test-atlas-deck-handoff.mjs
@@ -8,7 +8,8 @@ import { atlasDeckToIR } from '../src/scene/scaffold-to-ir.js';
 import { assembleDeck } from '../src/scene/assemble-deck.js';
 import { compile } from '../src/scene/index.js';
 
-let pass = 0, fail = 0;
+let pass = 0,
+  fail = 0;
 const ok = (c, n) => (c ? (pass++, console.log(`  ✓ ${n}`)) : (fail++, console.log(`  ✗ ${n}`)));
 console.log('=== atlas-deck handoff (contract pinned in CI) ===\n');
 
@@ -28,26 +29,61 @@ for (const f of readdirSync(`${H}/invalid`).filter((x) => x.endsWith('.json'))) 
 // ---- all 15 ammo decks validate + convert with usable coverage ---------------
 const ammo = readdirSync(`${H}/ammo`).filter((x) => x.endsWith('.json'));
 ok(ammo.length >= 15, `ammo has ≥15 decks (${ammo.length})`);
-let totalSlots = 0, totalSlides = 0, zeroDecks = [];
+let totalSlots = 0,
+  totalSlides = 0,
+  zeroDecks = [];
 for (const f of ammo) {
   const raw = read(`${H}/ammo/${f}`);
   const { ok: vok } = validateDeck(raw);
-  if (!vok) { ok(false, `ammo/${f} validates`); continue; }
+  if (!vok) {
+    ok(false, `ammo/${f} validates`);
+    continue;
+  }
   const r = atlasDeckToIR(raw);
   totalSlots += r.report.length;
   totalSlides += r.slides.length;
   if (r.slides.length === 0) zeroDecks.push(f);
 }
-ok(zeroDecks.length === 0, `every ammo deck yields ≥1 slide${zeroDecks.length ? ` (zero: ${zeroDecks.join(', ')})` : ''}`);
+ok(
+  zeroDecks.length === 0,
+  `every ammo deck yields ≥1 slide${zeroDecks.length ? ` (zero: ${zeroDecks.join(', ')})` : ''}`,
+);
 console.log(`  · ammo coverage: ${totalSlides}/${totalSlots} slots → slides`);
-ok(totalSlides / totalSlots >= 0.4, `ammo slot coverage ≥40% (${((totalSlides / totalSlots) * 100).toFixed(0)}%)`);
+// §9.5-3 hold fallback: page-count PARITY, not "usable coverage" — every slot
+// becomes a station (structural IR or hold). Was 59/123 (48%) before Wave 1.
+ok(
+  totalSlides === totalSlots,
+  `ammo slot coverage = 100% page parity (${totalSlides}/${totalSlots})`,
+);
+
+// ---- hold fallback shape (Wave 1) ---------------------------------------------
+{
+  const r = atlasDeckToIR(read(`${H}/ammo/eval-funding-round.json`));
+  const holds = r.report.filter((x) => x.outcome === 'ir:hold(fallback)');
+  ok(holds.length >= 4, `funding-round: no-structure pages fall back to hold (${holds.length})`);
+  const tldr = r.slides[r.report.findIndex((x) => x.title === 'TL;DR')];
+  ok(tldr && tldr.structure === 'hold', 'TL;DR page is a hold station');
+  ok(
+    tldr && typeof tldr.title === 'string' && tldr.title.length > 0,
+    `hold title lifted from cover atom ("${tldr && tldr.title.slice(0, 40)}…")`,
+  );
+  ok(
+    tldr &&
+      Array.isArray(tldr.nodes) &&
+      tldr.nodes.every((n) => typeof n === 'string' && n.length <= 90),
+    `hold bullets are label-length strings only (${tldr ? tldr.nodes.length : 0})`,
+  );
+}
 
 // ---- the recommended first target, end to end ---------------------------------
 {
   const r = atlasDeckToIR(read(`${H}/ammo/eval-qbr-earnings.json`));
   ok(r.slides.length >= 6, `qbr-earnings: ≥6 slides (${r.slides.length}/10)`);
   const scene = assembleDeck({ title: r.title, slides: r.slides }, { stage: true });
-  ok(scene.subjects.filter((s) => s.id.includes('stage-platform')).length === r.slides.length, 'staged: platform per station');
+  ok(
+    scene.subjects.filter((s) => s.id.includes('stage-platform')).length === r.slides.length,
+    'staged: platform per station',
+  );
   try {
     compile(scene, {});
     ok(true, 'atlas-deck → IR → staged deck → ONE compiled scene');
@@ -60,29 +96,59 @@ ok(totalSlides / totalSlots >= 0.4, `ammo slot coverage ≥40% (${((totalSlides 
 {
   // subjects/atoms alias (§5)
   const alias = {
-    format: 'atlas-deck', version: 1, title: 'alias',
-    slots: [{ sceneData: { atoms: [
-      { type: 'kpi-card', args: { value: '$10M', label: 'A' } },
-      { type: 'kpi-card', args: { value: '$4M', label: 'B' } },
-    ] } }],
+    format: 'atlas-deck',
+    version: 1,
+    title: 'alias',
+    slots: [
+      {
+        sceneData: {
+          atoms: [
+            { type: 'kpi-card', args: { value: '$10M', label: 'A' } },
+            { type: 'kpi-card', args: { value: '$4M', label: 'B' } },
+          ],
+        },
+      },
+    ],
   };
   const r = atlasDeckToIR(alias);
   ok(r.slides.length === 1, 'atoms alias accepted (§5 synonym)');
 
   // mixed-unit KPI page stays unaggregated (bars must not lie)
   const mixed = {
-    format: 'atlas-deck', version: 1, title: 'mixed',
-    slots: [{ sceneData: { subjects: [
-      { type: 'kpi-card', args: { value: '$10M', label: 'Revenue' } },
-      { type: 'kpi-card', args: { value: '+69%', label: 'Growth' } },
-    ] } }],
+    format: 'atlas-deck',
+    version: 1,
+    title: 'mixed',
+    slots: [
+      {
+        sceneData: {
+          subjects: [
+            { type: 'kpi-card', args: { value: '$10M', label: 'Revenue' } },
+            { type: 'kpi-card', args: { value: '+69%', label: 'Growth' } },
+          ],
+        },
+      },
+    ],
   };
-  ok(atlasDeckToIR(mixed).slides.length === 0, 'mixed-unit KPI page not force-aggregated');
+  // Since the §9.5-3 hold fallback, the page still becomes a station (page-
+  // count parity) — the assertion's spirit is that it must never become a
+  // MAGNITUDE (bars comparing $ against % would lie).
+  const mixedIR = atlasDeckToIR(mixed).slides[0];
+  ok(
+    mixedIR && mixedIR.structure === 'hold',
+    `mixed-unit KPI page not force-aggregated (got ${mixedIR ? mixedIR.structure : 'nothing'})`,
+  );
 
   // contract violation → reject with the validator's error
   let threw = null;
-  try { atlasDeckToIR({ format: 'atlas-deck', version: 1 }); } catch (e) { threw = e; }
-  ok(!!threw && /contract violation/.test(threw.message), 'invalid deck rejected with contract error');
+  try {
+    atlasDeckToIR({ format: 'atlas-deck', version: 1 });
+  } catch (e) {
+    threw = e;
+  }
+  ok(
+    !!threw && /contract violation/.test(threw.message),
+    'invalid deck rejected with contract error',
+  );
 }
 
 console.log(`\n${pass} passed, ${fail} failed`);

--- a/sdf-js/src/scene/scaffold-to-ir.js
+++ b/sdf-js/src/scene/scaffold-to-ir.js
@@ -760,6 +760,40 @@ function kpiSlotToIR(subjects) {
   };
 }
 
+// ---- hold fallback (§9.5-3: no-structure pages must not vanish) ----------------
+// Before this, a slot with no structural atom (pure cover / narration / icon
+// boards) was SKIPPED — 48% slot→station attrition across the ammo pack, and
+// the reason chapter (zone) grouping can't deploy on real corpus: a chapter
+// whose pages all vanish is an empty zone. A hold station keeps 3D page count
+// aligned with 2D. Title comes from the cover atom (the 2D end's own headline)
+// over the nav label; bullets are a few SHORT text lines fished from common
+// atom arg fields — narration goes to the DOM subtitle layer, so we only lift
+// label-length strings, never paragraphs.
+const HOLD_TEXT_FIELDS = ['subtitle', 'tagline', 'quote', 'caption'];
+export function holdSlotToIR(sceneData, label = '') {
+  const subjects = Array.isArray(sceneData?.subjects)
+    ? sceneData.subjects
+    : Array.isArray(sceneData?.atoms)
+      ? sceneData.atoms
+      : [];
+  const cover = subjects.find((s) => s && s.type === 'cover');
+  const title = String(cover?.args?.title || label || '').trim();
+  const nodes = [];
+  const push = (v) => {
+    if (typeof v !== 'string') return;
+    const t = v.trim();
+    if (t && t.length <= 90 && t !== title && !nodes.includes(t) && nodes.length < 4) nodes.push(t);
+  };
+  for (const s of subjects) {
+    const a = (s && s.args) || {};
+    for (const f of HOLD_TEXT_FIELDS) push(a[f]);
+    if (Array.isArray(a.items))
+      for (const it of a.items)
+        push(typeof it === 'string' ? it : it && (it.label ?? it.title ?? it.text));
+  }
+  return { structure: 'hold', title, nodes };
+}
+
 /**
  * slotToIR(sceneData) → IR | null
  * A slot carries several atom subjects (a cover + N content atoms); pick the
@@ -878,8 +912,15 @@ export function atlasDeckToIR(deckJson, opts = {}) {
       : Array.isArray(sceneData.atoms)
         ? sceneData.atoms
         : [];
-    const ir = slotToIR({ ...sceneData, subjects });
+    let ir = slotToIR({ ...sceneData, subjects });
     const label = slot.slotTitle || slot.slotName || `slot ${i}`;
+    let holdFallback = false;
+    if (!ir && allowed.includes('hold')) {
+      // §9.5-3: page-count parity — a no-structure page becomes a hold station
+      // instead of vanishing from the 3D deck.
+      ir = holdSlotToIR({ ...sceneData, subjects }, label);
+      holdFallback = true;
+    }
     if (!ir) {
       report.push({ slot: i, title: label, outcome: 'skipped:no-structural-atom' });
       return;
@@ -890,7 +931,11 @@ export function atlasDeckToIR(deckJson, opts = {}) {
     }
     if (!ir.title) ir.title = label;
     slides.push(ir);
-    report.push({ slot: i, title: label, outcome: `ir:${ir.structure}` });
+    report.push({
+      slot: i,
+      title: label,
+      outcome: holdFallback ? 'ir:hold(fallback)' : `ir:${ir.structure}`,
+    });
   });
   return { title: deck.title || 'atlas-deck', slides, report };
 }


### PR DESCRIPTION
## Wave 1 — hold 站发射(§9.5-3 backlog → 对抗讨论定为 zone 契约部署硬前置)

### 问题
无结构页(纯封面/叙事/icon 板)在 3D 端整页消失:15 个 ammo deck 实测 **59/123 slot(48%)**。用户上传 20 页看到 3D 只有 10 页本来就是事故;对抗讨论进一步确认它是空间框架部署的阻塞项——章节里的页全被吞 = 空 zone。

### 改动
- **`holdSlotToIR()`**(scaffold-to-ir.js):无结构 slot 回退为 hold 站。标题取 cover atom 的 headline(优先于导航 label);bullets 只捞 label 长度的短句(≤90 字符)——段落归 DOM 字幕层,不上 3D(两套文字系统规则)。
- **`atlasDeckToIR` 接入**:`skipped:no-structural-atom` → `ir:hold(fallback)`,report 里可区分。
- **实测:123/123 slot 全部成站(100% 页数对齐)**,64 个 hold 回退,15 deck 无一例外。
- 混单位 KPI 断言更新:精神保留(永不聚成说谎的 magnitude),形状从"整页消失"改为"成为 hold 站"。新增 4 条 hold 形状断言。
- 真机验证:新 fixture `figure.html?deck=handoff-funding-round&stage=1`(8 站,5 个 hold 回退)全链可播,TL;DR 站正常渲染。
- 顺手修 golden 比较器:pre-commit prettier 会重排 fixture JSON 缩进,原始字符串比较在 char 1 假阳 → 改为 parse→stringify 归一后比较(内容级仍然精确)。

### 测试
suite 143/143,lint 0 errors。

Merge 后我进 Wave 2(3D decor 家族 v1,盲测两臂共用)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)