### PR TITLE
fix(w5b): courtyard 世界延续感 — 盲测第一轮修正

### DIFF
--- a/sdf-js/fixtures/golden/assemble-deck-courtyard.json
+++ b/sdf-js/fixtures/golden/assemble-deck-courtyard.json
@@ -972,7 +972,7 @@
       "animation": [
         {
           "channel": "transform.translate.y",
-          "expr": "-1.293 + 2.286 * smoothstep(24.55, 25.15, t)"
+          "expr": "-1.293 + 2.286 * smoothstep(24.75, 25.35, t)"
         }
       ],
       "pattern": "cracked"
@@ -1016,7 +1016,7 @@
       "animation": [
         {
           "channel": "transform.translate.y",
-          "expr": "-1.541 + 2.783 * smoothstep(25.65, 26.25, t)"
+          "expr": "-1.541 + 2.783 * smoothstep(25.85, 26.45, t)"
         }
       ],
       "pattern": "cracked"
@@ -1060,7 +1060,7 @@
       "animation": [
         {
           "channel": "transform.translate.y",
-          "expr": "-1.900 + 3.500 * smoothstep(26.75, 27.35, t)"
+          "expr": "-1.900 + 3.500 * smoothstep(26.95, 27.55, t)"
         }
       ],
       "pattern": "cracked"
@@ -1104,7 +1104,7 @@
       "animation": [
         {
           "channel": "transform.translate.y",
-          "expr": "-2.203 + 4.107 * smoothstep(27.85, 28.45, t)"
+          "expr": "-2.203 + 4.107 * smoothstep(28.05, 28.65, t)"
         }
       ],
       "pattern": "cracked"
@@ -1148,7 +1148,7 @@
       "animation": [
         {
           "channel": "transform.translate.y",
-          "expr": "-2.452 + 4.603 * smoothstep(28.95, 29.55, t)"
+          "expr": "-2.452 + 4.603 * smoothstep(29.15, 29.75, t)"
         }
       ],
       "pattern": "cracked"
@@ -1194,7 +1194,7 @@
       "animation": [
         {
           "channel": "transform.translate.y",
-          "expr": "-2.700 + 5.100 * smoothstep(30.05, 30.65, t)"
+          "expr": "-2.700 + 5.100 * smoothstep(30.25, 30.85, t)"
         }
       ]
     },
@@ -1446,7 +1446,7 @@
       "animation": [
         {
           "channel": "transform.translate.y",
-          "expr": "-0.445 + 0.589 * smoothstep(37.85, 38.45, t)"
+          "expr": "-0.445 + 0.589 * smoothstep(38.05, 38.65, t)"
         }
       ],
       "pattern": "cracked"
@@ -1490,7 +1490,7 @@
       "animation": [
         {
           "channel": "transform.translate.y",
-          "expr": "-0.583 + 0.865 * smoothstep(38.95, 39.55, t)"
+          "expr": "-0.583 + 0.865 * smoothstep(39.15, 39.75, t)"
         }
       ],
       "pattern": "cracked"
@@ -1534,7 +1534,7 @@
       "animation": [
         {
           "channel": "transform.translate.y",
-          "expr": "-0.844 + 1.389 * smoothstep(40.05, 40.65, t)"
+          "expr": "-0.844 + 1.389 * smoothstep(40.25, 40.85, t)"
         }
       ],
       "pattern": "cracked"
@@ -1578,7 +1578,7 @@
       "animation": [
         {
           "channel": "transform.translate.y",
-          "expr": "-1.260 + 2.220 * smoothstep(41.15, 41.75, t)"
+          "expr": "-1.260 + 2.220 * smoothstep(41.35, 41.95, t)"
         }
       ],
       "pattern": "cracked"
@@ -1622,7 +1622,7 @@
       "animation": [
         {
           "channel": "transform.translate.y",
-          "expr": "-1.850 + 3.400 * smoothstep(42.25, 42.85, t)"
+          "expr": "-1.850 + 3.400 * smoothstep(42.45, 43.05, t)"
         }
       ],
       "pattern": "cracked"
@@ -1668,7 +1668,7 @@
       "animation": [
         {
           "channel": "transform.translate.y",
-          "expr": "-2.700 + 5.100 * smoothstep(43.35, 43.95, t)"
+          "expr": "-2.700 + 5.100 * smoothstep(43.55, 44.15, t)"
         }
       ]
     },
@@ -1922,7 +1922,7 @@
       "animation": [
         {
           "channel": "transform.translate.y",
-          "expr": "-2.700 + 5.100 * smoothstep(51.15, 51.75, t)"
+          "expr": "-2.700 + 5.100 * smoothstep(51.35, 51.95, t)"
         }
       ]
     },
@@ -1965,7 +1965,7 @@
       "animation": [
         {
           "channel": "transform.translate.y",
-          "expr": "-2.537 + 4.775 * smoothstep(52.25, 52.85, t)"
+          "expr": "-2.537 + 4.775 * smoothstep(52.45, 53.05, t)"
         }
       ],
       "pattern": "cracked"
@@ -2009,7 +2009,7 @@
       "animation": [
         {
           "channel": "transform.translate.y",
-          "expr": "-1.715 + 3.130 * smoothstep(53.35, 53.95, t)"
+          "expr": "-1.715 + 3.130 * smoothstep(53.55, 54.15, t)"
         }
       ],
       "pattern": "cracked"
@@ -2053,7 +2053,7 @@
       "animation": [
         {
           "channel": "transform.translate.y",
-          "expr": "-1.543 + 2.786 * smoothstep(54.45, 55.05, t)"
+          "expr": "-1.543 + 2.786 * smoothstep(54.65, 55.25, t)"
         }
       ],
       "pattern": "cracked"
@@ -2097,7 +2097,7 @@
       "animation": [
         {
           "channel": "transform.translate.y",
-          "expr": "-1.036 + 1.773 * smoothstep(55.55, 56.15, t)"
+          "expr": "-1.036 + 1.773 * smoothstep(55.75, 56.35, t)"
         }
       ],
       "pattern": "cracked"
@@ -2141,7 +2141,7 @@
       "animation": [
         {
           "channel": "transform.translate.y",
-          "expr": "-0.950 + 1.600 * smoothstep(56.65, 57.25, t)"
+          "expr": "-0.950 + 1.600 * smoothstep(56.85, 57.45, t)"
         }
       ],
       "pattern": "cracked"
@@ -2396,7 +2396,7 @@
       "animation": [
         {
           "channel": "transform.translate.y",
-          "expr": "-2.700 + 5.100 * smoothstep(64.45, 65.05, t)"
+          "expr": "-2.700 + 5.100 * smoothstep(64.65, 65.25, t)"
         }
       ]
     },
@@ -2439,7 +2439,7 @@
       "animation": [
         {
           "channel": "transform.translate.y",
-          "expr": "-2.507 + 4.715 * smoothstep(65.55, 66.15, t)"
+          "expr": "-2.507 + 4.715 * smoothstep(65.75, 66.35, t)"
         }
       ],
       "pattern": "cracked"
@@ -2483,7 +2483,7 @@
       "animation": [
         {
           "channel": "transform.translate.y",
-          "expr": "-1.802 + 3.303 * smoothstep(66.65, 67.25, t)"
+          "expr": "-1.802 + 3.303 * smoothstep(66.85, 67.45, t)"
         }
       ],
       "pattern": "cracked"
@@ -2527,7 +2527,7 @@
       "animation": [
         {
           "channel": "transform.translate.y",
-          "expr": "-1.559 + 2.818 * smoothstep(67.75, 68.35, t)"
+          "expr": "-1.559 + 2.818 * smoothstep(67.95, 68.55, t)"
         }
       ],
       "pattern": "cracked"
@@ -2571,7 +2571,7 @@
       "animation": [
         {
           "channel": "transform.translate.y",
-          "expr": "-1.329 + 2.358 * smoothstep(68.85, 69.45, t)"
+          "expr": "-1.329 + 2.358 * smoothstep(69.05, 69.65, t)"
         }
       ],
       "pattern": "cracked"
@@ -2615,7 +2615,7 @@
       "animation": [
         {
           "channel": "transform.translate.y",
-          "expr": "-1.270 + 2.240 * smoothstep(69.95, 70.55, t)"
+          "expr": "-1.270 + 2.240 * smoothstep(70.15, 70.75, t)"
         }
       ],
       "pattern": "cracked"
@@ -2907,7 +2907,7 @@
       "animation": [
         {
           "channel": "transform.translate.y",
-          "expr": "1.100 + 2.500 * smoothstep(77.70, 78.50, t) + 0.06 * sin(0.5 * t + -38.05)"
+          "expr": "1.100 + 2.500 * smoothstep(77.90, 78.70, t) + 0.06 * sin(0.5 * t + -38.15)"
         }
       ]
     },
@@ -2932,7 +2932,7 @@
       "animation": [
         {
           "channel": "transform.translate.y",
-          "expr": "1.100 + 2.500 * smoothstep(78.80, 79.60, t) + 0.06 * sin(0.5 * t + -35.95)"
+          "expr": "1.100 + 2.500 * smoothstep(79.00, 79.80, t) + 0.06 * sin(0.5 * t + -36.05)"
         }
       ]
     },
@@ -2957,7 +2957,7 @@
       "animation": [
         {
           "channel": "transform.translate.y",
-          "expr": "1.100 + 2.500 * smoothstep(79.90, 80.70, t) + 0.06 * sin(0.5 * t + -33.85)"
+          "expr": "1.100 + 2.500 * smoothstep(80.10, 80.90, t) + 0.06 * sin(0.5 * t + -33.95)"
         }
       ]
     },
@@ -3249,7 +3249,7 @@
       "animation": [
         {
           "channel": "transform.translate.y",
-          "expr": "4.620 - 1.1 * smoothstep(86.55, 87.05, t) + 0.018 * sin(1.3 * t + -112.19)"
+          "expr": "4.620 - 1.1 * smoothstep(86.95, 87.45, t) + 0.018 * sin(1.3 * t + -112.71)"
         }
       ]
     },
@@ -3273,7 +3273,7 @@
       "animation": [
         {
           "channel": "transform.translate.y",
-          "expr": "7.080 - 1.1 * smoothstep(86.67, 87.17, t) + 0.018 * sin(1.3 * t + -110.09)"
+          "expr": "7.080 - 1.1 * smoothstep(87.07, 87.57, t) + 0.018 * sin(1.3 * t + -110.61)"
         }
       ]
     },
@@ -3297,7 +3297,7 @@
       "animation": [
         {
           "channel": "transform.translate.y",
-          "expr": "6.351 - 1.1 * smoothstep(86.79, 87.29, t) + 0.018 * sin(1.3 * t + -107.99)"
+          "expr": "6.351 - 1.1 * smoothstep(87.19, 87.69, t) + 0.018 * sin(1.3 * t + -108.51)"
         }
       ]
     },
@@ -3321,7 +3321,7 @@
       "animation": [
         {
           "channel": "transform.translate.y",
-          "expr": "5.470 - 1.1 * smoothstep(86.91, 87.41, t) + 0.018 * sin(1.3 * t + -105.89)"
+          "expr": "5.470 - 1.1 * smoothstep(87.31, 87.81, t) + 0.018 * sin(1.3 * t + -106.41)"
         }
       ]
     },
@@ -3345,7 +3345,7 @@
       "animation": [
         {
           "channel": "transform.translate.y",
-          "expr": "4.721 - 1.1 * smoothstep(87.03, 87.53, t) + 0.018 * sin(1.3 * t + -103.79)"
+          "expr": "4.721 - 1.1 * smoothstep(87.43, 87.93, t) + 0.018 * sin(1.3 * t + -104.31)"
         }
       ]
     },
@@ -3369,7 +3369,7 @@
       "animation": [
         {
           "channel": "transform.translate.y",
-          "expr": "4.053 - 1.1 * smoothstep(87.15, 87.65, t) + 0.018 * sin(1.3 * t + -101.69)"
+          "expr": "4.053 - 1.1 * smoothstep(87.55, 88.05, t) + 0.018 * sin(1.3 * t + -102.21)"
         }
       ]
     },
@@ -3393,7 +3393,7 @@
       "animation": [
         {
           "channel": "transform.translate.y",
-          "expr": "2.920 - 1.1 * smoothstep(87.27, 87.77, t) + 0.018 * sin(1.3 * t + -99.59)"
+          "expr": "2.920 - 1.1 * smoothstep(87.67, 88.17, t) + 0.018 * sin(1.3 * t + -100.11)"
         }
       ]
     },
@@ -3417,7 +3417,7 @@
       "animation": [
         {
           "channel": "transform.translate.y",
-          "expr": "2.310 - 1.1 * smoothstep(87.39, 87.89, t) + 0.018 * sin(1.3 * t + -97.49)"
+          "expr": "2.310 - 1.1 * smoothstep(87.79, 88.29, t) + 0.018 * sin(1.3 * t + -98.01)"
         }
       ]
     },
@@ -3441,7 +3441,7 @@
       "animation": [
         {
           "channel": "transform.translate.y",
-          "expr": "1.700 - 1.1 * smoothstep(87.51, 88.01, t) + 0.018 * sin(1.3 * t + -95.39)"
+          "expr": "1.700 - 1.1 * smoothstep(87.91, 88.41, t) + 0.018 * sin(1.3 * t + -95.91)"
         }
       ]
     },
@@ -3468,7 +3468,7 @@
       "animation": [
         {
           "channel": "transform.translate.y",
-          "expr": "7.080 - 1.1 * smoothstep(87.83, 88.28, t)"
+          "expr": "7.080 - 1.1 * smoothstep(88.23, 88.68, t)"
         }
       ]
     },
@@ -3495,7 +3495,7 @@
       "animation": [
         {
           "channel": "transform.translate.y",
-          "expr": "6.351 - 1.1 * smoothstep(87.97, 88.42, t)"
+          "expr": "6.351 - 1.1 * smoothstep(88.37, 88.82, t)"
         }
       ]
     },
@@ -3522,7 +3522,7 @@
       "animation": [
         {
           "channel": "transform.translate.y",
-          "expr": "5.470 - 1.1 * smoothstep(88.11, 88.56, t)"
+          "expr": "5.470 - 1.1 * smoothstep(88.51, 88.96, t)"
         }
       ]
     },
@@ -3549,7 +3549,7 @@
       "animation": [
         {
           "channel": "transform.translate.y",
-          "expr": "4.721 - 1.1 * smoothstep(88.25, 88.70, t)"
+          "expr": "4.721 - 1.1 * smoothstep(88.65, 89.10, t)"
         }
       ]
     },
@@ -3576,7 +3576,7 @@
       "animation": [
         {
           "channel": "transform.translate.y",
-          "expr": "4.053 - 1.1 * smoothstep(88.39, 88.84, t)"
+          "expr": "4.053 - 1.1 * smoothstep(88.79, 89.24, t)"
         }
       ]
     },
@@ -3603,7 +3603,7 @@
       "animation": [
         {
           "channel": "transform.translate.y",
-          "expr": "4.620 - 1.1 * smoothstep(88.53, 88.98, t)"
+          "expr": "4.620 - 1.1 * smoothstep(88.93, 89.38, t)"
         }
       ]
     },
@@ -3630,7 +3630,7 @@
       "animation": [
         {
           "channel": "transform.translate.y",
-          "expr": "4.620 - 1.1 * smoothstep(88.67, 89.12, t)"
+          "expr": "4.620 - 1.1 * smoothstep(89.07, 89.52, t)"
         }
       ]
     },
@@ -3657,7 +3657,7 @@
       "animation": [
         {
           "channel": "transform.translate.y",
-          "expr": "2.920 - 1.1 * smoothstep(88.81, 89.26, t)"
+          "expr": "2.920 - 1.1 * smoothstep(89.21, 89.66, t)"
         }
       ]
     },
@@ -3684,7 +3684,7 @@
       "animation": [
         {
           "channel": "transform.translate.y",
-          "expr": "2.310 - 1.1 * smoothstep(88.95, 89.40, t)"
+          "expr": "2.310 - 1.1 * smoothstep(89.35, 89.80, t)"
         }
       ]
     },
@@ -3711,7 +3711,7 @@
       "animation": [
         {
           "channel": "transform.translate.y",
-          "expr": "1.700 - 1.1 * smoothstep(89.09, 89.54, t)"
+          "expr": "1.700 - 1.1 * smoothstep(89.49, 89.94, t)"
         }
       ]
     },
@@ -3735,7 +3735,7 @@
       "animation": [
         {
           "channel": "transform.translate.y",
-          "expr": "4.405 - 0.000 * smoothstep(86.30, 87.30, t) + 0.05 * sin(0.30 * t + -25.89)"
+          "expr": "4.405 - 0.000 * smoothstep(86.70, 87.70, t) + 0.05 * sin(0.30 * t + -26.01)"
         }
       ]
     },
@@ -3759,7 +3759,7 @@
       "animation": [
         {
           "channel": "transform.translate.y",
-          "expr": "4.400 - 0.000 * smoothstep(86.30, 87.30, t) + 0.07 * sin(0.35 * t + -28.91)"
+          "expr": "4.400 - 0.000 * smoothstep(86.70, 87.70, t) + 0.07 * sin(0.35 * t + -29.04)"
         }
       ]
     },
@@ -3783,7 +3783,7 @@
       "animation": [
         {
           "channel": "transform.translate.y",
-          "expr": "3.630 - 0.000 * smoothstep(86.30, 87.30, t) + 0.09 * sin(0.40 * t + -31.92)"
+          "expr": "3.630 - 0.000 * smoothstep(86.70, 87.70, t) + 0.09 * sin(0.40 * t + -32.08)"
         }
       ]
     },
@@ -3807,7 +3807,7 @@
       "animation": [
         {
           "channel": "transform.translate.y",
-          "expr": "4.223 - 0.000 * smoothstep(86.30, 87.30, t) + 0.05 * sin(0.45 * t + -34.94)"
+          "expr": "4.223 - 0.000 * smoothstep(86.70, 87.70, t) + 0.05 * sin(0.45 * t + -35.12)"
         }
       ]
     },
@@ -3831,7 +3831,7 @@
       "animation": [
         {
           "channel": "transform.translate.y",
-          "expr": "3.084 - 0.000 * smoothstep(86.30, 87.30, t) + 0.07 * sin(0.50 * t + -37.95)"
+          "expr": "3.084 - 0.000 * smoothstep(86.70, 87.70, t) + 0.07 * sin(0.50 * t + -38.15)"
         }
       ]
     },
@@ -3855,7 +3855,7 @@
       "animation": [
         {
           "channel": "transform.translate.y",
-          "expr": "3.818 - 0.000 * smoothstep(86.30, 87.30, t) + 0.09 * sin(0.30 * t + -25.67)"
+          "expr": "3.818 - 0.000 * smoothstep(86.70, 87.70, t) + 0.09 * sin(0.30 * t + -25.79)"
         }
       ]
     },
@@ -3879,7 +3879,7 @@
       "animation": [
         {
           "channel": "transform.translate.y",
-          "expr": "2.743 - 0.000 * smoothstep(86.30, 87.30, t) + 0.05 * sin(0.35 * t + -28.69)"
+          "expr": "2.743 - 0.000 * smoothstep(86.70, 87.70, t) + 0.05 * sin(0.35 * t + -28.82)"
         }
       ]
     },
@@ -3903,7 +3903,7 @@
       "animation": [
         {
           "channel": "transform.translate.y",
-          "expr": "3.248 - 0.000 * smoothstep(86.30, 87.30, t) + 0.07 * sin(0.40 * t + -31.70)"
+          "expr": "3.248 - 0.000 * smoothstep(86.70, 87.70, t) + 0.07 * sin(0.40 * t + -31.86)"
         }
       ]
     },
@@ -3927,7 +3927,7 @@
       "animation": [
         {
           "channel": "transform.translate.y",
-          "expr": "2.515 - 0.000 * smoothstep(86.30, 87.30, t) + 0.09 * sin(0.45 * t + -34.72)"
+          "expr": "2.515 - 0.000 * smoothstep(86.70, 87.70, t) + 0.09 * sin(0.45 * t + -34.90)"
         }
       ]
     },
@@ -3951,7 +3951,7 @@
       "animation": [
         {
           "channel": "transform.translate.y",
-          "expr": "2.626 - 0.000 * smoothstep(86.30, 87.30, t) + 0.05 * sin(0.50 * t + -37.73)"
+          "expr": "2.626 - 0.000 * smoothstep(86.70, 87.70, t) + 0.05 * sin(0.50 * t + -37.93)"
         }
       ]
     },
@@ -3975,7 +3975,7 @@
       "animation": [
         {
           "channel": "transform.translate.y",
-          "expr": "2.275 - 0.000 * smoothstep(86.30, 87.30, t) + 0.07 * sin(0.30 * t + -25.45)"
+          "expr": "2.275 - 0.000 * smoothstep(86.70, 87.70, t) + 0.07 * sin(0.30 * t + -25.57)"
         }
       ]
     },
@@ -3999,7 +3999,7 @@
       "animation": [
         {
           "channel": "transform.translate.y",
-          "expr": "2.074 - 0.000 * smoothstep(86.30, 87.30, t) + 0.09 * sin(0.35 * t + -28.47)"
+          "expr": "2.074 - 0.000 * smoothstep(86.70, 87.70, t) + 0.09 * sin(0.35 * t + -28.61)"
         }
       ]
     },
@@ -4023,7 +4023,7 @@
       "animation": [
         {
           "channel": "transform.translate.y",
-          "expr": "1.917 - 0.000 * smoothstep(86.30, 87.30, t) + 0.05 * sin(0.40 * t + -31.48)"
+          "expr": "1.917 - 0.000 * smoothstep(86.70, 87.70, t) + 0.05 * sin(0.40 * t + -31.64)"
         }
       ]
     },
@@ -4047,7 +4047,7 @@
       "animation": [
         {
           "channel": "transform.translate.y",
-          "expr": "1.675 - 0.000 * smoothstep(86.30, 87.30, t) + 0.07 * sin(0.45 * t + -34.50)"
+          "expr": "1.675 - 0.000 * smoothstep(86.70, 87.70, t) + 0.07 * sin(0.45 * t + -34.67)"
         }
       ]
     },
@@ -4071,7 +4071,7 @@
       "animation": [
         {
           "channel": "transform.translate.y",
-          "expr": "1.390 - 0.000 * smoothstep(86.30, 87.30, t) + 0.09 * sin(0.50 * t + -37.51)"
+          "expr": "1.390 - 0.000 * smoothstep(86.70, 87.70, t) + 0.09 * sin(0.50 * t + -37.71)"
         }
       ]
     },
@@ -4095,7 +4095,7 @@
       "animation": [
         {
           "channel": "transform.translate.y",
-          "expr": "1.443 - 0.000 * smoothstep(86.30, 87.30, t) + 0.05 * sin(0.30 * t + -25.23)"
+          "expr": "1.443 - 0.000 * smoothstep(86.70, 87.70, t) + 0.05 * sin(0.30 * t + -25.35)"
         }
       ]
     },
@@ -4119,7 +4119,7 @@
       "animation": [
         {
           "channel": "transform.translate.y",
-          "expr": "0.717 - 0.000 * smoothstep(86.30, 87.30, t) + 0.07 * sin(0.35 * t + -28.25)"
+          "expr": "0.717 - 0.000 * smoothstep(86.70, 87.70, t) + 0.07 * sin(0.35 * t + -28.38)"
         }
       ]
     },
@@ -4143,7 +4143,7 @@
       "animation": [
         {
           "channel": "transform.translate.y",
-          "expr": "1.316 - 0.000 * smoothstep(86.30, 87.30, t) + 0.09 * sin(0.40 * t + -31.26)"
+          "expr": "1.316 - 0.000 * smoothstep(86.70, 87.70, t) + 0.09 * sin(0.40 * t + -31.42)"
         }
       ]
     },
@@ -4167,7 +4167,7 @@
       "animation": [
         {
           "channel": "transform.translate.y",
-          "expr": "-0.006 - 0.000 * smoothstep(86.30, 87.30, t) + 0.05 * sin(0.45 * t + -34.28)"
+          "expr": "-0.006 - 0.000 * smoothstep(86.70, 87.70, t) + 0.05 * sin(0.45 * t + -34.45)"
         }
       ]
     },
@@ -4191,7 +4191,7 @@
       "animation": [
         {
           "channel": "transform.translate.y",
-          "expr": "1.174 - 0.000 * smoothstep(86.30, 87.30, t) + 0.07 * sin(0.50 * t + -37.29)"
+          "expr": "1.174 - 0.000 * smoothstep(86.70, 87.70, t) + 0.07 * sin(0.50 * t + -37.49)"
         }
       ]
     },
@@ -4215,7 +4215,7 @@
       "animation": [
         {
           "channel": "transform.translate.y",
-          "expr": "-0.644 - 0.000 * smoothstep(86.30, 87.30, t) + 0.09 * sin(0.30 * t + -25.01)"
+          "expr": "-0.644 - 0.000 * smoothstep(86.70, 87.70, t) + 0.09 * sin(0.30 * t + -25.13)"
         }
       ]
     },
@@ -4239,7 +4239,7 @@
       "animation": [
         {
           "channel": "transform.translate.y",
-          "expr": "0.879 - 0.000 * smoothstep(86.30, 87.30, t) + 0.05 * sin(0.35 * t + -28.03)"
+          "expr": "0.879 - 0.000 * smoothstep(86.70, 87.70, t) + 0.05 * sin(0.35 * t + -28.16)"
         }
       ]
     },
@@ -4361,7 +4361,7 @@
       "animation": [
         {
           "channel": "transform.translate.y",
-          "expr": "3.700 - 0.9 * smoothstep(97.05, 97.65, t)"
+          "expr": "3.700 - 0.9 * smoothstep(97.45, 98.05, t)"
         }
       ]
     },
@@ -4390,7 +4390,7 @@
       "animation": [
         {
           "channel": "transform.translate.y",
-          "expr": "2.900 - 0.9 * smoothstep(97.40, 98.00, t)"
+          "expr": "2.900 - 0.9 * smoothstep(97.80, 98.40, t)"
         }
       ]
     },
@@ -4417,7 +4417,7 @@
       "animation": [
         {
           "channel": "transform.translate.y",
-          "expr": "2.100 - 0.9 * smoothstep(97.75, 98.35, t)"
+          "expr": "2.100 - 0.9 * smoothstep(98.15, 98.75, t)"
         }
       ]
     },
@@ -4444,7 +4444,7 @@
       "animation": [
         {
           "channel": "transform.translate.y",
-          "expr": "1.300 - 0.9 * smoothstep(98.10, 98.70, t)"
+          "expr": "1.300 - 0.9 * smoothstep(98.50, 99.10, t)"
         }
       ]
     },
@@ -4582,7 +4582,7 @@
       "animation": [
         {
           "channel": "transform.translate.y",
-          "expr": "-2.700 + 5.100 * smoothstep(110.05, 110.65, t)"
+          "expr": "-2.700 + 5.100 * smoothstep(110.45, 111.05, t)"
         }
       ],
       "pattern": "cracked"
@@ -4626,7 +4626,7 @@
       "animation": [
         {
           "channel": "transform.translate.y",
-          "expr": "-2.656 + 5.013 * smoothstep(111.15, 111.75, t)"
+          "expr": "-2.656 + 5.013 * smoothstep(111.55, 112.15, t)"
         }
       ],
       "pattern": "cracked"
@@ -4670,7 +4670,7 @@
       "animation": [
         {
           "channel": "transform.translate.y",
-          "expr": "-2.538 + 4.775 * smoothstep(112.25, 112.85, t)"
+          "expr": "-2.538 + 4.775 * smoothstep(112.65, 113.25, t)"
         }
       ],
       "pattern": "cracked"
@@ -4714,7 +4714,7 @@
       "animation": [
         {
           "channel": "transform.translate.y",
-          "expr": "-2.443 + 4.585 * smoothstep(113.35, 113.95, t)"
+          "expr": "-2.443 + 4.585 * smoothstep(113.75, 114.35, t)"
         }
       ],
       "pattern": "cracked"
@@ -4758,7 +4758,7 @@
       "animation": [
         {
           "channel": "transform.translate.y",
-          "expr": "-2.324 + 4.348 * smoothstep(114.45, 115.05, t)"
+          "expr": "-2.324 + 4.348 * smoothstep(114.85, 115.45, t)"
         }
       ],
       "pattern": "cracked"
@@ -4802,7 +4802,7 @@
       "animation": [
         {
           "channel": "transform.translate.y",
-          "expr": "-2.181 + 4.062 * smoothstep(115.55, 116.15, t)"
+          "expr": "-2.181 + 4.062 * smoothstep(115.95, 116.55, t)"
         }
       ],
       "pattern": "cracked"
@@ -4848,7 +4848,7 @@
       "animation": [
         {
           "channel": "transform.translate.y",
-          "expr": "-2.086 + 3.872 * smoothstep(116.65, 117.25, t)"
+          "expr": "-2.086 + 3.872 * smoothstep(117.05, 117.65, t)"
         }
       ]
     },
@@ -5092,7 +5092,7 @@
       "animation": [
         {
           "channel": "transform.translate.y",
-          "expr": "4.150 - 1 * smoothstep(125.25, 125.80, t)"
+          "expr": "4.150 - 1 * smoothstep(125.85, 126.40, t)"
         }
       ]
     },
@@ -5137,7 +5137,7 @@
       "animation": [
         {
           "channel": "transform.translate.y",
-          "expr": "3.000 - 1 * smoothstep(126.75, 127.30, t)"
+          "expr": "3.000 - 1 * smoothstep(127.35, 127.90, t)"
         }
       ]
     },
@@ -5182,7 +5182,7 @@
       "animation": [
         {
           "channel": "transform.translate.y",
-          "expr": "3.000 - 1 * smoothstep(126.75, 127.30, t)"
+          "expr": "3.000 - 1 * smoothstep(127.35, 127.90, t)"
         }
       ]
     },
@@ -5227,7 +5227,7 @@
       "animation": [
         {
           "channel": "transform.translate.y",
-          "expr": "3.000 - 1 * smoothstep(126.75, 127.30, t)"
+          "expr": "3.000 - 1 * smoothstep(127.35, 127.90, t)"
         }
       ]
     },
@@ -5272,7 +5272,7 @@
       "animation": [
         {
           "channel": "transform.translate.y",
-          "expr": "1.850 - 1 * smoothstep(128.25, 128.80, t)"
+          "expr": "1.850 - 1 * smoothstep(128.85, 129.40, t)"
         }
       ]
     },
@@ -5487,7 +5487,7 @@
       "animation": [
         {
           "channel": "transform.translate.z",
-          "expr": "2.400 - 2.060 * smoothstep(136.15, 136.60, t)"
+          "expr": "2.400 - 2.060 * smoothstep(136.75, 137.20, t)"
         }
       ]
     },
@@ -5512,7 +5512,7 @@
       "animation": [
         {
           "channel": "transform.translate.z",
-          "expr": "2.400 - 2.060 * smoothstep(137.05, 137.50, t)"
+          "expr": "2.400 - 2.060 * smoothstep(137.65, 138.10, t)"
         }
       ]
     },
@@ -5537,7 +5537,7 @@
       "animation": [
         {
           "channel": "transform.translate.z",
-          "expr": "2.400 - 2.060 * smoothstep(137.95, 138.40, t)"
+          "expr": "2.400 - 2.060 * smoothstep(138.55, 139.00, t)"
         }
       ]
     },
@@ -5563,7 +5563,7 @@
       "animation": [
         {
           "channel": "transform.translate.z",
-          "expr": "2.400 - 2.060 * smoothstep(138.85, 139.30, t)"
+          "expr": "2.400 - 2.060 * smoothstep(139.45, 139.90, t)"
         }
       ]
     },
@@ -5588,7 +5588,7 @@
       "animation": [
         {
           "channel": "transform.translate.y",
-          "expr": "3.310 - 0.000 * smoothstep(134.90, 135.90, t) + 0.06 * sin(0.30 * t + -40.47)"
+          "expr": "3.310 - 0.000 * smoothstep(135.50, 136.50, t) + 0.06 * sin(0.30 * t + -40.65)"
         }
       ]
     },
@@ -5613,7 +5613,7 @@
       "animation": [
         {
           "channel": "transform.translate.y",
-          "expr": "2.110 - 0.000 * smoothstep(134.90, 135.90, t) + 0.08 * sin(0.37 * t + -47.71)"
+          "expr": "2.110 - 0.000 * smoothstep(135.50, 136.50, t) + 0.08 * sin(0.37 * t + -47.93)"
         }
       ]
     },
@@ -5638,7 +5638,7 @@
       "animation": [
         {
           "channel": "transform.translate.y",
-          "expr": "4.710 - 0.000 * smoothstep(134.90, 135.90, t) + 0.10 * sin(0.44 * t + -54.96)"
+          "expr": "4.710 - 0.000 * smoothstep(135.50, 136.50, t) + 0.10 * sin(0.44 * t + -55.22)"
         }
       ]
     },
@@ -5663,7 +5663,7 @@
       "animation": [
         {
           "channel": "transform.translate.y",
-          "expr": "4.110 - 0.000 * smoothstep(134.90, 135.90, t) + 0.12 * sin(0.51 * t + -68.48)"
+          "expr": "4.110 - 0.000 * smoothstep(135.50, 136.50, t) + 0.12 * sin(0.51 * t + -68.79)"
         }
       ]
     },
@@ -5801,7 +5801,7 @@
       "animation": [
         {
           "channel": "transform.translate.y",
-          "expr": "-0.540 + 0.780 * smoothstep(146.05, 146.65, t)"
+          "expr": "-0.540 + 0.780 * smoothstep(146.65, 147.25, t)"
         }
       ],
       "pattern": "cracked"
@@ -5845,7 +5845,7 @@
       "animation": [
         {
           "channel": "transform.translate.y",
-          "expr": "-1.500 + 2.700 * smoothstep(147.15, 147.75, t)"
+          "expr": "-1.500 + 2.700 * smoothstep(147.75, 148.35, t)"
         }
       ],
       "pattern": "cracked"
@@ -5891,7 +5891,7 @@
       "animation": [
         {
           "channel": "transform.translate.y",
-          "expr": "-2.700 + 5.100 * smoothstep(148.25, 148.85, t)"
+          "expr": "-2.700 + 5.100 * smoothstep(148.85, 149.45, t)"
         }
       ]
     },
@@ -6007,6 +6007,63 @@
         "kind": "normal",
         "roughness": 0.5,
         "clearcoat": 0.35
+      }
+    },
+    {
+      "id": "massing-center-0",
+      "type": "box",
+      "args": {
+        "dims": [2.2, 6.4, 2.2]
+      },
+      "transform": {
+        "translate": [0, 3.2, -6]
+      },
+      "material": {
+        "hue": 0.62,
+        "sat": 0.28,
+        "value": 0.32,
+        "metal": 0,
+        "glow": 0,
+        "kind": "normal",
+        "roughness": 0.85
+      }
+    },
+    {
+      "id": "massing-center-1",
+      "type": "box",
+      "args": {
+        "dims": [1.8, 4.8, 1.8]
+      },
+      "transform": {
+        "translate": [-2.6, 2.4, -11]
+      },
+      "material": {
+        "hue": 0.62,
+        "sat": 0.28,
+        "value": 0.32,
+        "metal": 0,
+        "glow": 0,
+        "kind": "normal",
+        "roughness": 0.85
+      }
+    },
+    {
+      "id": "massing-center-2",
+      "type": "box",
+      "args": {
+        "dims": [1.9, 5.8, 1.9]
+      },
+      "transform": {
+        "translate": [2.8, 2.9, -15]
+      },
+      "material": {
+        "hue": 0.62,
+        "sat": 0.28,
+        "value": 0.32,
+        "metal": 0,
+        "glow": 0,
+        "kind": "normal",
+        "roughness": 0.85
       }
     },
     {
@@ -6517,826 +6574,826 @@
       "text": "市场之一：中国手机网民规模（亿人）",
       "anchor": [32.23204451288551, 6.1, 23.220180761486848],
       "role": "title",
-      "revealAt": 22.9,
-      "hideAt": 35
+      "revealAt": 23.1,
+      "hideAt": 35.2
     },
     {
       "text": "2010",
       "anchor": [29.057044512885508, -0.02, 23.93018076148685],
       "role": "screen",
-      "revealAt": 25.349999999999998,
-      "hideAt": 35
+      "revealAt": 25.55,
+      "hideAt": 35.2
     },
     {
       "text": "3.6",
       "anchor": [29.057044512885508, 2.3062068965517244, 23.220180761486848],
       "role": "value",
       "radius": 0.36,
-      "revealAt": 25.349999999999998
+      "revealAt": 25.55
     },
     {
       "text": "2011",
       "anchor": [30.327044512885507, -0.02, 23.93018076148685],
       "role": "screen",
-      "revealAt": 26.45,
-      "hideAt": 35
+      "revealAt": 26.650000000000002,
+      "hideAt": 35.2
     },
     {
       "text": "4.5",
       "anchor": [30.327044512885507, 2.802758620689655, 23.220180761486848],
       "role": "value",
       "radius": 0.36,
-      "revealAt": 26.45
+      "revealAt": 26.650000000000002
     },
     {
       "text": "2012e",
       "anchor": [31.597044512885507, -0.02, 23.93018076148685],
       "role": "screen",
-      "revealAt": 27.549999999999997,
-      "hideAt": 35
+      "revealAt": 27.75,
+      "hideAt": 35.2
     },
     {
       "text": "5.8",
       "anchor": [31.597044512885507, 3.52, 23.220180761486848],
       "role": "value",
       "radius": 0.36,
-      "revealAt": 27.549999999999997
+      "revealAt": 27.75
     },
     {
       "text": "2013e",
       "anchor": [32.867044512885506, -0.02, 23.93018076148685],
       "role": "screen",
-      "revealAt": 28.65,
-      "hideAt": 35
+      "revealAt": 28.85,
+      "hideAt": 35.2
     },
     {
       "text": "6.9",
       "anchor": [32.867044512885506, 4.126896551724139, 23.220180761486848],
       "role": "value",
       "radius": 0.36,
-      "revealAt": 28.65
+      "revealAt": 28.85
     },
     {
       "text": "2014e",
       "anchor": [34.13704451288551, -0.02, 23.93018076148685],
       "role": "screen",
-      "revealAt": 29.75,
-      "hideAt": 35
+      "revealAt": 29.950000000000003,
+      "hideAt": 35.2
     },
     {
       "text": "7.8",
       "anchor": [34.13704451288551, 4.623448275862069, 23.220180761486848],
       "role": "value",
       "radius": 0.36,
-      "revealAt": 29.75
+      "revealAt": 29.950000000000003
     },
     {
       "text": "2015e",
       "anchor": [35.407044512885506, -0.02, 23.93018076148685],
       "role": "screen",
-      "revealAt": 30.849999999999998,
-      "hideAt": 35
+      "revealAt": 31.05,
+      "hideAt": 35.2
     },
     {
       "text": "8.7",
       "anchor": [35.407044512885506, 5.12, 23.220180761486848],
       "role": "value",
       "radius": 0.5,
-      "revealAt": 30.849999999999998
+      "revealAt": 31.05
     },
     {
       "text": "市场之二：移动互联网广告（亿元）",
       "anchor": [38.754353912369, 6.1, 8.728203762035232],
       "role": "title",
-      "revealAt": 36.2,
-      "hideAt": 48.300000000000004
+      "revealAt": 36.400000000000006,
+      "hideAt": 48.50000000000001
     },
     {
       "text": "2010",
       "anchor": [35.579353912369, -0.02, 9.438203762035233],
       "role": "screen",
-      "revealAt": 38.650000000000006,
-      "hideAt": 48.300000000000004
+      "revealAt": 38.85000000000001,
+      "hideAt": 48.50000000000001
     },
     {
       "text": "15.2",
       "anchor": [35.579353912369, 0.6092942109436954, 8.728203762035232],
       "role": "value",
       "radius": 0.36,
-      "revealAt": 38.650000000000006
+      "revealAt": 38.85000000000001
     },
     {
       "text": "2011",
       "anchor": [36.849353912369, -0.02, 9.438203762035233],
       "role": "screen",
-      "revealAt": 39.75,
-      "hideAt": 48.300000000000004
+      "revealAt": 39.95,
+      "hideAt": 48.50000000000001
     },
     {
       "text": "29.7",
       "anchor": [36.849353912369, 0.8852656621728787, 8.728203762035232],
       "role": "value",
       "radius": 0.36,
-      "revealAt": 39.75
+      "revealAt": 39.95
     },
     {
       "text": "2012e",
       "anchor": [38.119353912369, -0.02, 9.438203762035233],
       "role": "screen",
-      "revealAt": 40.85,
-      "hideAt": 48.300000000000004
+      "revealAt": 41.050000000000004,
+      "hideAt": 48.50000000000001
     },
     {
       "text": "57.2",
       "anchor": [38.119353912369, 1.4086597938144332, 8.728203762035232],
       "role": "value",
       "radius": 0.36,
-      "revealAt": 40.85
+      "revealAt": 41.050000000000004
     },
     {
       "text": "2013e",
       "anchor": [39.389353912368996, -0.02, 9.438203762035233],
       "role": "screen",
-      "revealAt": 41.95,
-      "hideAt": 48.300000000000004
+      "revealAt": 42.150000000000006,
+      "hideAt": 48.50000000000001
     },
     {
       "text": "100.9",
       "anchor": [39.389353912368996, 2.2403806502775576, 8.728203762035232],
       "role": "value",
       "radius": 0.36,
-      "revealAt": 41.95
+      "revealAt": 42.150000000000006
     },
     {
       "text": "2014e",
       "anchor": [40.659353912369, -0.02, 9.438203762035233],
       "role": "screen",
-      "revealAt": 43.050000000000004,
-      "hideAt": 48.300000000000004
+      "revealAt": 43.25000000000001,
+      "hideAt": 48.50000000000001
     },
     {
       "text": "162.9",
       "anchor": [40.659353912369, 3.420396510705789, 8.728203762035232],
       "role": "value",
       "radius": 0.36,
-      "revealAt": 43.050000000000004
+      "revealAt": 43.25000000000001
     },
     {
       "text": "2015e",
       "anchor": [41.929353912368995, -0.02, 9.438203762035233],
       "role": "screen",
-      "revealAt": 44.150000000000006,
-      "hideAt": 48.300000000000004
+      "revealAt": 44.35000000000001,
+      "hideAt": 48.50000000000001
     },
     {
       "text": "252.2",
       "anchor": [41.929353912368995, 5.12, 8.728203762035232],
       "role": "value",
       "radius": 0.5,
-      "revealAt": 44.150000000000006
+      "revealAt": 44.35000000000001
     },
     {
       "text": "市场之三：移动广告投放媒介（%）",
       "anchor": [39.07437339043131, 6.1, -7.160644679210782],
       "role": "title",
-      "revealAt": 49.50000000000001,
-      "hideAt": 61.60000000000001
+      "revealAt": 49.70000000000001,
+      "hideAt": 61.80000000000001
     },
     {
       "text": "电子阅读",
       "anchor": [35.899373390431315, -0.02, -6.450644679210782],
       "role": "screen",
-      "revealAt": 51.95000000000001,
-      "hideAt": 61.60000000000001
+      "revealAt": 52.15000000000001,
+      "hideAt": 61.80000000000001
     },
     {
       "text": "25.1",
       "anchor": [35.899373390431315, 5.12, -7.160644679210782],
       "role": "value",
       "radius": 0.5,
-      "revealAt": 51.95000000000001
+      "revealAt": 52.15000000000001
     },
     {
       "text": "手机游戏",
       "anchor": [37.16937339043131, -0.02, -6.450644679210782],
       "role": "screen",
-      "revealAt": 53.050000000000004,
-      "hideAt": 61.60000000000001
+      "revealAt": 53.25000000000001,
+      "hideAt": 61.80000000000001
     },
     {
       "text": "23.4",
       "anchor": [37.16937339043131, 4.794900398406374, -7.160644679210782],
       "role": "value",
       "radius": 0.36,
-      "revealAt": 53.050000000000004
+      "revealAt": 53.25000000000001
     },
     {
       "text": "在线影音",
       "anchor": [38.439373390431314, -0.02, -6.450644679210782],
       "role": "screen",
-      "revealAt": 54.150000000000006,
-      "hideAt": 61.60000000000001
+      "revealAt": 54.35000000000001,
+      "hideAt": 61.80000000000001
     },
     {
       "text": "14.8",
       "anchor": [38.439373390431314, 3.150278884462151, -7.160644679210782],
       "role": "value",
       "radius": 0.36,
-      "revealAt": 54.150000000000006
+      "revealAt": 54.35000000000001
     },
     {
       "text": "生活助手",
       "anchor": [39.70937339043131, -0.02, -6.450644679210782],
       "role": "screen",
-      "revealAt": 55.25000000000001,
-      "hideAt": 61.60000000000001
+      "revealAt": 55.45000000000001,
+      "hideAt": 61.80000000000001
     },
     {
       "text": "13",
       "anchor": [39.70937339043131, 2.80605577689243, -7.160644679210782],
       "role": "value",
       "radius": 0.36,
-      "revealAt": 55.25000000000001
+      "revealAt": 55.45000000000001
     },
     {
       "text": "休闲娱乐",
       "anchor": [40.97937339043131, -0.02, -6.450644679210782],
       "role": "screen",
-      "revealAt": 56.35000000000001,
-      "hideAt": 61.60000000000001
+      "revealAt": 56.55000000000001,
+      "hideAt": 61.80000000000001
     },
     {
       "text": "7.7",
       "anchor": [40.97937339043131, 1.7925099601593626, -7.160644679210782],
       "role": "value",
       "radius": 0.36,
-      "revealAt": 56.35000000000001
+      "revealAt": 56.55000000000001
     },
     {
       "text": "资讯新闻",
       "anchor": [42.24937339043131, -0.02, -6.450644679210782],
       "role": "screen",
-      "revealAt": 57.45,
-      "hideAt": 61.60000000000001
+      "revealAt": 57.650000000000006,
+      "hideAt": 61.80000000000001
     },
     {
       "text": "6.8",
       "anchor": [42.24937339043131, 1.6203984063745018, -7.160644679210782],
       "role": "value",
       "radius": 0.36,
-      "revealAt": 57.45
+      "revealAt": 57.650000000000006
     },
     {
       "text": "市场之四：泛阅读是最主要的用户行为（%）",
       "anchor": [33.14088667372333, 6.1, -21.903495578472942],
       "role": "title",
-      "revealAt": 62.80000000000001,
-      "hideAt": 74.9
+      "revealAt": 63.000000000000014,
+      "hideAt": 75.10000000000001
     },
     {
       "text": "泛阅读",
       "anchor": [29.96588667372333, -0.02, -21.19349557847294],
       "role": "screen",
-      "revealAt": 65.25000000000001,
-      "hideAt": 74.9
+      "revealAt": 65.45000000000002,
+      "hideAt": 75.10000000000001
     },
     {
       "text": "77.2",
       "anchor": [29.96588667372333, 5.12, -21.903495578472942],
       "role": "value",
       "radius": 0.5,
-      "revealAt": 65.25000000000001
+      "revealAt": 65.45000000000002
     },
     {
       "text": "即时通讯",
       "anchor": [31.23588667372333, -0.02, -21.19349557847294],
       "role": "screen",
-      "revealAt": 66.35000000000001,
-      "hideAt": 74.9
+      "revealAt": 66.55000000000001,
+      "hideAt": 75.10000000000001
     },
     {
       "text": "71",
       "anchor": [31.23588667372333, 4.734507772020725, -21.903495578472942],
       "role": "value",
       "radius": 0.36,
-      "revealAt": 66.35000000000001
+      "revealAt": 66.55000000000001
     },
     {
       "text": "社交网络",
       "anchor": [32.50588667372333, -0.02, -21.19349557847294],
       "role": "screen",
-      "revealAt": 67.45000000000002,
-      "hideAt": 74.9
+      "revealAt": 67.65000000000002,
+      "hideAt": 75.10000000000001
     },
     {
       "text": "48.3",
       "anchor": [32.50588667372333, 3.3231088082901548, -21.903495578472942],
       "role": "value",
       "radius": 0.36,
-      "revealAt": 67.45000000000002
+      "revealAt": 67.65000000000002
     },
     {
       "text": "视频",
       "anchor": [33.77588667372333, -0.02, -21.19349557847294],
       "role": "screen",
-      "revealAt": 68.55000000000001,
-      "hideAt": 74.9
+      "revealAt": 68.75000000000001,
+      "hideAt": 75.10000000000001
     },
     {
       "text": "40.5",
       "anchor": [33.77588667372333, 2.838134715025906, -21.903495578472942],
       "role": "value",
       "radius": 0.36,
-      "revealAt": 68.55000000000001
+      "revealAt": 68.75000000000001
     },
     {
       "text": "游戏",
       "anchor": [35.04588667372333, -0.02, -21.19349557847294],
       "role": "screen",
-      "revealAt": 69.65,
-      "hideAt": 74.9
+      "revealAt": 69.85000000000001,
+      "hideAt": 75.10000000000001
     },
     {
       "text": "33.1",
       "anchor": [35.04588667372333, 2.3780310880829014, -21.903495578472942],
       "role": "value",
       "radius": 0.36,
-      "revealAt": 69.65
+      "revealAt": 69.85000000000001
     },
     {
       "text": "工具",
       "anchor": [36.31588667372333, -0.02, -21.19349557847294],
       "role": "screen",
-      "revealAt": 70.75000000000001,
-      "hideAt": 74.9
+      "revealAt": 70.95000000000002,
+      "hideAt": 75.10000000000001
     },
     {
       "text": "31.2",
       "anchor": [36.31588667372333, 2.2598963730569945, -21.903495578472942],
       "role": "value",
       "radius": 0.36,
-      "revealAt": 70.75000000000001
+      "revealAt": 70.95000000000002
     },
     {
       "text": "泛阅读市场正经历变革",
       "anchor": [21.903495578472953, 5.2, -33.14088667372333],
       "role": "title",
-      "revealAt": 76.10000000000001,
-      "hideAt": 84.20000000000002
+      "revealAt": 76.30000000000001,
+      "hideAt": 84.4
     },
     {
       "text": "过去",
       "anchor": [28.203495578472953, 0.75, -33.14088667372333],
       "role": "card",
-      "revealAt": 76.10000000000001
+      "revealAt": 76.30000000000001
     },
     {
       "text": "现在",
       "anchor": [28.203495578472953, 3.6, -33.14088667372333],
       "role": "card",
-      "revealAt": 76.10000000000001
+      "revealAt": 76.30000000000001
     },
     {
       "text": "编辑挑选·连续阅读",
       "anchor": [25.30349557847295, 0.55, -32.24088667372333],
       "role": "screen",
-      "revealAt": 76.50000000000001,
-      "hideAt": 84.20000000000002
+      "revealAt": 76.70000000000002,
+      "hideAt": 84.4
     },
     {
       "text": "浏览/搜索/媒体转载",
       "anchor": [21.903495578472953, 0.55, -32.24088667372333],
       "role": "screen",
-      "revealAt": 76.7,
-      "hideAt": 84.20000000000002
+      "revealAt": 76.9,
+      "hideAt": 84.4
     },
     {
       "text": "PC",
       "anchor": [18.503495578472954, 0.55, -32.24088667372333],
       "role": "screen",
-      "revealAt": 76.9,
-      "hideAt": 84.20000000000002
+      "revealAt": 77.10000000000001,
+      "hideAt": 84.4
     },
     {
       "text": "个性化·社交化·碎片阅读",
       "anchor": [25.30349557847295, 3.6, -32.24088667372333],
       "role": "screen",
-      "revealAt": 78.55000000000001,
-      "hideAt": 84.20000000000002
+      "revealAt": 78.75000000000001,
+      "hideAt": 84.4
     },
     {
       "text": "关注/推荐/转发",
       "anchor": [21.903495578472953, 3.6, -32.24088667372333],
       "role": "screen",
-      "revealAt": 79.65,
-      "hideAt": 84.20000000000002
+      "revealAt": 79.85000000000001,
+      "hideAt": 84.4
     },
     {
       "text": "移动终端",
       "anchor": [18.503495578472954, 3.6, -32.24088667372333],
       "role": "screen",
-      "revealAt": 80.75000000000001,
-      "hideAt": 84.20000000000002
+      "revealAt": 80.95000000000002,
+      "hideAt": 84.4
     },
     {
       "text": "独创的个性化资讯发现引擎",
       "anchor": [-7.16064467921078, 7.180307652106461, -39.07437339043131],
       "role": "title",
-      "revealAt": 86.30000000000003,
-      "hideAt": 95.60000000000002
+      "revealAt": 86.7,
+      "hideAt": 96
     },
     {
       "text": "个性化发现引擎",
       "anchor": [-6.36064467921078, 3.5204111503539433, -39.07437339043131],
       "role": "card",
       "align": "left",
-      "revealAt": 87.15000000000002
+      "revealAt": 87.55
     },
     {
       "text": "新闻门户",
       "anchor": [-7.90694434621335, 5.980307652106461, -37.36566511704618],
       "role": "card",
       "align": "left",
-      "revealAt": 87.27000000000002
+      "revealAt": 87.67
     },
     {
       "text": "微博",
       "anchor": [-6.069027417786254, 5.250904506397122, -41.95956958288787],
       "role": "card",
       "align": "left",
-      "revealAt": 87.39000000000003
+      "revealAt": 87.79
     },
     {
       "text": "博客",
       "anchor": [-4.044142850878336, 4.3697567245487905, -36.70487096791028],
       "role": "card",
       "align": "left",
-      "revealAt": 87.51000000000002
+      "revealAt": 87.91
     },
     {
       "text": "视频",
       "anchor": [-9.69352761040059, 3.6213578719444897, -39.64473553762493],
       "role": "card",
       "align": "left",
-      "revealAt": 87.63000000000002
+      "revealAt": 88.03
     },
     {
       "text": "垂直信息",
       "anchor": [-3.314359319565574, 2.9527771216598238, -40.51882374790231],
       "role": "card",
       "align": "left",
-      "revealAt": 87.75000000000003
+      "revealAt": 88.15
     },
     {
       "text": "头条App",
       "anchor": [-6.997286175727586, 1.819620731911172, -36.46459326723141],
       "role": "card",
       "align": "left",
-      "revealAt": 87.87000000000002
+      "revealAt": 88.27
     },
     {
       "text": "Web版",
       "anchor": [-7.160745566003501, 1.2095751500786114, -41.062909852530545],
       "role": "card",
       "align": "left",
-      "revealAt": 87.99000000000002
+      "revealAt": 88.39
     },
     {
       "text": "用户",
       "anchor": [-6.236047042756742, 0.6000000000000001, -38.65970795321067],
       "role": "card",
       "align": "left",
-      "revealAt": 88.11000000000003
+      "revealAt": 88.51
     },
     {
       "text": "产品体验：从打开到留下",
       "anchor": [-21.903495578472956, 4.54, -33.14088667372332],
       "role": "title",
-      "revealAt": 96.80000000000003,
-      "hideAt": 107.20000000000003
+      "revealAt": 97.2,
+      "hideAt": 107.60000000000001
     },
     {
       "text": "简单丰富",
       "anchor": [-20.003495578472958, 2.8000000000000003, -33.14088667372332],
       "role": "screen",
       "align": "left",
-      "revealAt": 99.45000000000003,
-      "hideAt": 107.20000000000003
+      "revealAt": 99.85000000000001,
+      "hideAt": 107.60000000000001
     },
     {
       "text": "100",
       "anchor": [-21.903495578472956, 2.8000000000000003, -31.54088667372332],
       "role": "value",
       "radius": 0.36,
-      "revealAt": 99.45000000000003
+      "revealAt": 99.85000000000001
     },
     {
       "text": "最懂你",
       "anchor": [-20.167049057187057, 2, -33.14088667372332],
       "role": "screen",
       "align": "left",
-      "revealAt": 100.65000000000002,
-      "hideAt": 107.20000000000003
+      "revealAt": 101.05,
+      "hideAt": 107.60000000000001
     },
     {
       "text": "78",
       "anchor": [-21.903495578472956, 2, -31.704440152437424],
       "role": "value",
       "radius": 0.5,
-      "revealAt": 100.65000000000002
+      "revealAt": 101.05
     },
     {
       "text": "高质量评论",
       "anchor": [-20.35583151017625, 1.2000000000000002, -33.14088667372332],
       "role": "screen",
       "align": "left",
-      "revealAt": 101.85000000000002,
-      "hideAt": 107.20000000000003
+      "revealAt": 102.25,
+      "hideAt": 107.60000000000001
     },
     {
       "text": "56",
       "anchor": [-21.903495578472956, 1.2000000000000002, -31.89322260542662],
       "role": "value",
       "radius": 0.36,
-      "revealAt": 101.85000000000002
+      "revealAt": 102.25
     },
     {
       "text": "兴趣社区",
       "anchor": [-20.496191880695857, 0.3999999999999999, -33.14088667372332],
       "role": "screen",
       "align": "left",
-      "revealAt": 103.05000000000003,
-      "hideAt": 107.20000000000003
+      "revealAt": 103.45,
+      "hideAt": 107.60000000000001
     },
     {
       "text": "42",
       "anchor": [-21.903495578472956, 0.3999999999999999, -32.033582975946224],
       "role": "value",
       "radius": 0.36,
-      "revealAt": 103.05000000000003
+      "revealAt": 103.45
     },
     {
       "text": "IPHONE 用户周留存率（%）",
       "anchor": [-33.14088667372332, 6.1, -21.903495578472953],
       "role": "title",
-      "revealAt": 108.40000000000003,
-      "hideAt": 121.60000000000004
+      "revealAt": 108.80000000000001,
+      "hideAt": 122.00000000000001
     },
     {
       "text": "1周后",
       "anchor": [-36.950886673723325, -0.02, -21.19349557847295],
       "role": "screen",
-      "revealAt": 110.85000000000004,
-      "hideAt": 121.60000000000004
+      "revealAt": 111.25000000000001,
+      "hideAt": 122.00000000000001
     },
     {
       "text": "60.6",
       "anchor": [-36.950886673723325, 5.12, -21.903495578472953],
       "role": "value",
       "radius": 0.36,
-      "revealAt": 110.85000000000004
+      "revealAt": 111.25000000000001
     },
     {
       "text": "2周后",
       "anchor": [-35.68088667372332, -0.02, -21.19349557847295],
       "role": "screen",
-      "revealAt": 111.95000000000003,
-      "hideAt": 121.60000000000004
+      "revealAt": 112.35000000000001,
+      "hideAt": 122.00000000000001
     },
     {
       "text": "59.5",
       "anchor": [-35.68088667372332, 5.032871287128713, -21.903495578472953],
       "role": "value",
       "radius": 0.36,
-      "revealAt": 111.95000000000003
+      "revealAt": 112.35000000000001
     },
     {
       "text": "3周后",
       "anchor": [-34.410886673723326, -0.02, -21.19349557847295],
       "role": "screen",
-      "revealAt": 113.05000000000004,
-      "hideAt": 121.60000000000004
+      "revealAt": 113.45000000000002,
+      "hideAt": 122.00000000000001
     },
     {
       "text": "56.5",
       "anchor": [-34.410886673723326, 4.795247524752475, -21.903495578472953],
       "role": "value",
       "radius": 0.36,
-      "revealAt": 113.05000000000004
+      "revealAt": 113.45000000000002
     },
     {
       "text": "4周后",
       "anchor": [-33.14088667372332, -0.02, -21.19349557847295],
       "role": "screen",
-      "revealAt": 114.15000000000003,
-      "hideAt": 121.60000000000004
+      "revealAt": 114.55000000000001,
+      "hideAt": 122.00000000000001
     },
     {
       "text": "54.1",
       "anchor": [-33.14088667372332, 4.605148514851485, -21.903495578472953],
       "role": "value",
       "radius": 0.36,
-      "revealAt": 114.15000000000003
+      "revealAt": 114.55000000000001
     },
     {
       "text": "5周后",
       "anchor": [-31.870886673723323, -0.02, -21.19349557847295],
       "role": "screen",
-      "revealAt": 115.25000000000003,
-      "hideAt": 121.60000000000004
+      "revealAt": 115.65,
+      "hideAt": 122.00000000000001
     },
     {
       "text": "51.1",
       "anchor": [-31.870886673723323, 4.367524752475248, -21.903495578472953],
       "role": "value",
       "radius": 0.36,
-      "revealAt": 115.25000000000003
+      "revealAt": 115.65
     },
     {
       "text": "6周后",
       "anchor": [-30.600886673723323, -0.02, -21.19349557847295],
       "role": "screen",
-      "revealAt": 116.35000000000004,
-      "hideAt": 121.60000000000004
+      "revealAt": 116.75000000000001,
+      "hideAt": 122.00000000000001
     },
     {
       "text": "47.5",
       "anchor": [-30.600886673723323, 4.0823762376237624, -21.903495578472953],
       "role": "value",
       "radius": 0.36,
-      "revealAt": 116.35000000000004
+      "revealAt": 116.75000000000001
     },
     {
       "text": "7周后",
       "anchor": [-29.330886673723324, -0.02, -21.19349557847295],
       "role": "screen",
-      "revealAt": 117.45000000000003,
-      "hideAt": 121.60000000000004
+      "revealAt": 117.85000000000001,
+      "hideAt": 122.00000000000001
     },
     {
       "text": "45.1",
       "anchor": [-29.330886673723324, 3.8922772277227717, -21.903495578472953],
       "role": "value",
       "radius": 0.5,
-      "revealAt": 117.45000000000003
+      "revealAt": 117.85000000000001
     },
     {
       "text": "拥有丰富创业经验的团队",
       "anchor": [-39.07437339043131, 4.45, 7.160644679210778],
       "role": "title",
-      "revealAt": 123.70000000000005,
-      "hideAt": 133.70000000000005
+      "revealAt": 124.30000000000001,
+      "hideAt": 134.3
     },
     {
       "text": "张一鸣 创始人/CEO",
       "anchor": [-38.21437339043131, 3.15, 7.160644679210778],
       "role": "card",
       "align": "left",
-      "revealAt": 126.15000000000005
+      "revealAt": 126.75000000000001
     },
     {
       "text": "黄河 产品",
       "anchor": [-38.21437339043131, 2, 5.2606446792107775],
       "role": "card",
       "align": "left",
-      "revealAt": 127.65000000000005
+      "revealAt": 128.25
     },
     {
       "text": "梁汝波 研发",
       "anchor": [-36.56892512324088, 2, 8.110644679210777],
       "role": "card",
       "align": "left",
-      "revealAt": 127.65000000000005
+      "revealAt": 128.25
     },
     {
       "text": "屠锋锋 商务拓展",
       "anchor": [-39.859821657621744, 2, 8.110644679210779],
       "role": "card",
       "align": "left",
-      "revealAt": 127.65000000000005
+      "revealAt": 128.25
     },
     {
       "text": "微软/腾讯/百度系工程师团队",
       "anchor": [-37.07148151395094, 0.8500000000000001, 8.802354209401358],
       "role": "card",
       "align": "left",
-      "revealAt": 129.15000000000003
+      "revealAt": 129.75
     },
     {
       "text": "2013 业务发展计划",
       "anchor": [-33.140886673723315, 4.67, 21.90349557847297],
       "role": "title",
-      "revealAt": 134.90000000000003,
-      "hideAt": 143.20000000000005
+      "revealAt": 135.5,
+      "hideAt": 143.8
     },
     {
       "text": "产品与技术",
       "anchor": [-32.23088667372332, 4.19, 21.90349557847297],
       "role": "card",
       "align": "center",
-      "revealAt": 134.90000000000003
+      "revealAt": 135.5
     },
     {
       "text": "增长与变现",
       "anchor": [-34.05088667372331, 4.19, 21.90349557847297],
       "role": "card",
       "align": "center",
-      "revealAt": 134.90000000000003
+      "revealAt": 135.5
     },
     {
       "text": "深化",
       "anchor": [-35.45088667372332, 3.2199999999999998, 21.90349557847297],
       "role": "card",
       "align": "right",
-      "revealAt": 134.90000000000003
+      "revealAt": 135.5
     },
     {
       "text": "拓展",
       "anchor": [-35.45088667372332, 1.7999999999999998, 21.90349557847297],
       "role": "card",
       "align": "right",
-      "revealAt": 134.90000000000003
+      "revealAt": 135.5
     },
     {
       "text": "扩充信息类型和来源",
       "anchor": [-32.23088667372332, 2.88, 22.10349557847297],
       "role": "screen",
       "align": "center",
-      "revealAt": 136.65000000000003,
-      "hideAt": 143.20000000000005
+      "revealAt": 137.25,
+      "hideAt": 143.8
     },
     {
       "text": "深挖用户特征·升级推荐系统",
       "anchor": [-32.23088667372332, 1.4599999999999997, 22.10349557847297],
       "role": "screen",
       "align": "center",
-      "revealAt": 137.55000000000004,
-      "hideAt": 143.20000000000005
+      "revealAt": 138.15,
+      "hideAt": 143.8
     },
     {
       "text": "强化社区互动",
       "anchor": [-34.05088667372331, 2.88, 22.10349557847297],
       "role": "screen",
       "align": "center",
-      "revealAt": 138.45000000000005,
-      "hideAt": 143.20000000000005
+      "revealAt": 139.05,
+      "hideAt": 143.8
     },
     {
       "text": "国际化与商业化尝试",
       "anchor": [-34.05088667372331, 1.4599999999999997, 22.10349557847297],
       "role": "screen",
       "align": "center",
-      "revealAt": 139.35000000000002,
-      "hideAt": 143.20000000000005
+      "revealAt": 139.95,
+      "hideAt": 143.8
     },
     {
       "text": "移动 DAU 目标（万）",
       "anchor": [-21.903495578472924, 6.1, 33.140886673723344],
       "role": "title",
-      "revealAt": 144.40000000000003,
-      "hideAt": 153.20000000000005
+      "revealAt": 145,
+      "hideAt": 153.8
     },
     {
       "text": "2012",
       "anchor": [-23.173495578472924, -0.02, 33.850886673723345],
       "role": "screen",
-      "revealAt": 146.85000000000002,
-      "hideAt": 153.20000000000005
+      "revealAt": 147.45,
+      "hideAt": 153.8
     },
     {
       "text": "150",
       "anchor": [-23.173495578472924, 0.8, 33.140886673723344],
       "role": "value",
       "radius": 0.36,
-      "revealAt": 146.85000000000002
+      "revealAt": 147.45
     },
     {
       "text": "2013e",
       "anchor": [-21.903495578472924, -0.02, 33.850886673723345],
       "role": "screen",
-      "revealAt": 147.95000000000005,
-      "hideAt": 153.20000000000005
+      "revealAt": 148.55,
+      "hideAt": 153.8
     },
     {
       "text": "750",
       "anchor": [-21.903495578472924, 2.7199999999999998, 33.140886673723344],
       "role": "value",
       "radius": 0.36,
-      "revealAt": 147.95000000000005
+      "revealAt": 148.55
     },
     {
       "text": "2014e",
       "anchor": [-20.633495578472925, -0.02, 33.850886673723345],
       "role": "screen",
-      "revealAt": 149.05000000000004,
-      "hideAt": 153.20000000000005
+      "revealAt": 149.65,
+      "hideAt": 153.8
     },
     {
       "text": "1500",
       "anchor": [-20.633495578472925, 5.12, 33.140886673723344],
       "role": "value",
       "radius": 0.5,
-      "revealAt": 149.05000000000004
+      "revealAt": 149.65
     }
   ],
   "cameraSequence": {
@@ -7429,19 +7486,20 @@
         "station": 1
       },
       {
-        "duration": 0.9,
-        "pos": [6.596547977329165, 8, 41.37321738186662],
-        "target": [0, 1.2, 0],
-        "fov": 55,
+        "duration": 1.1,
+        "pos": [17.907075676838517, 7.800000000000001, 30.197821660767268],
+        "target": [14.162817805154203, 1.2, 9.28807230459474],
+        "fov": 52,
         "transition": "blend",
         "aperture": 0.1,
         "focalDistance": 39.725073795737075,
+        "shake": [0.1, 0.05],
         "ease": "inout"
       },
       {
         "duration": 1.2,
-        "pos": [21.801796245107337, 9.6, 43.37321738186662],
-        "target": [17.703522256442753, 3.456, 23.220180761486848],
+        "pos": [27.457060094862012, 9.4, 32.19782166076727],
+        "target": [24.784931159019855, 3.456, 23.220180761486848],
         "fov": 50,
         "transition": "blend",
         "aperture": 0,
@@ -7988,19 +8046,20 @@
         "station": 6
       },
       {
-        "duration": 0.9,
-        "pos": [19.46797124170201, 8, -17.40875367266483],
-        "target": [0, 1.2, 0],
-        "fov": 55,
+        "duration": 1.1,
+        "pos": [7.093407218628703, 6.320411150353943, -22.94621048084564],
+        "target": [-2.864257871684312, 1.2, -15.629749356172525],
+        "fov": 52,
         "transition": "blend",
         "aperture": 0.1,
         "focalDistance": 39.725073795737075,
+        "shake": [0.1, 0.05],
         "ease": "inout"
       },
       {
         "duration": 1.2,
-        "pos": [7.148996854900407, 9.6, -15.40875367266483],
-        "target": [-3.58032233960539, 3.5204111503539433, -39.07437339043131],
+        "pos": [0.9617148433637532, 7.920411150353942, -20.94621048084564],
+        "target": [-5.012451275447546, 3.5204111503539433, -39.07437339043131],
         "fov": 50,
         "transition": "blend",
         "aperture": 0,
@@ -8323,19 +8382,20 @@
         "station": 9
       },
       {
-        "duration": 0.9,
-        "pos": [-27.149753672664826, 8, -9.872321241702009],
-        "target": [0, 1.2, 0],
-        "fov": 55,
+        "duration": 1.1,
+        "pos": [-27.566104025661854, 7.04, 0.13845964029512955],
+        "target": [-15.629749356172525, 1.2, 2.8642578716843112],
+        "fov": 52,
         "transition": "blend",
         "aperture": 0.1,
         "focalDistance": 39.725073795737075,
+        "shake": [0.1, 0.05],
         "ease": "inout"
       },
       {
         "duration": 1.2,
-        "pos": [-32.06206353154807, 9.6, 13.960644679210777],
-        "target": [-19.537186695215656, 3.15, 7.160644679210778],
+        "pos": [-32.270238708046584, 8.64, 13.960644679210777],
+        "target": [-27.352061373301918, 3.15, 7.160644679210778],
         "fov": 50,
         "transition": "blend",
         "aperture": 0,
@@ -8612,43 +8672,43 @@
     ],
     "hitstops": [
       {
-        "at": 31.619999999999997,
+        "at": 31.82,
         "hold": 0.14
       },
       {
-        "at": 44.92,
+        "at": 45.120000000000005,
         "hold": 0.14
       },
       {
-        "at": 58.220000000000006,
+        "at": 58.42000000000001,
         "hold": 0.14
       },
       {
-        "at": 71.52000000000001,
+        "at": 71.72000000000001,
         "hold": 0.14
       },
       {
-        "at": 81.02000000000001,
+        "at": 81.22000000000001,
         "hold": 0.14
       },
       {
-        "at": 92.22000000000003,
+        "at": 92.62,
         "hold": 0.14
       },
       {
-        "at": 103.82000000000002,
+        "at": 104.22,
         "hold": 0.14
       },
       {
-        "at": 118.22000000000003,
+        "at": 118.62,
         "hold": 0.14
       },
       {
-        "at": 130.32000000000005,
+        "at": 130.92000000000002,
         "hold": 0.14
       },
       {
-        "at": 149.82000000000002,
+        "at": 150.42,
         "hold": 0.14
       }
     ]
@@ -8684,193 +8744,196 @@
       "tier": "hero"
     },
     {
-      "kind": "finale",
-      "stations": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12],
+      "kind": "transit",
+      "stations": [1, 2],
       "start": 20.8,
-      "end": 21.7
+      "end": 21.900000000000002,
+      "origin": [19.696344596048146, 0, 31.14727707595908]
     },
     {
       "kind": "transit",
       "stations": [1, 2],
-      "start": 21.7,
-      "end": 22.9,
+      "start": 21.900000000000002,
+      "end": 23.1,
       "origin": [19.696344596048146, 0, 31.14727707595908]
     },
     {
       "kind": "station",
       "stations": [2],
-      "start": 22.9,
-      "end": 35,
+      "start": 23.1,
+      "end": 35.2,
       "origin": [32.23204451288551, 0, 23.220180761486848],
       "tier": "content"
     },
     {
       "kind": "transit",
       "stations": [2, 3],
-      "start": 35,
-      "end": 36.2,
+      "start": 35.2,
+      "end": 36.400000000000006,
       "origin": [35.49319921262725, 0, 15.97419226176104]
     },
     {
       "kind": "station",
       "stations": [3],
-      "start": 36.2,
-      "end": 48.300000000000004,
+      "start": 36.400000000000006,
+      "end": 48.50000000000001,
       "origin": [38.754353912369, 0, 8.728203762035232],
       "tier": "content"
     },
     {
       "kind": "transit",
       "stations": [3, 4],
-      "start": 48.300000000000004,
-      "end": 49.50000000000001,
+      "start": 48.50000000000001,
+      "end": 49.70000000000001,
       "origin": [38.91436365140015, 0, 0.7837795414122248]
     },
     {
       "kind": "station",
       "stations": [4],
-      "start": 49.50000000000001,
-      "end": 61.60000000000001,
+      "start": 49.70000000000001,
+      "end": 61.80000000000001,
       "origin": [39.07437339043131, 0, -7.160644679210782],
       "tier": "content"
     },
     {
       "kind": "transit",
       "stations": [4, 5],
-      "start": 61.60000000000001,
-      "end": 62.80000000000001,
+      "start": 61.80000000000001,
+      "end": 63.000000000000014,
       "origin": [36.107630032077324, 0, -14.532070128841863]
     },
     {
       "kind": "station",
       "stations": [5],
-      "start": 62.80000000000001,
-      "end": 74.9,
+      "start": 63.000000000000014,
+      "end": 75.10000000000001,
       "origin": [33.14088667372333, 0, -21.903495578472942],
       "tier": "content"
     },
     {
       "kind": "transit",
       "stations": [5, 6],
-      "start": 74.9,
-      "end": 76.10000000000001,
+      "start": 75.10000000000001,
+      "end": 76.30000000000001,
       "origin": [27.522191126098143, 0, -27.522191126098136]
     },
     {
       "kind": "station",
       "stations": [6],
-      "start": 76.10000000000001,
-      "end": 84.20000000000002,
+      "start": 76.30000000000001,
+      "end": 84.4,
       "origin": [21.903495578472953, 0, -33.14088667372333],
       "tier": "content"
     },
     {
-      "kind": "finale",
-      "stations": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12],
-      "start": 84.20000000000002,
-      "end": 85.10000000000002
+      "kind": "transit",
+      "stations": [6, 7],
+      "start": 84.4,
+      "end": 85.5,
+      "origin": [7.3714254496310865, 0, -36.107630032077324]
     },
     {
       "kind": "transit",
       "stations": [6, 7],
-      "start": 85.10000000000002,
-      "end": 86.30000000000003,
+      "start": 85.5,
+      "end": 86.7,
       "origin": [7.3714254496310865, 0, -36.107630032077324]
     },
     {
       "kind": "station",
       "stations": [7],
-      "start": 86.30000000000003,
-      "end": 95.60000000000002,
+      "start": 86.7,
+      "end": 96,
       "origin": [-7.16064467921078, 0, -39.07437339043131],
       "tier": "content"
     },
     {
       "kind": "transit",
       "stations": [7, 8],
-      "start": 95.60000000000002,
-      "end": 96.80000000000003,
+      "start": 96,
+      "end": 97.2,
       "origin": [-14.532070128841868, 0, -36.10763003207732]
     },
     {
       "kind": "station",
       "stations": [8],
-      "start": 96.80000000000003,
-      "end": 107.20000000000003,
+      "start": 97.2,
+      "end": 107.60000000000001,
       "origin": [-21.903495578472956, 0, -33.14088667372332],
       "tier": "content"
     },
     {
       "kind": "transit",
       "stations": [8, 9],
-      "start": 107.20000000000003,
-      "end": 108.40000000000003,
+      "start": 107.60000000000001,
+      "end": 108.80000000000001,
       "origin": [-27.52219112609814, 0, -27.522191126098136]
     },
     {
       "kind": "station",
       "stations": [9],
-      "start": 108.40000000000003,
-      "end": 121.60000000000004,
+      "start": 108.80000000000001,
+      "end": 122.00000000000001,
       "origin": [-33.14088667372332, 0, -21.903495578472953],
       "tier": "content"
     },
     {
-      "kind": "finale",
-      "stations": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12],
-      "start": 121.60000000000004,
-      "end": 122.50000000000004
+      "kind": "transit",
+      "stations": [9, 10],
+      "start": 122.00000000000001,
+      "end": 123.10000000000001,
+      "origin": [-36.10763003207732, 0, -7.371425449631087]
     },
     {
       "kind": "transit",
       "stations": [9, 10],
-      "start": 122.50000000000004,
-      "end": 123.70000000000005,
+      "start": 123.10000000000001,
+      "end": 124.30000000000001,
       "origin": [-36.10763003207732, 0, -7.371425449631087]
     },
     {
       "kind": "station",
       "stations": [10],
-      "start": 123.70000000000005,
-      "end": 133.70000000000005,
+      "start": 124.30000000000001,
+      "end": 134.3,
       "origin": [-39.07437339043131, 0, 7.160644679210778],
       "tier": "content"
     },
     {
       "kind": "transit",
       "stations": [10, 11],
-      "start": 133.70000000000005,
-      "end": 134.90000000000003,
+      "start": 134.3,
+      "end": 135.5,
       "origin": [-36.10763003207731, 0, 14.532070128841873]
     },
     {
       "kind": "station",
       "stations": [11],
-      "start": 134.90000000000003,
-      "end": 143.20000000000005,
+      "start": 135.5,
+      "end": 143.8,
       "origin": [-33.140886673723315, 0, 21.90349557847297],
       "tier": "content"
     },
     {
       "kind": "transit",
       "stations": [11, 12],
-      "start": 143.20000000000005,
-      "end": 144.40000000000003,
+      "start": 143.8,
+      "end": 145,
       "origin": [-27.52219112609812, 0, 27.522191126098157]
     },
     {
       "kind": "station",
       "stations": [12],
-      "start": 144.40000000000003,
-      "end": 153.20000000000005,
+      "start": 145,
+      "end": 153.8,
       "origin": [-21.903495578472924, 0, 33.140886673723344],
       "tier": "content"
     },
     {
       "kind": "finale",
       "stations": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12],
-      "start": 153.20000000000005,
-      "end": 156.20000000000005
+      "start": 153.8,
+      "end": 156.8
     }
   ],
   "defaults": {

--- a/sdf-js/scripts/test-courtyard.mjs
+++ b/sdf-js/scripts/test-courtyard.mjs
@@ -48,11 +48,19 @@ const stations = new Map(
 
 // ---- camera: the vista lives in DESIGNATED beats --------------------------------
 {
+  // Blind-test round 1: thresholds became TRANSIT windows (full-world
+  // boundaries popped geometry — the continuity break radial won on).
   const fullWins = scene.deckWindows.filter((w) => w.kind === 'finale');
-  // overlook (after cover) + 3 chapter thresholds + the deck finale = 5
+  ok(fullWins.length === 2, `only overlook + finale stay full-world (${fullWins.length})`);
+  const transits = scene.deckWindows.filter((w) => w.kind === 'transit');
   ok(
-    fullWins.length === 5,
-    `overlook + 3 thresholds + finale = 5 full-world windows (${fullWins.length})`,
+    transits.length === DECK.slides.length - 1 + DECK.zones.length - 1,
+    `12 slings + 3 threshold slings, all plain transit windows (${transits.length})`,
+  );
+  const cover = scene.deckWindows.find((w) => w.kind === 'station' && w.stations[0] === 0);
+  ok(
+    cover.stations.length === 1,
+    'cover window stays single-station (48s-to-first-frame regression guard)',
   );
   const overlook = scene.cameraSequence.shots.find((sh) => sh.beat === 'overlook');
   ok(!!overlook, 'overlook beat exists (the TOC page 3D twin)');
@@ -73,7 +81,12 @@ const stations = new Map(
 // ---- massing: budget conservation + never distance-culled -----------------------
 {
   const massing = scene.subjects.filter((s) => s.id.startsWith('massing-'));
-  ok(massing.length === DECK.zones.length * 2, `1 hull + 1 tower per chapter (${massing.length})`);
+  ok(
+    massing.length === DECK.zones.length * 2 + 3,
+    `1 hull + 1 tower per chapter + 3 world-heart proxies (${massing.length})`,
+  );
+  const heart = massing.filter((s) => s.id.startsWith('massing-center-'));
+  ok(heart.length === 3, 'world-heart proxy present (centre never vanishes between windows)');
   // NaN in a translate bakes 'NaN' into GLSL and kills the whole program at
   // compile — caught live once (centroid accumulator read [2] of an [x,z] pair)
   ok(
@@ -82,11 +95,13 @@ const stations = new Map(
   );
   const ringR2 = Math.hypot(stations.get(2)[0], stations.get(2)[2]);
   ok(
-    massing.every((s) => {
-      const t = s.transform.translate;
-      return Math.abs(Math.hypot(t[0], t[2]) - (ringR2 + 34)) < ringR2 * 0.35;
-    }),
-    'massing sits in the fixed band outside the ring',
+    massing
+      .filter((s) => !s.id.startsWith('massing-center-'))
+      .every((s) => {
+        const t = s.transform.translate;
+        return Math.abs(Math.hypot(t[0], t[2]) - (ringR2 + 34)) < ringR2 * 0.35;
+      }),
+    'chapter massing sits in the fixed band outside the ring',
   );
   const stWin = scene.deckWindows.find((w) => w.kind === 'station' && w.stations[0] === 3);
   const sliced = sliceDeckWindow(scene, stWin);

--- a/sdf-js/src/scene/assemble-deck.js
+++ b/sdf-js/src/scene/assemble-deck.js
@@ -138,7 +138,7 @@ function courtyardPlan(slides, zones, stride) {
 // sliceDeckWindow keeps these in EVERY window and never distance-culls them
 // (the far side is exactly what foreshadowing needs); the horizon-slab quota
 // shrinks in exchange (dressing budget conservation, see sliceDeckWindow).
-function zoneMassing(zones, origins, ringR, center) {
+function zoneMassing(zones, origins, ringR, center, centerIdx) {
   const out = [];
   const mat = {
     hue: 0.62,
@@ -149,6 +149,29 @@ function zoneMassing(zones, origins, ringR, center) {
     kind: 'normal',
     roughness: 0.85,
   };
+  // WORLD-HEART PROXY (blind-test round 1 fix): the cover forest lives in
+  // station 0's windows only, so during every chapter the courtyard centre
+  // simply DID NOT EXIST, then popped in at each threshold — the single
+  // biggest continuity break vs radial ("世界的延续感"). A few always-on
+  // silhouette blocks (massing- prefix = kept in every window) stand in for
+  // the forest at distance; when the real forest is present they sit inside
+  // its dark mass and disappear into it.
+  if (centerIdx != null) {
+    const heart = [
+      { t: [center[0], 3.2, center[1] - 6], d: [2.2, 6.4, 2.2] },
+      { t: [center[0] - 2.6, 2.4, center[1] - 11], d: [1.8, 4.8, 1.8] },
+      { t: [center[0] + 2.8, 2.9, center[1] - 15], d: [1.9, 5.8, 1.9] },
+    ];
+    heart.forEach((h, i) =>
+      out.push({
+        id: `massing-center-${i}`,
+        type: 'box',
+        args: { dims: h.d },
+        transform: { translate: h.t },
+        material: mat,
+      }),
+    );
+  }
   const bandR = ringR + 34;
   zones.forEach((members, z) => {
     const pts = members.map((i) => origins[i]).filter(Boolean);
@@ -270,31 +293,42 @@ export function assembleDeck(deck, opts = {}) {
       // an ambient promise). Sees the whole ring → an honest full-world
       // window ('finale' kind: sliceDeckWindow returns the unsliced scene).
       if (plan && plan.zoneOf[k] !== plan.zoneOf[k - 1]) {
-        const dur = 0.9;
+        // Blind-test round 1 rewrite: the threshold is now a LONGER SLING in
+        // radial's own camera language (what won the continuity read), not a
+        // detour to a map view — the camera keeps travelling, the gaze drifts
+        // toward the courtyard heart mid-flight and flows on to the new
+        // chapter. Window is a plain transit (2 stations + always-on massing
+        // + world-heart proxy), NOT full-world: the geometry pop at full-
+        // world boundaries was the continuity break itself.
+        const dur = 1.1;
         const [cx, cz] = plan.center;
         const risePos = [
-          prevPayoff.pos[0] * 0.85 + cx * 0.15,
-          Math.max(prevPayoff.pos[1], 4.5) + 3.5,
-          prevPayoff.pos[2] * 0.85 + cz * 0.15,
+          (prevPayoff.pos[0] + heroPos[0]) / 2 + (cx - (prevPayoff.pos[0] + heroPos[0]) / 2) * 0.2,
+          Math.max(prevPayoff.pos[1], heroPos[1]) + 3.4,
+          (prevPayoff.pos[2] + heroPos[2]) / 2 + (cz - (prevPayoff.pos[2] + heroPos[2]) / 2) * 0.2,
         ];
+        const riseTarget = [cx * 0.6 + heroTarget[0] * 0.4, 1.2, cz * 0.6 + heroTarget[2] * 0.4];
         shots.push({
           duration: dur,
           pos: risePos,
-          target: [cx, 1.2, cz],
-          fov: 55,
+          target: riseTarget,
+          fov: 52,
           transition: 'blend',
           aperture: 0.1, // deep focus — the vista beat reads the WORLD, not a subject
           focalDistance: plan.ringR,
+          shake: [0.1, 0.05], // the sling keeps its physicality across the seam
           ease: 'inout',
         });
+        const prevO = origins[k - 1];
         windows.push({
-          kind: 'finale',
-          stations: deck.slides.map((_, i) => i),
+          kind: 'transit',
+          stations: [k - 1, k],
           start: clock,
           end: clock + dur,
+          origin: [(prevO[0] + origin[0]) / 2, 0, (prevO[2] + origin[2]) / 2],
         });
         clock += dur;
-        prevPayoff = { pos: risePos, target: [cx, 1.2, cz] };
+        prevPayoff = { pos: risePos, target: riseTarget };
       }
       const dur = 1.2;
       shots.push({
@@ -388,6 +422,12 @@ export function assembleDeck(deck, opts = {}) {
     const stationDur = seqDuration(st.cameraSequence.shots);
     windows.push({
       kind: 'station',
+      // NOTE: the cover window stays single-station on purpose — carrying the
+      // whole world here was tried and cost 48s to FIRST FRAME (the giant
+      // shader becomes the boot shader). The world-heart proxy + chapter
+      // massing already ride every window, so the world's silhouette is
+      // present from frame one at leaf-budget cost; only ring station
+      // CONTENT appears at the overlook (a reveal that beat can own).
       stations: [k],
       start: clock,
       end: clock + stationDur,
@@ -507,7 +547,9 @@ export function assembleDeck(deck, opts = {}) {
       ]);
   // Courtyard: chapter massing joins the world (background swapped from pure
   // scenery to MEANING — user decision 2026-07-12: slabs yield their quota).
-  const massingSubjects = plan ? zoneMassing(plan.zones, origins, plan.ringR, plan.center) : [];
+  const massingSubjects = plan
+    ? zoneMassing(plan.zones, origins, plan.ringR, plan.center, plan.centerIdx)
+    : [];
 
   const baseDefaults = env
     ? env.defaults


### PR DESCRIPTION
## 盲测第一轮的裁决与修正

**结果(如实记录)**:两臂都显著好于旧版;**radial 在"世界的延续感"上胜过 courtyard**——场景之间镜头有连续移动,世界一直在。按你的指示:courtyard 学习 radial 的镜头运用形式。

### 病因诊断
不是镜头路径不连续(位置全是 blend 插值)——是**世界本身不连续**:

- threshold/overlook 用全景窗口,进出边界时远处站点**整批弹入弹出**
- 最狠的一条:**环心石林在章节播放期间根本不存在**(它只活在 station 0 的窗口里),到章界才突然冒出来
- radial 没有中心件、transit 永远两站,所以完全没有这个断裂——这就是 B 的"延续感"

### 修正三件套
1. **world-heart proxy**:3 块常驻剪影(`massing-center-` 前缀,骑 massing 通道,每个窗口都在)站在石林位置——世界之心永不消失;真石林出现时 proxy 没入其暗体量
2. **threshold 降为普通 transit 窗口** + 镜头改写成 radial 语言的**加长 sling**(中段视线飘向中庭,带 shake 物理感)——不再是"去地图视角的支线"
3. **cover 窗口保持单站**:试过带全世界,首帧从 <1s 涨到 **48.8s**(巨型 shader 变开机 shader),回退——proxy + massing 已让世界剪影从第一帧就在

overlook 保持全景(它是地图 beat,"一切在此展开"是它的语义,弹入即 reveal)。

21 断言全绿,146/146,真机首帧亚秒恢复。

Merge 后建议**重跑一次盲测**(同一个 blind-deck.html,新 session 会重新洗牌)——看修正后 courtyard 能不能把延续感追回来。

🤖 Generated with [Claude Code](https://claude.com/claude-code)