### PR TITLE
docs(blender-borrow): Blender 借法 spec + 四波计划 + 生态调研归档

### DIFF
--- a/docs/superpowers/notes/2026-07-13-blender-ecosystem-survey.md
+++ b/docs/superpowers/notes/2026-07-13-blender-ecosystem-survey.md
@@ -1,0 +1,65 @@
+# 2026-07-13 — text-to-Blender 生态调研(Blender 借法 spec 的证据基础)
+
+> 四路调研(主综合 + BlenderGPT 品类深挖 + blender-mcp 生态深挖 + Infinigen 源码实读),
+> star 数均为 2026-07 GitHub 实抓。借法判定见 `../specs/2026-07-13-blender-borrow-spec.md`。
+> 本文件是核实过的事实底账(项目/数字/失败模式),供日后查证。
+
+## 一、项目清单(核实数据)
+
+| 项目 | Star | 状态 | 中间表示 | 关键事实 |
+|---|---|---|---|---|
+| ahujasid/blender-mcp | 23.8k | 活跃放缓 | 结构化感知 + **任意 exec 写操作** + 资产库工具×18 | 建模类结构化工具为零;头号 issue=连接稳定;安全评分 Grade D(unsandboxed exec/路径穿越/SSRF) |
+| Blender Lab 官方 MCP(5.1+) | — | 2026-04 起 | null-byte JSON over TCP,本质仍 exec | **Anthropic 成为 Blender 基金 Corporate Patron(€240k/年)**;场景刻意收窄=调试/批处理 |
+| gd3kr/BlenderGPT | 4,957 | 死(2024-06) | 自由 bpy + 正则提取 + exec,无重试无上下文 | 插件先于生成代码腐烂(OpenAI API 改版杀全插件);作者转行卖资产生成(blendergpt.org) |
+| BlenderGPT 系仿品×9 | 1-126 | 全灭只剩 1 个活 | 同上 | 唯一活的靠 g4f 白嫖;唯一做全错误重试闭环的是闭源商业品(F.A.S.T.) |
+| FreedomIntelligence/BlenderLLM | 269 | 论文态 | 微调 Qwen2.5-Coder-7B 生成 bpy | **GPT-4o 裸写 bpy 仅 0.565/0.444 分,o1 0.687,微调后 0.748**(CADBench)——通用模型上限被钉死 |
+| RFingAdam/mcp-blender | 3 | 活 | **218 个结构化工具**(28 种 modifier/7 个 geonode) | 数据模型覆盖最深,市场无人买单——通用 DCC 的 API 面太大 |
+| 3D-GPT(ANU/牛津) | 851 | 部分开源 | **Infinigen 生成器参数**(LLM 只填参) | 需给每个函数配文档+可读重构版+示例(LLM/documents/);表达力被生成器库封顶 |
+| SceneCraft(ICML24 Oral) | 未开源 | — | 关系场景图→数值约束函数→求解→bpy | 双循环:GPT-4V 看图批评 + 函数沉淀 library learning |
+| Holodeck(AI2, CVPR24) | 560 | 停更 | 结构化 JSON + 空间关系约束 + DFS/MILP 求解 | **LLM 从不直接吐坐标**;版本钉死资产库导致复现地狱 |
+| SceneTeller / LayoutGPT | 58 / 402 | 停更 | LLM 直接吐 bbox 坐标(JSON / CSS 语法) | 都需要事后清洗重叠/越界——LLM 吐坐标不可靠的直接证据 |
+| BlenderAlchemy(ECCV24) | 94 | 低维护 | **编辑既有程序**(VLM 评审树搜索) | 唯一深用 shader/geonode 的;每轮真渲染+VLM,贵且不可靠 |
+| princeton-vl/Infinigen | 7,088 | 本周仍提交 | AssetFactory + gin + node transpiler | 见下节 |
+
+## 二、Infinigen 源码实读(借法的正面参照)
+
+- **AssetFactory 两级 seed**:`factory_seed` 物种级(构造时 `FixedSeed` 内采样共享参数),
+  实例 seed = `int_hash((factory_seed, i))` —— 同种不同体。`spawn_asset` 是不可 override
+  的模板方法(seed 上下文 + bpy.data GC 包好再调 `create_asset`)。
+  ↔ Atlas decor 的 voice lane / per-station lane 独立收敛于同构。
+- **placeholder 两阶段 + 距离 LOD**:`create_placeholder`(粗盒,供布局/相机规划)与
+  `create_asset`(高细节)分离,`face_size` 按相机距离定。↔ massing proxy / stone-full。
+- **node transpiler(v2.7.1,双表示)**:美术在 Blender 搭 nodes → 1 秒转 Python
+  (`nw.new_node(...)` 形式)→ 开发者手工把常量替换成 numpy 分布(生成文件头自动
+  import uniform/normal 就为这步)。资产库长到几百个生成器的供给端机制。
+- **Indoors 约束 DSL**:硬约束(布尔,`*` 连接)× 软评分(加权 maximize/minimize)
+  + 多阶段模拟退火;moves 含改生成器参数。词汇:`related_to/count/in_range/
+  StableAgainst/SupportedBy/accessibility_cost/...`(home.py 1488 行)。
+- **Infinigen 2.0 / procfunc**(进行中):官方把巨型工厂类+散装 gin 重写为
+  "可组合可随机化函数块 + trace-to-code" —— 工厂类不是终局的官方自认。
+- **它交的税**(issue 实测):安装地狱(bpy 锁 4.2.0+自编译 C 扩展)、最小场景
+  10min/16GB、跨平台同 seed 不可复现(文档挂横幅认账)、gin 无统一 schema。
+
+## 三、五条集体经验(借法判定的依据)
+
+1. **自由 bpy 代码是被证伪的一端**:双端版本漂移 + 幻觉 + 不可 diff;品类时间线
+   (2023 引爆 → 2026 开源全灭)+ CADBench 定量上限。
+2. **赢家表示 = 声明式场景图 + 关系约束,坐标交求解器**(SceneCraft/Holodeck/
+   Infinigen-Indoors 独立收敛)——Atlas IR(relations 一等公民、renderer 解算)同构。
+3. **值得借的是数据模型不是 API**:modifier stack / collections / datablock /
+   双表示;constraints/drivers/NLA 全生态无一被 LLM 侧用上,不借。
+4. **生成器 = 工厂 × 参数分布 × seed 是 LLM 填参的最佳颗粒度**(3D-GPT 实证),
+   复利继续投 atom 参数面与文档格式。
+5. **两个税避开**:运行时重量(内嵌巨型宿主/版本钉死资产)与 VLM 看图主回路
+   (只配兜底 QA)。附:全生态公认缺"几何验证层"——Atlas 的 validator/sanity/
+   golden 是差异化卖点;结构化深覆盖在通用 DCC 无人买单,但演示垂直域窄,
+   封闭 schema 可行,该教训不迁移。
+
+## 四、战略注脚
+
+- rung-2(LLM 调用 Blender)正在机构化(官方 MCP + Anthropic 赞助)——Atlas 差异化
+  钉死 rung-3(LLM 写世界)+ 演示垂直。
+- blender-mcp 23.8k star = MCP 分发时机的胜利 → Atlas-MCP backlog 的优先级佐证;
+  教训:**永不暴露 exec 逃生舱**,只暴露 schema 工具 + atlas_render。
+- "3D 端的 ArtBlocks = Infinigen":AssetFactory 生成器可按 ArtBlocks 50 课模式
+  做研读语料(待 user 排期)。

--- a/docs/superpowers/plans/2026-07-13-blender-borrow-plan.md
+++ b/docs/superpowers/plans/2026-07-13-blender-borrow-plan.md
@@ -1,0 +1,51 @@
+# Plan: Blender 借法实施(四波)
+
+> Spec:`../specs/2026-07-13-blender-borrow-spec.md`(先读)。
+> 节奏:每波一个 PR,user merge 后进下一波;A/B 可紧连,C 前重估,D 单独立项。
+
+## Wave A — 材质引用 + collections
+
+1. spec.js:`scene.materials` 注册表 + `subject.material` string 引用解析
+   (悬空引用 ERROR);`scene.collections` + `subject.collection` schema。
+2. assembleDeck 双写:每个 subject 附 collection(station-k / path-k / massing /
+   horizon / decor-*),注册表带切片语义(kind/cull/budget);id 前缀原样保留。
+3. sliceDeckWindow 切到 collection 元数据驱动(fallback:无 collection 场景走
+   旧正则——迁移期兼容 author/text-to-ir 老产物)。
+4. 消费者迁移 checklist(23 文件清单):deck-shader-windows、beats、figure-core、
+   test 魔数逐个切;全绿后删 fallback(可拆成 A2 小 PR)。
+5. 材质注册:assembleDeck/renderers 的重复材质抽到注册表(36 种);decor voice
+   与章节 accent 改走注册表改写。
+6. 守卫:golden 重烤一次 + 语义等价断言(切片结果与旧正则逐 id 一致)。
+
+## Wave B — modifiers v1(expansion)
+
+1. `src/scene/modifiers.js`:四个修饰符的展开器 + `expandModifiers()`;
+   接入 apply-studio-scene 管线(expandStage 之后)。
+2. spec.js 校验(未知 type ERROR;参数域检查;count 上限接 sanity 预算)。
+3. 改写产出端:assembleDeck 面包屑(12×array)、horizonSilhouettes(1×radial)、
+   guard(mirror)、zoneMassing;deck-decor stelae/inlay(radial/array+scatter);
+   render-network stardust(scatter)。
+4. **语义等价快照**:展开产物与改写前手工 subjects 逐字段一致(一次性验证脚本,
+   等价确认后 golden 重烤)。
+5. 文档:atom/生成器作者指南补 modifiers 一节(LLM 面的 few-shot 示例,
+   prompt 保持 SHORT 原则不变——modifiers 是 lift 输出面,不是 prompt 面)。
+
+## Wave C — domain-rep lowering(stone/rich)
+
+1. compile 按 renderMode 分支:array→opRepLim、radial→角度扇区折叠、
+   mirror→abs 折叠;scatter 恒 expansion。
+2. 验证:BOB-vs-FLY 双渲染器对照(域重复的 Lipschitz/法线/阴影);
+   窗口 leaf 预算断言更新(面包屑 84→12、石板 14→1);laptop 实测复验。
+3. 风险预案:任一渲染档出 artifact → 该档回落 expansion(lowering 是纯优化,
+   语义由 expansion 定义)。
+
+## Wave D(远期,单独立项)— analytic 解析重复求交
+
+box/sphere 阵列的 k 近邻实例解析求交;立项前先量化 B/C 之后 analytic 档还剩
+多少 leaf 压力,可能不再需要。
+
+## 里程碑判据
+
+- A 完成:grep 无人再消费 `/^s(\d+)-/`(除 fallback);材质注册表接管 deck 配色。
+- B 完成:字节 deck subjects 319→≤100;golden/fidelity/全套绿。
+- C 完成:content 窗口平均 leaf 数下降 ≥40%,laptop 帧率复验报告。

--- a/docs/superpowers/specs/2026-07-13-blender-borrow-spec.md
+++ b/docs/superpowers/specs/2026-07-13-blender-borrow-spec.md
@@ -1,0 +1,157 @@
+# Spec: Blender 借法 — modifier stack / collections / 材质引用
+
+> 来源:user 提议以 Blender 为 3D 端参考系(2026-07-13)→ text-to-Blender 生态调研
+> (20 项目,star 实抓;结论存 memory `project_blender_reference_intel`)→ user 拍板
+> "借法 spec 优先"。本 spec 定义 SceneData 契约的三个 Blender 式扩展与分波实施。
+>
+> 调研的三条前提结论(为什么借这三个、不借别的):
+> ① 自由 bpy 代码路线被市场证伪(BlenderGPT 品类全灭、GPT-4o 裸写 bpy 仅 0.565 分),
+>   赢家表示 = 声明式场景图 + 关系约束 —— Atlas 架构拿到反向背书,借法只在数据模型层;
+> ② constraints/drivers/NLA 在全部调研项目中无一被 LLM 侧成功使用 —— **不借**;
+> ③ Infinigen 2.0 正把巨型工厂类重写成"可组合可随机化函数块" —— 我们的链式 API
+>   已在终点,借的是它的**组织概念**(两级 seed/LOD/供给流水线),不是实现。
+
+## 0. 量化的问题(字节 radial deck 实测)
+
+- 319 个 subjects 中:84 个面包屑 = 12 条阵列;14 块地平线 = 1 个环形阵列;
+  6 块 guard = 3 对镜像;stelae/inlay/stardust 全是手工展开的散布。
+- 36 种材质被内联约 300 次(无 datablock 复用)。
+- collections 只存在于 id 前缀字符串契约(`/^s(\d+)-/`、`/^path-/`、`massing-`),
+  sliceDeckWindow 靠正则解析,23 个文件挂在命名约定上(对抗讨论点名的脆性)。
+- shader leaf 数对编译/运行成本超线性(#286 实测)——重复几何逐叶展开是病根之一。
+
+## 1. Modifier stack(`subject.modifiers`)
+
+### 1.1 契约
+
+```jsonc
+{
+  "id": "runway",
+  "type": "box",
+  "args": { "dims": [1.7, 0.05, 0.32] },
+  "modifiers": [
+    { "type": "array",  "count": 7, "offset": [2.3, 0, 0] },
+    { "type": "mirror", "axis": "x" }
+  ],
+  "transform": { "translate": [0, 0.03, 0] },
+  "material": "runway-strip"
+}
+```
+
+- `modifiers` 可选数组,**按序应用**,作用于 subject **局部空间**(先 modifiers,
+  后 transform —— 与 Blender 语义一致)。
+- v1 四个修饰符(Blender 对应物:Array / Array-circle / Mirror / Scatter):
+
+| type | 参数 | 语义 |
+|---|---|---|
+| `array` | `count ≥ 2`, `offset: [x,y,z]` | 线性阵列(面包屑、跑道、栅栏) |
+| `radial` | `count ≥ 2`, `radius`, `center?: [x,z]=[0,0]`, `startAngle?=0` | 环形阵列(地平线石板、stelae 环、柱环) |
+| `mirror` | `axis: 'x'\|'z'` | 镜像对(guard 石、对称布景) |
+| `scatter` | `count`, `region: {kind:'annulus'\|'box', ...}`, `seed` | 确定性散布(星尘、碎石场;= Generator-S 的声明式化) |
+
+- **不做**(调研否决):constraints、drivers(动画 expr 文法已覆盖)、
+  along-path(v1 用 array 逐段近似;曲线路径等真实需求出现再议)、
+  嵌套 modifier 作用于 union children(v1 只作用于 subject 整体)。
+
+### 1.2 两类实现语义(诚实分界)
+
+- **expansion(v1 全部四个)**:编译期展开为 N 个内部叶子——纯语义层收益
+  (JSON 变小、LLM 面变干净、id 契约消失),**leaf 数不变、性能不变**。
+- **domain-rep(v2,仅 array/radial/mirror)**:GLSL 域重复(opRepLim / 角度折叠 /
+  abs 折叠),N 实例 = **1 个 leaf** —— 这才是 leaf 超线性的修法。
+- 分界写进契约注释:`scatter` 永远是 expansion(不规则摆放无法域重复);
+  array/radial/mirror 的 lowering 由渲染档决定(见 1.4)。
+
+### 1.3 展开语义细则
+
+- 实例 id:`{subject.id}#0..N-1`(内部命名,**不进入任何窗口切片契约**——
+  切片按 collection 走,见 §2)。
+- `animation` exprs 作用于**整个修饰后 subject**(所有实例同步动;per-instance
+  相位差 v1 不做——现有 decor 的逐实例 jitter 继续用 scatter 的 seed 通道)。
+- scatter 的确定性:复用 `makeHashRand` 命名 lane(`{subject.id}:{i}`),
+  同 seed 永远同布局(mint-hash 契约语义)。
+- 与 sanity checker:展开后的叶子计入 subject-count/leaf 预算检查(不许借
+  modifiers 绕过预算告警)。
+
+### 1.4 渲染档交互(关键工程事实)
+
+analytic(产品默认)是**整帧模式**:任何不支持的形状导致整帧回退 stone。因此:
+
+- **v1(expansion)对 analytic 零影响**——展开后就是普通叶子,SUPPORTED 照旧。
+- **v2(domain-rep)只在 stone/rich 生效**;analytic 路径继续消费展开形态
+  (compile 按 renderMode 选 lowering)。
+- **v3(可选,远期)**:analytic 的解析重复求交(对 box/sphere 阵列解析求 k 近邻
+  实例)——单独立项,不阻塞 v1/v2。
+
+## 2. Collections(一等公民分组)
+
+### 2.1 契约
+
+```jsonc
+{
+  "collections": {
+    "station-3":  { "kind": "station", "station": 3 },
+    "path-2":     { "kind": "transit-path", "from": 2 },
+    "massing":    { "kind": "dressing", "cull": "never" },
+    "horizon":    { "kind": "dressing", "cull": "nearest", "budget": { "hero": 7, "content": 3 } },
+    "decor-st3":  { "kind": "decor", "station": 3 }
+  },
+  "subjects": [ { "id": "mono-1", "collection": "station-3", ... } ]
+}
+```
+
+- `subject.collection` 可选字符串;`scene.collections` 注册表携带**切片语义**
+  (kind / 归属站 / 裁剪策略 / 预算)——今天散落在 sliceDeckWindow 正则与常量里
+  的规则,全部变成数据。
+- sliceDeckWindow 改为按 collection 元数据过滤;**id 从此只是身份,不再承载
+  路由语义**。`/^s(\d+)-/` 等正则在迁移期保留为 fallback,消费者切完即删。
+- 嵌套 v1 不做(Blender 支持,我们的场景两层足够:deck → collection → subject)。
+
+### 2.2 迁移纪律
+
+- 纯增量:先加字段与注册表(assembleDeck 双写:collection + 旧 id 前缀),
+  golden 重烤一次;消费者(deck-shader-windows / beats / figure-core hideAt /
+  test 魔数)逐个切到 collection;全部切完后删正则 fallback。
+- 23 文件消费面清单(对抗讨论产出)作为迁移 checklist 附在 plan。
+
+## 3. 材质引用(datablock 复用)
+
+```jsonc
+{
+  "materials": { "mono-gold": { "hue": 0.11, "sat": 0.78, ... } },
+  "subjects": [ { "id": "mono-5", "material": "mono-gold" } ]
+}
+```
+
+- `subject.material` 接受 **string(引用)或 object(内联)**,两者长期共存
+  (内联是 LLM 单发场景的正确形态;引用是 deck 装配的正确形态)。
+- 解析在 `resolveMaterial`(spec.js)一处完成;悬空引用 = validator ERROR
+  (材质是视觉身份,静默回退会产生"看起来对了"的错)。
+- 收益:字节 deck 36 种材质 ×300 次内联 → 36 条注册 + 300 个字符串;
+  统一改色(章节 accent、decor voice)从"改 300 处"变"改注册表"。
+
+## 4. 验证与守卫
+
+- spec.js:modifiers/collections/materials 三个 schema 的完整校验
+  (validator/evaluator 同步律照旧);未知 modifier type = ERROR(fail loud)。
+- 新增 `expandModifiers()` 进 runtime 管线:
+  `expandVariants → expandStage → expandModifiers → expandChartLabels → compile`。
+- goldens:每波语义变更各重烤一次并在 PR 说明;fidelity 双审计不受影响
+  (overlay 不变)。
+- 预算断言:test 层验证"展开后 leaf 数 = 手工展开时代的数"(byte-level 等价的
+  modifier 版:**语义等价快照**——展开产物与旧手工 subjects 逐字段一致)。
+
+## 5. 分波
+
+| 波 | 内容 | 收益 | 风险 |
+|---|---|---|---|
+| **A** | 材质引用 + collections(含 sliceDeckWindow 切换、双写迁移) | 契约卫生;id 正则契约退役 | 低(纯增量+golden) |
+| **B** | modifiers v1(expansion)+ assembleDeck/decor/renderers 改用声明式 | subjects 319→约 80;LLM/作者面简化;Generator-S Phase 2 落地 | 中(语义等价快照守卫) |
+| **C** | domain-rep lowering(stone/rich) | leaf 数 ↓(面包屑 84→12、石板 14→1)——超线性病根 | 中高(GLSL;Lipschitz/阴影验证) |
+| **D**(远期) | analytic 解析重复求交 | 产品默认档吃到 perf | 高,单独立项 |
+
+## 6. 非目标
+
+- 不做 constraints / drivers / NLA / shader graph / 嵌套 collections(调研否决);
+- 不做 bpy 式命令 API、不内嵌任何外部运行时(轻运行时是我们的差异化税盾);
+- 不改 IR / atlas-deck 契约(本 spec 全部在 SceneData 层,2D 端零感知)。


### PR DESCRIPTION
## Blender 借法 — spec 先行

三件套:

1. **调研底账**(notes):20 项目核实数据(blender-mcp 23.8k/官方 MCP + Anthropic 赞助/BlenderGPT 品类全灭时间线/CADBench 0.565 上限/Infinigen 源码细节)+ 五条集体经验
2. **Spec**:三个 SceneData 扩展的完整契约
   - `subject.modifiers`(array/radial/mirror/scatter 四修饰符;**v1 expansion / v2 domain-rep 的诚实分界**——语义收益先落地,leaf 超线性的修复在 v2;analytic 整帧模式的交互写清)
   - `scene.collections` + `subject.collection`(切片语义从 id 正则变成数据,23 文件消费面迁移纪律)
   - `scene.materials` 引用(悬空引用 = ERROR)
   - **不借清单**:constraints/drivers/NLA(全生态无一被 LLM 侧用上)、bpy 式 API、外部运行时
3. **Plan**:四波,每波一 PR——A 材质+collections → B modifiers expansion(字节 deck 319→约 80 subjects,同时就是搁置的 Generator-S Phase 2)→ C domain-rep lowering(面包屑 84→12 叶、石板 14→1 叶)→ D analytic 解析重复(远期单独立项)

2D 端零感知(全部在 SceneData 层,不动 IR/atlas-deck 契约)。

Merge 后我从 Wave A 开始。

🤖 Generated with [Claude Code](https://claude.com/claude-code)