### PR TITLE
feat(w7): 面包屑连续性 — 世界永不在镜头前弹入

### DIFF
--- a/sdf-js/scripts/test-deck-decor.mjs
+++ b/sdf-js/scripts/test-deck-decor.mjs
@@ -85,8 +85,8 @@ const ANALYTIC_TYPES = new Set(['box', 'sphere', 'capsule', 'ellipsoid', 'cylind
   const sliced = sliceDeckWindow(scene, stWin);
   const decorIn = sliced.subjects.filter((x) => /-decor-/.test(x.id));
   ok(
-    decorIn.every((x) => x.id.startsWith('s3-decor-')),
-    'station window carries ONLY its own station decor',
+    decorIn.every((x) => x.id.startsWith('s3-decor-') || x.id.startsWith('path-3-decor-')),
+    'station window carries only its own decor + the OUTGOING inlay (continuity: the world ahead never pops in)',
   );
   ok(
     decorIn.length <= STATION_DECOR_MAX,

--- a/sdf-js/src/scene/assemble-deck.js
+++ b/sdf-js/src/scene/assemble-deck.js
@@ -619,11 +619,14 @@ export function sliceDeckWindow(scene, win) {
     if (st) return wanted.has(Number(st[1]));
     const path = /^path-(\d+)-/.exec(id);
     if (path) {
-      // Breadcrumbs earn their keep during TRANSIT flyovers; inside a station
-      // they're floor dots at the frame edge costing a full SDF eval per
-      // march step each. Station windows drop them all.
-      if (win.kind === 'station') return false;
       const i = Number(path[1]);
+      // Breadcrumbs earn their keep during TRANSIT flyovers. Station windows
+      // keep only the OUTGOING segment (path-k, leading to the next arena):
+      // when the transit starts, its path is ALREADY there — the world never
+      // pops in ahead of the lens (total-continuity lock). The incoming
+      // segment (path-(k-1)) still drops, but that pop happens BEHIND the
+      // camera at arrival, where nobody is looking. +5 leaves per station.
+      if (win.kind === 'station') return wanted.has(i);
       return wanted.has(i) || wanted.has(i + 1);
     }
     return true;


### PR DESCRIPTION
总连续第三层(几何 pop 扫尾):站窗口原本丢弃全部面包屑,**transit 起飞瞬间路径点 + inlay 在镜头正前方整批弹入**——正是"世界延续感"的破坏点之一。

改法:站窗口保留**出发段**(path-k,通往下一竞技场)——起飞时路径已经在那里;入站段(path-(k-1))仍然丢弃,但那次消失发生在**镜头身后**,无人看见。每站窗口 +5 dots + 3 inlay,leaf 预算内。

原则沉淀:**世界可以在镜头身后整理自己,永远不许在镜头前方无中生有。**

suite 147/147。

🤖 Generated with [Claude Code](https://claude.com/claude-code)