### PR TITLE
feat(w6): decor 默认开启 — deck 名即艺术身份

### DIFF
--- a/sdf-js/apps/present/figure.js
+++ b/sdf-js/apps/present/figure.js
@@ -27,8 +27,11 @@ const paletteId = params.get('palette');
 const theme = paletteId === '0' ? null : getTheme(paletteId || 'pitch-spectrum');
 const palette = theme ? { anchor: theme.accent, colors: theme.colors } : null;
 // ?seed=<hash> — Layer C deck decor (seeded art identity, same lanes as the
-// 2D decor engine). Absent → undecorated (unchanged default for now).
-const decorSeed = params.get('seed') || undefined;
+// 2D decor engine). DEFAULT ON for decks since W6: the deck's own name is its
+// art identity (same deck → same world, forever — the 2D mint-hash covenant).
+// ?seed=0 turns decor off; any other value overrides the identity.
+const seedParam = params.get('seed');
+const decorSeed = seedParam === '0' ? undefined : seedParam || deckName || undefined;
 const scene = deckName
   ? assembleDeck(ir, { env, layout, stage, palette, decorSeed })
   : renderIR(ir, { env, stage });


### PR DESCRIPTION
Wave 2 留的口子,两轮盲测已验证等价装饰,现在翻默认:

- deck 播放默认带 decor,**seed = deck 名**(同 deck 永远同世界——2D mint-hash 的契约语义搬到 3D)
- `?seed=0` 关闭;`?seed=<hash>` 覆盖身份
- solo figure(`?ir=`)不变

一行级改动,lint 干净。接下来 ② 节奏 token、① 速度连续两个 PR 陆续来。

🤖 Generated with [Claude Code](https://claude.com/claude-code)