### PR TITLE
feat(w6): 节奏 token — Layer B 时间半边(字节不变迁移)

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -160,6 +160,7 @@ const TESTS = [
   { category: 'scene', file: 'sdf-js/scripts/test-assemble-deck-golden.mjs' },
   { category: 'scene', file: 'sdf-js/scripts/test-deck-decor.mjs' },
   { category: 'scene', file: 'sdf-js/scripts/test-layout-tokens.mjs' },
+  { category: 'scene', file: 'sdf-js/scripts/test-tempo-tokens.mjs' },
   { category: 'scene', file: 'sdf-js/scripts/test-courtyard.mjs' },
   { category: 'scene', file: 'sdf-js/scripts/test-camera-shake.mjs' },
   { category: 'scene', file: 'sdf-js/scripts/test-text-to-ir.mjs' },

--- a/sdf-js/scripts/test-tempo-tokens.mjs
+++ b/sdf-js/scripts/test-tempo-tokens.mjs
@@ -1,0 +1,56 @@
+// sdf-js/scripts/test-tempo-tokens.mjs — Layer B temporal half: the breathing
+// dial. Same discipline as layout-tokens: prove real CONSUMPTION (mutate a
+// token → downstream durations re-derive), not just extraction theater.
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+import { TEMPO, introLead } from '../src/scene/tempo-tokens.js';
+import { renderMagnitude } from '../src/scene/render-magnitude.js';
+import { assembleDeck } from '../src/scene/assemble-deck.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const DECK = JSON.parse(readFileSync(resolve(__dirname, '../scenes/ir/bytedance-bp.json'), 'utf8'));
+
+let pass = 0,
+  fail = 0;
+const ok = (c, n) => (c ? (pass++, console.log(`  ✓ ${n}`)) : (fail++, console.log(`  ✗ ${n}`)));
+const near = (a, b) => Math.abs(a - b) < 1e-9;
+console.log('=== tempo tokens (Layer B: the breathing dial) ===\n');
+
+const IR = { structure: 'magnitude', title: 'T', nodes: ['a', 'b', 'c'], magnitude: [1, 3, 2] };
+
+// ---- consumption: render-magnitude --------------------------------------------
+{
+  const s = renderMagnitude(IR);
+  ok(near(s.cameraSequence.shots[0].duration, TEMPO.hero), 'hero beat = TEMPO.hero');
+  ok(near(s.cameraSequence.shots[1].duration, TEMPO.crane), 'crane beat = TEMPO.crane');
+  ok(near(s.cameraSequence.shots.at(-1).duration, TEMPO.payoff), 'payoff beat = TEMPO.payoff');
+  ok(near(introLead(), TEMPO.hero + TEMPO.crane), 'introLead = hero + crane');
+}
+
+// ---- consumption: deck-level beats ---------------------------------------------
+{
+  const scene = assembleDeck(DECK, { layout: 'courtyard' });
+  const overlook = scene.cameraSequence.shots.find((sh) => sh.beat === 'overlook');
+  ok(near(overlook.duration, TEMPO.overlook), 'overlook beat = TEMPO.overlook');
+  ok(near(scene.cameraSequence.shots.at(-1).duration, TEMPO.finale), 'finale beat = TEMPO.finale');
+}
+
+// ---- the dial actually dials (mutate → re-derive → restore) ---------------------
+{
+  const orig = TEMPO.beatHold;
+  TEMPO.beatHold = orig + 0.4;
+  const s = renderMagnitude(IR);
+  const track = s.cameraSequence.shots[2]; // first tracking beat
+  ok(near(track.duration, orig + 0.4), 'changing TEMPO.beatHold re-derives the walk rhythm');
+  // reveals ride the same clock — the label must still land on its beat
+  const firstReveal = s.overlay.find((o) => o.revealAt != null);
+  ok(
+    near(firstReveal.revealAt, TEMPO.hero + TEMPO.crane + 0.35),
+    'reveal times re-derive from the same tokens (labels stay on beat)',
+  );
+  TEMPO.beatHold = orig;
+}
+
+console.log(`\n${pass}/${pass + fail} passed`);
+process.exit(fail ? 1 : 0);

--- a/sdf-js/src/scene/assemble-deck.js
+++ b/sdf-js/src/scene/assemble-deck.js
@@ -16,6 +16,7 @@
 import { renderIR } from './render-ir.js';
 import { getEnvironment, horizonSilhouettes } from './environments.js';
 import { makeDeckDecor } from './deck-decor.js';
+import { TEMPO } from './tempo-tokens.js';
 
 // Every structure renderer emits build-ins of exactly this shape:
 //   "<A> - <D> * smoothstep(<t0>, <t1>, t)"            (drop from above)
@@ -300,7 +301,7 @@ export function assembleDeck(deck, opts = {}) {
         // chapter. Window is a plain transit (2 stations + always-on massing
         // + world-heart proxy), NOT full-world: the geometry pop at full-
         // world boundaries was the continuity break itself.
-        const dur = 1.1;
+        const dur = TEMPO.threshold;
         const [cx, cz] = plan.center;
         const risePos = [
           (prevPayoff.pos[0] + heroPos[0]) / 2 + (cx - (prevPayoff.pos[0] + heroPos[0]) / 2) * 0.2,
@@ -330,7 +331,7 @@ export function assembleDeck(deck, opts = {}) {
         clock += dur;
         prevPayoff = { pos: risePos, target: riseTarget };
       }
-      const dur = 1.2;
+      const dur = TEMPO.transit;
       shots.push({
         duration: dur,
         pos: [
@@ -444,7 +445,7 @@ export function assembleDeck(deck, opts = {}) {
     // one high beat framing the whole courtyard — the 2D TOC page's 3D twin
     // ("here is everything we will visit"). Full-world window, like finale.
     if (plan && k === plan.centerIdx) {
-      const dur = 2.2;
+      const dur = TEMPO.overlook;
       const [cx, cz] = plan.center;
       // near-top-down: the overlook reads as the deck's MAP ("here is
       // everything we will visit") — 3/4 views kept letting the centre forest
@@ -518,7 +519,7 @@ export function assembleDeck(deck, opts = {}) {
     const cz = origins.reduce((s, o) => s + o[2], 0) / origins.length;
     const span = Math.max(1, ...origins.map((o) => Math.hypot(o[0] - cx, o[2] - cz))) * 2 + stride;
     shots.push({
-      duration: 3.0,
+      duration: TEMPO.finale,
       pos: [cx + span * 0.25, span * 0.5 + 4.5, cz + span * 0.95],
       target: [cx, 1.2, cz],
       fov: 48,
@@ -532,7 +533,7 @@ export function assembleDeck(deck, opts = {}) {
       kind: 'finale',
       stations: deck.slides.map((_, i) => i),
       start: clock,
-      end: clock + 3.0,
+      end: clock + TEMPO.finale,
     });
   }
 

--- a/sdf-js/src/scene/render-magnitude.js
+++ b/sdf-js/src/scene/render-magnitude.js
@@ -20,6 +20,7 @@
 import { validateIR } from './ir.js';
 import { getEnvironment } from './environments.js';
 import { MODULE, SCALE, centeredRow, rowSpan as rowSpanOf } from './layout-tokens.js';
+import { TEMPO, introLead as introLeadOf } from './tempo-tokens.js';
 
 const label = (n) => (typeof n === 'string' ? n : (n && (n.label ?? n.name)) || '');
 
@@ -85,8 +86,9 @@ export function renderMagnitude(ir, opts = {}) {
   const xOf = (i) => centeredRow(i, N);
 
   // Tracking-beat timing: monolith i erupts as the camera's beat i begins.
-  const introLead = 2.1; // hero 0.9 + crane 1.2
-  const holdEach = 1.1;
+  // Durations come from the shared tempo tokens (Layer B temporal half).
+  const introLead = introLeadOf(); // hero + crane
+  const holdEach = TEMPO.beatHold;
   const riseStart = (k) => introLead + k * holdEach - 0.45;
 
   const subjects = [];
@@ -164,7 +166,7 @@ export function renderMagnitude(ir, opts = {}) {
   const shots = [
     // 1 — hero low angle at the tallest (the champion)
     {
-      duration: 0.9,
+      duration: TEMPO.hero,
       pos: [xOf(tallest) + 1.6, 0.5, 3.6],
       target: [xOf(tallest), tallH * 0.72, 0],
       fov: 54,
@@ -174,7 +176,7 @@ export function renderMagnitude(ir, opts = {}) {
     },
     // 2 — crane over the lineup
     {
-      duration: 1.2,
+      duration: TEMPO.crane,
       pos: [0.6, tallH + 2.2, rowSpan * 0.5 + 2.6],
       target: [0, tallH * 0.45, 0],
       fov: 48,
@@ -205,7 +207,7 @@ export function renderMagnitude(ir, opts = {}) {
   // 4 — the super: at the emphasis monolith's base, looking UP its height
   const superAt = shots.reduce((s, sh) => s + sh.duration, 0); // presentation time of the impact
   shots.push({
-    duration: 1.0,
+    duration: TEMPO.superHold,
     pos: [gx + 0.75, 0.22, 1.3],
     target: [gx, gH * 0.9, 0],
     fov: 44,
@@ -221,7 +223,7 @@ export function renderMagnitude(ir, opts = {}) {
   // 5 — payoff pull-back: the whole skyline
   const payoffDist = (rowSpan * 0.85 + 3.2) * (env ? env.payoffZoom : 1);
   shots.push({
-    duration: 2.4,
+    duration: TEMPO.payoff,
     pos: [1.2, tallH * 0.55 + 1.0 + (env ? 0.5 : 0), payoffDist],
     target: [0, tallH * 0.4, 0],
     fov: 44,

--- a/sdf-js/src/scene/tempo-tokens.js
+++ b/sdf-js/src/scene/tempo-tokens.js
@@ -1,0 +1,33 @@
+// sdf-js/src/scene/tempo-tokens.js — Layer B, the TEMPORAL half.
+//
+// layout-tokens.js owns the spatial rhythm (module / stride / scale contrast);
+// this module owns the BREATHING — how long the camera dwells and how fast it
+// travels. Under the total-continuity rule (feedback lock 2026-07-12: the
+// camera never cuts, so pacing is the ONLY instrument of emphasis left),
+// these durations are the deck's information-density dial: a beat that used
+// to be a hard cut now reads as fast-approach-then-dwell, and the dwell
+// length IS the emphasis.
+//
+// Extraction discipline (same as layout-tokens): renderers migrate one at a
+// time, output byte-identical, goldens gate it. render-magnitude is the pilot
+// (the five-beat grammar's reference implementation); the deck-level beats
+// (transit/threshold/overlook/finale) live in assemble-deck and migrate here
+// with it.
+
+export const TEMPO = {
+  // five-beat station grammar (per-structure renderers)
+  hero: 0.9, // beat 1 — low-angle meet-the-champion
+  crane: 1.2, // beat 2 — up and over the lineup
+  beatHold: 1.1, // beat 3 — per-item dwell during the tracking walk
+  superHold: 1.0, // beat 4 — the punch-in dwell (impact lives here)
+  payoff: 2.4, // beat 5 — the pull-back read of the whole form
+
+  // deck-level beats (assemble-deck)
+  transit: 1.2, // station→station sling
+  threshold: 1.1, // chapter-seam sling (courtyard)
+  overlook: 2.2, // the TOC map beat (courtyard)
+  finale: 3.0, // the whole-deck money shot
+};
+
+/** hero + crane — when the tracking walk (beat 3) begins. */
+export const introLead = () => TEMPO.hero + TEMPO.crane;


### PR DESCRIPTION
## ② 节奏 token

总连续之后,**节奏是唯一剩下的强调工具**——镜头不再切,停在哪里、停多久就是强调本身。所以时长常量必须有单一来源,这是"deck 级统一调呼吸"的前置。

- `tempo-tokens.js`:五拍语法时长(hero/crane/beatHold/superHold/payoff)+ deck 级四拍(transit/threshold/overlook/finale)
- render-magnitude(五拍参考实现)+ assemble-deck 迁移消费;其余 renderer 照 touched-then-migrate
- **字节不变双重验证**:baseline 对比 + 四个 golden 不用 --update 直接过
- **真消费断言**:改 `TEMPO.beatHold` → 追踪节奏与 reveal 时刻同步重推导(标签永远落在自己的拍上——时长和字幕骑同一个时钟,这是这次抽取真正买到的保证)

suite 147/147,lint 0 errors。接下来 ①(速度连续)最后一个 PR。

🤖 Generated with [Claude Code](https://claude.com/claude-code)