### PR TITLE
Sprint 90: 范本五调 (居中/上提/删小字/转场页/中文题)

### DIFF
--- a/sdf-js/examples/scaffold-pipeline/antfun-launchpad-v1/deck.json
+++ b/sdf-js/examples/scaffold-pipeline/antfun-launchpad-v1/deck.json
@@ -35,7 +35,7 @@
   {
    "slotIdx": 2,
    "slotName": "key-figures",
-   "slotTitle": "Key Figures",
+   "slotTitle": "ANT 收费模式",
    "sourceSlideIdx": 9,
    "liftFile": "slots/slot-02-key-figures.json",
    "error": null,
@@ -239,7 +239,7 @@
   {
    "slotIdx": 12,
    "slotName": "comparison",
-   "slotTitle": "Comparison",
+   "slotTitle": "pump.fun 机制基准",
    "sourceSlideIdx": 2,
    "liftFile": "slots/slot-12-comparison.json",
    "error": null,
@@ -257,7 +257,7 @@
   {
    "slotIdx": 13,
    "slotName": "mechanism",
-   "slotTitle": "How It Works",
+   "slotTitle": "一笔交易的 ANT 之旅",
    "sourceSlideIdx": 19,
    "liftFile": "slots/slot-13-mechanism.json",
    "error": null,
@@ -275,7 +275,7 @@
   {
    "slotIdx": 14,
    "slotName": "data-appendix",
-   "slotTitle": "Data Appendix",
+   "slotTitle": "数据附录",
    "sourceSlideIdx": 20,
    "liftFile": "slots/slot-14-data-appendix.json",
    "error": null,
@@ -339,7 +339,7 @@
   {
    "slotIdx": 18,
    "slotName": "quote",
-   "slotTitle": "Key Quote",
+   "slotTitle": "ANTFUN 理念",
    "sourceSlideIdx": 13,
    "liftFile": "slots/slot-18-quote.json",
    "error": null,
@@ -352,7 +352,7 @@
   {
    "slotIdx": 19,
    "slotName": "outlook",
-   "slotTitle": "Outlook",
+   "slotTitle": "ANT 飞轮:合流与缓释",
    "sourceSlideIdx": 21,
    "liftFile": "slots/slot-19-outlook.json",
    "error": null,
@@ -365,7 +365,7 @@
   {
    "slotIdx": 20,
    "slotName": "summary",
-   "slotTitle": "Summary",
+   "slotTitle": "总结:ANT 五重角色",
    "sourceSlideIdx": 16,
    "liftFile": "slots/slot-20-summary.json",
    "error": null,

--- a/sdf-js/examples/scaffold-pipeline/antfun-launchpad-v1/slots/slot-02-key-figures.json
+++ b/sdf-js/examples/scaffold-pipeline/antfun-launchpad-v1/slots/slot-02-key-figures.json
@@ -14,8 +14,9 @@
     "w": 1280,
     "h": 120,
     "args": {
-     "title": "Key Figures",
-     "style": "gradient"
+     "title": "ANT 收费模式",
+     "style": "gradient",
+     "subtitle": "关键数字一览 — 全部以 ANT 收取"
     }
    },
    {

--- a/sdf-js/examples/scaffold-pipeline/antfun-launchpad-v1/slots/slot-12-comparison.json
+++ b/sdf-js/examples/scaffold-pipeline/antfun-launchpad-v1/slots/slot-12-comparison.json
@@ -14,8 +14,9 @@
     "w": 1280,
     "h": 120,
     "args": {
-     "title": "Comparison",
-     "style": "gradient"
+     "title": "pump.fun 机制基准",
+     "style": "gradient",
+     "subtitle": "行业定位与教训"
     }
    },
    {

--- a/sdf-js/examples/scaffold-pipeline/antfun-launchpad-v1/slots/slot-13-mechanism.json
+++ b/sdf-js/examples/scaffold-pipeline/antfun-launchpad-v1/slots/slot-13-mechanism.json
@@ -14,8 +14,9 @@
     "w": 1280,
     "h": 120,
     "args": {
-     "title": "How It Works",
-     "style": "gradient"
+     "title": "一笔交易的 ANT 之旅",
+     "style": "gradient",
+     "subtitle": "完整经济闭环"
     }
    },
    {

--- a/sdf-js/examples/scaffold-pipeline/antfun-launchpad-v1/slots/slot-14-data-appendix.json
+++ b/sdf-js/examples/scaffold-pipeline/antfun-launchpad-v1/slots/slot-14-data-appendix.json
@@ -14,8 +14,9 @@
     "w": 1280,
     "h": 100,
     "args": {
-     "title": "Data Appendix",
-     "style": "gradient"
+     "title": "数据附录",
+     "style": "gradient",
+     "subtitle": "费用与销毁基准"
     }
    },
    {

--- a/sdf-js/examples/scaffold-pipeline/antfun-launchpad-v1/slots/slot-18-quote.json
+++ b/sdf-js/examples/scaffold-pipeline/antfun-launchpad-v1/slots/slot-18-quote.json
@@ -14,7 +14,7 @@
     "w": 1280,
     "h": 100,
     "args": {
-     "title": "Key Quote",
+     "title": "ANTFUN 理念",
      "style": "gradient"
     }
    },

--- a/sdf-js/examples/scaffold-pipeline/antfun-launchpad-v1/slots/slot-19-outlook.json
+++ b/sdf-js/examples/scaffold-pipeline/antfun-launchpad-v1/slots/slot-19-outlook.json
@@ -14,7 +14,7 @@
     "w": 1280,
     "h": 100,
     "args": {
-     "title": "Outlook",
+     "title": "ANT 飞轮:合流与缓释",
      "style": "gradient"
     }
    },

--- a/sdf-js/examples/scaffold-pipeline/antfun-launchpad-v1/slots/slot-20-summary.json
+++ b/sdf-js/examples/scaffold-pipeline/antfun-launchpad-v1/slots/slot-20-summary.json
@@ -14,7 +14,7 @@
     "w": 1280,
     "h": 120,
     "args": {
-     "title": "Summary",
+     "title": "总结:ANT 五重角色",
      "style": "gradient"
     }
    },

--- a/sdf-js/src/present/art-mount.js
+++ b/sdf-js/src/present/art-mount.js
@@ -121,6 +121,18 @@ export async function loadArtMount(entry, base) {
     throw new Error(`art-mount: ${entry?.id || '?'} has no usable large mint`);
   }
   const cover = await loadImage(base + entry.files.large);
+  // Sprint 90 (user: 转场页用另一个 hash 的另一张图): large VARIANTS —
+  // extra mints of the same artwork under different hashes, cached as
+  // <id>-large-t<k>.png. Absent variants are fine; transitions fall back
+  // to the cover itself.
+  const variants = [];
+  for (let k = 0; k < 8; k++) {
+    try {
+      variants.push(await loadImage(`${base}${entry.id}-large-t${k}.png`));
+    } catch {
+      break; // contiguous t0..tn convention
+    }
+  }
   const strip = [];
   for (let k = 0; k < 3; k++) {
     try {
@@ -142,6 +154,7 @@ export async function loadArtMount(entry, base) {
     artist: entry.artist,
     cover,
     strip,
+    variants,
     // Sprint 87: prebaked palette from the manifest wins (bake once, render
     // anywhere — the gallery shows the same swatches the deck will wear)
     palette: entry.palette || extractMountPalette(cover),
@@ -231,6 +244,70 @@ export function mountUnderlayDecor(baseDecor, mount, mode = 'hetero') {
   const homo = MOUNT_FAMILY_OF[mount.id];
   const family = mode === 'homo' && homo ? homo : underlayFamilyFor(mount.id);
   return { ...baseDecor, family };
+}
+
+/**
+ * insertTransitions(slots, mount) — Sprint 90 (user: 6 个子目录就有 6 个
+ * 转场页, 封面式排版突出生成艺术, 另一个 hash 另一张图)。
+ * A transition page is synthesized BEFORE each section-boundary slot
+ * (slotName ending in "-lead", plus the risk/summary boundary when the
+ * agenda promises more sections than leads). It is a pure-cover slot:
+ * full-bleed artwork (a different mint VARIANT per transition) + the
+ * section title, centered like the deck cover. Returns a NEW slot list;
+ * synthetic slots carry _transition: {index} so renderers can pick art.
+ */
+export function insertTransitions(slots, mount) {
+  if (!mount) return slots;
+  const agenda = slots.find((s) => s.slotName === 'agenda');
+  const labels = [];
+  if (agenda?.sceneData?.subjects) {
+    for (const sub of agenda.sceneData.subjects) {
+      if (sub?.type === 'agenda-list' && Array.isArray(sub.args?.items)) {
+        for (const it of sub.args.items) if (it?.label) labels.push(String(it.label));
+      }
+    }
+  }
+  const isBoundary = (s, i) =>
+    /-lead$/.test(s.slotName || '') || ((s.slotName || '') === 'risk-matrix' && labels.length > 5);
+  const out = [];
+  let t = 0;
+  for (let i = 0; i < slots.length; i++) {
+    const s = slots[i];
+    if (isBoundary(s, i) && t < Math.max(labels.length, 6)) {
+      const title = labels[t] || s.slotTitle || '';
+      out.push({
+        slotIdx: s.slotIdx - 0.5,
+        slotName: `transition-${t + 1}`,
+        slotTitle: title,
+        _transition: { index: t },
+        sceneData: {
+          subjects: [
+            {
+              type: 'cover',
+              x: 0,
+              y: 0,
+              w: 1280,
+              h: 720,
+              args: {
+                title,
+                subtitle: `${String(t + 1).padStart(2, '0')} / ${Math.max(labels.length, 6)}`,
+              },
+            },
+          ],
+        },
+      });
+      t++;
+    }
+    out.push(s);
+  }
+  return out;
+}
+
+/** transitionArt(mount, slot) → the variant image for a synthetic slot. */
+export function transitionArt(mount, slot) {
+  if (!slot?._transition || !mount) return null;
+  const pool = mount.variants?.length ? mount.variants : [mount.cover];
+  return pool[slot._transition.index % pool.length];
 }
 
 /** fetchMintManifest(base) → manifest array, or null when the cache is absent. */

--- a/sdf-js/src/present/atoms-2d/presentation/cover.js
+++ b/sdf-js/src/present/atoms-2d/presentation/cover.js
@@ -96,7 +96,7 @@ export function drawPseudo3D(ctx, args, opts = {}) {
     // Sprint 80: the scrim is LOCAL — a radial vignette anchored on the
     // title block. A full-surface wash greys the artwork (cream Ringers
     // grounds turned to fog); the painting owns the rest of the frame.
-    const scx = x + w * 0.24;
+    const scx = x + w * (h > 200 ? 0.5 : 0.24); // centered covers → centered vignette
     const scy = y + h * 0.5;
     const scr = ctx.createRadialGradient(scx, scy, 0, scx, scy, w * 0.52);
     const base = overlayInk ? '246, 243, 236' : '8, 10, 16';
@@ -137,7 +137,12 @@ export function drawPseudo3D(ctx, args, opts = {}) {
   // titles at 72px ran ~400px past the right edge — cover had no width
   // fitting at all). Floor 20px; at the floor a still-too-long title is the
   // author's problem to shorten, not ours to clip.
-  let titleSize = Math.max(18, Math.min(Math.round(h * 0.14), 72));
+  // Sprint 90 (user: 目录页标题字太小): banner BANDS (h ≤ 200) size type
+  // to the band — a 120px band carries ~40px titles, not 18px whispers.
+  const isBand = h <= 200;
+  let titleSize = isBand
+    ? Math.max(26, Math.min(Math.round(h * 0.34), 46))
+    : Math.max(18, Math.min(Math.round(h * 0.14), 72));
   {
     const maxW = w - PAD * 2;
     ctx.save();
@@ -159,7 +164,10 @@ export function drawPseudo3D(ctx, args, opts = {}) {
   }
   const metaSize = Math.max(10, Math.min(Math.round(h * 0.038), 14));
 
-  const titleX = x + PAD;
+  // Sprint 90 (user: 大标题居中): full covers center the title block;
+  // bands stay left-aligned next to the label position.
+  const centered = !isBand && (style === 'overlay' || style === 'gradient');
+  const titleX = centered ? x + w / 2 : x + PAD;
 
   // Vertical layout: start from center, nudge up slightly
   const blockH = titleSize + (subtitle ? subtitleSize + 8 : 0);
@@ -180,7 +188,7 @@ export function drawPseudo3D(ctx, args, opts = {}) {
   }
   ctx.fillStyle = overlayInk ? 'rgba(24, 26, 32, 0.95)' : 'rgba(255,255,255,0.97)';
   ctx.font = `900 ${titleSize}px "Inter Display", Inter, system-ui, sans-serif`;
-  ctx.textAlign = 'left';
+  ctx.textAlign = centered ? 'center' : 'left';
   ctx.textBaseline = 'top';
   ctx.fillText(String(title), titleX, blockTop);
 
@@ -191,6 +199,7 @@ export function drawPseudo3D(ctx, args, opts = {}) {
     ctx.textBaseline = 'top';
     ctx.fillText(String(subtitle), titleX, blockTop + titleSize + 8);
   }
+  ctx.textAlign = 'left';
 
   // ---- Metadata strip — bottom-right ----
   const metaParts = [];

--- a/sdf-js/src/present/atoms-2d/renderer.js
+++ b/sdf-js/src/present/atoms-2d/renderer.js
@@ -53,7 +53,7 @@ export async function renderSceneDataToCanvas(canvas, sceneData, opts = {}) {
   // lattice at paint time (deck.json keeps raw lift geometry). opts.align
   // === false opts out (visual-audit replays raw coordinates).
   const aligned = opts.align === false ? sceneData : alignSceneData(sceneData);
-  const subjects = Array.isArray(aligned?.subjects) ? aligned.subjects : [];
+  let subjects = Array.isArray(aligned?.subjects) ? aligned.subjects : [];
 
   // Decoration layer (Sprint 41): generative backdrop, theme-constrained +
   // seeded. Content slides get it UNDER the atoms ('subtle'); pure-cover
@@ -163,6 +163,27 @@ export async function renderSceneDataToCanvas(canvas, sceneData, opts = {}) {
       intensity: decor.intensity || UNDER_INTENSITY[role] || 'subtle',
     });
   }
+  // Sprint 90 (user: 目录页 Overview 小字与"核心主题"冲突 — 标题上提):
+  // on agenda banner pages the body heading (agenda-list args.title) is
+  // HOISTED into the banner as its title, the English slot label retires,
+  // and agenda item sublabels (小字) are dropped — the numbered titles
+  // carry the page. opts.bannerTitle overrides everything when provided.
+  let bannerTitle = opts.bannerTitle || null;
+  let bannerSubtitle = opts.bannerSubtitle || null;
+  if (bannerCanvas && role === 'agenda') {
+    subjects = subjects.slice(); // never mutate the caller's array
+    for (let i = 0; i < subjects.length; i++) {
+      const s2 = subjects[i];
+      if (s2 && s2.type === 'agenda-list' && s2.args) {
+        if (!bannerTitle && s2.args.title) bannerTitle = s2.args.title;
+        const items = Array.isArray(s2.args.items)
+          ? s2.args.items.map((it) => ({ ...it, sublabel: undefined }))
+          : s2.args.items;
+        subjects[i] = { ...s2, args: { ...s2.args, title: undefined, items } };
+      }
+    }
+  }
+
   let rendered = 0;
   let skipped = 0;
   const errors = [];
@@ -213,7 +234,12 @@ export async function renderSceneDataToCanvas(canvas, sceneData, opts = {}) {
     }
     const args =
       (coverCanvas && s.type === 'cover') || isBannerAtom
-        ? { ...s.args, style: 'overlay' }
+        ? {
+            ...s.args,
+            style: 'overlay',
+            ...(isBannerAtom && bannerTitle ? { title: bannerTitle } : {}),
+            ...(isBannerAtom && bannerSubtitle ? { subtitle: bannerSubtitle } : {}),
+          }
         : s.args || {};
     const style = deckStyle || s.style || 'pseudo3d';
     const subjectOpts = {


### PR DESCRIPTION
user 以 Two Mathematicians 版为范本的五点微调, 全部落地; 转场页 = 每节一页封面式全幅真迹 (6 个不同 hash 变体), 26 页范本 PDF 已交付。测试 145/146 (golden 漂移系 3D 端已知)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)