### PR TITLE
Sprint 92: 封面级对抗淘汰 (166→135)

### DIFF
--- a/sdf-js/examples/original-mints/index.html
+++ b/sdf-js/examples/original-mints/index.html
@@ -189,7 +189,7 @@
           card.className = 'card' + (ok ? '' : ' blocked');
           const thumbFile = ok ? `${m.id}-small-0.png` : null;
           card.innerHTML = `
-            ${ok ? `<img class="thumb" loading="lazy" src="${BASE}${thumbFile}" onerror="this.src='${BASE}${m.files?.small || m.files?.large || ''}'">` : '<div class="thumb" style="display:grid;place-items:center;color:#5a5b66">WebGL 待补</div>'}
+            ${ok ? `<img class="thumb" loading="lazy" src="${BASE}${thumbFile}" onerror="this.src='${BASE}${m.files?.small || m.files?.large || ''}'">` : `<div class="thumb" style="display:grid;place-items:center;color:#5a5b66">${String(m.status).startsWith('culled') ? '已裁汰 (封面级)' : 'WebGL 待补'}</div>`}
             <div class="meta">
               <div class="name">${m.id} · ${m.name}</div>
               <div class="artist">${m.artist || ''}</div>


### PR DESCRIPTION
user: 全库存跑一遍对抗, 效果差的去掉 (Cattleya 洗白/Quine 空白类)。三轮: R1 全量指标 → 发现好封面双通道成立 (细节型 BUSY vs 大胆极简型 Ringers, 单一饱和度/边缘阈值都会误杀) → R2 边界 26 件目检留 17 → R3 幸存者抽检零漏网。裁 31 留 135, manifest 非破坏标记。

🤖 Generated with [Claude Code](https://claude.com/claude-code)