### PR TITLE
feat(w5): deck 级盲测仪器 — radial vs courtyard(Phase 1 出口)

### DIFF
--- a/sdf-js/apps/present/blind-deck.html
+++ b/sdf-js/apps/present/blind-deck.html
@@ -1,0 +1,120 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>Deck A/B — which reads better?</title>
+    <style>
+      html,
+      body {
+        margin: 0;
+        height: 100%;
+        background: #0e0f12;
+        font-family: -apple-system, Inter, sans-serif;
+        color: #eee;
+      }
+      .bar {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        gap: 12px;
+        padding: 12px;
+      }
+      .bar .q {
+        font-size: 14px;
+        font-weight: 600;
+        margin-right: 12px;
+        color: #bbb;
+      }
+      .bar button {
+        font-size: 14px;
+        padding: 9px 20px;
+        border-radius: 6px;
+        border: 1px solid #555;
+        background: #1c1e24;
+        color: #eee;
+        cursor: pointer;
+      }
+      .bar button.play {
+        border-color: #3b82f6;
+      }
+      .bar button.pick {
+        border-color: #f59e0b;
+      }
+      .bar button:disabled {
+        opacity: 0.35;
+        cursor: default;
+      }
+      #stage {
+        position: fixed;
+        inset: 56px 0 0 0;
+      }
+      #stage iframe {
+        width: 100%;
+        height: 100%;
+        border: 0;
+      }
+      #verdict {
+        text-align: center;
+        padding: 10px;
+        font-size: 14px;
+        color: #f59e0b;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="bar">
+      <span class="q">同一份 deck、同一艺术 seed、同一镜头纪律 — 哪个版本读起来更好?</span>
+      <button class="play" data-arm="A">▶ 版本 A</button>
+      <button class="play" data-arm="B">▶ 版本 B</button>
+      <button class="pick" data-arm="A" disabled>选 A</button>
+      <button class="pick" data-arm="B" disabled>选 B</button>
+    </div>
+    <div id="stage"></div>
+    <div id="verdict"></div>
+    <script type="module">
+      // W5 blind instrument (spec §5): baseline = the SHIPPED radial (never
+      // line — that would smuggle in the already-shipped ring-vs-line delta),
+      // both arms share one decor seed (等价装饰, user decision #4), and the
+      // conclusion is only ever "courtyard 体验 > radial", nothing grander.
+      const params = new URLSearchParams(location.search);
+      const deck = params.get('deck') || 'bytedance-bp';
+      const seed = params.get('seed') || 'atlas-01';
+      const stage = params.get('stage') || '1';
+      const ARMS = ['radial', 'courtyard'];
+
+      // Stable per-session shuffle: refreshing mid-test must not reshuffle.
+      const key = `blind-deck:${deck}:${seed}`;
+      let flip = sessionStorage.getItem(key);
+      if (flip == null) {
+        flip = Math.random() < 0.5 ? '1' : '0';
+        sessionStorage.setItem(key, flip);
+      }
+      const armOf = { A: ARMS[+flip], B: ARMS[1 - +flip] };
+
+      const stageEl = document.getElementById('stage');
+      const watched = new Set();
+      const picks = document.querySelectorAll('button.pick');
+      document.querySelectorAll('button.play').forEach((b) =>
+        b.addEventListener('click', () => {
+          const arm = b.dataset.arm;
+          stageEl.innerHTML = '';
+          const f = document.createElement('iframe');
+          // fps=0: the HUD is a potential tell (warm-up counts differ)
+          f.src = `./figure.html?deck=${encodeURIComponent(deck)}&layout=${armOf[arm]}&stage=${stage}&seed=${encodeURIComponent(seed)}&fps=0`;
+          stageEl.appendChild(f);
+          watched.add(arm);
+          if (watched.size === 2) picks.forEach((p) => (p.disabled = false));
+        }),
+      );
+      picks.forEach((b) =>
+        b.addEventListener('click', () => {
+          const arm = b.dataset.arm;
+          const layout = armOf[arm];
+          console.log('BLIND PICK', arm, '→', layout); // tally offline
+          document.getElementById('verdict').textContent =
+            `已记录:你选了版本 ${arm} = ${layout}(A=${armOf.A} · B=${armOf.B})`;
+        }),
+      );
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## Wave 5 — 盲测仪器(Phase 1 出口)

`apps/present/blind-deck.html?deck=bytedance-bp&seed=atlas-01` — 同一份 deck、同一艺术 seed、同一镜头纪律,两臂顺序全屏播放,看完才能投票,投票后揭盲。

合议的四条实验约束全部落地:

1. **baseline = shipped radial**(绝不用 line——否则混入"环形 vs 直线"这个已 ship 差异)
2. **双臂等价装饰**(同 decor seed,你拍板的 #4)
3. A/B 分配随机但 session 内稳定(刷新不重洗);**fps HUD 隐藏**(预热计数是 tell)
4. 结论宣称范围锁定 **"courtyard 体验 > radial"**,不得引申为"空间组织 IR 有效"

真机全链验证过(双臂预热、解锁、投票、揭盲)。

### 怎么跑
1. Merge 后打开 `http://127.0.0.1:8001/apps/present/blind-deck.html`
2. ▶ 版本 A 看完(~2.5 分钟),▶ 版本 B 看完
3. 凭体验选一个——页面揭盲告诉你选的是哪个 layout
4. 把结果告诉我

### 结果的分叉(Phase 1 出口逻辑)
- **courtyard 胜** → 空间组织假设拿到第一份证据;下一步与你重议延后项(2D outline 立项、契约请求 §9.5、spine 排期、SpatialPlan IR 的 rule-of-two)
- **radial 胜** → 空间组织假设记为证伪归档;Wave 1-3 的产出(hold 页数对齐、decor 家族、模数 token)独立留存,courtyard 分支停

🤖 Generated with [Claude Code](https://claude.com/claude-code)