### PR TITLE
feat(w5c): 总连续 — deck 播放消灭一切镜头硬切

### DIFF
--- a/sdf-js/fixtures/golden/assemble-deck-courtyard.json
+++ b/sdf-js/fixtures/golden/assemble-deck-courtyard.json
@@ -7406,7 +7406,8 @@
         "fov": 44,
         "aperture": 0.35,
         "focalDistance": 9.2,
-        "ease": "out"
+        "ease": "out",
+        "transition": "blend"
       },
       {
         "duration": 2.2,
@@ -7461,7 +7462,8 @@
         "fov": 46,
         "aperture": 0.3,
         "focalDistance": 8.6,
-        "ease": "out"
+        "ease": "out",
+        "transition": "blend"
       },
       {
         "duration": 6.8,
@@ -7514,7 +7516,8 @@
         "fov": 54,
         "aperture": 0.55,
         "focalDistance": 4,
-        "ease": "out"
+        "ease": "out",
+        "transition": "blend"
       },
       {
         "duration": 1.2,
@@ -7597,7 +7600,7 @@
         "pos": [36.157044512885506, 0.22, 24.52018076148685],
         "target": [35.407044512885506, 4.32, 23.220180761486848],
         "fov": 44,
-        "transition": "cut",
+        "transition": "blend",
         "beat": "super",
         "aperture": [0.9, 0.45],
         "focalDistance": 1.8,
@@ -7637,7 +7640,8 @@
         "fov": 54,
         "aperture": 0.55,
         "focalDistance": 4,
-        "ease": "out"
+        "ease": "out",
+        "transition": "blend"
       },
       {
         "duration": 1.2,
@@ -7720,7 +7724,7 @@
         "pos": [42.679353912368995, 0.22, 10.028203762035233],
         "target": [41.929353912368995, 4.32, 8.728203762035232],
         "fov": 44,
-        "transition": "cut",
+        "transition": "blend",
         "beat": "super",
         "aperture": [0.9, 0.45],
         "focalDistance": 1.8,
@@ -7760,7 +7764,8 @@
         "fov": 54,
         "aperture": 0.55,
         "focalDistance": 4,
-        "ease": "out"
+        "ease": "out",
+        "transition": "blend"
       },
       {
         "duration": 1.2,
@@ -7843,7 +7848,7 @@
         "pos": [36.649373390431315, 0.22, -5.8606446792107825],
         "target": [35.899373390431315, 4.32, -7.160644679210782],
         "fov": 44,
-        "transition": "cut",
+        "transition": "blend",
         "beat": "super",
         "aperture": [0.9, 0.45],
         "focalDistance": 1.8,
@@ -7883,7 +7888,8 @@
         "fov": 54,
         "aperture": 0.55,
         "focalDistance": 4,
-        "ease": "out"
+        "ease": "out",
+        "transition": "blend"
       },
       {
         "duration": 1.2,
@@ -7966,7 +7972,7 @@
         "pos": [30.71588667372333, 0.22, -20.60349557847294],
         "target": [29.96588667372333, 4.32, -21.903495578472942],
         "fov": 44,
-        "transition": "cut",
+        "transition": "blend",
         "beat": "super",
         "aperture": [0.9, 0.45],
         "focalDistance": 1.8,
@@ -8006,7 +8012,8 @@
         "fov": 48,
         "aperture": 0.3,
         "focalDistance": 6.2,
-        "ease": "out"
+        "ease": "out",
+        "transition": "blend"
       },
       {
         "duration": 3.3000000000000003,
@@ -8023,7 +8030,7 @@
         "pos": [25.903495578472953, 3.2, -31.040886673723328],
         "target": [25.30349557847295, 3.6, -33.14088667372333],
         "fov": 42,
-        "transition": "cut",
+        "transition": "blend",
         "beat": "super",
         "aperture": [0.9, 0.45],
         "focalDistance": 2.2,
@@ -8074,7 +8081,8 @@
         "fov": 56,
         "aperture": 0.55,
         "focalDistance": 2.7869340062334165,
-        "ease": "out"
+        "ease": "out",
+        "transition": "blend"
       },
       {
         "duration": 1.3,
@@ -8124,7 +8132,7 @@
         "pos": [-6.66064467921078, 3.420411150353943, -37.57437339043131],
         "target": [-7.16064467921078, 3.5804111503539433, -39.07437339043131],
         "fov": 40,
-        "transition": "cut",
+        "transition": "blend",
         "beat": "super",
         "aperture": [0.9, 0.45],
         "focalDistance": 1.6,
@@ -8164,7 +8172,8 @@
         "fov": 54,
         "aperture": 0.55,
         "focalDistance": 5.5,
-        "ease": "out"
+        "ease": "out",
+        "transition": "blend"
       },
       {
         "duration": 1.3,
@@ -8225,7 +8234,7 @@
         "pos": [-21.353495578472955, 1.85, -31.240886673723324],
         "target": [-21.903495578472956, 2.12, -33.14088667372332],
         "fov": 40,
-        "transition": "cut",
+        "transition": "blend",
         "beat": "super",
         "aperture": [0.9, 0.45],
         "focalDistance": 2,
@@ -8265,7 +8274,8 @@
         "fov": 54,
         "aperture": 0.55,
         "focalDistance": 4,
-        "ease": "out"
+        "ease": "out",
+        "transition": "blend"
       },
       {
         "duration": 1.2,
@@ -8359,7 +8369,7 @@
         "pos": [-28.58088667372332, 0.22, -20.603495578472952],
         "target": [-29.330886673723324, 3.215049504950495, -21.903495578472953],
         "fov": 44,
-        "transition": "cut",
+        "transition": "blend",
         "beat": "super",
         "aperture": [0.9, 0.45],
         "focalDistance": 1.8,
@@ -8410,7 +8420,8 @@
         "fov": 52,
         "aperture": 0.55,
         "focalDistance": 5,
-        "ease": "out"
+        "ease": "out",
+        "transition": "blend"
       },
       {
         "duration": 1.2,
@@ -8460,7 +8471,7 @@
         "pos": [-38.57437339043131, 3.05, 8.760644679210777],
         "target": [-39.07437339043131, 3.23, 7.160644679210778],
         "fov": 40,
-        "transition": "cut",
+        "transition": "blend",
         "beat": "super",
         "aperture": [0.9, 0.45],
         "focalDistance": 1.7,
@@ -8500,7 +8511,8 @@
         "fov": 48,
         "aperture": 0.12,
         "focalDistance": 5.296,
-        "ease": "out"
+        "ease": "out",
+        "transition": "blend"
       },
       {
         "duration": 0.9,
@@ -8547,7 +8559,7 @@
         "pos": [-33.55088667372331, 1.9999999999999998, 24.00349557847297],
         "target": [-34.05088667372331, 1.7999999999999998, 22.10349557847297],
         "fov": 44,
-        "transition": "cut",
+        "transition": "blend",
         "beat": "super",
         "aperture": [0.7, 0.35],
         "focalDistance": 2,
@@ -8586,7 +8598,8 @@
         "fov": 54,
         "aperture": 0.55,
         "focalDistance": 4,
-        "ease": "out"
+        "ease": "out",
+        "transition": "blend"
       },
       {
         "duration": 1.2,
@@ -8636,7 +8649,7 @@
         "pos": [-19.883495578472925, 0.22, 34.44088667372334],
         "target": [-20.633495578472925, 4.32, 33.140886673723344],
         "fov": 44,
-        "transition": "cut",
+        "transition": "blend",
         "beat": "super",
         "aperture": [0.9, 0.45],
         "focalDistance": 1.8,

--- a/sdf-js/fixtures/golden/assemble-deck-grid.json
+++ b/sdf-js/fixtures/golden/assemble-deck-grid.json
@@ -7197,7 +7197,8 @@
         "fov": 44,
         "aperture": 0.35,
         "focalDistance": 9.2,
-        "ease": "out"
+        "ease": "out",
+        "transition": "blend"
       },
       {
         "duration": 2.2,
@@ -7239,7 +7240,8 @@
         "fov": 46,
         "aperture": 0.3,
         "focalDistance": 8.6,
-        "ease": "out"
+        "ease": "out",
+        "transition": "blend"
       },
       {
         "duration": 6.8,
@@ -7281,7 +7283,8 @@
         "fov": 54,
         "aperture": 0.55,
         "focalDistance": 4,
-        "ease": "out"
+        "ease": "out",
+        "transition": "blend"
       },
       {
         "duration": 1.2,
@@ -7364,7 +7367,7 @@
         "pos": [35.925, 0.22, 1.3],
         "target": [35.175, 4.32, 0],
         "fov": 44,
-        "transition": "cut",
+        "transition": "blend",
         "beat": "super",
         "aperture": [0.9, 0.45],
         "focalDistance": 1.8,
@@ -7404,7 +7407,8 @@
         "fov": 54,
         "aperture": 0.55,
         "focalDistance": 4,
-        "ease": "out"
+        "ease": "out",
+        "transition": "blend"
       },
       {
         "duration": 1.2,
@@ -7487,7 +7491,7 @@
         "pos": [51.925, 0.22, 1.3],
         "target": [51.175, 4.32, 0],
         "fov": 44,
-        "transition": "cut",
+        "transition": "blend",
         "beat": "super",
         "aperture": [0.9, 0.45],
         "focalDistance": 1.8,
@@ -7527,7 +7531,8 @@
         "fov": 54,
         "aperture": 0.55,
         "focalDistance": 4,
-        "ease": "out"
+        "ease": "out",
+        "transition": "blend"
       },
       {
         "duration": 1.2,
@@ -7610,7 +7615,7 @@
         "pos": [-2.425, 0.22, -14.7],
         "target": [-3.175, 4.32, -16],
         "fov": 44,
-        "transition": "cut",
+        "transition": "blend",
         "beat": "super",
         "aperture": [0.9, 0.45],
         "focalDistance": 1.8,
@@ -7650,7 +7655,8 @@
         "fov": 54,
         "aperture": 0.55,
         "focalDistance": 4,
-        "ease": "out"
+        "ease": "out",
+        "transition": "blend"
       },
       {
         "duration": 1.2,
@@ -7733,7 +7739,7 @@
         "pos": [13.575, 0.22, -14.7],
         "target": [12.825, 4.32, -16],
         "fov": 44,
-        "transition": "cut",
+        "transition": "blend",
         "beat": "super",
         "aperture": [0.9, 0.45],
         "focalDistance": 1.8,
@@ -7773,7 +7779,8 @@
         "fov": 48,
         "aperture": 0.3,
         "focalDistance": 6.2,
-        "ease": "out"
+        "ease": "out",
+        "transition": "blend"
       },
       {
         "duration": 3.3000000000000003,
@@ -7790,7 +7797,7 @@
         "pos": [36, 3.2, -13.9],
         "target": [35.4, 3.6, -16],
         "fov": 42,
-        "transition": "cut",
+        "transition": "blend",
         "beat": "super",
         "aperture": [0.9, 0.45],
         "focalDistance": 2.2,
@@ -7830,7 +7837,8 @@
         "fov": 56,
         "aperture": 0.55,
         "focalDistance": 2.7869340062334165,
-        "ease": "out"
+        "ease": "out",
+        "transition": "blend"
       },
       {
         "duration": 1.3,
@@ -7880,7 +7888,7 @@
         "pos": [48.5, 3.420411150353943, -14.5],
         "target": [48, 3.5804111503539433, -16],
         "fov": 40,
-        "transition": "cut",
+        "transition": "blend",
         "beat": "super",
         "aperture": [0.9, 0.45],
         "focalDistance": 1.6,
@@ -7920,7 +7928,8 @@
         "fov": 54,
         "aperture": 0.55,
         "focalDistance": 5.5,
-        "ease": "out"
+        "ease": "out",
+        "transition": "blend"
       },
       {
         "duration": 1.3,
@@ -7981,7 +7990,7 @@
         "pos": [0.55, 1.85, -30.1],
         "target": [0, 2.12, -32],
         "fov": 40,
-        "transition": "cut",
+        "transition": "blend",
         "beat": "super",
         "aperture": [0.9, 0.45],
         "focalDistance": 2,
@@ -8021,7 +8030,8 @@
         "fov": 54,
         "aperture": 0.55,
         "focalDistance": 4,
-        "ease": "out"
+        "ease": "out",
+        "transition": "blend"
       },
       {
         "duration": 1.2,
@@ -8115,7 +8125,7 @@
         "pos": [20.560000000000002, 0.22, -30.7],
         "target": [19.81, 3.215049504950495, -32],
         "fov": 44,
-        "transition": "cut",
+        "transition": "blend",
         "beat": "super",
         "aperture": [0.9, 0.45],
         "focalDistance": 1.8,
@@ -8155,7 +8165,8 @@
         "fov": 52,
         "aperture": 0.55,
         "focalDistance": 5,
-        "ease": "out"
+        "ease": "out",
+        "transition": "blend"
       },
       {
         "duration": 1.2,
@@ -8205,7 +8216,7 @@
         "pos": [32.5, 3.05, -30.4],
         "target": [32, 3.23, -32],
         "fov": 40,
-        "transition": "cut",
+        "transition": "blend",
         "beat": "super",
         "aperture": [0.9, 0.45],
         "focalDistance": 1.7,
@@ -8245,7 +8256,8 @@
         "fov": 48,
         "aperture": 0.12,
         "focalDistance": 5.296,
-        "ease": "out"
+        "ease": "out",
+        "transition": "blend"
       },
       {
         "duration": 0.9,
@@ -8292,7 +8304,7 @@
         "pos": [47.59, 1.9999999999999998, -29.9],
         "target": [47.09, 1.7999999999999998, -31.8],
         "fov": 44,
-        "transition": "cut",
+        "transition": "blend",
         "beat": "super",
         "aperture": [0.7, 0.35],
         "focalDistance": 2,
@@ -8331,7 +8343,8 @@
         "fov": 54,
         "aperture": 0.55,
         "focalDistance": 4,
-        "ease": "out"
+        "ease": "out",
+        "transition": "blend"
       },
       {
         "duration": 1.2,
@@ -8381,7 +8394,7 @@
         "pos": [2.02, 0.22, -46.7],
         "target": [1.27, 4.32, -48],
         "fov": 44,
-        "transition": "cut",
+        "transition": "blend",
         "beat": "super",
         "aperture": [0.9, 0.45],
         "focalDistance": 1.8,

--- a/sdf-js/fixtures/golden/assemble-deck-line.json
+++ b/sdf-js/fixtures/golden/assemble-deck-line.json
@@ -7197,7 +7197,8 @@
         "fov": 44,
         "aperture": 0.35,
         "focalDistance": 9.2,
-        "ease": "out"
+        "ease": "out",
+        "transition": "blend"
       },
       {
         "duration": 2.2,
@@ -7239,7 +7240,8 @@
         "fov": 46,
         "aperture": 0.3,
         "focalDistance": 8.6,
-        "ease": "out"
+        "ease": "out",
+        "transition": "blend"
       },
       {
         "duration": 6.8,
@@ -7281,7 +7283,8 @@
         "fov": 54,
         "aperture": 0.55,
         "focalDistance": 4,
-        "ease": "out"
+        "ease": "out",
+        "transition": "blend"
       },
       {
         "duration": 1.2,
@@ -7364,7 +7367,7 @@
         "pos": [35.925, 0.22, 1.3],
         "target": [35.175, 4.32, 0],
         "fov": 44,
-        "transition": "cut",
+        "transition": "blend",
         "beat": "super",
         "aperture": [0.9, 0.45],
         "focalDistance": 1.8,
@@ -7404,7 +7407,8 @@
         "fov": 54,
         "aperture": 0.55,
         "focalDistance": 4,
-        "ease": "out"
+        "ease": "out",
+        "transition": "blend"
       },
       {
         "duration": 1.2,
@@ -7487,7 +7491,7 @@
         "pos": [51.925, 0.22, 1.3],
         "target": [51.175, 4.32, 0],
         "fov": 44,
-        "transition": "cut",
+        "transition": "blend",
         "beat": "super",
         "aperture": [0.9, 0.45],
         "focalDistance": 1.8,
@@ -7527,7 +7531,8 @@
         "fov": 54,
         "aperture": 0.55,
         "focalDistance": 4,
-        "ease": "out"
+        "ease": "out",
+        "transition": "blend"
       },
       {
         "duration": 1.2,
@@ -7610,7 +7615,7 @@
         "pos": [61.575, 0.22, 1.3],
         "target": [60.825, 4.32, 0],
         "fov": 44,
-        "transition": "cut",
+        "transition": "blend",
         "beat": "super",
         "aperture": [0.9, 0.45],
         "focalDistance": 1.8,
@@ -7650,7 +7655,8 @@
         "fov": 54,
         "aperture": 0.55,
         "focalDistance": 4,
-        "ease": "out"
+        "ease": "out",
+        "transition": "blend"
       },
       {
         "duration": 1.2,
@@ -7733,7 +7739,7 @@
         "pos": [77.575, 0.22, 1.3],
         "target": [76.825, 4.32, 0],
         "fov": 44,
-        "transition": "cut",
+        "transition": "blend",
         "beat": "super",
         "aperture": [0.9, 0.45],
         "focalDistance": 1.8,
@@ -7773,7 +7779,8 @@
         "fov": 48,
         "aperture": 0.3,
         "focalDistance": 6.2,
-        "ease": "out"
+        "ease": "out",
+        "transition": "blend"
       },
       {
         "duration": 3.3000000000000003,
@@ -7790,7 +7797,7 @@
         "pos": [100, 3.2, 2.1],
         "target": [99.4, 3.6, 0],
         "fov": 42,
-        "transition": "cut",
+        "transition": "blend",
         "beat": "super",
         "aperture": [0.9, 0.45],
         "focalDistance": 2.2,
@@ -7830,7 +7837,8 @@
         "fov": 56,
         "aperture": 0.55,
         "focalDistance": 2.7869340062334165,
-        "ease": "out"
+        "ease": "out",
+        "transition": "blend"
       },
       {
         "duration": 1.3,
@@ -7880,7 +7888,7 @@
         "pos": [112.5, 3.420411150353943, 1.5],
         "target": [112, 3.5804111503539433, 0],
         "fov": 40,
-        "transition": "cut",
+        "transition": "blend",
         "beat": "super",
         "aperture": [0.9, 0.45],
         "focalDistance": 1.6,
@@ -7920,7 +7928,8 @@
         "fov": 54,
         "aperture": 0.55,
         "focalDistance": 5.5,
-        "ease": "out"
+        "ease": "out",
+        "transition": "blend"
       },
       {
         "duration": 1.3,
@@ -7981,7 +7990,7 @@
         "pos": [128.55, 1.85, 1.9],
         "target": [128, 2.12, 0],
         "fov": 40,
-        "transition": "cut",
+        "transition": "blend",
         "beat": "super",
         "aperture": [0.9, 0.45],
         "focalDistance": 2,
@@ -8021,7 +8030,8 @@
         "fov": 54,
         "aperture": 0.55,
         "focalDistance": 4,
-        "ease": "out"
+        "ease": "out",
+        "transition": "blend"
       },
       {
         "duration": 1.2,
@@ -8115,7 +8125,7 @@
         "pos": [148.56, 0.22, 1.3],
         "target": [147.81, 3.215049504950495, 0],
         "fov": 44,
-        "transition": "cut",
+        "transition": "blend",
         "beat": "super",
         "aperture": [0.9, 0.45],
         "focalDistance": 1.8,
@@ -8155,7 +8165,8 @@
         "fov": 52,
         "aperture": 0.55,
         "focalDistance": 5,
-        "ease": "out"
+        "ease": "out",
+        "transition": "blend"
       },
       {
         "duration": 1.2,
@@ -8205,7 +8216,7 @@
         "pos": [160.5, 3.05, 1.6],
         "target": [160, 3.23, 0],
         "fov": 40,
-        "transition": "cut",
+        "transition": "blend",
         "beat": "super",
         "aperture": [0.9, 0.45],
         "focalDistance": 1.7,
@@ -8245,7 +8256,8 @@
         "fov": 48,
         "aperture": 0.12,
         "focalDistance": 5.296,
-        "ease": "out"
+        "ease": "out",
+        "transition": "blend"
       },
       {
         "duration": 0.9,
@@ -8292,7 +8304,7 @@
         "pos": [175.59, 1.9999999999999998, 2.1],
         "target": [175.09, 1.7999999999999998, 0.2],
         "fov": 44,
-        "transition": "cut",
+        "transition": "blend",
         "beat": "super",
         "aperture": [0.7, 0.35],
         "focalDistance": 2,
@@ -8331,7 +8343,8 @@
         "fov": 54,
         "aperture": 0.55,
         "focalDistance": 4,
-        "ease": "out"
+        "ease": "out",
+        "transition": "blend"
       },
       {
         "duration": 1.2,
@@ -8381,7 +8394,7 @@
         "pos": [194.02, 0.22, 1.3],
         "target": [193.27, 4.32, 0],
         "fov": 44,
-        "transition": "cut",
+        "transition": "blend",
         "beat": "super",
         "aperture": [0.9, 0.45],
         "focalDistance": 1.8,

--- a/sdf-js/fixtures/golden/assemble-deck-radial.json
+++ b/sdf-js/fixtures/golden/assemble-deck-radial.json
@@ -7197,7 +7197,8 @@
         "fov": 44,
         "aperture": 0.35,
         "focalDistance": 9.2,
-        "ease": "out"
+        "ease": "out",
+        "transition": "blend"
       },
       {
         "duration": 2.2,
@@ -7239,7 +7240,8 @@
         "fov": 46,
         "aperture": 0.3,
         "focalDistance": 8.6,
-        "ease": "out"
+        "ease": "out",
+        "transition": "blend"
       },
       {
         "duration": 6.8,
@@ -7281,7 +7283,8 @@
         "fov": 54,
         "aperture": 0.55,
         "focalDistance": 4,
-        "ease": "out"
+        "ease": "out",
+        "transition": "blend"
       },
       {
         "duration": 1.2,
@@ -7364,7 +7367,7 @@
         "pos": [31.169245671105404, 0.22, 20.105344987209882],
         "target": [30.419245671105404, 4.32, 18.80534498720988],
         "fov": 44,
-        "transition": "cut",
+        "transition": "blend",
         "beat": "super",
         "aperture": [0.9, 0.45],
         "focalDistance": 1.8,
@@ -7404,7 +7407,8 @@
         "fov": 54,
         "aperture": 0.55,
         "focalDistance": 4,
-        "ease": "out"
+        "ease": "out",
+        "transition": "blend"
       },
       {
         "duration": 1.2,
@@ -7487,7 +7491,7 @@
         "pos": [36.787861067690216, 0.22, 5.290273765196559],
         "target": [36.037861067690216, 4.32, 3.9902737651965587],
         "fov": 44,
-        "transition": "cut",
+        "transition": "blend",
         "beat": "super",
         "aperture": [0.9, 0.45],
         "focalDistance": 1.8,
@@ -7527,7 +7531,8 @@
         "fov": 54,
         "aperture": 0.55,
         "focalDistance": 4,
-        "ease": "out"
+        "ease": "out",
+        "transition": "blend"
       },
       {
         "duration": 1.2,
@@ -7610,7 +7615,7 @@
         "pos": [28.527991034075757, 0.22, -10.43892108841144],
         "target": [27.777991034075757, 4.32, -11.738921088411441],
         "fov": 44,
-        "transition": "cut",
+        "transition": "blend",
         "beat": "super",
         "aperture": [0.9, 0.45],
         "focalDistance": 1.8,
@@ -7650,7 +7655,8 @@
         "fov": 54,
         "aperture": 0.55,
         "focalDistance": 4,
-        "ease": "out"
+        "ease": "out",
+        "transition": "blend"
       },
       {
         "duration": 1.2,
@@ -7733,7 +7739,7 @@
         "pos": [19.527163778534103, 0.22, -23.47887058999947],
         "target": [18.777163778534103, 4.32, -24.77887058999947],
         "fov": 44,
-        "transition": "cut",
+        "transition": "blend",
         "beat": "super",
         "aperture": [0.9, 0.45],
         "focalDistance": 1.8,
@@ -7773,7 +7779,8 @@
         "fov": 48,
         "aperture": 0.3,
         "focalDistance": 6.2,
-        "ease": "out"
+        "ease": "out",
+        "transition": "blend"
       },
       {
         "duration": 3.3000000000000003,
@@ -7790,7 +7797,7 @@
         "pos": [11.922360353582558, 3.2, -30.042279457180825],
         "target": [11.322360353582557, 3.6, -32.14227945718083],
         "fov": 42,
-        "transition": "cut",
+        "transition": "blend",
         "beat": "super",
         "aperture": [0.9, 0.45],
         "focalDistance": 2.2,
@@ -7830,7 +7837,8 @@
         "fov": 56,
         "aperture": 0.55,
         "focalDistance": 2.7869340062334165,
-        "ease": "out"
+        "ease": "out",
+        "transition": "blend"
       },
       {
         "duration": 1.3,
@@ -7880,7 +7888,7 @@
         "pos": [-7.422360353582548, 3.420411150353943, -30.642279457180827],
         "target": [-7.922360353582548, 3.5804111503539433, -32.14227945718083],
         "fov": 40,
-        "transition": "cut",
+        "transition": "blend",
         "beat": "super",
         "aperture": [0.9, 0.45],
         "focalDistance": 1.6,
@@ -7920,7 +7928,8 @@
         "fov": 54,
         "aperture": 0.55,
         "focalDistance": 5.5,
-        "ease": "out"
+        "ease": "out",
+        "transition": "blend"
       },
       {
         "duration": 1.3,
@@ -7981,7 +7990,7 @@
         "pos": [-21.402163778534096, 1.85, -22.878870589999476],
         "target": [-21.952163778534096, 2.12, -24.778870589999475],
         "fov": 40,
-        "transition": "cut",
+        "transition": "blend",
         "beat": "super",
         "aperture": [0.9, 0.45],
         "focalDistance": 2,
@@ -8021,7 +8030,8 @@
         "fov": 54,
         "aperture": 0.55,
         "focalDistance": 4,
-        "ease": "out"
+        "ease": "out",
+        "transition": "blend"
       },
       {
         "duration": 1.2,
@@ -8115,7 +8125,7 @@
         "pos": [-26.392991034075756, 0.22, -10.438921088411456],
         "target": [-27.142991034075756, 3.215049504950495, -11.738921088411457],
         "fov": 44,
-        "transition": "cut",
+        "transition": "blend",
         "beat": "super",
         "aperture": [0.9, 0.45],
         "focalDistance": 1.8,
@@ -8155,7 +8165,8 @@
         "fov": 52,
         "aperture": 0.55,
         "focalDistance": 5,
-        "ease": "out"
+        "ease": "out",
+        "transition": "blend"
       },
       {
         "duration": 1.2,
@@ -8205,7 +8216,7 @@
         "pos": [-32.36286106769022, 3.05, 5.5902737651965655],
         "target": [-32.86286106769022, 3.23, 3.990273765196565],
         "fov": 40,
-        "transition": "cut",
+        "transition": "blend",
         "beat": "super",
         "aperture": [0.9, 0.45],
         "focalDistance": 1.7,
@@ -8245,7 +8256,8 @@
         "fov": 48,
         "aperture": 0.12,
         "focalDistance": 5.296,
-        "ease": "out"
+        "ease": "out",
+        "transition": "blend"
       },
       {
         "duration": 0.9,
@@ -8292,7 +8304,7 @@
         "pos": [-27.654245671105425, 1.9999999999999998, 20.905344987209848],
         "target": [-28.154245671105425, 1.7999999999999998, 19.005344987209845],
         "fov": 44,
-        "transition": "cut",
+        "transition": "blend",
         "beat": "super",
         "aperture": [0.7, 0.35],
         "focalDistance": 2,
@@ -8331,7 +8343,8 @@
         "fov": 54,
         "aperture": 0.55,
         "focalDistance": 4,
-        "ease": "out"
+        "ease": "out",
+        "transition": "blend"
       },
       {
         "duration": 1.2,
@@ -8381,7 +8394,7 @@
         "pos": [-13.364301920023097, 0.22, 30.612338301628192],
         "target": [-14.114301920023097, 4.32, 29.31233830162819],
         "fov": 44,
-        "transition": "cut",
+        "transition": "blend",
         "beat": "super",
         "aperture": [0.9, 0.45],
         "focalDistance": 1.8,

--- a/sdf-js/scripts/test-courtyard.mjs
+++ b/sdf-js/scripts/test-courtyard.mjs
@@ -147,6 +147,15 @@ const stations = new Map(
   );
 }
 
+// ---- total continuity (2026-07-12 directive): deck playback never cuts ----------
+{
+  for (const layout of ['radial', 'courtyard']) {
+    const s = assembleDeck(DECK, { layout });
+    const cuts = s.cameraSequence.shots.filter((sh, i) => i > 0 && sh.transition !== 'blend');
+    ok(cuts.length === 0, `${layout}: zero cut transitions in deck playback (${cuts.length})`);
+  }
+}
+
 // ---- determinism + validity ------------------------------------------------------
 {
   const again = assembleDeck(DECK, { layout: 'courtyard' });

--- a/sdf-js/src/scene/assemble-deck.js
+++ b/sdf-js/src/scene/assemble-deck.js
@@ -402,11 +402,20 @@ export function assembleDeck(deck, opts = {}) {
 
     // Camera: shift shots in space + append (time shift is implicit — durations chain).
     // Beat tags ride along; tagged shots get their station index for the presenter.
+    // TOTAL CONTINUITY (2026-07-12 user directive: camera continuity is the
+    // FIRST element of world-feel — no discontinuity may exist in deck
+    // playback): every station shot becomes a blend. The evaluator's default
+    // transition is 'cut', so an unmarked hero shot was a hard jump at every
+    // station entry, and the SUPER's hard cut was a jump mid-station. The
+    // super keeps its punch through ease 'out' (fast rush + settle), shake,
+    // exposure and hitstop — impact stays, teleporting goes. Solo figure
+    // pages (?ir=) keep the fighting-game cuts untouched.
     st.cameraSequence.shots.forEach((sh) => {
       shots.push({
         ...sh,
         pos: addV(sh.pos, origin),
         target: addV(sh.target, origin),
+        transition: 'blend',
         ...(sh.beat ? { station: k } : {}),
       });
     });


### PR DESCRIPTION
## 总连续(你的指令:连续感 = 世界感第一要素,极端化)

盘点发现不连续远比想象多:**evaluator 的默认 transition 是 cut**——不止 6 个 SUPER 硬切,每个站的 hero shot(没写 transition 字段)都是硬跳。两臂各有 **13 个站入场跳变 + 6 个 super 跳变**。

### 修法
`assembleDeck` 追加站 shot 时统一改写 `transition:'blend'`——deck 级总闸,一处修全部;solo figure 页(`?ir=`)保留格斗游戏硬切语法不动。

SUPER 的冲击感不丢:ease `out` 急推 + shake + exposure 爆点 + hitstop 全部保留——**冲击留下,瞬移消失**。shot 时长全部不变,hitstop 和窗口时间线零影响。

### 验证
- 30Hz 全时间线扫描:radial 最大帧间位移 1.74 / courtyard 2.79 单位——全是 whip/overlook 的平滑运动峰值,无瞬移
- 新断言:两臂 deck 全程零 cut(23/23)
- goldens ×4 重生成(站 shot 全部新增 transition 字段——本 PR 的语义变更,非漂移)
- suite 146/146

Merge 后:`blind-deck.html` 两臂都是极端连续版,可以再对比看;然后进入你说的"下一步优化方向"讨论。

🤖 Generated with [Claude Code](https://claude.com/claude-code)