### PR TITLE
feat(w3): Layer B 首切口 — 模数 token 系统, render-magnitude 迁移(逐字节不变)

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -159,6 +159,7 @@ const TESTS = [
   { category: 'scene', file: 'sdf-js/scripts/test-assemble-deck.mjs' },
   { category: 'scene', file: 'sdf-js/scripts/test-assemble-deck-golden.mjs' },
   { category: 'scene', file: 'sdf-js/scripts/test-deck-decor.mjs' },
+  { category: 'scene', file: 'sdf-js/scripts/test-layout-tokens.mjs' },
   { category: 'scene', file: 'sdf-js/scripts/test-camera-shake.mjs' },
   { category: 'scene', file: 'sdf-js/scripts/test-text-to-ir.mjs' },
   { category: 'scene', file: 'sdf-js/scripts/test-hitstop.mjs' },

--- a/sdf-js/scripts/test-layout-tokens.mjs
+++ b/sdf-js/scripts/test-layout-tokens.mjs
@@ -1,0 +1,66 @@
+// sdf-js/scripts/test-layout-tokens.mjs — Layer B first cut: the module system.
+// Two claims: (1) the operators are correct composition math; (2) render-
+// magnitude actually CONSUMES the tokens — geometry re-derives when a token
+// changes (the whole point of extraction; hardcoded copies would pass a
+// byte-identity check but freeze the system).
+import { MODULE, SCALE, stride, centeredRow, rowSpan } from '../src/scene/layout-tokens.js';
+import { renderMagnitude } from '../src/scene/render-magnitude.js';
+
+let pass = 0,
+  fail = 0;
+const ok = (c, n) => (c ? (pass++, console.log(`  ✓ ${n}`)) : (fail++, console.log(`  ✗ ${n}`)));
+const near = (a, b) => Math.abs(a - b) < 1e-9;
+console.log('=== layout tokens (Layer B: module / rhythm / alignment) ===\n');
+
+// ---- operator math -------------------------------------------------------------
+ok(near(stride(), MODULE.unit + MODULE.gap), 'stride = module + breath');
+ok(near(centeredRow(0, 1), 0), 'single item sits on the origin');
+ok(near(centeredRow(0, 4) + centeredRow(3, 4), 0), 'row is symmetric about the origin');
+ok(near(centeredRow(2, 5) - centeredRow(1, 5), stride()), 'neighbors are one stride apart');
+ok(
+  near(rowSpan(5), centeredRow(4, 5) - centeredRow(0, 5) + MODULE.unit),
+  'rowSpan = outer edge to outer edge',
+);
+ok(SCALE.monumental / SCALE.intimate > 3, 'monumental vs intimate is a real contrast (>3×)');
+
+// ---- render-magnitude consumes the tokens ---------------------------------------
+const IR = {
+  structure: 'magnitude',
+  title: 'T',
+  nodes: ['a', 'b', 'c'],
+  magnitude: [1, 3, 2],
+};
+{
+  const s = renderMagnitude(IR);
+  const monos = s.subjects.filter((x) => /^mono-/.test(x.id));
+  ok(
+    monos.every((m) => near(m.args.dims[0], MODULE.unit)),
+    'monolith footprint = MODULE.unit',
+  );
+  const xs = monos.map((m) => m.transform.translate[0]).sort((a, b) => a - b);
+  ok(near(xs[1] - xs[0], stride()), 'monolith rhythm = stride token');
+  const plinth = s.subjects.find((x) => /^plinth-/.test(x.id));
+  ok(
+    near(plinth.args.dims[0], MODULE.unit + MODULE.plinthPad) &&
+      near(plinth.args.dims[1], MODULE.plinthH),
+    'plinth derives from plinthPad/plinthH tokens',
+  );
+  const tallest = monos.reduce((a, b) => (a.args.dims[1] > b.args.dims[1] ? a : b));
+  ok(near(tallest.args.dims[1], SCALE.monumental), 'champion height = SCALE.monumental');
+}
+
+// token change → geometry re-derives (mutate, render, restore)
+{
+  const orig = MODULE.gap;
+  MODULE.gap = orig + 0.3;
+  const s = renderMagnitude(IR);
+  const xs = s.subjects
+    .filter((x) => /^mono-/.test(x.id))
+    .map((m) => m.transform.translate[0])
+    .sort((a, b) => a - b);
+  ok(near(xs[1] - xs[0], MODULE.unit + orig + 0.3), 'changing MODULE.gap re-derives the rhythm');
+  MODULE.gap = orig;
+}
+
+console.log(`\n${pass}/${pass + fail} passed`);
+process.exit(fail ? 1 : 0);

--- a/sdf-js/src/scene/layout-tokens.js
+++ b/sdf-js/src/scene/layout-tokens.js
@@ -1,0 +1,42 @@
+// sdf-js/src/scene/layout-tokens.js — Layer B (排布系统), first cut.
+//
+// The debate verdict re-founded the spatial framework as a COMPOSITION system:
+// the user's words "排布 / 对齐 / 对比" are layout-grid vocabulary, and their
+// 3D implementation is a shared module system — spacing tokens, alignment
+// operators, a monumental-vs-intimate scale contrast — not per-renderer magic
+// numbers. This module is the first cut: it extracts render-magnitude's
+// hardcoded coordinates (the `xOf(i)` the debate kept pointing at) into named
+// tokens. Other renderers migrate as they are touched — extraction must be
+// output-identical (the assemble-deck goldens gate it), so we do it renderer
+// by renderer, never as a big bang.
+//
+// Vocabulary:
+//   MODULE — the base dimensional tokens (one source for footprints/gaps/
+//     plinths). Change `unit` here and every consuming renderer re-derives.
+//   stride() — module + breathing: the atomic horizontal rhythm.
+//   centeredRow / rowSpan — alignment operators for the row archetype
+//     (items centered on the origin, span measured edge to edge).
+//   SCALE — the contrast axis: monumental (towers over the camera) vs
+//     intimate (hand-height). Deliberate breaks between these two registers
+//     are how "对比" is made, per the composition thesis.
+
+export const MODULE = {
+  unit: 0.72, // base footprint module (a monolith's W)
+  gap: 0.55, // inter-module breathing
+  plinthPad: 0.34, // plinth overhang beyond the module footprint
+  plinthH: 0.12, // plinth slab thickness — the pedestal datum step
+};
+
+export const SCALE = {
+  monumental: 4.8, // the champion's ceiling — towers over the tracking camera
+  intimate: 1.1, // hand-height register (tracking-shot eye level)
+};
+
+/** The atomic horizontal rhythm: one module + one breath. */
+export const stride = () => MODULE.unit + MODULE.gap;
+
+/** Center-aligned row position: item i of n, centered on the origin. */
+export const centeredRow = (i, n, s = stride()) => (i - (n - 1) / 2) * s;
+
+/** Edge-to-edge span of a centered row of n modules. */
+export const rowSpan = (n, s = stride(), w = MODULE.unit) => (n - 1) * s + w;

--- a/sdf-js/src/scene/render-magnitude.js
+++ b/sdf-js/src/scene/render-magnitude.js
@@ -19,6 +19,7 @@
 //   5. payoff pull-back — the whole skyline in one frame
 import { validateIR } from './ir.js';
 import { getEnvironment } from './environments.js';
+import { MODULE, SCALE, centeredRow, rowSpan as rowSpanOf } from './layout-tokens.js';
 
 const label = (n) => (typeof n === 'string' ? n : (n && (n.label ?? n.name)) || '');
 
@@ -75,12 +76,13 @@ export function renderMagnitude(ir, opts = {}) {
   const emphasis = new Set(ir.emphasis && ir.emphasis.length ? ir.emphasis : [tallest]);
 
   // Row layout: equal footprints, height = linear encoding (honest comparison).
-  const W = 0.72; // monolith footprint
-  const gapX = 0.55;
-  const stride = W + gapX;
-  const H_MAX = 4.8; // monumental: the champion TOWERS (analytic engine pays for it)
+  // Dimensions come from the shared layout tokens (Layer B): the module system
+  // owns footprint/gap/plinth; this renderer owns only the ENCODING (height ∝
+  // magnitude) and the monumental register choice.
+  const W = MODULE.unit; // monolith footprint
+  const H_MAX = SCALE.monumental; // the champion TOWERS (analytic engine pays for it)
   const height = (i) => Math.max(0.12, (Number(mag[i]) / mMax) * H_MAX);
-  const xOf = (i) => (i - (N - 1) / 2) * stride;
+  const xOf = (i) => centeredRow(i, N);
 
   // Tracking-beat timing: monolith i erupts as the camera's beat i begins.
   const introLead = 2.1; // hero 0.9 + crane 1.2
@@ -99,8 +101,8 @@ export function renderMagnitude(ir, opts = {}) {
     subjects.push({
       id: `plinth-${i}`,
       type: 'box',
-      args: { dims: [W + 0.34, 0.12, W + 0.34] },
-      transform: { translate: [xOf(i), 0.06, 0] },
+      args: { dims: [W + MODULE.plinthPad, MODULE.plinthH, W + MODULE.plinthPad] },
+      transform: { translate: [xOf(i), MODULE.plinthH / 2, 0] },
       material: {
         hue: 0.58,
         sat: 0.1,
@@ -130,7 +132,7 @@ export function renderMagnitude(ir, opts = {}) {
   // Flanking stone rows: two receding lines of black slabs behind the row —
   // perspective guides converging on the data, and their long directional
   // shadows dress the floor for free (analytic soft shadows).
-  const rowSpanG = (N - 1) * stride + W;
+  const rowSpanG = rowSpanOf(N);
   for (let g = 0; g < 3; g++) {
     const gh = 2.2 + g * 1.3;
     for (const side of [-1, 1]) {
@@ -155,7 +157,7 @@ export function renderMagnitude(ir, opts = {}) {
   }
 
   // ---- camera: five beats, magnitude variation --------------------------------
-  const rowSpan = (N - 1) * stride + W;
+  const rowSpan = rowSpanOf(N);
   const tallH = height(tallest);
   const gx = xOf(emphasisIdx);
   const gH = height(emphasisIdx);
@@ -188,7 +190,9 @@ export function renderMagnitude(ir, opts = {}) {
     const H = height(i);
     shots.push({
       duration: holdEach,
-      pos: [x + 0.9, Math.min(1.1, H * 0.55 + 0.35), 2.5],
+      // camera rides the INTIMATE register during the walk-among-giants — the
+      // scale contrast against SCALE.monumental is the "对比" operator itself
+      pos: [x + 0.9, Math.min(SCALE.intimate, H * 0.55 + 0.35), 2.5],
       target: [x, Math.max(H * 0.55, 0.5), 0],
       fov: 46,
       transition: 'blend',


### PR DESCRIPTION
## Wave 3 — 排布系统首切口(Layer B)

对抗讨论把用户四词"排布/对齐/对比"的直接实现层定为 Layer B(构图系统),并点名 render-magnitude 的 `xOf(i)` 硬编码坐标是第一个工作对象。本 PR 是最小切口:

- **`layout-tokens.js`**:`MODULE`(unit / gap / plinthPad / plinthH 四个尺寸 token)+ `SCALE`(monumental 4.8 / intimate 1.1 —— 对比双档,纪念性 vs 亲密尺度的刻意断裂就是"对比"操作子本身)+ 三个对齐操作子 `stride()` / `centeredRow()` / `rowSpan()`
- **render-magnitude 迁移**:footprint / 间距 / plinth 尺寸 / 冠军高度 / 追踪镜头眼高全部改为消费 token
- **逐字节不变,双重验证**:① 独立 baseline 前后对比 BYTE-IDENTICAL;② 三个 assemble-deck golden **不用 --update 直接过**(真实语料级)
- **"真消费"断言**:测试里改 `MODULE.gap` → 几何重推导才算过——硬拷贝数值能骗过字节比对,骗不过这条
- 其余 renderer 按 touched-then-migrate 原则逐个迁移,不搞 big bang(golden 挡在前面)

suite 145/145,lint 0 errors。

Merge 后进 **Wave 4:courtyard layout 分支**(zone 感知圆心 + 朝中庭合成镜头 + zone massing 进预算 + 环心/石林冲突解法)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)