### PR TITLE
feat(w7): 产品路径保真 — hold 提取升级(数值优先)+ handoff 审计钉进 CI

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -150,6 +150,7 @@ const TESTS = [
   { category: 'scene', file: 'sdf-js/scripts/test-beats.mjs' },
   { category: 'scene', file: 'sdf-js/scripts/test-script-spans.mjs' },
   { category: 'scene', file: 'sdf-js/scripts/test-atlas-deck-handoff.mjs' },
+  { category: 'scene', file: 'sdf-js/scripts/audit-handoff-fidelity.mjs' },
   { category: 'scene', file: 'sdf-js/scripts/test-deck-windows.mjs' },
   { category: 'scene', file: 'sdf-js/scripts/test-render-hold.mjs' },
   { category: 'scene', file: 'sdf-js/scripts/test-analytic-renderer.mjs' },

--- a/sdf-js/scenes/ir/handoff-funding-round.json
+++ b/sdf-js/scenes/ir/handoff-funding-round.json
@@ -9,7 +9,13 @@
     {
       "structure": "hold",
       "title": "TL;DR",
-      "nodes": ["Every merchant is fighting to own the relationship with their shoppers"]
+      "nodes": [
+        "AI-Driven Personalization · Agentic shopping + marketing agents",
+        "Every merchant is fighting to own the relationship with their shoppers",
+        "Platform Evolution",
+        "AI Agents",
+        "Funding Acceleration"
+      ]
     },
     {
       "structure": "magnitude",
@@ -26,7 +32,7 @@
     {
       "structure": "hold",
       "title": "Challenges",
-      "nodes": []
+      "nodes": ["Returns Network Scaling", "Infrastructure", "Operations", "Network", "Efficiency"]
     },
     {
       "structure": "sequence",

--- a/sdf-js/scripts/audit-handoff-fidelity.mjs
+++ b/sdf-js/scripts/audit-handoff-fidelity.mjs
@@ -1,0 +1,74 @@
+// sdf-js/scripts/audit-handoff-fidelity.mjs — PRODUCT-PATH fidelity, pinned in
+// CI. The sibling audit (audit-2d-fidelity) checks IR→3D; this one checks the
+// lossier hop: 2D atlas-deck slots → IR (atlasDeckToIR). The covenant tested
+// here is the numbers-are-payload rule: every VALUE the 2D page shows (kpi
+// value, stat-banner value, donut centre readout) must survive into the IR —
+// as a magnitude display string on aggregated pages, or as a hold bullet on
+// no-structure pages.
+//
+// Two severity tiers:
+//   HARD (exits 1): a hold-fallback slot lost a value — pure extraction bug.
+//   SOFT (reported): a STRUCTURAL slot's sibling atoms lost values (the
+//     chosen structure can't carry a stray "$81M" from a neighboring card —
+//     IR has no notes channel yet; candidate for the §9.5 conversation).
+import { readFileSync, readdirSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+import { atlasDeckToIR } from '../src/scene/scaffold-to-ir.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const AMMO = resolve(__dirname, '../examples/deck-handoff/ammo');
+
+function payloadValues(sceneData) {
+  const subjects = sceneData.subjects || sceneData.atoms || [];
+  const vals = [];
+  for (const s of subjects) {
+    const a = (s && s.args) || {};
+    if ((s.type === 'kpi-card' || s.type === 'stat-banner') && a.value != null)
+      vals.push(String(a.value).trim());
+    if (a.centerValue != null) vals.push(String(a.centerValue).trim());
+    if (s.type === 'dashboard-multi-kpi-composite' && Array.isArray(a.kpis))
+      for (const k of a.kpis) if (k && k.value != null) vals.push(String(k.value).trim());
+  }
+  return vals.filter((v) => v.length > 0 && v.length <= 40);
+}
+
+let hard = 0,
+  soft = 0;
+for (const f of readdirSync(AMMO).filter((x) => x.endsWith('.json'))) {
+  const raw = readFileSync(`${AMMO}/${f}`, 'utf8');
+  const deck = JSON.parse(raw);
+  const { slides, report } = atlasDeckToIR(raw);
+  const lines = [];
+  (deck.slots || []).forEach((slot, i) => {
+    const r = report[i];
+    const slideIdx = report.slice(0, i + 1).filter((x) => x.outcome.startsWith('ir:')).length - 1;
+    if (!r.outcome.startsWith('ir:')) return;
+    const ir = slides[slideIdx];
+    const irText = [
+      ir.title,
+      ...(ir.nodes || []).map((n) => (typeof n === 'string' ? n : n.label)),
+      ...(ir.display || []),
+    ]
+      .filter(Boolean)
+      .join(' | ');
+    for (const v of payloadValues(slot.sceneData || {})) {
+      if (irText.includes(v)) continue;
+      if (r.outcome === 'ir:hold(fallback)') {
+        hard++;
+        lines.push(`  ✗ HARD [${r.title}] hold lost value "${v}"`);
+      } else {
+        soft++;
+        lines.push(`  · soft [${r.title}] ${r.outcome} sibling lost value "${v}"`);
+      }
+    }
+  });
+  if (lines.length) {
+    console.log(`=== ${f} ===`);
+    lines.forEach((l) => console.log(l));
+  }
+}
+console.log(
+  `\nhold-fallback value losses (HARD): ${hard} · structural sibling losses (soft, backlog): ${soft}`,
+);
+process.exit(hard ? 1 : 0);

--- a/sdf-js/src/scene/scaffold-to-ir.js
+++ b/sdf-js/src/scene/scaffold-to-ir.js
@@ -770,6 +770,7 @@ function kpiSlotToIR(subjects) {
 // atom arg fields — narration goes to the DOM subtitle layer, so we only lift
 // label-length strings, never paragraphs.
 const HOLD_TEXT_FIELDS = ['subtitle', 'tagline', 'quote', 'caption'];
+const HOLD_MAX_BULLETS = 6; // render-hold handles 6 (投资亮点 is the reference page)
 export function holdSlotToIR(sceneData, label = '') {
   const subjects = Array.isArray(sceneData?.subjects)
     ? sceneData.subjects
@@ -782,14 +783,42 @@ export function holdSlotToIR(sceneData, label = '') {
   const push = (v) => {
     if (typeof v !== 'string') return;
     const t = v.trim();
-    if (t && t.length <= 90 && t !== title && !nodes.includes(t) && nodes.length < 4) nodes.push(t);
+    if (t && t.length <= 90 && t !== title && !nodes.includes(t) && nodes.length < HOLD_MAX_BULLETS)
+      nodes.push(t);
   };
+  const pair = (val, lab) =>
+    val != null && lab
+      ? `${String(val).trim()} · ${String(lab).trim()}`
+      : val != null
+        ? String(val)
+        : lab;
+  // PASS 1 — VALUE PAYLOADS first (2D-fidelity: numbers are payload, the Rule
+  // 18-24 covenant — a $81M on the source page must never vanish): kpi-card /
+  // stat-banner value+label pairs, donut centre readouts, fishbone effect,
+  // kanban board title. These claim bullet slots before any prose does.
+  for (const s of subjects) {
+    const a = (s && s.args) || {};
+    if (s.type === 'kpi-card' || s.type === 'stat-banner') push(pair(a.value, a.label));
+    // multi-KPI dashboards that failed magnitude aggregation (mixed units)
+    // still carry their numbers — each one is payload
+    if (s.type === 'dashboard-multi-kpi-composite' && Array.isArray(a.kpis))
+      for (const kpi of a.kpis) push(pair(kpi && kpi.value, kpi && kpi.label));
+    if (a.centerValue != null) push(pair(a.centerValue, a.centerLabel));
+    if (typeof a.effect === 'string') push(a.effect);
+    if (typeof a.title === 'string' && s.type !== 'cover') push(a.title);
+  }
+  // PASS 2 — short prose: quotes/subtitles, item labels, pillar headings,
+  // kanban column names. Paragraph-length text stays in the DOM subtitle
+  // layer's territory and is never lifted (two-text-systems rule).
   for (const s of subjects) {
     const a = (s && s.args) || {};
     for (const f of HOLD_TEXT_FIELDS) push(a[f]);
     if (Array.isArray(a.items))
       for (const it of a.items)
         push(typeof it === 'string' ? it : it && (it.label ?? it.title ?? it.text));
+    if (Array.isArray(a.pillars)) for (const p of a.pillars) push(p && p.heading);
+    if (Array.isArray(a.columns)) for (const c of a.columns) push(c && c.name);
+    if (Array.isArray(a.branches)) for (const b of a.branches) push(b && b.label);
   }
   return { structure: 'hold', title, nodes };
 }


### PR DESCRIPTION
## 相似度第二跳:2D slot → IR(比 IR→3D 更漏的那一跳)

契约 = **数字即 payload**(Rule 18-24 的搬运):源页上的 $81M 永远不许消失。

- **holdSlotToIR 两遍提取**:PASS 1 数值 payload 优先占位(kpi/stat 的 value·label 对、dashboard-multi-kpi 的 kpis[]、donut 中心读数、fishbone effect、板块标题),PASS 2 短句(quote/subtitle/items/pillar headings/kanban 列名);bullets cap 4→6;段落长文本仍归 DOM 字幕层
- **audit-handoff-fidelity 钉进 CI**,双严重度:
  - **HARD**(exit 1):hold 槽丢数值 = 纯提取 bug —— 15 个 ammo 实测 **3→0**(一组 "98万台/21%/350台" 曾整组消失)
  - **soft**(报告不拦):结构槽的兄弟 atom 丢值(76 处)—— 选中的结构 IR 带不动旁边散落的 "$81M"卡片,因为 **IR 没有 notes 通道**;这是下一次和 2D 端 §9.5 对话的候选议题,已有量化证据
- 升级后的 TL;DR 站 bullets 实例:`AI-Driven Personalization · Agentic shopping + marketing agents` / quote / 三个 pillar headings —— 源页读感基本齐了

suite 147/147。

🤖 Generated with [Claude Code](https://claude.com/claude-code)