### PR TITLE
feat(wave-a): Blender 借法第一波 — collections 一等公民 + 材质注册表

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -163,6 +163,7 @@ const TESTS = [
   { category: 'scene', file: 'sdf-js/scripts/test-layout-tokens.mjs' },
   { category: 'scene', file: 'sdf-js/scripts/test-tempo-tokens.mjs' },
   { category: 'scene', file: 'sdf-js/scripts/test-courtyard.mjs' },
+  { category: 'scene', file: 'sdf-js/scripts/test-scene-collections.mjs' },
   { category: 'scene', file: 'sdf-js/scripts/audit-2d-fidelity.mjs' },
   { category: 'scene', file: 'sdf-js/scripts/test-camera-shake.mjs' },
   { category: 'scene', file: 'sdf-js/scripts/test-text-to-ir.mjs' },

--- a/sdf-js/fixtures/golden/assemble-deck-courtyard.json
+++ b/sdf-js/fixtures/golden/assemble-deck-courtyard.json
@@ -1,6 +1,434 @@
 {
   "v": 1,
   "name": "(deck) 最懂你的头条 — 2013 管理层陈述",
+  "collections": {
+    "station-0": {
+      "kind": "station",
+      "station": 0
+    },
+    "path-0": {
+      "kind": "transit-path",
+      "from": 0
+    },
+    "station-1": {
+      "kind": "station",
+      "station": 1
+    },
+    "path-1": {
+      "kind": "transit-path",
+      "from": 1
+    },
+    "station-2": {
+      "kind": "station",
+      "station": 2
+    },
+    "path-2": {
+      "kind": "transit-path",
+      "from": 2
+    },
+    "station-3": {
+      "kind": "station",
+      "station": 3
+    },
+    "path-3": {
+      "kind": "transit-path",
+      "from": 3
+    },
+    "station-4": {
+      "kind": "station",
+      "station": 4
+    },
+    "path-4": {
+      "kind": "transit-path",
+      "from": 4
+    },
+    "station-5": {
+      "kind": "station",
+      "station": 5
+    },
+    "path-5": {
+      "kind": "transit-path",
+      "from": 5
+    },
+    "station-6": {
+      "kind": "station",
+      "station": 6
+    },
+    "path-6": {
+      "kind": "transit-path",
+      "from": 6
+    },
+    "station-7": {
+      "kind": "station",
+      "station": 7
+    },
+    "path-7": {
+      "kind": "transit-path",
+      "from": 7
+    },
+    "station-8": {
+      "kind": "station",
+      "station": 8
+    },
+    "path-8": {
+      "kind": "transit-path",
+      "from": 8
+    },
+    "station-9": {
+      "kind": "station",
+      "station": 9
+    },
+    "path-9": {
+      "kind": "transit-path",
+      "from": 9
+    },
+    "station-10": {
+      "kind": "station",
+      "station": 10
+    },
+    "path-10": {
+      "kind": "transit-path",
+      "from": 10
+    },
+    "station-11": {
+      "kind": "station",
+      "station": 11
+    },
+    "path-11": {
+      "kind": "transit-path",
+      "from": 11
+    },
+    "station-12": {
+      "kind": "station",
+      "station": 12
+    },
+    "massing": {
+      "kind": "dressing",
+      "cull": "never"
+    },
+    "horizon": {
+      "kind": "dressing",
+      "cull": "nearest",
+      "budget": {
+        "hero": 7,
+        "content": 3
+      },
+      "yieldTo": "massing"
+    },
+    "env": {
+      "kind": "dressing",
+      "cull": "never"
+    }
+  },
+  "materials": {
+    "mat-0": {
+      "hue": 0.62,
+      "sat": 0.25,
+      "value": 0.1,
+      "kind": "normal",
+      "roughness": 0.48,
+      "clearcoat": 0.45
+    },
+    "mat-1": {
+      "hue": 0.58,
+      "sat": 0.25,
+      "value": 0.85,
+      "glow": 0.45,
+      "kind": "normal",
+      "roughness": 0.5,
+      "clearcoat": 0.2
+    },
+    "mat-2": {
+      "hue": 0.62,
+      "sat": 0.25,
+      "value": 0.1,
+      "kind": "normal",
+      "roughness": 0.4,
+      "clearcoat": 0.45
+    },
+    "mat-3": {
+      "hue": 0.995,
+      "sat": 0.85,
+      "value": 0.78,
+      "glow": 0.12,
+      "kind": "normal",
+      "roughness": 0.3,
+      "clearcoat": 0.5
+    },
+    "mat-4": {
+      "hue": 0.995,
+      "sat": 0.15,
+      "value": 0.8,
+      "glow": 0.5,
+      "kind": "normal",
+      "roughness": 0.4
+    },
+    "mat-5": {
+      "hue": 0.11,
+      "sat": 0.78,
+      "value": 0.95,
+      "glow": 0.1,
+      "kind": "normal",
+      "roughness": 0.22,
+      "clearcoat": 0.6
+    },
+    "mat-6": {
+      "hue": 0.58,
+      "sat": 0.1,
+      "value": 0.55,
+      "kind": "normal",
+      "roughness": 0.6,
+      "clearcoat": 0.1
+    },
+    "mat-7": {
+      "hue": 0.55,
+      "sat": 0.62,
+      "value": 0.82,
+      "kind": "normal",
+      "roughness": 0.3,
+      "clearcoat": 0.45
+    },
+    "mat-8": {
+      "hue": 0.5680000000000001,
+      "sat": 0.648,
+      "value": 0.7759999999999999,
+      "kind": "normal",
+      "roughness": 0.3,
+      "clearcoat": 0.45
+    },
+    "mat-9": {
+      "hue": 0.5860000000000001,
+      "sat": 0.676,
+      "value": 0.732,
+      "kind": "normal",
+      "roughness": 0.3,
+      "clearcoat": 0.45
+    },
+    "mat-10": {
+      "hue": 0.6040000000000001,
+      "sat": 0.704,
+      "value": 0.688,
+      "kind": "normal",
+      "roughness": 0.3,
+      "clearcoat": 0.45
+    },
+    "mat-11": {
+      "hue": 0.622,
+      "sat": 0.732,
+      "value": 0.6439999999999999,
+      "kind": "normal",
+      "roughness": 0.3,
+      "clearcoat": 0.45
+    },
+    "mat-12": {
+      "hue": 0.11,
+      "sat": 0.78,
+      "value": 0.95,
+      "metal": 0,
+      "glow": 0.1,
+      "kind": "normal",
+      "roughness": 0.22,
+      "clearcoat": 0.6
+    },
+    "mat-13": {
+      "hue": 0.62,
+      "sat": 0.25,
+      "value": 0.14,
+      "kind": "normal",
+      "roughness": 0.5,
+      "clearcoat": 0.35
+    },
+    "mat-14": {
+      "hue": 0.64,
+      "sat": 0.76,
+      "value": 0.6,
+      "kind": "normal",
+      "roughness": 0.3,
+      "clearcoat": 0.45
+    },
+    "mat-15": {
+      "hue": 0.995,
+      "sat": 0.85,
+      "value": 0.78,
+      "glow": 0.24,
+      "kind": "normal",
+      "roughness": 0.3,
+      "clearcoat": 0.5
+    },
+    "mat-16": {
+      "hue": 0.62875,
+      "sat": 0.76,
+      "value": 0.5875,
+      "kind": "normal",
+      "roughness": 0.55,
+      "clearcoat": 0.2
+    },
+    "mat-17": {
+      "hue": 0.6175,
+      "sat": 0.74,
+      "value": 0.625,
+      "kind": "normal",
+      "roughness": 0.55,
+      "clearcoat": 0.2
+    },
+    "mat-18": {
+      "hue": 0.60625,
+      "sat": 0.72,
+      "value": 0.6625000000000001,
+      "kind": "normal",
+      "roughness": 0.55,
+      "clearcoat": 0.2
+    },
+    "mat-19": {
+      "hue": 0.58,
+      "sat": 0.25,
+      "value": 0.55,
+      "glow": 0.08,
+      "kind": "normal",
+      "roughness": 0.6,
+      "clearcoat": 0.15
+    },
+    "mat-20": {
+      "hue": 0.62,
+      "sat": 0.2,
+      "value": 0.18,
+      "kind": "normal",
+      "roughness": 0.5
+    },
+    "mat-21": {
+      "hue": 0.55,
+      "sat": 0.62,
+      "value": 0.85,
+      "kind": "normal",
+      "roughness": 0.3,
+      "clearcoat": 0.45
+    },
+    "mat-22": {
+      "hue": 0.6100000000000001,
+      "sat": 0.7266666666666667,
+      "value": 0.65,
+      "kind": "normal",
+      "roughness": 0.3,
+      "clearcoat": 0.45
+    },
+    "mat-23": {
+      "hue": 0.64,
+      "sat": 0.78,
+      "value": 0.55,
+      "kind": "normal",
+      "roughness": 0.3,
+      "clearcoat": 0.45
+    },
+    "mat-24": {
+      "hue": 0.5650000000000001,
+      "sat": 0.6433333333333333,
+      "value": 0.7833333333333333,
+      "kind": "normal",
+      "roughness": 0.3,
+      "clearcoat": 0.45
+    },
+    "mat-25": {
+      "hue": 0.5800000000000001,
+      "sat": 0.6666666666666666,
+      "value": 0.7466666666666666,
+      "kind": "normal",
+      "roughness": 0.3,
+      "clearcoat": 0.45
+    },
+    "mat-26": {
+      "hue": 0.5950000000000001,
+      "sat": 0.69,
+      "value": 0.71,
+      "kind": "normal",
+      "roughness": 0.3,
+      "clearcoat": 0.45
+    },
+    "mat-27": {
+      "hue": 0.6100000000000001,
+      "sat": 0.7133333333333334,
+      "value": 0.6733333333333333,
+      "kind": "normal",
+      "roughness": 0.3,
+      "clearcoat": 0.45
+    },
+    "mat-28": {
+      "hue": 0.625,
+      "sat": 0.7366666666666667,
+      "value": 0.6366666666666666,
+      "kind": "normal",
+      "roughness": 0.3,
+      "clearcoat": 0.45
+    },
+    "mat-29": {
+      "hue": 0.11,
+      "sat": 0.78,
+      "value": 0.95,
+      "metal": 0,
+      "glow": 0.04,
+      "kind": "normal",
+      "roughness": 0.22,
+      "clearcoat": 0.6
+    },
+    "mat-30": {
+      "hue": 0.5950000000000001,
+      "sat": 0.7,
+      "value": 0.71,
+      "kind": "normal",
+      "roughness": 0.3,
+      "clearcoat": 0.45
+    },
+    "mat-31": {
+      "hue": 0.64,
+      "sat": 0.78,
+      "value": 0.57,
+      "kind": "normal",
+      "roughness": 0.3,
+      "clearcoat": 0.45
+    },
+    "mat-32": {
+      "hue": 0.62,
+      "sat": 0.3,
+      "value": 0.22,
+      "kind": "normal",
+      "roughness": 0.4,
+      "clearcoat": 0.3
+    },
+    "mat-33": {
+      "hue": 0.6,
+      "sat": 0.1,
+      "value": 0.3,
+      "kind": "normal",
+      "roughness": 0.7,
+      "clearcoat": 0.1
+    },
+    "mat-34": {
+      "hue": 0.57,
+      "sat": 0.55,
+      "value": 0.72,
+      "kind": "normal",
+      "roughness": 0.3,
+      "clearcoat": 0.45
+    },
+    "mat-35": {
+      "hue": 0.62,
+      "sat": 0.28,
+      "value": 0.32,
+      "metal": 0,
+      "glow": 0,
+      "kind": "normal",
+      "roughness": 0.85
+    },
+    "mat-36": {
+      "hue": 0.62,
+      "sat": 0.25,
+      "value": 0.14,
+      "metal": 0,
+      "glow": 0,
+      "kind": "normal",
+      "roughness": 0.5,
+      "clearcoat": 0.35
+    }
+  },
   "subjects": [
     {
       "id": "s0-mono-title",
@@ -12,14 +440,8 @@
       "transform": {
         "translate": [0, 2.7, -1.4]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.1,
-        "kind": "normal",
-        "roughness": 0.48,
-        "clearcoat": 0.45
-      }
+      "material": "mat-0",
+      "collection": "station-0"
     },
     {
       "id": "s0-forest-0-l0",
@@ -32,14 +454,8 @@
         "translate": [-3.4, 4, -6],
         "rotate": [0, -0.12, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.1,
-        "kind": "normal",
-        "roughness": 0.48,
-        "clearcoat": 0.45
-      }
+      "material": "mat-0",
+      "collection": "station-0"
     },
     {
       "id": "s0-forest-0-l1",
@@ -52,14 +468,8 @@
         "translate": [-6.4, 4, -8.2],
         "rotate": [0, -0.2, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.1,
-        "kind": "normal",
-        "roughness": 0.48,
-        "clearcoat": 0.45
-      }
+      "material": "mat-0",
+      "collection": "station-0"
     },
     {
       "id": "s0-forest-0-r0",
@@ -72,14 +482,8 @@
         "translate": [3.4, 4, -6],
         "rotate": [0, 0.12, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.1,
-        "kind": "normal",
-        "roughness": 0.48,
-        "clearcoat": 0.45
-      }
+      "material": "mat-0",
+      "collection": "station-0"
     },
     {
       "id": "s0-forest-0-r1",
@@ -92,14 +496,8 @@
         "translate": [6.4, 4, -8.2],
         "rotate": [0, 0.2, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.1,
-        "kind": "normal",
-        "roughness": 0.48,
-        "clearcoat": 0.45
-      }
+      "material": "mat-0",
+      "collection": "station-0"
     },
     {
       "id": "s0-forest-1-l0",
@@ -112,14 +510,8 @@
         "translate": [-4.5, 5.75, -12.5],
         "rotate": [0, -0.12, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.1,
-        "kind": "normal",
-        "roughness": 0.48,
-        "clearcoat": 0.45
-      }
+      "material": "mat-0",
+      "collection": "station-0"
     },
     {
       "id": "s0-forest-1-l1",
@@ -132,14 +524,8 @@
         "translate": [-7.5, 5.75, -14.7],
         "rotate": [0, -0.2, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.1,
-        "kind": "normal",
-        "roughness": 0.48,
-        "clearcoat": 0.45
-      }
+      "material": "mat-0",
+      "collection": "station-0"
     },
     {
       "id": "s0-forest-1-r0",
@@ -152,14 +538,8 @@
         "translate": [4.5, 5.75, -12.5],
         "rotate": [0, 0.12, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.1,
-        "kind": "normal",
-        "roughness": 0.48,
-        "clearcoat": 0.45
-      }
+      "material": "mat-0",
+      "collection": "station-0"
     },
     {
       "id": "s0-forest-1-r1",
@@ -172,14 +552,8 @@
         "translate": [7.5, 5.75, -14.7],
         "rotate": [0, 0.2, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.1,
-        "kind": "normal",
-        "roughness": 0.48,
-        "clearcoat": 0.45
-      }
+      "material": "mat-0",
+      "collection": "station-0"
     },
     {
       "id": "s0-forest-2-l0",
@@ -192,14 +566,8 @@
         "translate": [-5.6, 7.5, -19],
         "rotate": [0, -0.12, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.1,
-        "kind": "normal",
-        "roughness": 0.48,
-        "clearcoat": 0.45
-      }
+      "material": "mat-0",
+      "collection": "station-0"
     },
     {
       "id": "s0-forest-2-l1",
@@ -212,14 +580,8 @@
         "translate": [-8.600000000000001, 7.5, -21.2],
         "rotate": [0, -0.2, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.1,
-        "kind": "normal",
-        "roughness": 0.48,
-        "clearcoat": 0.45
-      }
+      "material": "mat-0",
+      "collection": "station-0"
     },
     {
       "id": "s0-forest-2-r0",
@@ -232,14 +594,8 @@
         "translate": [5.6, 7.5, -19],
         "rotate": [0, 0.12, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.1,
-        "kind": "normal",
-        "roughness": 0.48,
-        "clearcoat": 0.45
-      }
+      "material": "mat-0",
+      "collection": "station-0"
     },
     {
       "id": "s0-forest-2-r1",
@@ -252,14 +608,8 @@
         "translate": [8.600000000000001, 7.5, -21.2],
         "rotate": [0, 0.2, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.1,
-        "kind": "normal",
-        "roughness": 0.48,
-        "clearcoat": 0.45
-      }
+      "material": "mat-0",
+      "collection": "station-0"
     },
     {
       "id": "s0-forest-3-l0",
@@ -272,14 +622,8 @@
         "translate": [-6.7, 9.25, -25.5],
         "rotate": [0, -0.12, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.1,
-        "kind": "normal",
-        "roughness": 0.48,
-        "clearcoat": 0.45
-      }
+      "material": "mat-0",
+      "collection": "station-0"
     },
     {
       "id": "s0-forest-3-l1",
@@ -292,14 +636,8 @@
         "translate": [-9.700000000000001, 9.25, -27.7],
         "rotate": [0, -0.2, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.1,
-        "kind": "normal",
-        "roughness": 0.48,
-        "clearcoat": 0.45
-      }
+      "material": "mat-0",
+      "collection": "station-0"
     },
     {
       "id": "s0-forest-3-r0",
@@ -312,14 +650,8 @@
         "translate": [6.7, 9.25, -25.5],
         "rotate": [0, 0.12, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.1,
-        "kind": "normal",
-        "roughness": 0.48,
-        "clearcoat": 0.45
-      }
+      "material": "mat-0",
+      "collection": "station-0"
     },
     {
       "id": "s0-forest-3-r1",
@@ -332,14 +664,8 @@
         "translate": [9.700000000000001, 9.25, -27.7],
         "rotate": [0, 0.2, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.1,
-        "kind": "normal",
-        "roughness": 0.48,
-        "clearcoat": 0.45
-      }
+      "material": "mat-0",
+      "collection": "station-0"
     },
     {
       "id": "s0-floater-0",
@@ -352,20 +678,14 @@
         "translate": [-6.5, 3.4, -6],
         "rotate": [0, -1, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.1,
-        "kind": "normal",
-        "roughness": 0.48,
-        "clearcoat": 0.45
-      },
+      "material": "mat-0",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "3.400 - 0.000 * smoothstep(0.00, 1.00, t) + 0.07 * sin(0.35 * t + 0.00)"
         }
-      ]
+      ],
+      "collection": "station-0"
     },
     {
       "id": "s0-floater-1",
@@ -378,20 +698,14 @@
         "translate": [4.8, 2.6, -7.5],
         "rotate": [0, -0.5, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.1,
-        "kind": "normal",
-        "roughness": 0.48,
-        "clearcoat": 0.45
-      },
+      "material": "mat-0",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "2.600 - 0.000 * smoothstep(0.00, 1.00, t) + 0.09 * sin(0.43 * t + 2.10)"
         }
-      ]
+      ],
+      "collection": "station-0"
     },
     {
       "id": "s0-floater-2",
@@ -404,20 +718,14 @@
         "translate": [-3.2, 4.6, -9],
         "rotate": [0, 0, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.1,
-        "kind": "normal",
-        "roughness": 0.48,
-        "clearcoat": 0.45
-      },
+      "material": "mat-0",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "4.600 - 0.000 * smoothstep(0.00, 1.00, t) + 0.11 * sin(0.51 * t + 4.20)"
         }
-      ]
+      ],
+      "collection": "station-0"
     },
     {
       "id": "s0-floater-3",
@@ -430,20 +738,14 @@
         "translate": [7.2, 4, -5],
         "rotate": [0, 0.5, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.1,
-        "kind": "normal",
-        "roughness": 0.48,
-        "clearcoat": 0.45
-      },
+      "material": "mat-0",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "4.000 - 0.000 * smoothstep(0.00, 1.00, t) + 0.13 * sin(0.59 * t + 0.02)"
         }
-      ]
+      ],
+      "collection": "station-0"
     },
     {
       "id": "s0-floater-4",
@@ -456,20 +758,14 @@
         "translate": [-9.5, 5.8, -12],
         "rotate": [0, 1, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.1,
-        "kind": "normal",
-        "roughness": 0.48,
-        "clearcoat": 0.45
-      },
+      "material": "mat-0",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "5.800 - 0.000 * smoothstep(0.00, 1.00, t) + 0.15 * sin(0.67 * t + 2.12)"
         }
-      ]
+      ],
+      "collection": "station-0"
     },
     {
       "id": "s0-floater-5",
@@ -482,20 +778,14 @@
         "translate": [10.5, 5.2, -10],
         "rotate": [0, 1.5, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.1,
-        "kind": "normal",
-        "roughness": 0.48,
-        "clearcoat": 0.45
-      },
+      "material": "mat-0",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "5.200 - 0.000 * smoothstep(0.00, 1.00, t) + 0.17 * sin(0.75 * t + 4.22)"
         }
-      ]
+      ],
+      "collection": "station-0"
     },
     {
       "id": "s0-floater-6",
@@ -508,20 +798,14 @@
         "translate": [2.2, 7, -14],
         "rotate": [0, 2, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.1,
-        "kind": "normal",
-        "roughness": 0.48,
-        "clearcoat": 0.45
-      },
+      "material": "mat-0",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "7.000 - 0.000 * smoothstep(0.00, 1.00, t) + 0.19 * sin(0.83 * t + 0.04)"
         }
-      ]
+      ],
+      "collection": "station-0"
     },
     {
       "id": "s0-floater-7",
@@ -534,20 +818,14 @@
         "translate": [-5.8, 6.4, -16],
         "rotate": [0, 2.5, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.1,
-        "kind": "normal",
-        "roughness": 0.48,
-        "clearcoat": 0.45
-      },
+      "material": "mat-0",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "6.400 - 0.000 * smoothstep(0.00, 1.00, t) + 0.21 * sin(0.91 * t + 2.14)"
         }
-      ]
+      ],
+      "collection": "station-0"
     },
     {
       "id": "s0-floater-8",
@@ -560,20 +838,14 @@
         "translate": [6.8, 2, -13],
         "rotate": [0, 3, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.1,
-        "kind": "normal",
-        "roughness": 0.48,
-        "clearcoat": 0.45
-      },
+      "material": "mat-0",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "2.000 - 0.000 * smoothstep(0.00, 1.00, t) + 0.23 * sin(0.99 * t + 4.24)"
         }
-      ]
+      ],
+      "collection": "station-0"
     },
     {
       "id": "path-0-1",
@@ -585,15 +857,8 @@
         "translate": [0.8950805849013479, 0.03, 4.884296673803914],
         "rotate": [0, -1.3895505967801007, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-0"
     },
     {
       "id": "path-0-2",
@@ -605,15 +870,8 @@
         "translate": [1.7901611698026958, 0.03, 9.768593347607828],
         "rotate": [0, -1.3895505967801007, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-0"
     },
     {
       "id": "path-0-3",
@@ -625,15 +883,8 @@
         "translate": [2.6852417547040437, 0.03, 14.652890021411743],
         "rotate": [0, -1.3895505967801007, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-0"
     },
     {
       "id": "path-0-4",
@@ -645,15 +896,8 @@
         "translate": [3.5803223396053916, 0.03, 19.537186695215656],
         "rotate": [0, -1.3895505967801007, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-0"
     },
     {
       "id": "path-0-5",
@@ -665,15 +909,8 @@
         "translate": [4.4754029245067395, 0.03, 24.42148336901957],
         "rotate": [0, -1.3895505967801007, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-0"
     },
     {
       "id": "path-0-6",
@@ -685,15 +922,8 @@
         "translate": [5.370483509408087, 0.03, 29.305780042823486],
         "rotate": [0, -1.3895505967801007, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-0"
     },
     {
       "id": "path-0-7",
@@ -705,15 +935,8 @@
         "translate": [6.265564094309435, 0.03, 34.190076716627395],
         "rotate": [0, -1.3895505967801007, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-0"
     },
     {
       "id": "s1-dome",
@@ -724,14 +947,8 @@
       "transform": {
         "translate": [7.160644679210783, 0, 37.87437339043131]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.1,
-        "kind": "normal",
-        "roughness": 0.4,
-        "clearcoat": 0.45
-      }
+      "material": "mat-2",
+      "collection": "station-1"
     },
     {
       "id": "s1-orb-0",
@@ -742,21 +959,14 @@
       "transform": {
         "translate": [10.648546422935995, 2.2, 38.52090933556559]
       },
-      "material": {
-        "hue": 0.995,
-        "sat": 0.85,
-        "value": 0.78,
-        "glow": 0.12,
-        "kind": "normal",
-        "roughness": 0.3,
-        "clearcoat": 0.5
-      },
+      "material": "mat-3",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "3.800 - 1.600 * smoothstep(11.65, 12.20, t) + 0.04 * sin(0.6 * t + -5.88)"
         }
-      ]
+      ],
+      "collection": "station-1"
     },
     {
       "id": "s1-orb-stem-0",
@@ -768,14 +978,8 @@
       "transform": {
         "translate": [10.648546422935995, 1.1, 38.52090933556559]
       },
-      "material": {
-        "hue": 0.995,
-        "sat": 0.15,
-        "value": 0.8,
-        "glow": 0.5,
-        "kind": "normal",
-        "roughness": 0.4
-      }
+      "material": "mat-4",
+      "collection": "station-1"
     },
     {
       "id": "s1-orb-1",
@@ -786,21 +990,14 @@
       "transform": {
         "translate": [9.510739130150348, 2.2, 38.88225981580357]
       },
-      "material": {
-        "hue": 0.11,
-        "sat": 0.78,
-        "value": 0.95,
-        "glow": 0.1,
-        "kind": "normal",
-        "roughness": 0.22,
-        "clearcoat": 0.6
-      },
+      "material": "mat-5",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "3.800 - 1.600 * smoothstep(12.65, 13.20, t) + 0.04 * sin(0.6 * t + -4.18)"
         }
-      ]
+      ],
+      "collection": "station-1"
     },
     {
       "id": "s1-orb-stem-1",
@@ -812,14 +1009,8 @@
       "transform": {
         "translate": [9.510739130150348, 1.1, 38.88225981580357]
       },
-      "material": {
-        "hue": 0.995,
-        "sat": 0.15,
-        "value": 0.8,
-        "glow": 0.5,
-        "kind": "normal",
-        "roughness": 0.4
-      }
+      "material": "mat-4",
+      "collection": "station-1"
     },
     {
       "id": "s1-orb-2",
@@ -830,21 +1021,14 @@
       "transform": {
         "translate": [7.989111567781136, 2.2, 39.079001065403475]
       },
-      "material": {
-        "hue": 0.995,
-        "sat": 0.85,
-        "value": 0.78,
-        "glow": 0.12,
-        "kind": "normal",
-        "roughness": 0.3,
-        "clearcoat": 0.5
-      },
+      "material": "mat-3",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "3.800 - 1.600 * smoothstep(13.65, 14.20, t) + 0.04 * sin(0.6 * t + -2.48)"
         }
-      ]
+      ],
+      "collection": "station-1"
     },
     {
       "id": "s1-orb-stem-2",
@@ -856,14 +1040,8 @@
       "transform": {
         "translate": [7.989111567781136, 1.1, 39.079001065403475]
       },
-      "material": {
-        "hue": 0.995,
-        "sat": 0.15,
-        "value": 0.8,
-        "glow": 0.5,
-        "kind": "normal",
-        "roughness": 0.4
-      }
+      "material": "mat-4",
+      "collection": "station-1"
     },
     {
       "id": "s1-orb-3",
@@ -874,21 +1052,14 @@
       "transform": {
         "translate": [6.332177790640431, 2.2, 39.079001065403475]
       },
-      "material": {
-        "hue": 0.995,
-        "sat": 0.85,
-        "value": 0.78,
-        "glow": 0.12,
-        "kind": "normal",
-        "roughness": 0.3,
-        "clearcoat": 0.5
-      },
+      "material": "mat-3",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "3.800 - 1.600 * smoothstep(14.65, 15.20, t) + 0.04 * sin(0.6 * t + -0.78)"
         }
-      ]
+      ],
+      "collection": "station-1"
     },
     {
       "id": "s1-orb-stem-3",
@@ -900,14 +1071,8 @@
       "transform": {
         "translate": [6.332177790640431, 1.1, 39.079001065403475]
       },
-      "material": {
-        "hue": 0.995,
-        "sat": 0.15,
-        "value": 0.8,
-        "glow": 0.5,
-        "kind": "normal",
-        "roughness": 0.4
-      }
+      "material": "mat-4",
+      "collection": "station-1"
     },
     {
       "id": "s1-orb-4",
@@ -918,21 +1083,14 @@
       "transform": {
         "translate": [4.81055022827122, 2.2, 38.88225981580357]
       },
-      "material": {
-        "hue": 0.995,
-        "sat": 0.85,
-        "value": 0.78,
-        "glow": 0.12,
-        "kind": "normal",
-        "roughness": 0.3,
-        "clearcoat": 0.5
-      },
+      "material": "mat-3",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "3.800 - 1.600 * smoothstep(15.65, 16.20, t) + 0.04 * sin(0.6 * t + -5.36)"
         }
-      ]
+      ],
+      "collection": "station-1"
     },
     {
       "id": "s1-orb-stem-4",
@@ -944,14 +1102,8 @@
       "transform": {
         "translate": [4.81055022827122, 1.1, 38.88225981580357]
       },
-      "material": {
-        "hue": 0.995,
-        "sat": 0.15,
-        "value": 0.8,
-        "glow": 0.5,
-        "kind": "normal",
-        "roughness": 0.4
-      }
+      "material": "mat-4",
+      "collection": "station-1"
     },
     {
       "id": "s1-orb-5",
@@ -962,21 +1114,14 @@
       "transform": {
         "translate": [3.672742935485571, 2.2, 38.52090933556559]
       },
-      "material": {
-        "hue": 0.995,
-        "sat": 0.85,
-        "value": 0.78,
-        "glow": 0.12,
-        "kind": "normal",
-        "roughness": 0.3,
-        "clearcoat": 0.5
-      },
+      "material": "mat-3",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "3.800 - 1.600 * smoothstep(16.65, 17.20, t) + 0.04 * sin(0.6 * t + -3.66)"
         }
-      ]
+      ],
+      "collection": "station-1"
     },
     {
       "id": "s1-orb-stem-5",
@@ -988,14 +1133,8 @@
       "transform": {
         "translate": [3.672742935485571, 1.1, 38.52090933556559]
       },
-      "material": {
-        "hue": 0.995,
-        "sat": 0.15,
-        "value": 0.8,
-        "glow": 0.5,
-        "kind": "normal",
-        "roughness": 0.4
-      }
+      "material": "mat-4",
+      "collection": "station-1"
     },
     {
       "id": "path-1-1",
@@ -1007,15 +1146,8 @@
         "translate": [10.294569658420123, 0.03, 37.09259931181325],
         "rotate": [0, 0.5638756044904756, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-1"
     },
     {
       "id": "path-1-2",
@@ -1027,15 +1159,8 @@
         "translate": [13.428494637629464, 0.03, 35.11082523319519],
         "rotate": [0, 0.5638756044904756, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-1"
     },
     {
       "id": "path-1-3",
@@ -1047,15 +1172,8 @@
         "translate": [16.562419616838806, 0.03, 33.12905115457714],
         "rotate": [0, 0.5638756044904756, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-1"
     },
     {
       "id": "path-1-4",
@@ -1067,15 +1185,8 @@
         "translate": [19.696344596048146, 0.03, 31.14727707595908],
         "rotate": [0, 0.5638756044904756, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-1"
     },
     {
       "id": "path-1-5",
@@ -1087,15 +1198,8 @@
         "translate": [22.830269575257486, 0.03, 29.165502997341022],
         "rotate": [0, 0.5638756044904756, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-1"
     },
     {
       "id": "path-1-6",
@@ -1107,15 +1211,8 @@
         "translate": [25.96419455446683, 0.03, 27.183728918722963],
         "rotate": [0, 0.5638756044904756, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-1"
     },
     {
       "id": "path-1-7",
@@ -1127,15 +1224,8 @@
         "translate": [29.09811953367617, 0.03, 25.201954840104904],
         "rotate": [0, 0.5638756044904756, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-1"
     },
     {
       "id": "s2-plinth-0",
@@ -1146,14 +1236,8 @@
       "transform": {
         "translate": [35.407044512885506, 0.06, 23.220180761486848]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.1,
-        "value": 0.55,
-        "kind": "normal",
-        "roughness": 0.6,
-        "clearcoat": 0.1
-      }
+      "material": "mat-6",
+      "collection": "station-2"
     },
     {
       "id": "s2-mono-0",
@@ -1165,21 +1249,15 @@
       "transform": {
         "translate": [35.407044512885506, 0.9931034482758622, 23.220180761486848]
       },
-      "material": {
-        "hue": 0.55,
-        "sat": 0.62,
-        "value": 0.82,
-        "kind": "normal",
-        "roughness": 0.3,
-        "clearcoat": 0.45
-      },
+      "material": "mat-7",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "-1.293 + 2.286 * smoothstep(24.75, 25.35, t)"
         }
       ],
-      "pattern": "cracked"
+      "pattern": "cracked",
+      "collection": "station-2"
     },
     {
       "id": "s2-plinth-1",
@@ -1190,14 +1268,8 @@
       "transform": {
         "translate": [34.13704451288551, 0.06, 23.220180761486848]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.1,
-        "value": 0.55,
-        "kind": "normal",
-        "roughness": 0.6,
-        "clearcoat": 0.1
-      }
+      "material": "mat-6",
+      "collection": "station-2"
     },
     {
       "id": "s2-mono-1",
@@ -1209,21 +1281,15 @@
       "transform": {
         "translate": [34.13704451288551, 1.2413793103448276, 23.220180761486848]
       },
-      "material": {
-        "hue": 0.5680000000000001,
-        "sat": 0.648,
-        "value": 0.7759999999999999,
-        "kind": "normal",
-        "roughness": 0.3,
-        "clearcoat": 0.45
-      },
+      "material": "mat-8",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "-1.541 + 2.783 * smoothstep(25.85, 26.45, t)"
         }
       ],
-      "pattern": "cracked"
+      "pattern": "cracked",
+      "collection": "station-2"
     },
     {
       "id": "s2-plinth-2",
@@ -1234,14 +1300,8 @@
       "transform": {
         "translate": [32.867044512885506, 0.06, 23.220180761486848]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.1,
-        "value": 0.55,
-        "kind": "normal",
-        "roughness": 0.6,
-        "clearcoat": 0.1
-      }
+      "material": "mat-6",
+      "collection": "station-2"
     },
     {
       "id": "s2-mono-2",
@@ -1253,21 +1313,15 @@
       "transform": {
         "translate": [32.867044512885506, 1.6, 23.220180761486848]
       },
-      "material": {
-        "hue": 0.5860000000000001,
-        "sat": 0.676,
-        "value": 0.732,
-        "kind": "normal",
-        "roughness": 0.3,
-        "clearcoat": 0.45
-      },
+      "material": "mat-9",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "-1.900 + 3.500 * smoothstep(26.95, 27.55, t)"
         }
       ],
-      "pattern": "cracked"
+      "pattern": "cracked",
+      "collection": "station-2"
     },
     {
       "id": "s2-plinth-3",
@@ -1278,14 +1332,8 @@
       "transform": {
         "translate": [31.597044512885507, 0.06, 23.220180761486848]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.1,
-        "value": 0.55,
-        "kind": "normal",
-        "roughness": 0.6,
-        "clearcoat": 0.1
-      }
+      "material": "mat-6",
+      "collection": "station-2"
     },
     {
       "id": "s2-mono-3",
@@ -1297,21 +1345,15 @@
       "transform": {
         "translate": [31.597044512885507, 1.9034482758620692, 23.220180761486848]
       },
-      "material": {
-        "hue": 0.6040000000000001,
-        "sat": 0.704,
-        "value": 0.688,
-        "kind": "normal",
-        "roughness": 0.3,
-        "clearcoat": 0.45
-      },
+      "material": "mat-10",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "-2.203 + 4.107 * smoothstep(28.05, 28.65, t)"
         }
       ],
-      "pattern": "cracked"
+      "pattern": "cracked",
+      "collection": "station-2"
     },
     {
       "id": "s2-plinth-4",
@@ -1322,14 +1364,8 @@
       "transform": {
         "translate": [30.327044512885507, 0.06, 23.220180761486848]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.1,
-        "value": 0.55,
-        "kind": "normal",
-        "roughness": 0.6,
-        "clearcoat": 0.1
-      }
+      "material": "mat-6",
+      "collection": "station-2"
     },
     {
       "id": "s2-mono-4",
@@ -1341,21 +1377,15 @@
       "transform": {
         "translate": [30.327044512885507, 2.1517241379310343, 23.220180761486848]
       },
-      "material": {
-        "hue": 0.622,
-        "sat": 0.732,
-        "value": 0.6439999999999999,
-        "kind": "normal",
-        "roughness": 0.3,
-        "clearcoat": 0.45
-      },
+      "material": "mat-11",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "-2.452 + 4.603 * smoothstep(29.15, 29.75, t)"
         }
       ],
-      "pattern": "cracked"
+      "pattern": "cracked",
+      "collection": "station-2"
     },
     {
       "id": "s2-plinth-5",
@@ -1366,14 +1396,8 @@
       "transform": {
         "translate": [29.057044512885508, 0.06, 23.220180761486848]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.1,
-        "value": 0.55,
-        "kind": "normal",
-        "roughness": 0.6,
-        "clearcoat": 0.1
-      }
+      "material": "mat-6",
+      "collection": "station-2"
     },
     {
       "id": "s2-mono-5",
@@ -1385,22 +1409,14 @@
       "transform": {
         "translate": [29.057044512885508, 2.4, 23.220180761486848]
       },
-      "material": {
-        "hue": 0.11,
-        "sat": 0.78,
-        "value": 0.95,
-        "metal": 0,
-        "glow": 0.1,
-        "kind": "normal",
-        "roughness": 0.22,
-        "clearcoat": 0.6
-      },
+      "material": "mat-12",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "-2.700 + 5.100 * smoothstep(30.25, 30.85, t)"
         }
-      ]
+      ],
+      "collection": "station-2"
     },
     {
       "id": "s2-guard-l-0",
@@ -1412,14 +1428,8 @@
         "translate": [24.09704451288551, 1.1, 24.420180761486847],
         "rotate": [0, -0.3, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-13",
+      "collection": "station-2"
     },
     {
       "id": "s2-guard-r-0",
@@ -1431,14 +1441,8 @@
         "translate": [40.367044512885506, 1.1, 24.420180761486847],
         "rotate": [0, 0.3, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-13",
+      "collection": "station-2"
     },
     {
       "id": "s2-guard-l-1",
@@ -1450,14 +1454,8 @@
         "translate": [24.69704451288551, 1.75, 18.62018076148685],
         "rotate": [0, -0.3, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-13",
+      "collection": "station-2"
     },
     {
       "id": "s2-guard-r-1",
@@ -1469,14 +1467,8 @@
         "translate": [39.767044512885505, 1.75, 18.62018076148685],
         "rotate": [0, 0.3, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-13",
+      "collection": "station-2"
     },
     {
       "id": "s2-guard-l-2",
@@ -1488,14 +1480,8 @@
         "translate": [23.297044512885506, 2.4000000000000004, 16.420180761486847],
         "rotate": [0, -0.3, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-13",
+      "collection": "station-2"
     },
     {
       "id": "s2-guard-r-2",
@@ -1507,14 +1493,8 @@
         "translate": [41.16704451288551, 2.4000000000000004, 16.420180761486847],
         "rotate": [0, 0.3, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-13",
+      "collection": "station-2"
     },
     {
       "id": "path-2-1",
@@ -1526,15 +1506,8 @@
         "translate": [33.047333187820946, 0.03, 21.408683636555395],
         "rotate": [0, 1.1478896234270402, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-2"
     },
     {
       "id": "path-2-2",
@@ -1546,15 +1519,8 @@
         "translate": [33.862621862756384, 0.03, 19.597186511623946],
         "rotate": [0, 1.1478896234270402, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-2"
     },
     {
       "id": "path-2-3",
@@ -1566,15 +1532,8 @@
         "translate": [34.677910537691815, 0.03, 17.785689386692493],
         "rotate": [0, 1.1478896234270402, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-2"
     },
     {
       "id": "path-2-4",
@@ -1586,15 +1545,8 @@
         "translate": [35.49319921262725, 0.03, 15.97419226176104],
         "rotate": [0, 1.1478896234270402, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-2"
     },
     {
       "id": "path-2-5",
@@ -1606,15 +1558,8 @@
         "translate": [36.30848788756269, 0.03, 14.162695136829587],
         "rotate": [0, 1.1478896234270402, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-2"
     },
     {
       "id": "path-2-6",
@@ -1626,15 +1571,8 @@
         "translate": [37.12377656249812, 0.03, 12.351198011898136],
         "rotate": [0, 1.1478896234270402, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-2"
     },
     {
       "id": "path-2-7",
@@ -1646,15 +1584,8 @@
         "translate": [37.93906523743356, 0.03, 10.539700886966685],
         "rotate": [0, 1.1478896234270402, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-2"
     },
     {
       "id": "s3-plinth-0",
@@ -1665,14 +1596,8 @@
       "transform": {
         "translate": [41.929353912368995, 0.06, 8.728203762035232]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.1,
-        "value": 0.55,
-        "kind": "normal",
-        "roughness": 0.6,
-        "clearcoat": 0.1
-      }
+      "material": "mat-6",
+      "collection": "station-3"
     },
     {
       "id": "s3-mono-0",
@@ -1684,21 +1609,15 @@
       "transform": {
         "translate": [41.929353912368995, 0.14464710547184773, 8.728203762035232]
       },
-      "material": {
-        "hue": 0.55,
-        "sat": 0.62,
-        "value": 0.82,
-        "kind": "normal",
-        "roughness": 0.3,
-        "clearcoat": 0.45
-      },
+      "material": "mat-7",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "-0.445 + 0.589 * smoothstep(38.05, 38.65, t)"
         }
       ],
-      "pattern": "cracked"
+      "pattern": "cracked",
+      "collection": "station-3"
     },
     {
       "id": "s3-plinth-1",
@@ -1709,14 +1628,8 @@
       "transform": {
         "translate": [40.659353912369, 0.06, 8.728203762035232]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.1,
-        "value": 0.55,
-        "kind": "normal",
-        "roughness": 0.6,
-        "clearcoat": 0.1
-      }
+      "material": "mat-6",
+      "collection": "station-3"
     },
     {
       "id": "s3-mono-1",
@@ -1728,21 +1641,15 @@
       "transform": {
         "translate": [40.659353912369, 0.28263283108643933, 8.728203762035232]
       },
-      "material": {
-        "hue": 0.5680000000000001,
-        "sat": 0.648,
-        "value": 0.7759999999999999,
-        "kind": "normal",
-        "roughness": 0.3,
-        "clearcoat": 0.45
-      },
+      "material": "mat-8",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "-0.583 + 0.865 * smoothstep(39.15, 39.75, t)"
         }
       ],
-      "pattern": "cracked"
+      "pattern": "cracked",
+      "collection": "station-3"
     },
     {
       "id": "s3-plinth-2",
@@ -1753,14 +1660,8 @@
       "transform": {
         "translate": [39.389353912368996, 0.06, 8.728203762035232]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.1,
-        "value": 0.55,
-        "kind": "normal",
-        "roughness": 0.6,
-        "clearcoat": 0.1
-      }
+      "material": "mat-6",
+      "collection": "station-3"
     },
     {
       "id": "s3-mono-2",
@@ -1772,21 +1673,15 @@
       "transform": {
         "translate": [39.389353912368996, 0.5443298969072166, 8.728203762035232]
       },
-      "material": {
-        "hue": 0.5860000000000001,
-        "sat": 0.676,
-        "value": 0.732,
-        "kind": "normal",
-        "roughness": 0.3,
-        "clearcoat": 0.45
-      },
+      "material": "mat-9",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "-0.844 + 1.389 * smoothstep(40.25, 40.85, t)"
         }
       ],
-      "pattern": "cracked"
+      "pattern": "cracked",
+      "collection": "station-3"
     },
     {
       "id": "s3-plinth-3",
@@ -1797,14 +1692,8 @@
       "transform": {
         "translate": [38.119353912369, 0.06, 8.728203762035232]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.1,
-        "value": 0.55,
-        "kind": "normal",
-        "roughness": 0.6,
-        "clearcoat": 0.1
-      }
+      "material": "mat-6",
+      "collection": "station-3"
     },
     {
       "id": "s3-mono-3",
@@ -1816,21 +1705,15 @@
       "transform": {
         "translate": [38.119353912369, 0.9601903251387788, 8.728203762035232]
       },
-      "material": {
-        "hue": 0.6040000000000001,
-        "sat": 0.704,
-        "value": 0.688,
-        "kind": "normal",
-        "roughness": 0.3,
-        "clearcoat": 0.45
-      },
+      "material": "mat-10",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "-1.260 + 2.220 * smoothstep(41.35, 41.95, t)"
         }
       ],
-      "pattern": "cracked"
+      "pattern": "cracked",
+      "collection": "station-3"
     },
     {
       "id": "s3-plinth-4",
@@ -1841,14 +1724,8 @@
       "transform": {
         "translate": [36.849353912369, 0.06, 8.728203762035232]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.1,
-        "value": 0.55,
-        "kind": "normal",
-        "roughness": 0.6,
-        "clearcoat": 0.1
-      }
+      "material": "mat-6",
+      "collection": "station-3"
     },
     {
       "id": "s3-mono-4",
@@ -1860,21 +1737,15 @@
       "transform": {
         "translate": [36.849353912369, 1.5501982553528946, 8.728203762035232]
       },
-      "material": {
-        "hue": 0.622,
-        "sat": 0.732,
-        "value": 0.6439999999999999,
-        "kind": "normal",
-        "roughness": 0.3,
-        "clearcoat": 0.45
-      },
+      "material": "mat-11",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "-1.850 + 3.400 * smoothstep(42.45, 43.05, t)"
         }
       ],
-      "pattern": "cracked"
+      "pattern": "cracked",
+      "collection": "station-3"
     },
     {
       "id": "s3-plinth-5",
@@ -1885,14 +1756,8 @@
       "transform": {
         "translate": [35.579353912369, 0.06, 8.728203762035232]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.1,
-        "value": 0.55,
-        "kind": "normal",
-        "roughness": 0.6,
-        "clearcoat": 0.1
-      }
+      "material": "mat-6",
+      "collection": "station-3"
     },
     {
       "id": "s3-mono-5",
@@ -1904,22 +1769,14 @@
       "transform": {
         "translate": [35.579353912369, 2.4, 8.728203762035232]
       },
-      "material": {
-        "hue": 0.11,
-        "sat": 0.78,
-        "value": 0.95,
-        "metal": 0,
-        "glow": 0.1,
-        "kind": "normal",
-        "roughness": 0.22,
-        "clearcoat": 0.6
-      },
+      "material": "mat-12",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "-2.700 + 5.100 * smoothstep(43.55, 44.15, t)"
         }
-      ]
+      ],
+      "collection": "station-3"
     },
     {
       "id": "s3-guard-l-0",
@@ -1931,14 +1788,8 @@
         "translate": [30.619353912369, 1.1, 9.928203762035231],
         "rotate": [0, -0.3, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-13",
+      "collection": "station-3"
     },
     {
       "id": "s3-guard-r-0",
@@ -1950,14 +1801,8 @@
         "translate": [46.889353912368996, 1.1, 9.928203762035231],
         "rotate": [0, 0.3, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-13",
+      "collection": "station-3"
     },
     {
       "id": "s3-guard-l-1",
@@ -1969,14 +1814,8 @@
         "translate": [31.219353912368998, 1.75, 4.128203762035232],
         "rotate": [0, -0.3, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-13",
+      "collection": "station-3"
     },
     {
       "id": "s3-guard-r-1",
@@ -1988,14 +1827,8 @@
         "translate": [46.289353912368995, 1.75, 4.128203762035232],
         "rotate": [0, 0.3, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-13",
+      "collection": "station-3"
     },
     {
       "id": "s3-guard-l-2",
@@ -2007,14 +1840,8 @@
         "translate": [29.819353912368996, 2.4000000000000004, 1.9282037620352313],
         "rotate": [0, -0.3, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-13",
+      "collection": "station-3"
     },
     {
       "id": "s3-guard-r-2",
@@ -2026,14 +1853,8 @@
         "translate": [47.689353912369, 2.4000000000000004, 1.9282037620352313],
         "rotate": [0, 0.3, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-13",
+      "collection": "station-3"
     },
     {
       "id": "path-3-1",
@@ -2045,15 +1866,8 @@
         "translate": [38.79435634712679, 0.03, 6.7420977068794805],
         "rotate": [0, 1.5506579123488082, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-3"
     },
     {
       "id": "path-3-2",
@@ -2065,15 +1879,8 @@
         "translate": [38.834358781884575, 0.03, 4.755991651723728],
         "rotate": [0, 1.5506579123488082, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-3"
     },
     {
       "id": "path-3-3",
@@ -2085,15 +1892,8 @@
         "translate": [38.87436121664236, 0.03, 2.769885596567976],
         "rotate": [0, 1.5506579123488082, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-3"
     },
     {
       "id": "path-3-4",
@@ -2105,15 +1905,8 @@
         "translate": [38.91436365140015, 0.03, 0.7837795414122244],
         "rotate": [0, 1.5506579123488082, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-3"
     },
     {
       "id": "path-3-5",
@@ -2125,15 +1918,8 @@
         "translate": [38.95436608615795, 0.03, -1.202326513743527],
         "rotate": [0, 1.5506579123488082, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-3"
     },
     {
       "id": "path-3-6",
@@ -2145,15 +1931,8 @@
         "translate": [38.994368520915735, 0.03, -3.1884325688992803],
         "rotate": [0, 1.5506579123488082, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-3"
     },
     {
       "id": "path-3-7",
@@ -2165,15 +1944,8 @@
         "translate": [39.03437095567352, 0.03, -5.174538624055032],
         "rotate": [0, 1.5506579123488082, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-3"
     },
     {
       "id": "s4-plinth-0",
@@ -2184,14 +1956,8 @@
       "transform": {
         "translate": [42.24937339043131, 0.06, -7.160644679210782]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.1,
-        "value": 0.55,
-        "kind": "normal",
-        "roughness": 0.6,
-        "clearcoat": 0.1
-      }
+      "material": "mat-6",
+      "collection": "station-4"
     },
     {
       "id": "s4-mono-0",
@@ -2203,22 +1969,14 @@
       "transform": {
         "translate": [42.24937339043131, 2.4, -7.160644679210782]
       },
-      "material": {
-        "hue": 0.11,
-        "sat": 0.78,
-        "value": 0.95,
-        "metal": 0,
-        "glow": 0.1,
-        "kind": "normal",
-        "roughness": 0.22,
-        "clearcoat": 0.6
-      },
+      "material": "mat-12",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "-2.700 + 5.100 * smoothstep(51.35, 51.95, t)"
         }
-      ]
+      ],
+      "collection": "station-4"
     },
     {
       "id": "s4-plinth-1",
@@ -2229,14 +1987,8 @@
       "transform": {
         "translate": [40.97937339043131, 0.06, -7.160644679210782]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.1,
-        "value": 0.55,
-        "kind": "normal",
-        "roughness": 0.6,
-        "clearcoat": 0.1
-      }
+      "material": "mat-6",
+      "collection": "station-4"
     },
     {
       "id": "s4-mono-1",
@@ -2248,21 +2000,15 @@
       "transform": {
         "translate": [40.97937339043131, 2.2374501992031868, -7.160644679210782]
       },
-      "material": {
-        "hue": 0.5680000000000001,
-        "sat": 0.648,
-        "value": 0.7759999999999999,
-        "kind": "normal",
-        "roughness": 0.3,
-        "clearcoat": 0.45
-      },
+      "material": "mat-8",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "-2.537 + 4.775 * smoothstep(52.45, 53.05, t)"
         }
       ],
-      "pattern": "cracked"
+      "pattern": "cracked",
+      "collection": "station-4"
     },
     {
       "id": "s4-plinth-2",
@@ -2273,14 +2019,8 @@
       "transform": {
         "translate": [39.70937339043131, 0.06, -7.160644679210782]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.1,
-        "value": 0.55,
-        "kind": "normal",
-        "roughness": 0.6,
-        "clearcoat": 0.1
-      }
+      "material": "mat-6",
+      "collection": "station-4"
     },
     {
       "id": "s4-mono-2",
@@ -2292,21 +2032,15 @@
       "transform": {
         "translate": [39.70937339043131, 1.4151394422310757, -7.160644679210782]
       },
-      "material": {
-        "hue": 0.5860000000000001,
-        "sat": 0.676,
-        "value": 0.732,
-        "kind": "normal",
-        "roughness": 0.3,
-        "clearcoat": 0.45
-      },
+      "material": "mat-9",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "-1.715 + 3.130 * smoothstep(53.55, 54.15, t)"
         }
       ],
-      "pattern": "cracked"
+      "pattern": "cracked",
+      "collection": "station-4"
     },
     {
       "id": "s4-plinth-3",
@@ -2317,14 +2051,8 @@
       "transform": {
         "translate": [38.439373390431314, 0.06, -7.160644679210782]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.1,
-        "value": 0.55,
-        "kind": "normal",
-        "roughness": 0.6,
-        "clearcoat": 0.1
-      }
+      "material": "mat-6",
+      "collection": "station-4"
     },
     {
       "id": "s4-mono-3",
@@ -2336,21 +2064,15 @@
       "transform": {
         "translate": [38.439373390431314, 1.2430278884462151, -7.160644679210782]
       },
-      "material": {
-        "hue": 0.6040000000000001,
-        "sat": 0.704,
-        "value": 0.688,
-        "kind": "normal",
-        "roughness": 0.3,
-        "clearcoat": 0.45
-      },
+      "material": "mat-10",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "-1.543 + 2.786 * smoothstep(54.65, 55.25, t)"
         }
       ],
-      "pattern": "cracked"
+      "pattern": "cracked",
+      "collection": "station-4"
     },
     {
       "id": "s4-plinth-4",
@@ -2361,14 +2083,8 @@
       "transform": {
         "translate": [37.16937339043131, 0.06, -7.160644679210782]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.1,
-        "value": 0.55,
-        "kind": "normal",
-        "roughness": 0.6,
-        "clearcoat": 0.1
-      }
+      "material": "mat-6",
+      "collection": "station-4"
     },
     {
       "id": "s4-mono-4",
@@ -2380,21 +2096,15 @@
       "transform": {
         "translate": [37.16937339043131, 0.7362549800796813, -7.160644679210782]
       },
-      "material": {
-        "hue": 0.622,
-        "sat": 0.732,
-        "value": 0.6439999999999999,
-        "kind": "normal",
-        "roughness": 0.3,
-        "clearcoat": 0.45
-      },
+      "material": "mat-11",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "-1.036 + 1.773 * smoothstep(55.75, 56.35, t)"
         }
       ],
-      "pattern": "cracked"
+      "pattern": "cracked",
+      "collection": "station-4"
     },
     {
       "id": "s4-plinth-5",
@@ -2405,14 +2115,8 @@
       "transform": {
         "translate": [35.899373390431315, 0.06, -7.160644679210782]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.1,
-        "value": 0.55,
-        "kind": "normal",
-        "roughness": 0.6,
-        "clearcoat": 0.1
-      }
+      "material": "mat-6",
+      "collection": "station-4"
     },
     {
       "id": "s4-mono-5",
@@ -2424,21 +2128,15 @@
       "transform": {
         "translate": [35.899373390431315, 0.6501992031872509, -7.160644679210782]
       },
-      "material": {
-        "hue": 0.64,
-        "sat": 0.76,
-        "value": 0.6,
-        "kind": "normal",
-        "roughness": 0.3,
-        "clearcoat": 0.45
-      },
+      "material": "mat-14",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "-0.950 + 1.600 * smoothstep(56.85, 57.45, t)"
         }
       ],
-      "pattern": "cracked"
+      "pattern": "cracked",
+      "collection": "station-4"
     },
     {
       "id": "s4-guard-l-0",
@@ -2450,14 +2148,8 @@
         "translate": [30.939373390431314, 1.1, -5.960644679210782],
         "rotate": [0, -0.3, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-13",
+      "collection": "station-4"
     },
     {
       "id": "s4-guard-r-0",
@@ -2469,14 +2161,8 @@
         "translate": [47.20937339043131, 1.1, -5.960644679210782],
         "rotate": [0, 0.3, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-13",
+      "collection": "station-4"
     },
     {
       "id": "s4-guard-l-1",
@@ -2488,14 +2174,8 @@
         "translate": [31.53937339043131, 1.75, -11.760644679210781],
         "rotate": [0, -0.3, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-13",
+      "collection": "station-4"
     },
     {
       "id": "s4-guard-r-1",
@@ -2507,14 +2187,8 @@
         "translate": [46.609373390431315, 1.75, -11.760644679210781],
         "rotate": [0, 0.3, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-13",
+      "collection": "station-4"
     },
     {
       "id": "s4-guard-l-2",
@@ -2526,14 +2200,8 @@
         "translate": [30.13937339043131, 2.4000000000000004, -13.960644679210784],
         "rotate": [0, -0.3, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-13",
+      "collection": "station-4"
     },
     {
       "id": "s4-guard-r-2",
@@ -2545,14 +2213,8 @@
         "translate": [48.009373390431314, 2.4000000000000004, -13.960644679210784],
         "rotate": [0, 0.3, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-13",
+      "collection": "station-4"
     },
     {
       "id": "path-4-1",
@@ -2564,15 +2226,8 @@
         "translate": [38.33268755084281, 0.03, -9.003501041618552],
         "rotate": [0, 1.9534262012705768, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-4"
     },
     {
       "id": "path-4-2",
@@ -2584,15 +2239,8 @@
         "translate": [37.591001711254314, 0.03, -10.846357404026321],
         "rotate": [0, 1.9534262012705768, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-4"
     },
     {
       "id": "path-4-3",
@@ -2604,15 +2252,8 @@
         "translate": [36.849315871665816, 0.03, -12.689213766434092],
         "rotate": [0, 1.9534262012705768, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-4"
     },
     {
       "id": "path-4-4",
@@ -2624,15 +2265,8 @@
         "translate": [36.107630032077324, 0.03, -14.532070128841863],
         "rotate": [0, 1.9534262012705768, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-4"
     },
     {
       "id": "path-4-5",
@@ -2644,15 +2278,8 @@
         "translate": [35.365944192488826, 0.03, -16.37492649124963],
         "rotate": [0, 1.9534262012705768, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-4"
     },
     {
       "id": "path-4-6",
@@ -2664,15 +2291,8 @@
         "translate": [34.62425835290033, 0.03, -18.2177828536574],
         "rotate": [0, 1.9534262012705768, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-4"
     },
     {
       "id": "path-4-7",
@@ -2684,15 +2304,8 @@
         "translate": [33.88257251331183, 0.03, -20.060639216065173],
         "rotate": [0, 1.9534262012705768, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-4"
     },
     {
       "id": "s5-plinth-0",
@@ -2703,14 +2316,8 @@
       "transform": {
         "translate": [36.31588667372333, 0.06, -21.903495578472942]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.1,
-        "value": 0.55,
-        "kind": "normal",
-        "roughness": 0.6,
-        "clearcoat": 0.1
-      }
+      "material": "mat-6",
+      "collection": "station-5"
     },
     {
       "id": "s5-mono-0",
@@ -2722,22 +2329,14 @@
       "transform": {
         "translate": [36.31588667372333, 2.4, -21.903495578472942]
       },
-      "material": {
-        "hue": 0.11,
-        "sat": 0.78,
-        "value": 0.95,
-        "metal": 0,
-        "glow": 0.1,
-        "kind": "normal",
-        "roughness": 0.22,
-        "clearcoat": 0.6
-      },
+      "material": "mat-12",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "-2.700 + 5.100 * smoothstep(64.65, 65.25, t)"
         }
-      ]
+      ],
+      "collection": "station-5"
     },
     {
       "id": "s5-plinth-1",
@@ -2748,14 +2347,8 @@
       "transform": {
         "translate": [35.04588667372333, 0.06, -21.903495578472942]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.1,
-        "value": 0.55,
-        "kind": "normal",
-        "roughness": 0.6,
-        "clearcoat": 0.1
-      }
+      "material": "mat-6",
+      "collection": "station-5"
     },
     {
       "id": "s5-mono-1",
@@ -2767,21 +2360,15 @@
       "transform": {
         "translate": [35.04588667372333, 2.2072538860103625, -21.903495578472942]
       },
-      "material": {
-        "hue": 0.5680000000000001,
-        "sat": 0.648,
-        "value": 0.7759999999999999,
-        "kind": "normal",
-        "roughness": 0.3,
-        "clearcoat": 0.45
-      },
+      "material": "mat-8",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "-2.507 + 4.715 * smoothstep(65.75, 66.35, t)"
         }
       ],
-      "pattern": "cracked"
+      "pattern": "cracked",
+      "collection": "station-5"
     },
     {
       "id": "s5-plinth-2",
@@ -2792,14 +2379,8 @@
       "transform": {
         "translate": [33.77588667372333, 0.06, -21.903495578472942]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.1,
-        "value": 0.55,
-        "kind": "normal",
-        "roughness": 0.6,
-        "clearcoat": 0.1
-      }
+      "material": "mat-6",
+      "collection": "station-5"
     },
     {
       "id": "s5-mono-2",
@@ -2811,21 +2392,15 @@
       "transform": {
         "translate": [33.77588667372333, 1.5015544041450775, -21.903495578472942]
       },
-      "material": {
-        "hue": 0.5860000000000001,
-        "sat": 0.676,
-        "value": 0.732,
-        "kind": "normal",
-        "roughness": 0.3,
-        "clearcoat": 0.45
-      },
+      "material": "mat-9",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "-1.802 + 3.303 * smoothstep(66.85, 67.45, t)"
         }
       ],
-      "pattern": "cracked"
+      "pattern": "cracked",
+      "collection": "station-5"
     },
     {
       "id": "s5-plinth-3",
@@ -2836,14 +2411,8 @@
       "transform": {
         "translate": [32.50588667372333, 0.06, -21.903495578472942]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.1,
-        "value": 0.55,
-        "kind": "normal",
-        "roughness": 0.6,
-        "clearcoat": 0.1
-      }
+      "material": "mat-6",
+      "collection": "station-5"
     },
     {
       "id": "s5-mono-3",
@@ -2855,21 +2424,15 @@
       "transform": {
         "translate": [32.50588667372333, 1.2590673575129532, -21.903495578472942]
       },
-      "material": {
-        "hue": 0.6040000000000001,
-        "sat": 0.704,
-        "value": 0.688,
-        "kind": "normal",
-        "roughness": 0.3,
-        "clearcoat": 0.45
-      },
+      "material": "mat-10",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "-1.559 + 2.818 * smoothstep(67.95, 68.55, t)"
         }
       ],
-      "pattern": "cracked"
+      "pattern": "cracked",
+      "collection": "station-5"
     },
     {
       "id": "s5-plinth-4",
@@ -2880,14 +2443,8 @@
       "transform": {
         "translate": [31.23588667372333, 0.06, -21.903495578472942]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.1,
-        "value": 0.55,
-        "kind": "normal",
-        "roughness": 0.6,
-        "clearcoat": 0.1
-      }
+      "material": "mat-6",
+      "collection": "station-5"
     },
     {
       "id": "s5-mono-4",
@@ -2899,21 +2456,15 @@
       "transform": {
         "translate": [31.23588667372333, 1.0290155440414508, -21.903495578472942]
       },
-      "material": {
-        "hue": 0.622,
-        "sat": 0.732,
-        "value": 0.6439999999999999,
-        "kind": "normal",
-        "roughness": 0.3,
-        "clearcoat": 0.45
-      },
+      "material": "mat-11",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "-1.329 + 2.358 * smoothstep(69.05, 69.65, t)"
         }
       ],
-      "pattern": "cracked"
+      "pattern": "cracked",
+      "collection": "station-5"
     },
     {
       "id": "s5-plinth-5",
@@ -2924,14 +2475,8 @@
       "transform": {
         "translate": [29.96588667372333, 0.06, -21.903495578472942]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.1,
-        "value": 0.55,
-        "kind": "normal",
-        "roughness": 0.6,
-        "clearcoat": 0.1
-      }
+      "material": "mat-6",
+      "collection": "station-5"
     },
     {
       "id": "s5-mono-5",
@@ -2943,21 +2488,15 @@
       "transform": {
         "translate": [29.96588667372333, 0.9699481865284973, -21.903495578472942]
       },
-      "material": {
-        "hue": 0.64,
-        "sat": 0.76,
-        "value": 0.6,
-        "kind": "normal",
-        "roughness": 0.3,
-        "clearcoat": 0.45
-      },
+      "material": "mat-14",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "-1.270 + 2.240 * smoothstep(70.15, 70.75, t)"
         }
       ],
-      "pattern": "cracked"
+      "pattern": "cracked",
+      "collection": "station-5"
     },
     {
       "id": "s5-guard-l-0",
@@ -2969,14 +2508,8 @@
         "translate": [25.00588667372333, 1.1, -20.703495578472943],
         "rotate": [0, -0.3, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-13",
+      "collection": "station-5"
     },
     {
       "id": "s5-guard-r-0",
@@ -2988,14 +2521,8 @@
         "translate": [41.27588667372333, 1.1, -20.703495578472943],
         "rotate": [0, 0.3, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-13",
+      "collection": "station-5"
     },
     {
       "id": "s5-guard-l-1",
@@ -3007,14 +2534,8 @@
         "translate": [25.60588667372333, 1.75, -26.503495578472943],
         "rotate": [0, -0.3, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-13",
+      "collection": "station-5"
     },
     {
       "id": "s5-guard-r-1",
@@ -3026,14 +2547,8 @@
         "translate": [40.675886673723326, 1.75, -26.503495578472943],
         "rotate": [0, 0.3, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-13",
+      "collection": "station-5"
     },
     {
       "id": "s5-guard-l-2",
@@ -3045,14 +2560,8 @@
         "translate": [24.205886673723327, 2.4000000000000004, -28.703495578472943],
         "rotate": [0, -0.3, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-13",
+      "collection": "station-5"
     },
     {
       "id": "s5-guard-r-2",
@@ -3064,14 +2573,8 @@
         "translate": [42.07588667372333, 2.4000000000000004, -28.703495578472943],
         "rotate": [0, 0.3, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-13",
+      "collection": "station-5"
     },
     {
       "id": "path-5-1",
@@ -3083,15 +2586,8 @@
         "translate": [31.73621278681703, 0.03, -23.30816946537924],
         "rotate": [0, 2.3561944901923444, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-5"
     },
     {
       "id": "path-5-2",
@@ -3103,15 +2599,8 @@
         "translate": [30.331538899910736, 0.03, -24.71284335228554],
         "rotate": [0, 2.3561944901923444, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-5"
     },
     {
       "id": "path-5-3",
@@ -3123,15 +2612,8 @@
         "translate": [28.926865013004438, 0.03, -26.117517239191837],
         "rotate": [0, 2.3561944901923444, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-5"
     },
     {
       "id": "path-5-4",
@@ -3143,15 +2625,8 @@
         "translate": [27.522191126098143, 0.03, -27.522191126098136],
         "rotate": [0, 2.3561944901923444, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-5"
     },
     {
       "id": "path-5-5",
@@ -3163,15 +2638,8 @@
         "translate": [26.117517239191844, 0.03, -28.926865013004434],
         "rotate": [0, 2.3561944901923444, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-5"
     },
     {
       "id": "path-5-6",
@@ -3183,15 +2651,8 @@
         "translate": [24.712843352285546, 0.03, -30.331538899910733],
         "rotate": [0, 2.3561944901923444, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-5"
     },
     {
       "id": "path-5-7",
@@ -3203,15 +2664,8 @@
         "translate": [23.30816946537925, 0.03, -31.73621278681703],
         "rotate": [0, 2.3561944901923444, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-5"
     },
     {
       "id": "s6-past-0",
@@ -3223,14 +2677,8 @@
       "transform": {
         "translate": [25.30349557847295, 0.55, -33.14088667372333]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-13",
+      "collection": "station-6"
     },
     {
       "id": "s6-past-1",
@@ -3242,14 +2690,8 @@
       "transform": {
         "translate": [21.903495578472953, 0.55, -33.14088667372333]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-13",
+      "collection": "station-6"
     },
     {
       "id": "s6-past-2",
@@ -3261,14 +2703,8 @@
       "transform": {
         "translate": [18.503495578472954, 0.55, -33.14088667372333]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-13",
+      "collection": "station-6"
     },
     {
       "id": "s6-now-3",
@@ -3279,21 +2715,14 @@
       "transform": {
         "translate": [25.30349557847295, 3.6, -33.14088667372333]
       },
-      "material": {
-        "hue": 0.995,
-        "sat": 0.85,
-        "value": 0.78,
-        "glow": 0.24,
-        "kind": "normal",
-        "roughness": 0.3,
-        "clearcoat": 0.5
-      },
+      "material": "mat-15",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "1.100 + 2.500 * smoothstep(77.90, 78.70, t) + 0.06 * sin(0.5 * t + -38.15)"
         }
-      ]
+      ],
+      "collection": "station-6"
     },
     {
       "id": "s6-now-4",
@@ -3304,21 +2733,14 @@
       "transform": {
         "translate": [21.903495578472953, 3.6, -33.14088667372333]
       },
-      "material": {
-        "hue": 0.995,
-        "sat": 0.85,
-        "value": 0.78,
-        "glow": 0.12,
-        "kind": "normal",
-        "roughness": 0.3,
-        "clearcoat": 0.5
-      },
+      "material": "mat-3",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "1.100 + 2.500 * smoothstep(79.00, 79.80, t) + 0.06 * sin(0.5 * t + -36.05)"
         }
-      ]
+      ],
+      "collection": "station-6"
     },
     {
       "id": "s6-now-5",
@@ -3329,21 +2751,14 @@
       "transform": {
         "translate": [18.503495578472954, 3.6, -33.14088667372333]
       },
-      "material": {
-        "hue": 0.995,
-        "sat": 0.85,
-        "value": 0.78,
-        "glow": 0.12,
-        "kind": "normal",
-        "roughness": 0.3,
-        "clearcoat": 0.5
-      },
+      "material": "mat-3",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "1.100 + 2.500 * smoothstep(80.10, 80.90, t) + 0.06 * sin(0.5 * t + -33.95)"
         }
-      ]
+      ],
+      "collection": "station-6"
     },
     {
       "id": "s6-trail-0-0",
@@ -3355,14 +2770,8 @@
         "translate": [25.30349557847295, 1.5, -33.14088667372333],
         "rotate": [0, 0, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-13",
+      "collection": "station-6"
     },
     {
       "id": "s6-trail-0-1",
@@ -3374,14 +2783,8 @@
         "translate": [25.30349557847295, 2.2199999999999998, -33.14088667372333],
         "rotate": [0, 0.3, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-13",
+      "collection": "station-6"
     },
     {
       "id": "s6-trail-0-2",
@@ -3393,14 +2796,8 @@
         "translate": [25.30349557847295, 2.94, -33.14088667372333],
         "rotate": [0, 0.6, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-13",
+      "collection": "station-6"
     },
     {
       "id": "s6-trail-1-0",
@@ -3412,14 +2809,8 @@
         "translate": [21.903495578472953, 1.5, -33.14088667372333],
         "rotate": [0, 0, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-13",
+      "collection": "station-6"
     },
     {
       "id": "s6-trail-1-1",
@@ -3431,14 +2822,8 @@
         "translate": [21.903495578472953, 2.2199999999999998, -33.14088667372333],
         "rotate": [0, 0.3, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-13",
+      "collection": "station-6"
     },
     {
       "id": "s6-trail-1-2",
@@ -3450,14 +2835,8 @@
         "translate": [21.903495578472953, 2.94, -33.14088667372333],
         "rotate": [0, 0.6, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-13",
+      "collection": "station-6"
     },
     {
       "id": "s6-trail-2-0",
@@ -3469,14 +2848,8 @@
         "translate": [18.503495578472954, 1.5, -33.14088667372333],
         "rotate": [0, 0, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-13",
+      "collection": "station-6"
     },
     {
       "id": "s6-trail-2-1",
@@ -3488,14 +2861,8 @@
         "translate": [18.503495578472954, 2.2199999999999998, -33.14088667372333],
         "rotate": [0, 0.3, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-13",
+      "collection": "station-6"
     },
     {
       "id": "s6-trail-2-2",
@@ -3507,14 +2874,8 @@
         "translate": [18.503495578472954, 2.94, -33.14088667372333],
         "rotate": [0, 0.6, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-13",
+      "collection": "station-6"
     },
     {
       "id": "path-6-1",
@@ -3526,15 +2887,8 @@
         "translate": [18.270478046262486, 0.03, -33.88257251331183],
         "rotate": [0, 2.940208509128909, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-6"
     },
     {
       "id": "path-6-2",
@@ -3546,15 +2900,8 @@
         "translate": [14.63746051405202, 0.03, -34.62425835290033],
         "rotate": [0, 2.940208509128909, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-6"
     },
     {
       "id": "path-6-3",
@@ -3566,15 +2913,8 @@
         "translate": [11.004442981841553, 0.03, -35.365944192488826],
         "rotate": [0, 2.940208509128909, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-6"
     },
     {
       "id": "path-6-4",
@@ -3586,15 +2926,8 @@
         "translate": [7.3714254496310865, 0.03, -36.107630032077324],
         "rotate": [0, 2.940208509128909, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-6"
     },
     {
       "id": "path-6-5",
@@ -3606,15 +2939,8 @@
         "translate": [3.73840791742062, 0.03, -36.849315871665816],
         "rotate": [0, 2.940208509128909, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-6"
     },
     {
       "id": "path-6-6",
@@ -3626,15 +2952,8 @@
         "translate": [0.10539038521015343, 0.03, -37.591001711254314],
         "rotate": [0, 2.940208509128909, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-6"
     },
     {
       "id": "path-6-7",
@@ -3646,15 +2965,8 @@
         "translate": [-3.527627147000313, 0.03, -38.33268755084281],
         "rotate": [0, 2.940208509128909, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-6"
     },
     {
       "id": "s7-net-node-0",
@@ -3665,22 +2977,14 @@
       "transform": {
         "translate": [-7.16064467921078, 3.5204111503539433, -39.07437339043131]
       },
-      "material": {
-        "hue": 0.11,
-        "sat": 0.78,
-        "value": 0.95,
-        "metal": 0,
-        "glow": 0.1,
-        "kind": "normal",
-        "roughness": 0.22,
-        "clearcoat": 0.6
-      },
+      "material": "mat-12",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "4.620 - 1.1 * smoothstep(86.95, 87.45, t) + 0.018 * sin(1.3 * t + -112.71)"
         }
-      ]
+      ],
+      "collection": "station-7"
     },
     {
       "id": "s7-net-node-1",
@@ -3691,20 +2995,14 @@
       "transform": {
         "translate": [-8.70694434621335, 5.980307652106461, -37.36566511704618]
       },
-      "material": {
-        "hue": 0.62875,
-        "sat": 0.76,
-        "value": 0.5875,
-        "kind": "normal",
-        "roughness": 0.55,
-        "clearcoat": 0.2
-      },
+      "material": "mat-16",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "7.080 - 1.1 * smoothstep(87.07, 87.57, t) + 0.018 * sin(1.3 * t + -110.61)"
         }
-      ]
+      ],
+      "collection": "station-7"
     },
     {
       "id": "s7-net-node-2",
@@ -3715,20 +3013,14 @@
       "transform": {
         "translate": [-6.869027417786254, 5.250904506397122, -41.95956958288787]
       },
-      "material": {
-        "hue": 0.62875,
-        "sat": 0.76,
-        "value": 0.5875,
-        "kind": "normal",
-        "roughness": 0.55,
-        "clearcoat": 0.2
-      },
+      "material": "mat-16",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "6.351 - 1.1 * smoothstep(87.19, 87.69, t) + 0.018 * sin(1.3 * t + -108.51)"
         }
-      ]
+      ],
+      "collection": "station-7"
     },
     {
       "id": "s7-net-node-3",
@@ -3739,20 +3031,14 @@
       "transform": {
         "translate": [-4.8441428508783355, 4.3697567245487905, -36.70487096791028]
       },
-      "material": {
-        "hue": 0.62875,
-        "sat": 0.76,
-        "value": 0.5875,
-        "kind": "normal",
-        "roughness": 0.55,
-        "clearcoat": 0.2
-      },
+      "material": "mat-16",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "5.470 - 1.1 * smoothstep(87.31, 87.81, t) + 0.018 * sin(1.3 * t + -106.41)"
         }
-      ]
+      ],
+      "collection": "station-7"
     },
     {
       "id": "s7-net-node-4",
@@ -3763,20 +3049,14 @@
       "transform": {
         "translate": [-10.49352761040059, 3.6213578719444897, -39.64473553762493]
       },
-      "material": {
-        "hue": 0.62875,
-        "sat": 0.76,
-        "value": 0.5875,
-        "kind": "normal",
-        "roughness": 0.55,
-        "clearcoat": 0.2
-      },
+      "material": "mat-16",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "4.721 - 1.1 * smoothstep(87.43, 87.93, t) + 0.018 * sin(1.3 * t + -104.31)"
         }
-      ]
+      ],
+      "collection": "station-7"
     },
     {
       "id": "s7-net-node-5",
@@ -3787,20 +3067,14 @@
       "transform": {
         "translate": [-4.114359319565574, 2.9527771216598238, -40.51882374790231]
       },
-      "material": {
-        "hue": 0.62875,
-        "sat": 0.76,
-        "value": 0.5875,
-        "kind": "normal",
-        "roughness": 0.55,
-        "clearcoat": 0.2
-      },
+      "material": "mat-16",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "4.053 - 1.1 * smoothstep(87.55, 88.05, t) + 0.018 * sin(1.3 * t + -102.21)"
         }
-      ]
+      ],
+      "collection": "station-7"
     },
     {
       "id": "s7-net-node-6",
@@ -3811,20 +3085,14 @@
       "transform": {
         "translate": [-7.797286175727586, 1.819620731911172, -36.46459326723141]
       },
-      "material": {
-        "hue": 0.6175,
-        "sat": 0.74,
-        "value": 0.625,
-        "kind": "normal",
-        "roughness": 0.55,
-        "clearcoat": 0.2
-      },
+      "material": "mat-17",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "2.920 - 1.1 * smoothstep(87.67, 88.17, t) + 0.018 * sin(1.3 * t + -100.11)"
         }
-      ]
+      ],
+      "collection": "station-7"
     },
     {
       "id": "s7-net-node-7",
@@ -3835,20 +3103,14 @@
       "transform": {
         "translate": [-7.960745566003501, 1.2095751500786114, -41.062909852530545]
       },
-      "material": {
-        "hue": 0.6175,
-        "sat": 0.74,
-        "value": 0.625,
-        "kind": "normal",
-        "roughness": 0.55,
-        "clearcoat": 0.2
-      },
+      "material": "mat-17",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "2.310 - 1.1 * smoothstep(87.79, 88.29, t) + 0.018 * sin(1.3 * t + -98.01)"
         }
-      ]
+      ],
+      "collection": "station-7"
     },
     {
       "id": "s7-net-node-8",
@@ -3859,20 +3121,14 @@
       "transform": {
         "translate": [-7.036047042756742, 0.6000000000000001, -38.65970795321067]
       },
-      "material": {
-        "hue": 0.60625,
-        "sat": 0.72,
-        "value": 0.6625000000000001,
-        "kind": "normal",
-        "roughness": 0.55,
-        "clearcoat": 0.2
-      },
+      "material": "mat-18",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "1.700 - 1.1 * smoothstep(87.91, 88.41, t) + 0.018 * sin(1.3 * t + -95.91)"
         }
-      ]
+      ],
+      "collection": "station-7"
     },
     {
       "id": "s7-net-edge-0",
@@ -3885,21 +3141,14 @@
       "transform": {
         "translate": [-8.70694434621335, 5.980307652106461, -37.36566511704618]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.55,
-        "glow": 0.08,
-        "kind": "normal",
-        "roughness": 0.6,
-        "clearcoat": 0.15
-      },
+      "material": "mat-19",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "7.080 - 1.1 * smoothstep(88.23, 88.68, t)"
         }
-      ]
+      ],
+      "collection": "station-7"
     },
     {
       "id": "s7-net-edge-1",
@@ -3912,21 +3161,14 @@
       "transform": {
         "translate": [-6.869027417786254, 5.250904506397122, -41.95956958288787]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.55,
-        "glow": 0.08,
-        "kind": "normal",
-        "roughness": 0.6,
-        "clearcoat": 0.15
-      },
+      "material": "mat-19",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "6.351 - 1.1 * smoothstep(88.37, 88.82, t)"
         }
-      ]
+      ],
+      "collection": "station-7"
     },
     {
       "id": "s7-net-edge-2",
@@ -3939,21 +3181,14 @@
       "transform": {
         "translate": [-4.8441428508783355, 4.3697567245487905, -36.70487096791028]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.55,
-        "glow": 0.08,
-        "kind": "normal",
-        "roughness": 0.6,
-        "clearcoat": 0.15
-      },
+      "material": "mat-19",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "5.470 - 1.1 * smoothstep(88.51, 88.96, t)"
         }
-      ]
+      ],
+      "collection": "station-7"
     },
     {
       "id": "s7-net-edge-3",
@@ -3966,21 +3201,14 @@
       "transform": {
         "translate": [-10.49352761040059, 3.6213578719444897, -39.64473553762493]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.55,
-        "glow": 0.08,
-        "kind": "normal",
-        "roughness": 0.6,
-        "clearcoat": 0.15
-      },
+      "material": "mat-19",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "4.721 - 1.1 * smoothstep(88.65, 89.10, t)"
         }
-      ]
+      ],
+      "collection": "station-7"
     },
     {
       "id": "s7-net-edge-4",
@@ -3993,21 +3221,14 @@
       "transform": {
         "translate": [-4.114359319565574, 2.9527771216598238, -40.51882374790231]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.55,
-        "glow": 0.08,
-        "kind": "normal",
-        "roughness": 0.6,
-        "clearcoat": 0.15
-      },
+      "material": "mat-19",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "4.053 - 1.1 * smoothstep(88.79, 89.24, t)"
         }
-      ]
+      ],
+      "collection": "station-7"
     },
     {
       "id": "s7-net-edge-5",
@@ -4020,21 +3241,14 @@
       "transform": {
         "translate": [-7.16064467921078, 3.5204111503539433, -39.07437339043131]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.55,
-        "glow": 0.08,
-        "kind": "normal",
-        "roughness": 0.6,
-        "clearcoat": 0.15
-      },
+      "material": "mat-19",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "4.620 - 1.1 * smoothstep(88.93, 89.38, t)"
         }
-      ]
+      ],
+      "collection": "station-7"
     },
     {
       "id": "s7-net-edge-6",
@@ -4047,21 +3261,14 @@
       "transform": {
         "translate": [-7.16064467921078, 3.5204111503539433, -39.07437339043131]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.55,
-        "glow": 0.08,
-        "kind": "normal",
-        "roughness": 0.6,
-        "clearcoat": 0.15
-      },
+      "material": "mat-19",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "4.620 - 1.1 * smoothstep(89.07, 89.52, t)"
         }
-      ]
+      ],
+      "collection": "station-7"
     },
     {
       "id": "s7-net-edge-7",
@@ -4074,21 +3281,14 @@
       "transform": {
         "translate": [-7.797286175727586, 1.819620731911172, -36.46459326723141]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.55,
-        "glow": 0.08,
-        "kind": "normal",
-        "roughness": 0.6,
-        "clearcoat": 0.15
-      },
+      "material": "mat-19",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "2.920 - 1.1 * smoothstep(89.21, 89.66, t)"
         }
-      ]
+      ],
+      "collection": "station-7"
     },
     {
       "id": "s7-net-edge-8",
@@ -4101,21 +3301,14 @@
       "transform": {
         "translate": [-7.960745566003501, 1.2095751500786114, -41.062909852530545]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.55,
-        "glow": 0.08,
-        "kind": "normal",
-        "roughness": 0.6,
-        "clearcoat": 0.15
-      },
+      "material": "mat-19",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "2.310 - 1.1 * smoothstep(89.35, 89.80, t)"
         }
-      ]
+      ],
+      "collection": "station-7"
     },
     {
       "id": "s7-net-edge-9",
@@ -4128,21 +3321,14 @@
       "transform": {
         "translate": [-7.036047042756742, 0.6000000000000001, -38.65970795321067]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.55,
-        "glow": 0.08,
-        "kind": "normal",
-        "roughness": 0.6,
-        "clearcoat": 0.15
-      },
+      "material": "mat-19",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "1.700 - 1.1 * smoothstep(89.49, 89.94, t)"
         }
-      ]
+      ],
+      "collection": "station-7"
     },
     {
       "id": "s7-dust-0",
@@ -4154,19 +3340,14 @@
         "translate": [-5.908770051844035, 4.405000000000001, -39.07437339043131],
         "rotate": [0, 0, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.2,
-        "value": 0.18,
-        "kind": "normal",
-        "roughness": 0.5
-      },
+      "material": "mat-20",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "4.405 - 0.000 * smoothstep(86.70, 87.70, t) + 0.05 * sin(0.30 * t + -26.01)"
         }
-      ]
+      ],
+      "collection": "station-7"
     },
     {
       "id": "s7-dust-1",
@@ -4178,19 +3359,14 @@
         "translate": [-6.603552530718751, 4.399558176477956, -41.341305779586364],
         "rotate": [0, 0.9, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.2,
-        "value": 0.18,
-        "kind": "normal",
-        "roughness": 0.5
-      },
+      "material": "mat-20",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "4.400 - 0.000 * smoothstep(86.70, 87.70, t) + 0.07 * sin(0.35 * t + -29.04)"
         }
-      ]
+      ],
+      "collection": "station-7"
     },
     {
       "id": "s7-dust-2",
@@ -4202,19 +3378,14 @@
         "translate": [-9.052528741849766, 3.629579332748476, -40.06398804939126],
         "rotate": [0, 1.8, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.2,
-        "value": 0.18,
-        "kind": "normal",
-        "roughness": 0.5
-      },
+      "material": "mat-20",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "3.630 - 0.000 * smoothstep(86.70, 87.70, t) + 0.09 * sin(0.40 * t + -32.08)"
         }
-      ]
+      ],
+      "collection": "station-7"
     },
     {
       "id": "s7-dust-3",
@@ -4226,19 +3397,14 @@
         "translate": [-9.770785032433931, 4.222504230305474, -36.115836220577535],
         "rotate": [0, 2.7, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.2,
-        "value": 0.18,
-        "kind": "normal",
-        "roughness": 0.5
-      },
+      "material": "mat-20",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "4.223 - 0.000 * smoothstep(86.70, 87.70, t) + 0.05 * sin(0.45 * t + -35.12)"
         }
-      ]
+      ],
+      "collection": "station-7"
     },
     {
       "id": "s7-dust-4",
@@ -4250,19 +3416,14 @@
         "translate": [-5.909654376247273, 3.0836452719433054, -37.27264253677254],
         "rotate": [0, 0.5, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.2,
-        "value": 0.18,
-        "kind": "normal",
-        "roughness": 0.5
-      },
+      "material": "mat-20",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "3.084 - 0.000 * smoothstep(86.70, 87.70, t) + 0.07 * sin(0.50 * t + -38.15)"
         }
-      ]
+      ],
+      "collection": "station-7"
     },
     {
       "id": "s7-dust-5",
@@ -4274,19 +3435,14 @@
         "translate": [-2.4033031061725945, 3.8177730524847187, -40.89736570683438],
         "rotate": [0, 1.4, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.2,
-        "value": 0.18,
-        "kind": "normal",
-        "roughness": 0.5
-      },
+      "material": "mat-20",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "3.818 - 0.000 * smoothstep(86.70, 87.70, t) + 0.09 * sin(0.30 * t + -25.79)"
         }
-      ]
+      ],
+      "collection": "station-7"
     },
     {
       "id": "s7-dust-6",
@@ -4298,19 +3454,14 @@
         "translate": [-7.435105919771303, 2.742972950909394, -41.25924369198499],
         "rotate": [0, 2.3000000000000003, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.2,
-        "value": 0.18,
-        "kind": "normal",
-        "roughness": 0.5
-      },
+      "material": "mat-20",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "2.743 - 0.000 * smoothstep(86.70, 87.70, t) + 0.05 * sin(0.35 * t + -28.82)"
         }
-      ]
+      ],
+      "collection": "station-7"
     },
     {
       "id": "s7-dust-7",
@@ -4322,19 +3473,14 @@
         "translate": [-12.798329973358396, 3.247721417838311, -39.73133717677095],
         "rotate": [0, 0.09999999999999964, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.2,
-        "value": 0.18,
-        "kind": "normal",
-        "roughness": 0.5
-      },
+      "material": "mat-20",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "3.248 - 0.000 * smoothstep(86.70, 87.70, t) + 0.07 * sin(0.40 * t + -31.86)"
         }
-      ]
+      ],
+      "collection": "station-7"
     },
     {
       "id": "s7-dust-8",
@@ -4346,19 +3492,14 @@
         "translate": [-8.017054190396411, 2.514577769081229, -36.7781129419987],
         "rotate": [0, 1, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.2,
-        "value": 0.18,
-        "kind": "normal",
-        "roughness": 0.5
-      },
+      "material": "mat-20",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "2.515 - 0.000 * smoothstep(86.70, 87.70, t) + 0.09 * sin(0.45 * t + -34.90)"
         }
-      ]
+      ],
+      "collection": "station-7"
     },
     {
       "id": "s7-dust-9",
@@ -4370,19 +3511,14 @@
         "translate": [-2.5083930445905853, 2.626149955099641, -35.90556780527729],
         "rotate": [0, 1.8999999999999995, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.2,
-        "value": 0.18,
-        "kind": "normal",
-        "roughness": 0.5
-      },
+      "material": "mat-20",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "2.626 - 0.000 * smoothstep(86.70, 87.70, t) + 0.05 * sin(0.50 * t + -37.93)"
         }
-      ]
+      ],
+      "collection": "station-7"
     },
     {
       "id": "s7-dust-10",
@@ -4394,19 +3530,14 @@
         "translate": [-4.927122044028076, 2.2751364752104166, -41.080737692557705],
         "rotate": [0, 2.8, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.2,
-        "value": 0.18,
-        "kind": "normal",
-        "roughness": 0.5
-      },
+      "material": "mat-20",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "2.275 - 0.000 * smoothstep(86.70, 87.70, t) + 0.07 * sin(0.30 * t + -25.57)"
         }
-      ]
+      ],
+      "collection": "station-7"
     },
     {
       "id": "s7-dust-11",
@@ -4418,19 +3549,14 @@
         "translate": [-9.533064958900408, 2.074057518564027, -43.512571345192285],
         "rotate": [0, 0.6000000000000001, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.2,
-        "value": 0.18,
-        "kind": "normal",
-        "roughness": 0.5
-      },
+      "material": "mat-20",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "2.074 - 0.000 * smoothstep(86.70, 87.70, t) + 0.09 * sin(0.35 * t + -28.61)"
         }
-      ]
+      ],
+      "collection": "station-7"
     },
     {
       "id": "s7-dust-12",
@@ -4442,19 +3568,14 @@
         "translate": [-10.777276304113308, 1.9174150657237594, -38.15116975595403],
         "rotate": [0, 1.5000000000000004, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.2,
-        "value": 0.18,
-        "kind": "normal",
-        "roughness": 0.5
-      },
+      "material": "mat-20",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "1.917 - 0.000 * smoothstep(86.70, 87.70, t) + 0.05 * sin(0.40 * t + -31.64)"
         }
-      ]
+      ],
+      "collection": "station-7"
     },
     {
       "id": "s7-dust-13",
@@ -4466,19 +3587,14 @@
         "translate": [-7.123996755605687, 1.6748001647187152, -34.982889843299475],
         "rotate": [0, 2.400000000000001, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.2,
-        "value": 0.18,
-        "kind": "normal",
-        "roughness": 0.5
-      },
+      "material": "mat-20",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "1.675 - 0.000 * smoothstep(86.70, 87.70, t) + 0.07 * sin(0.45 * t + -34.67)"
         }
-      ]
+      ],
+      "collection": "station-7"
     },
     {
       "id": "s7-dust-14",
@@ -4490,19 +3606,14 @@
         "translate": [-2.889714115375024, 1.3899081353990992, -38.065280878855724],
         "rotate": [0, 0.1999999999999993, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.2,
-        "value": 0.18,
-        "kind": "normal",
-        "roughness": 0.5
-      },
+      "material": "mat-20",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "1.390 - 0.000 * smoothstep(86.70, 87.70, t) + 0.09 * sin(0.50 * t + -37.71)"
         }
-      ]
+      ],
+      "collection": "station-7"
     },
     {
       "id": "s7-dust-15",
@@ -4514,19 +3625,14 @@
         "translate": [-5.761812632760796, 1.44284528397345, -41.80791166100386],
         "rotate": [0, 1.0999999999999996, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.2,
-        "value": 0.18,
-        "kind": "normal",
-        "roughness": 0.5
-      },
+      "material": "mat-20",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "1.443 - 0.000 * smoothstep(86.70, 87.70, t) + 0.05 * sin(0.30 * t + -25.35)"
         }
-      ]
+      ],
+      "collection": "station-7"
     },
     {
       "id": "s7-dust-16",
@@ -4538,19 +3644,14 @@
         "translate": [-10.689916159211425, 0.7171594937718098, -42.13226190404997],
         "rotate": [0, 2, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.2,
-        "value": 0.18,
-        "kind": "normal",
-        "roughness": 0.5
-      },
+      "material": "mat-20",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "0.717 - 0.000 * smoothstep(86.70, 87.70, t) + 0.07 * sin(0.35 * t + -28.38)"
         }
-      ]
+      ],
+      "collection": "station-7"
     },
     {
       "id": "s7-dust-17",
@@ -4562,19 +3663,14 @@
         "translate": [-8.951697094554323, 1.3160592709780925, -37.80687192726037],
         "rotate": [0, 2.9000000000000004, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.2,
-        "value": 0.18,
-        "kind": "normal",
-        "roughness": 0.5
-      },
+      "material": "mat-20",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "1.316 - 0.000 * smoothstep(86.70, 87.70, t) + 0.09 * sin(0.40 * t + -31.42)"
         }
-      ]
+      ],
+      "collection": "station-7"
     },
     {
       "id": "s7-dust-18",
@@ -4586,19 +3682,14 @@
         "translate": [-5.585005508148772, -0.005841134412181592, -35.070241841110594],
         "rotate": [0, 0.6999999999999988, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.2,
-        "value": 0.18,
-        "kind": "normal",
-        "roughness": 0.5
-      },
+      "material": "mat-20",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "-0.006 - 0.000 * smoothstep(86.70, 87.70, t) + 0.05 * sin(0.45 * t + -34.45)"
         }
-      ]
+      ],
+      "collection": "station-7"
     },
     {
       "id": "s7-dust-19",
@@ -4610,19 +3701,14 @@
         "translate": [-5.6424795634121425, 1.1743019526359513, -39.27891232335929],
         "rotate": [0, 1.600000000000001, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.2,
-        "value": 0.18,
-        "kind": "normal",
-        "roughness": 0.5
-      },
+      "material": "mat-20",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "1.174 - 0.000 * smoothstep(86.70, 87.70, t) + 0.07 * sin(0.50 * t + -37.49)"
         }
-      ]
+      ],
+      "collection": "station-7"
     },
     {
       "id": "s7-dust-20",
@@ -4634,19 +3720,14 @@
         "translate": [-6.838158518537315, -0.6439061141122786, -42.075320069981174],
         "rotate": [0, 2.4999999999999996, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.2,
-        "value": 0.18,
-        "kind": "normal",
-        "roughness": 0.5
-      },
+      "material": "mat-20",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "-0.644 - 0.000 * smoothstep(86.70, 87.70, t) + 0.09 * sin(0.30 * t + -25.13)"
         }
-      ]
+      ],
+      "collection": "station-7"
     },
     {
       "id": "s7-dust-21",
@@ -4658,19 +3739,14 @@
         "translate": [-7.865633815667515, 0.879070215106386, -39.33013589279424],
         "rotate": [0, 0.3000000000000016, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.2,
-        "value": 0.18,
-        "kind": "normal",
-        "roughness": 0.5
-      },
+      "material": "mat-20",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "0.879 - 0.000 * smoothstep(86.70, 87.70, t) + 0.05 * sin(0.35 * t + -28.16)"
         }
-      ]
+      ],
+      "collection": "station-7"
     },
     {
       "id": "path-7-1",
@@ -4682,15 +3758,8 @@
         "translate": [-9.003501041618552, 0.03, -38.33268755084281],
         "rotate": [0, -2.758962779114113, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-7"
     },
     {
       "id": "path-7-2",
@@ -4702,15 +3771,8 @@
         "translate": [-10.846357404026325, 0.03, -37.591001711254314],
         "rotate": [0, -2.758962779114113, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-7"
     },
     {
       "id": "path-7-3",
@@ -4722,15 +3784,8 @@
         "translate": [-12.689213766434095, 0.03, -36.849315871665816],
         "rotate": [0, -2.758962779114113, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-7"
     },
     {
       "id": "path-7-4",
@@ -4742,15 +3797,8 @@
         "translate": [-14.532070128841868, 0.03, -36.10763003207732],
         "rotate": [0, -2.758962779114113, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-7"
     },
     {
       "id": "path-7-5",
@@ -4762,15 +3810,8 @@
         "translate": [-16.37492649124964, 0.03, -35.36594419248882],
         "rotate": [0, -2.758962779114113, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-7"
     },
     {
       "id": "path-7-6",
@@ -4782,15 +3823,8 @@
         "translate": [-18.21778285365741, 0.03, -34.62425835290032],
         "rotate": [0, -2.758962779114113, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-7"
     },
     {
       "id": "path-7-7",
@@ -4802,15 +3836,8 @@
         "translate": [-20.060639216065184, 0.03, -33.88257251331182],
         "rotate": [0, -2.758962779114113, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-7"
     },
     {
       "id": "s8-stage-0",
@@ -4824,20 +3851,14 @@
       "transform": {
         "translate": [-21.903495578472956, 2.8000000000000003, -33.14088667372332]
       },
-      "material": {
-        "hue": 0.55,
-        "sat": 0.62,
-        "value": 0.85,
-        "kind": "normal",
-        "roughness": 0.3,
-        "clearcoat": 0.45
-      },
+      "material": "mat-21",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "3.700 - 0.9 * smoothstep(97.45, 98.05, t)"
         }
-      ]
+      ],
+      "collection": "station-8"
     },
     {
       "id": "s8-stage-1",
@@ -4851,22 +3872,14 @@
       "transform": {
         "translate": [-21.903495578472956, 2, -33.14088667372332]
       },
-      "material": {
-        "hue": 0.11,
-        "sat": 0.78,
-        "value": 0.95,
-        "metal": 0,
-        "glow": 0.1,
-        "kind": "normal",
-        "roughness": 0.22,
-        "clearcoat": 0.6
-      },
+      "material": "mat-12",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "2.900 - 0.9 * smoothstep(97.80, 98.40, t)"
         }
-      ]
+      ],
+      "collection": "station-8"
     },
     {
       "id": "s8-stage-2",
@@ -4880,20 +3893,14 @@
       "transform": {
         "translate": [-21.903495578472956, 1.2000000000000002, -33.14088667372332]
       },
-      "material": {
-        "hue": 0.6100000000000001,
-        "sat": 0.7266666666666667,
-        "value": 0.65,
-        "kind": "normal",
-        "roughness": 0.3,
-        "clearcoat": 0.45
-      },
+      "material": "mat-22",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "2.100 - 0.9 * smoothstep(98.15, 98.75, t)"
         }
-      ]
+      ],
+      "collection": "station-8"
     },
     {
       "id": "s8-stage-3",
@@ -4907,20 +3914,14 @@
       "transform": {
         "translate": [-21.903495578472956, 0.3999999999999999, -33.14088667372332]
       },
-      "material": {
-        "hue": 0.64,
-        "sat": 0.78,
-        "value": 0.55,
-        "kind": "normal",
-        "roughness": 0.3,
-        "clearcoat": 0.45
-      },
+      "material": "mat-23",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "1.300 - 0.9 * smoothstep(98.50, 99.10, t)"
         }
-      ]
+      ],
+      "collection": "station-8"
     },
     {
       "id": "path-8-1",
@@ -4932,15 +3933,8 @@
         "translate": [-23.30816946537925, 0.03, -31.736212786817028],
         "rotate": [0, -2.356194490192345, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-8"
     },
     {
       "id": "path-8-2",
@@ -4952,15 +3946,8 @@
         "translate": [-24.712843352285546, 0.03, -30.33153889991073],
         "rotate": [0, -2.356194490192345, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-8"
     },
     {
       "id": "path-8-3",
@@ -4972,15 +3959,8 @@
         "translate": [-26.117517239191844, 0.03, -28.926865013004434],
         "rotate": [0, -2.356194490192345, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-8"
     },
     {
       "id": "path-8-4",
@@ -4992,15 +3972,8 @@
         "translate": [-27.52219112609814, 0.03, -27.522191126098136],
         "rotate": [0, -2.356194490192345, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-8"
     },
     {
       "id": "path-8-5",
@@ -5012,15 +3985,8 @@
         "translate": [-28.926865013004434, 0.03, -26.11751723919184],
         "rotate": [0, -2.356194490192345, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-8"
     },
     {
       "id": "path-8-6",
@@ -5032,15 +3998,8 @@
         "translate": [-30.331538899910733, 0.03, -24.712843352285546],
         "rotate": [0, -2.356194490192345, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-8"
     },
     {
       "id": "path-8-7",
@@ -5052,15 +4011,8 @@
         "translate": [-31.736212786817028, 0.03, -23.30816946537925],
         "rotate": [0, -2.356194490192345, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-8"
     },
     {
       "id": "s9-plinth-0",
@@ -5071,14 +4023,8 @@
       "transform": {
         "translate": [-29.330886673723324, 0.06, -21.903495578472953]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.1,
-        "value": 0.55,
-        "kind": "normal",
-        "roughness": 0.6,
-        "clearcoat": 0.1
-      }
+      "material": "mat-6",
+      "collection": "station-9"
     },
     {
       "id": "s9-mono-0",
@@ -5090,21 +4036,15 @@
       "transform": {
         "translate": [-29.330886673723324, 2.4, -21.903495578472953]
       },
-      "material": {
-        "hue": 0.55,
-        "sat": 0.62,
-        "value": 0.82,
-        "kind": "normal",
-        "roughness": 0.3,
-        "clearcoat": 0.45
-      },
+      "material": "mat-7",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "-2.700 + 5.100 * smoothstep(110.45, 111.05, t)"
         }
       ],
-      "pattern": "cracked"
+      "pattern": "cracked",
+      "collection": "station-9"
     },
     {
       "id": "s9-plinth-1",
@@ -5115,14 +4055,8 @@
       "transform": {
         "translate": [-30.600886673723323, 0.06, -21.903495578472953]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.1,
-        "value": 0.55,
-        "kind": "normal",
-        "roughness": 0.6,
-        "clearcoat": 0.1
-      }
+      "material": "mat-6",
+      "collection": "station-9"
     },
     {
       "id": "s9-mono-1",
@@ -5134,21 +4068,15 @@
       "transform": {
         "translate": [-30.600886673723323, 2.3564356435643563, -21.903495578472953]
       },
-      "material": {
-        "hue": 0.5650000000000001,
-        "sat": 0.6433333333333333,
-        "value": 0.7833333333333333,
-        "kind": "normal",
-        "roughness": 0.3,
-        "clearcoat": 0.45
-      },
+      "material": "mat-24",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "-2.656 + 5.013 * smoothstep(111.55, 112.15, t)"
         }
       ],
-      "pattern": "cracked"
+      "pattern": "cracked",
+      "collection": "station-9"
     },
     {
       "id": "s9-plinth-2",
@@ -5159,14 +4087,8 @@
       "transform": {
         "translate": [-31.870886673723323, 0.06, -21.903495578472953]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.1,
-        "value": 0.55,
-        "kind": "normal",
-        "roughness": 0.6,
-        "clearcoat": 0.1
-      }
+      "material": "mat-6",
+      "collection": "station-9"
     },
     {
       "id": "s9-mono-2",
@@ -5178,21 +4100,15 @@
       "transform": {
         "translate": [-31.870886673723323, 2.2376237623762374, -21.903495578472953]
       },
-      "material": {
-        "hue": 0.5800000000000001,
-        "sat": 0.6666666666666666,
-        "value": 0.7466666666666666,
-        "kind": "normal",
-        "roughness": 0.3,
-        "clearcoat": 0.45
-      },
+      "material": "mat-25",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "-2.538 + 4.775 * smoothstep(112.65, 113.25, t)"
         }
       ],
-      "pattern": "cracked"
+      "pattern": "cracked",
+      "collection": "station-9"
     },
     {
       "id": "s9-plinth-3",
@@ -5203,14 +4119,8 @@
       "transform": {
         "translate": [-33.14088667372332, 0.06, -21.903495578472953]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.1,
-        "value": 0.55,
-        "kind": "normal",
-        "roughness": 0.6,
-        "clearcoat": 0.1
-      }
+      "material": "mat-6",
+      "collection": "station-9"
     },
     {
       "id": "s9-mono-3",
@@ -5222,21 +4132,15 @@
       "transform": {
         "translate": [-33.14088667372332, 2.1425742574257423, -21.903495578472953]
       },
-      "material": {
-        "hue": 0.5950000000000001,
-        "sat": 0.69,
-        "value": 0.71,
-        "kind": "normal",
-        "roughness": 0.3,
-        "clearcoat": 0.45
-      },
+      "material": "mat-26",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "-2.443 + 4.585 * smoothstep(113.75, 114.35, t)"
         }
       ],
-      "pattern": "cracked"
+      "pattern": "cracked",
+      "collection": "station-9"
     },
     {
       "id": "s9-plinth-4",
@@ -5247,14 +4151,8 @@
       "transform": {
         "translate": [-34.410886673723326, 0.06, -21.903495578472953]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.1,
-        "value": 0.55,
-        "kind": "normal",
-        "roughness": 0.6,
-        "clearcoat": 0.1
-      }
+      "material": "mat-6",
+      "collection": "station-9"
     },
     {
       "id": "s9-mono-4",
@@ -5266,21 +4164,15 @@
       "transform": {
         "translate": [-34.410886673723326, 2.023762376237624, -21.903495578472953]
       },
-      "material": {
-        "hue": 0.6100000000000001,
-        "sat": 0.7133333333333334,
-        "value": 0.6733333333333333,
-        "kind": "normal",
-        "roughness": 0.3,
-        "clearcoat": 0.45
-      },
+      "material": "mat-27",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "-2.324 + 4.348 * smoothstep(114.85, 115.45, t)"
         }
       ],
-      "pattern": "cracked"
+      "pattern": "cracked",
+      "collection": "station-9"
     },
     {
       "id": "s9-plinth-5",
@@ -5291,14 +4183,8 @@
       "transform": {
         "translate": [-35.68088667372332, 0.06, -21.903495578472953]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.1,
-        "value": 0.55,
-        "kind": "normal",
-        "roughness": 0.6,
-        "clearcoat": 0.1
-      }
+      "material": "mat-6",
+      "collection": "station-9"
     },
     {
       "id": "s9-mono-5",
@@ -5310,21 +4196,15 @@
       "transform": {
         "translate": [-35.68088667372332, 1.881188118811881, -21.903495578472953]
       },
-      "material": {
-        "hue": 0.625,
-        "sat": 0.7366666666666667,
-        "value": 0.6366666666666666,
-        "kind": "normal",
-        "roughness": 0.3,
-        "clearcoat": 0.45
-      },
+      "material": "mat-28",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "-2.181 + 4.062 * smoothstep(115.95, 116.55, t)"
         }
       ],
-      "pattern": "cracked"
+      "pattern": "cracked",
+      "collection": "station-9"
     },
     {
       "id": "s9-plinth-6",
@@ -5335,14 +4215,8 @@
       "transform": {
         "translate": [-36.950886673723325, 0.06, -21.903495578472953]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.1,
-        "value": 0.55,
-        "kind": "normal",
-        "roughness": 0.6,
-        "clearcoat": 0.1
-      }
+      "material": "mat-6",
+      "collection": "station-9"
     },
     {
       "id": "s9-mono-6",
@@ -5354,22 +4228,14 @@
       "transform": {
         "translate": [-36.950886673723325, 1.786138613861386, -21.903495578472953]
       },
-      "material": {
-        "hue": 0.11,
-        "sat": 0.78,
-        "value": 0.95,
-        "metal": 0,
-        "glow": 0.1,
-        "kind": "normal",
-        "roughness": 0.22,
-        "clearcoat": 0.6
-      },
+      "material": "mat-12",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "-2.086 + 3.872 * smoothstep(117.05, 117.65, t)"
         }
-      ]
+      ],
+      "collection": "station-9"
     },
     {
       "id": "s9-guard-l-0",
@@ -5381,14 +4247,8 @@
         "translate": [-41.910886673723326, 1.1, -20.703495578472953],
         "rotate": [0, -0.3, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-13",
+      "collection": "station-9"
     },
     {
       "id": "s9-guard-r-0",
@@ -5400,14 +4260,8 @@
         "translate": [-24.370886673723323, 1.1, -20.703495578472953],
         "rotate": [0, 0.3, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-13",
+      "collection": "station-9"
     },
     {
       "id": "s9-guard-l-1",
@@ -5419,14 +4273,8 @@
         "translate": [-41.310886673723324, 1.75, -26.50349557847295],
         "rotate": [0, -0.3, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-13",
+      "collection": "station-9"
     },
     {
       "id": "s9-guard-r-1",
@@ -5438,14 +4286,8 @@
         "translate": [-24.97088667372332, 1.75, -26.50349557847295],
         "rotate": [0, 0.3, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-13",
+      "collection": "station-9"
     },
     {
       "id": "s9-guard-l-2",
@@ -5457,14 +4299,8 @@
         "translate": [-42.71088667372332, 2.4000000000000004, -28.703495578472953],
         "rotate": [0, -0.3, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-13",
+      "collection": "station-9"
     },
     {
       "id": "s9-guard-r-2",
@@ -5476,14 +4312,8 @@
         "translate": [-23.570886673723322, 2.4000000000000004, -28.703495578472953],
         "rotate": [0, 0.3, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-13",
+      "collection": "station-9"
     },
     {
       "id": "path-9-1",
@@ -5495,15 +4325,8 @@
         "translate": [-33.88257251331182, 0.03, -18.270478046262486],
         "rotate": [0, -1.772180471255781, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-9"
     },
     {
       "id": "path-9-2",
@@ -5515,15 +4338,8 @@
         "translate": [-34.62425835290032, 0.03, -14.63746051405202],
         "rotate": [0, -1.772180471255781, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-9"
     },
     {
       "id": "path-9-3",
@@ -5535,15 +4351,8 @@
         "translate": [-35.36594419248882, 0.03, -11.004442981841553],
         "rotate": [0, -1.772180471255781, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-9"
     },
     {
       "id": "path-9-4",
@@ -5555,15 +4364,8 @@
         "translate": [-36.10763003207732, 0.03, -7.3714254496310865],
         "rotate": [0, -1.772180471255781, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-9"
     },
     {
       "id": "path-9-5",
@@ -5575,15 +4377,8 @@
         "translate": [-36.849315871665816, 0.03, -3.73840791742062],
         "rotate": [0, -1.772180471255781, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-9"
     },
     {
       "id": "path-9-6",
@@ -5595,15 +4390,8 @@
         "translate": [-37.591001711254314, 0.03, -0.10539038521015343],
         "rotate": [0, -1.772180471255781, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-9"
     },
     {
       "id": "path-9-7",
@@ -5615,15 +4403,8 @@
         "translate": [-38.33268755084281, 0.03, 3.527627147000313],
         "rotate": [0, -1.772180471255781, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-9"
     },
     {
       "id": "s10-node-0",
@@ -5643,22 +4424,14 @@
       "transform": {
         "translate": [-39.07437339043131, 3.15, 7.160644679210778]
       },
-      "material": {
-        "hue": 0.11,
-        "sat": 0.78,
-        "value": 0.95,
-        "metal": 0,
-        "glow": 0.04,
-        "kind": "normal",
-        "roughness": 0.22,
-        "clearcoat": 0.6
-      },
+      "material": "mat-29",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "4.150 - 1 * smoothstep(125.85, 126.40, t)"
         }
-      ]
+      ],
+      "collection": "station-10"
     },
     {
       "id": "s10-node-1",
@@ -5690,20 +4463,14 @@
       "transform": {
         "translate": [-39.07437339043131, 2, 5.2606446792107775]
       },
-      "material": {
-        "hue": 0.5950000000000001,
-        "sat": 0.7,
-        "value": 0.71,
-        "kind": "normal",
-        "roughness": 0.3,
-        "clearcoat": 0.45
-      },
+      "material": "mat-30",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "3.000 - 1 * smoothstep(127.35, 127.90, t)"
         }
-      ]
+      ],
+      "collection": "station-10"
     },
     {
       "id": "s10-node-2",
@@ -5735,20 +4502,14 @@
       "transform": {
         "translate": [-37.42892512324088, 2, 8.110644679210777]
       },
-      "material": {
-        "hue": 0.5950000000000001,
-        "sat": 0.7,
-        "value": 0.71,
-        "kind": "normal",
-        "roughness": 0.3,
-        "clearcoat": 0.45
-      },
+      "material": "mat-30",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "3.000 - 1 * smoothstep(127.35, 127.90, t)"
         }
-      ]
+      ],
+      "collection": "station-10"
     },
     {
       "id": "s10-node-3",
@@ -5780,20 +4541,14 @@
       "transform": {
         "translate": [-40.71982165762174, 2, 8.110644679210779]
       },
-      "material": {
-        "hue": 0.5950000000000001,
-        "sat": 0.7,
-        "value": 0.71,
-        "kind": "normal",
-        "roughness": 0.3,
-        "clearcoat": 0.45
-      },
+      "material": "mat-30",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "3.000 - 1 * smoothstep(127.35, 127.90, t)"
         }
-      ]
+      ],
+      "collection": "station-10"
     },
     {
       "id": "s10-node-4",
@@ -5825,20 +4580,14 @@
       "transform": {
         "translate": [-37.93148151395094, 0.8500000000000001, 8.802354209401358]
       },
-      "material": {
-        "hue": 0.64,
-        "sat": 0.78,
-        "value": 0.57,
-        "kind": "normal",
-        "roughness": 0.3,
-        "clearcoat": 0.45
-      },
+      "material": "mat-31",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "1.850 - 1 * smoothstep(128.85, 129.40, t)"
         }
-      ]
+      ],
+      "collection": "station-10"
     },
     {
       "id": "path-10-1",
@@ -5850,15 +4599,8 @@
         "translate": [-38.33268755084281, 0.03, 9.003501041618552],
         "rotate": [0, -1.1881664523192166, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-10"
     },
     {
       "id": "path-10-2",
@@ -5870,15 +4612,8 @@
         "translate": [-37.591001711254314, 0.03, 10.846357404026326],
         "rotate": [0, -1.1881664523192166, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-10"
     },
     {
       "id": "path-10-3",
@@ -5890,15 +4625,8 @@
         "translate": [-36.849315871665816, 0.03, 12.6892137664341],
         "rotate": [0, -1.1881664523192166, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-10"
     },
     {
       "id": "path-10-4",
@@ -5910,15 +4638,8 @@
         "translate": [-36.10763003207731, 0.03, 14.532070128841873],
         "rotate": [0, -1.1881664523192166, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-10"
     },
     {
       "id": "path-10-5",
@@ -5930,15 +4651,8 @@
         "translate": [-35.36594419248881, 0.03, 16.374926491249646],
         "rotate": [0, -1.1881664523192166, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-10"
     },
     {
       "id": "path-10-6",
@@ -5950,15 +4664,8 @@
         "translate": [-34.62425835290031, 0.03, 18.217782853657422],
         "rotate": [0, -1.1881664523192166, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-10"
     },
     {
       "id": "path-10-7",
@@ -5970,15 +4677,8 @@
         "translate": [-33.882572513311814, 0.03, 20.060639216065198],
         "rotate": [0, -1.1881664523192166, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-10"
     },
     {
       "id": "s11-backboard",
@@ -5990,14 +4690,8 @@
       "transform": {
         "translate": [-33.140886673723315, 2.51, 21.56349557847297]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.3,
-        "value": 0.22,
-        "kind": "normal",
-        "roughness": 0.4,
-        "clearcoat": 0.3
-      }
+      "material": "mat-32",
+      "collection": "station-11"
     },
     {
       "id": "s11-cell-0-0",
@@ -6009,14 +4703,8 @@
       "transform": {
         "translate": [-32.23088667372332, 3.2199999999999998, 21.90349557847297]
       },
-      "material": {
-        "hue": 0.6,
-        "sat": 0.1,
-        "value": 0.3,
-        "kind": "normal",
-        "roughness": 0.7,
-        "clearcoat": 0.1
-      }
+      "material": "mat-33",
+      "collection": "station-11"
     },
     {
       "id": "s11-cell-1-0",
@@ -6028,14 +4716,8 @@
       "transform": {
         "translate": [-34.05088667372331, 3.2199999999999998, 21.90349557847297]
       },
-      "material": {
-        "hue": 0.6,
-        "sat": 0.1,
-        "value": 0.3,
-        "kind": "normal",
-        "roughness": 0.7,
-        "clearcoat": 0.1
-      }
+      "material": "mat-33",
+      "collection": "station-11"
     },
     {
       "id": "s11-cell-0-1",
@@ -6047,14 +4729,8 @@
       "transform": {
         "translate": [-32.23088667372332, 1.7999999999999998, 21.90349557847297]
       },
-      "material": {
-        "hue": 0.6,
-        "sat": 0.1,
-        "value": 0.3,
-        "kind": "normal",
-        "roughness": 0.7,
-        "clearcoat": 0.1
-      }
+      "material": "mat-33",
+      "collection": "station-11"
     },
     {
       "id": "s11-cell-1-1",
@@ -6066,14 +4742,8 @@
       "transform": {
         "translate": [-34.05088667372331, 1.7999999999999998, 21.90349557847297]
       },
-      "material": {
-        "hue": 0.6,
-        "sat": 0.1,
-        "value": 0.3,
-        "kind": "normal",
-        "roughness": 0.7,
-        "clearcoat": 0.1
-      }
+      "material": "mat-33",
+      "collection": "station-11"
     },
     {
       "id": "s11-item-0",
@@ -6085,20 +4755,14 @@
       "transform": {
         "translate": [-32.23088667372332, 3.2199999999999998, 22.24349557847297]
       },
-      "material": {
-        "hue": 0.57,
-        "sat": 0.55,
-        "value": 0.72,
-        "kind": "normal",
-        "roughness": 0.3,
-        "clearcoat": 0.45
-      },
+      "material": "mat-34",
       "animation": [
         {
           "channel": "transform.translate.z",
           "expr": "2.400 - 2.060 * smoothstep(136.75, 137.20, t)"
         }
-      ]
+      ],
+      "collection": "station-11"
     },
     {
       "id": "s11-item-1",
@@ -6110,20 +4774,14 @@
       "transform": {
         "translate": [-32.23088667372332, 1.7999999999999998, 22.24349557847297]
       },
-      "material": {
-        "hue": 0.57,
-        "sat": 0.55,
-        "value": 0.72,
-        "kind": "normal",
-        "roughness": 0.3,
-        "clearcoat": 0.45
-      },
+      "material": "mat-34",
       "animation": [
         {
           "channel": "transform.translate.z",
           "expr": "2.400 - 2.060 * smoothstep(137.65, 138.10, t)"
         }
-      ]
+      ],
+      "collection": "station-11"
     },
     {
       "id": "s11-item-2",
@@ -6135,20 +4793,14 @@
       "transform": {
         "translate": [-34.05088667372331, 3.2199999999999998, 22.24349557847297]
       },
-      "material": {
-        "hue": 0.57,
-        "sat": 0.55,
-        "value": 0.72,
-        "kind": "normal",
-        "roughness": 0.3,
-        "clearcoat": 0.45
-      },
+      "material": "mat-34",
       "animation": [
         {
           "channel": "transform.translate.z",
           "expr": "2.400 - 2.060 * smoothstep(138.55, 139.00, t)"
         }
-      ]
+      ],
+      "collection": "station-11"
     },
     {
       "id": "s11-item-3",
@@ -6160,21 +4812,14 @@
       "transform": {
         "translate": [-34.05088667372331, 1.7999999999999998, 22.24349557847297]
       },
-      "material": {
-        "hue": 0.11,
-        "sat": 0.78,
-        "value": 0.95,
-        "glow": 0.1,
-        "kind": "normal",
-        "roughness": 0.22,
-        "clearcoat": 0.6
-      },
+      "material": "mat-5",
       "animation": [
         {
           "channel": "transform.translate.z",
           "expr": "2.400 - 2.060 * smoothstep(139.45, 139.90, t)"
         }
-      ]
+      ],
+      "collection": "station-11"
     },
     {
       "id": "s11-flank-0",
@@ -6186,20 +4831,14 @@
         "translate": [-37.30088667372331, 3.3099999999999996, 19.70349557847297],
         "rotate": [0, -0.9, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      },
+      "material": "mat-13",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "3.310 - 0.000 * smoothstep(135.50, 136.50, t) + 0.06 * sin(0.30 * t + -40.65)"
         }
-      ]
+      ],
+      "collection": "station-11"
     },
     {
       "id": "s11-flank-1",
@@ -6211,20 +4850,14 @@
         "translate": [-28.680886673723315, 2.11, 18.90349557847297],
         "rotate": [0, -0.4, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      },
+      "material": "mat-13",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "2.110 - 0.000 * smoothstep(135.50, 136.50, t) + 0.08 * sin(0.37 * t + -47.93)"
         }
-      ]
+      ],
+      "collection": "station-11"
     },
     {
       "id": "s11-flank-2",
@@ -6236,20 +4869,14 @@
         "translate": [-39.100886673723316, 4.71, 16.40349557847297],
         "rotate": [0, 0.09999999999999998, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      },
+      "material": "mat-13",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "4.710 - 0.000 * smoothstep(135.50, 136.50, t) + 0.10 * sin(0.44 * t + -55.22)"
         }
-      ]
+      ],
+      "collection": "station-11"
     },
     {
       "id": "s11-flank-3",
@@ -6261,20 +4888,14 @@
         "translate": [-26.580886673723317, 4.109999999999999, 15.40349557847297],
         "rotate": [0, 0.6, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      },
+      "material": "mat-13",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "4.110 - 0.000 * smoothstep(135.50, 136.50, t) + 0.12 * sin(0.51 * t + -68.79)"
         }
-      ]
+      ],
+      "collection": "station-11"
     },
     {
       "id": "path-11-1",
@@ -6286,15 +4907,8 @@
         "translate": [-31.736212786817017, 0.03, 23.308169465379265],
         "rotate": [0, -0.7853981633974475, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-11"
     },
     {
       "id": "path-11-2",
@@ -6306,15 +4920,8 @@
         "translate": [-30.33153889991072, 0.03, 24.712843352285564],
         "rotate": [0, -0.7853981633974475, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-11"
     },
     {
       "id": "path-11-3",
@@ -6326,15 +4933,8 @@
         "translate": [-28.926865013004416, 0.03, 26.117517239191862],
         "rotate": [0, -0.7853981633974475, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-11"
     },
     {
       "id": "path-11-4",
@@ -6346,15 +4946,8 @@
         "translate": [-27.52219112609812, 0.03, 27.522191126098157],
         "rotate": [0, -0.7853981633974475, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-11"
     },
     {
       "id": "path-11-5",
@@ -6366,15 +4959,8 @@
         "translate": [-26.11751723919182, 0.03, 28.926865013004452],
         "rotate": [0, -0.7853981633974475, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-11"
     },
     {
       "id": "path-11-6",
@@ -6386,15 +4972,8 @@
         "translate": [-24.71284335228552, 0.03, 30.33153889991075],
         "rotate": [0, -0.7853981633974475, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-11"
     },
     {
       "id": "path-11-7",
@@ -6406,15 +4985,8 @@
         "translate": [-23.308169465379223, 0.03, 31.73621278681705],
         "rotate": [0, -0.7853981633974475, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-11"
     },
     {
       "id": "s12-plinth-0",
@@ -6425,14 +4997,8 @@
       "transform": {
         "translate": [-20.633495578472925, 0.06, 33.140886673723344]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.1,
-        "value": 0.55,
-        "kind": "normal",
-        "roughness": 0.6,
-        "clearcoat": 0.1
-      }
+      "material": "mat-6",
+      "collection": "station-12"
     },
     {
       "id": "s12-mono-0",
@@ -6444,21 +5010,15 @@
       "transform": {
         "translate": [-20.633495578472925, 0.24, 33.140886673723344]
       },
-      "material": {
-        "hue": 0.55,
-        "sat": 0.62,
-        "value": 0.82,
-        "kind": "normal",
-        "roughness": 0.3,
-        "clearcoat": 0.45
-      },
+      "material": "mat-7",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "-0.540 + 0.780 * smoothstep(146.65, 147.25, t)"
         }
       ],
-      "pattern": "cracked"
+      "pattern": "cracked",
+      "collection": "station-12"
     },
     {
       "id": "s12-plinth-1",
@@ -6469,14 +5029,8 @@
       "transform": {
         "translate": [-21.903495578472924, 0.06, 33.140886673723344]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.1,
-        "value": 0.55,
-        "kind": "normal",
-        "roughness": 0.6,
-        "clearcoat": 0.1
-      }
+      "material": "mat-6",
+      "collection": "station-12"
     },
     {
       "id": "s12-mono-1",
@@ -6488,21 +5042,15 @@
       "transform": {
         "translate": [-21.903495578472924, 1.2, 33.140886673723344]
       },
-      "material": {
-        "hue": 0.5950000000000001,
-        "sat": 0.69,
-        "value": 0.71,
-        "kind": "normal",
-        "roughness": 0.3,
-        "clearcoat": 0.45
-      },
+      "material": "mat-26",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "-1.500 + 2.700 * smoothstep(147.75, 148.35, t)"
         }
       ],
-      "pattern": "cracked"
+      "pattern": "cracked",
+      "collection": "station-12"
     },
     {
       "id": "s12-plinth-2",
@@ -6513,14 +5061,8 @@
       "transform": {
         "translate": [-23.173495578472924, 0.06, 33.140886673723344]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.1,
-        "value": 0.55,
-        "kind": "normal",
-        "roughness": 0.6,
-        "clearcoat": 0.1
-      }
+      "material": "mat-6",
+      "collection": "station-12"
     },
     {
       "id": "s12-mono-2",
@@ -6532,22 +5074,14 @@
       "transform": {
         "translate": [-23.173495578472924, 2.4, 33.140886673723344]
       },
-      "material": {
-        "hue": 0.11,
-        "sat": 0.78,
-        "value": 0.95,
-        "metal": 0,
-        "glow": 0.1,
-        "kind": "normal",
-        "roughness": 0.22,
-        "clearcoat": 0.6
-      },
+      "material": "mat-12",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "-2.700 + 5.100 * smoothstep(148.85, 149.45, t)"
         }
-      ]
+      ],
+      "collection": "station-12"
     },
     {
       "id": "s12-guard-l-0",
@@ -6559,14 +5093,8 @@
         "translate": [-28.133495578472925, 1.1, 34.34088667372335],
         "rotate": [0, -0.3, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-13",
+      "collection": "station-12"
     },
     {
       "id": "s12-guard-r-0",
@@ -6578,14 +5106,8 @@
         "translate": [-15.673495578472924, 1.1, 34.34088667372335],
         "rotate": [0, 0.3, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-13",
+      "collection": "station-12"
     },
     {
       "id": "s12-guard-l-1",
@@ -6597,14 +5119,8 @@
         "translate": [-27.533495578472923, 1.75, 28.540886673723342],
         "rotate": [0, -0.3, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-13",
+      "collection": "station-12"
     },
     {
       "id": "s12-guard-r-1",
@@ -6616,14 +5132,8 @@
         "translate": [-16.273495578472925, 1.75, 28.540886673723342],
         "rotate": [0, 0.3, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-13",
+      "collection": "station-12"
     },
     {
       "id": "s12-guard-l-2",
@@ -6635,14 +5145,8 @@
         "translate": [-28.933495578472925, 2.4000000000000004, 26.340886673723343],
         "rotate": [0, -0.3, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-13",
+      "collection": "station-12"
     },
     {
       "id": "s12-guard-r-2",
@@ -6654,14 +5158,8 @@
         "translate": [-14.873495578472923, 2.4000000000000004, 26.340886673723343],
         "rotate": [0, 0.3, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-13",
+      "collection": "station-12"
     },
     {
       "id": "massing-center-0",
@@ -6672,15 +5170,8 @@
       "transform": {
         "translate": [0, 3.2, -6]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.28,
-        "value": 0.32,
-        "metal": 0,
-        "glow": 0,
-        "kind": "normal",
-        "roughness": 0.85
-      }
+      "material": "mat-35",
+      "collection": "massing"
     },
     {
       "id": "massing-center-1",
@@ -6691,15 +5182,8 @@
       "transform": {
         "translate": [-2.6, 2.4, -11]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.28,
-        "value": 0.32,
-        "metal": 0,
-        "glow": 0,
-        "kind": "normal",
-        "roughness": 0.85
-      }
+      "material": "mat-35",
+      "collection": "massing"
     },
     {
       "id": "massing-center-2",
@@ -6710,15 +5194,8 @@
       "transform": {
         "translate": [2.8, 2.9, -15]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.28,
-        "value": 0.32,
-        "metal": 0,
-        "glow": 0,
-        "kind": "normal",
-        "roughness": 0.85
-      }
+      "material": "mat-35",
+      "collection": "massing"
     },
     {
       "id": "massing-z0-hull",
@@ -6729,15 +5206,8 @@
       "transform": {
         "translate": [13.28931596488358, -2.8800000000000003, 72.5174502266342]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.28,
-        "value": 0.32,
-        "metal": 0,
-        "glow": 0,
-        "kind": "normal",
-        "roughness": 0.85
-      }
+      "material": "mat-35",
+      "collection": "massing"
     },
     {
       "id": "massing-z0-tower",
@@ -6748,15 +5218,8 @@
       "transform": {
         "translate": [16.03331596488358, 2.5600000000000005, 71.53745022663419]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.28,
-        "value": 0.32,
-        "metal": 0,
-        "glow": 0,
-        "kind": "normal",
-        "roughness": 0.85
-      }
+      "material": "mat-35",
+      "collection": "massing"
     },
     {
       "id": "massing-z1-hull",
@@ -6767,15 +5230,8 @@
       "transform": {
         "translate": [72.51745022663418, -4.365, -13.289315964883572]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.28,
-        "value": 0.32,
-        "metal": 0,
-        "glow": 0,
-        "kind": "normal",
-        "roughness": 0.85
-      }
+      "material": "mat-35",
+      "collection": "massing"
     },
     {
       "id": "massing-z1-tower",
@@ -6786,15 +5242,8 @@
       "transform": {
         "translate": [76.43745022663418, 3.88, -14.689315964883573]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.28,
-        "value": 0.32,
-        "metal": 0,
-        "glow": 0,
-        "kind": "normal",
-        "roughness": 0.85
-      }
+      "material": "mat-35",
+      "collection": "massing"
     },
     {
       "id": "massing-z2-hull",
@@ -6805,15 +5254,8 @@
       "transform": {
         "translate": [-40.65031662901047, -3.375, -61.50559538894061]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.28,
-        "value": 0.32,
-        "metal": 0,
-        "glow": 0,
-        "kind": "normal",
-        "roughness": 0.85
-      }
+      "material": "mat-35",
+      "collection": "massing"
     },
     {
       "id": "massing-z2-tower",
@@ -6824,15 +5266,8 @@
       "transform": {
         "translate": [-37.514316629010466, 3, -62.62559538894061]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.28,
-        "value": 0.32,
-        "metal": 0,
-        "glow": 0,
-        "kind": "normal",
-        "roughness": 0.85
-      }
+      "material": "mat-35",
+      "collection": "massing"
     },
     {
       "id": "massing-z3-hull",
@@ -6843,15 +5278,8 @@
       "transform": {
         "translate": [-61.5055953889406, -3.375, 40.65031662901049]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.28,
-        "value": 0.32,
-        "metal": 0,
-        "glow": 0,
-        "kind": "normal",
-        "roughness": 0.85
-      }
+      "material": "mat-35",
+      "collection": "massing"
     },
     {
       "id": "massing-z3-tower",
@@ -6862,15 +5290,8 @@
       "transform": {
         "translate": [-58.369595388940596, 3, 39.53031662901049]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.28,
-        "value": 0.32,
-        "metal": 0,
-        "glow": 0,
-        "kind": "normal",
-        "roughness": 0.85
-      }
+      "material": "mat-35",
+      "collection": "massing"
     },
     {
       "id": "horizon-0",
@@ -6882,16 +5303,8 @@
         "translate": [1.2263089363890987, 7.016592952333921, 146.67096777177466],
         "rotate": [0, 0, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "metal": 0,
-        "glow": 0,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-36",
+      "collection": "horizon"
     },
     {
       "id": "horizon-1",
@@ -6903,16 +5316,8 @@
         "translate": [64.5329298516853, 7.62296579657653, 91.08047383992307],
         "rotate": [0, 0.34528374665954953, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "metal": 0,
-        "glow": 0,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-36",
+      "collection": "horizon"
     },
     {
       "id": "horizon-2",
@@ -6924,16 +5329,8 @@
         "translate": [43.39754332424673, 4.819555072083943, 56.41238060860907],
         "rotate": [0, -0.3486303089654353, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "metal": 0,
-        "glow": 0,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-36",
+      "collection": "horizon"
     },
     {
       "id": "horizon-3",
@@ -6945,16 +5342,8 @@
         "translate": [134.46622904649587, 4.842001421418689, -17.175477915113298],
         "rotate": [0, 0.006725560193740241, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "metal": 0,
-        "glow": 0,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-36",
+      "collection": "horizon"
     },
     {
       "id": "horizon-4",
@@ -6966,16 +5355,8 @@
         "translate": [134.66618037907008, 7.640377316314558, 14.168395165144068],
         "rotate": [0, 0.3418395632353122, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "metal": 0,
-        "glow": 0,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-36",
+      "collection": "horizon"
     },
     {
       "id": "horizon-5",
@@ -6987,16 +5368,8 @@
         "translate": [42.816902701975984, 6.990241111126378, -60.495683719332064],
         "rotate": [0, -0.35187830398866804, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "metal": 0,
-        "glow": 0,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-36",
+      "collection": "horizon"
     },
     {
       "id": "horizon-6",
@@ -7008,16 +5381,8 @@
         "translate": [65.80315081682447, 4.3376940527581525, -93.36080373692268],
         "rotate": [0, 0.01344921888845539, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "metal": 0,
-        "glow": 0,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-36",
+      "collection": "horizon"
     },
     {
       "id": "horizon-7",
@@ -7029,16 +5394,8 @@
         "translate": [-1.3953903972815036, 5.582809968766616, -150.31673056098157],
         "rotate": [0, 0.33829873245717335, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "metal": 0,
-        "glow": 0,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-36",
+      "collection": "horizon"
     },
     {
       "id": "horizon-8",
@@ -7050,16 +5407,8 @@
         "translate": [-45.43582032906106, 7.956071234520032, -72.65186988494834],
         "rotate": [0, -0.35502681343260184, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "metal": 0,
-        "glow": 0,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-36",
+      "collection": "horizon"
     },
     {
       "id": "horizon-9",
@@ -7071,16 +5420,8 @@
         "translate": [-52.155267541445745, 6.178620822448911, -73.67225718275498],
         "rotate": [0, 0.020169075122725907, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "metal": 0,
-        "glow": 0,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-36",
+      "collection": "horizon"
     },
     {
       "id": "horizon-10",
@@ -7092,16 +5433,8 @@
         "translate": [-148.08101776841508, 4.204050667126552, 14.763947213869454],
         "rotate": [0, 0.33466225541442246, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "metal": 0,
-        "glow": 0,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-36",
+      "collection": "horizon"
     },
     {
       "id": "horizon-11",
@@ -7113,16 +5446,8 @@
         "translate": [-104.28482505381457, 6.424407144257572, -14.704759955716549],
         "rotate": [0, -0.35807494712787274, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "metal": 0,
-        "glow": 0,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-36",
+      "collection": "horizon"
     },
     {
       "id": "horizon-12",
@@ -7134,16 +5459,8 @@
         "translate": [-40.94467813570855, 7.900940120366205, 59.06064086865428],
         "rotate": [0, 0.02688322901019139, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "metal": 0,
-        "glow": 0,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-36",
+      "collection": "horizon"
     },
     {
       "id": "horizon-13",
@@ -7155,16 +5472,8 @@
         "translate": [-80.49790324126236, 5.34938983448815, 110.4302823633431],
         "rotate": [0, 0.3309311602381515, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "metal": 0,
-        "glow": 0,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-36",
+      "collection": "horizon"
     }
   ],
   "overlay": [

--- a/sdf-js/fixtures/golden/assemble-deck-grid.json
+++ b/sdf-js/fixtures/golden/assemble-deck-grid.json
@@ -1,6 +1,425 @@
 {
   "v": 1,
   "name": "(deck) 最懂你的头条 — 2013 管理层陈述",
+  "collections": {
+    "station-0": {
+      "kind": "station",
+      "station": 0
+    },
+    "path-0": {
+      "kind": "transit-path",
+      "from": 0
+    },
+    "station-1": {
+      "kind": "station",
+      "station": 1
+    },
+    "path-1": {
+      "kind": "transit-path",
+      "from": 1
+    },
+    "station-2": {
+      "kind": "station",
+      "station": 2
+    },
+    "path-2": {
+      "kind": "transit-path",
+      "from": 2
+    },
+    "station-3": {
+      "kind": "station",
+      "station": 3
+    },
+    "path-3": {
+      "kind": "transit-path",
+      "from": 3
+    },
+    "station-4": {
+      "kind": "station",
+      "station": 4
+    },
+    "path-4": {
+      "kind": "transit-path",
+      "from": 4
+    },
+    "station-5": {
+      "kind": "station",
+      "station": 5
+    },
+    "path-5": {
+      "kind": "transit-path",
+      "from": 5
+    },
+    "station-6": {
+      "kind": "station",
+      "station": 6
+    },
+    "path-6": {
+      "kind": "transit-path",
+      "from": 6
+    },
+    "station-7": {
+      "kind": "station",
+      "station": 7
+    },
+    "path-7": {
+      "kind": "transit-path",
+      "from": 7
+    },
+    "station-8": {
+      "kind": "station",
+      "station": 8
+    },
+    "path-8": {
+      "kind": "transit-path",
+      "from": 8
+    },
+    "station-9": {
+      "kind": "station",
+      "station": 9
+    },
+    "path-9": {
+      "kind": "transit-path",
+      "from": 9
+    },
+    "station-10": {
+      "kind": "station",
+      "station": 10
+    },
+    "path-10": {
+      "kind": "transit-path",
+      "from": 10
+    },
+    "station-11": {
+      "kind": "station",
+      "station": 11
+    },
+    "path-11": {
+      "kind": "transit-path",
+      "from": 11
+    },
+    "station-12": {
+      "kind": "station",
+      "station": 12
+    },
+    "massing": {
+      "kind": "dressing",
+      "cull": "never"
+    },
+    "horizon": {
+      "kind": "dressing",
+      "cull": "nearest",
+      "budget": {
+        "hero": 7,
+        "content": 3
+      },
+      "yieldTo": "massing"
+    },
+    "env": {
+      "kind": "dressing",
+      "cull": "never"
+    }
+  },
+  "materials": {
+    "mat-0": {
+      "hue": 0.62,
+      "sat": 0.25,
+      "value": 0.1,
+      "kind": "normal",
+      "roughness": 0.48,
+      "clearcoat": 0.45
+    },
+    "mat-1": {
+      "hue": 0.58,
+      "sat": 0.25,
+      "value": 0.85,
+      "glow": 0.45,
+      "kind": "normal",
+      "roughness": 0.5,
+      "clearcoat": 0.2
+    },
+    "mat-2": {
+      "hue": 0.62,
+      "sat": 0.25,
+      "value": 0.1,
+      "kind": "normal",
+      "roughness": 0.4,
+      "clearcoat": 0.45
+    },
+    "mat-3": {
+      "hue": 0.995,
+      "sat": 0.85,
+      "value": 0.78,
+      "glow": 0.12,
+      "kind": "normal",
+      "roughness": 0.3,
+      "clearcoat": 0.5
+    },
+    "mat-4": {
+      "hue": 0.995,
+      "sat": 0.15,
+      "value": 0.8,
+      "glow": 0.5,
+      "kind": "normal",
+      "roughness": 0.4
+    },
+    "mat-5": {
+      "hue": 0.11,
+      "sat": 0.78,
+      "value": 0.95,
+      "glow": 0.1,
+      "kind": "normal",
+      "roughness": 0.22,
+      "clearcoat": 0.6
+    },
+    "mat-6": {
+      "hue": 0.58,
+      "sat": 0.1,
+      "value": 0.55,
+      "kind": "normal",
+      "roughness": 0.6,
+      "clearcoat": 0.1
+    },
+    "mat-7": {
+      "hue": 0.55,
+      "sat": 0.62,
+      "value": 0.82,
+      "kind": "normal",
+      "roughness": 0.3,
+      "clearcoat": 0.45
+    },
+    "mat-8": {
+      "hue": 0.5680000000000001,
+      "sat": 0.648,
+      "value": 0.7759999999999999,
+      "kind": "normal",
+      "roughness": 0.3,
+      "clearcoat": 0.45
+    },
+    "mat-9": {
+      "hue": 0.5860000000000001,
+      "sat": 0.676,
+      "value": 0.732,
+      "kind": "normal",
+      "roughness": 0.3,
+      "clearcoat": 0.45
+    },
+    "mat-10": {
+      "hue": 0.6040000000000001,
+      "sat": 0.704,
+      "value": 0.688,
+      "kind": "normal",
+      "roughness": 0.3,
+      "clearcoat": 0.45
+    },
+    "mat-11": {
+      "hue": 0.622,
+      "sat": 0.732,
+      "value": 0.6439999999999999,
+      "kind": "normal",
+      "roughness": 0.3,
+      "clearcoat": 0.45
+    },
+    "mat-12": {
+      "hue": 0.11,
+      "sat": 0.78,
+      "value": 0.95,
+      "metal": 0,
+      "glow": 0.1,
+      "kind": "normal",
+      "roughness": 0.22,
+      "clearcoat": 0.6
+    },
+    "mat-13": {
+      "hue": 0.62,
+      "sat": 0.25,
+      "value": 0.14,
+      "kind": "normal",
+      "roughness": 0.5,
+      "clearcoat": 0.35
+    },
+    "mat-14": {
+      "hue": 0.64,
+      "sat": 0.76,
+      "value": 0.6,
+      "kind": "normal",
+      "roughness": 0.3,
+      "clearcoat": 0.45
+    },
+    "mat-15": {
+      "hue": 0.995,
+      "sat": 0.85,
+      "value": 0.78,
+      "glow": 0.24,
+      "kind": "normal",
+      "roughness": 0.3,
+      "clearcoat": 0.5
+    },
+    "mat-16": {
+      "hue": 0.62875,
+      "sat": 0.76,
+      "value": 0.5875,
+      "kind": "normal",
+      "roughness": 0.55,
+      "clearcoat": 0.2
+    },
+    "mat-17": {
+      "hue": 0.6175,
+      "sat": 0.74,
+      "value": 0.625,
+      "kind": "normal",
+      "roughness": 0.55,
+      "clearcoat": 0.2
+    },
+    "mat-18": {
+      "hue": 0.60625,
+      "sat": 0.72,
+      "value": 0.6625000000000001,
+      "kind": "normal",
+      "roughness": 0.55,
+      "clearcoat": 0.2
+    },
+    "mat-19": {
+      "hue": 0.58,
+      "sat": 0.25,
+      "value": 0.55,
+      "glow": 0.08,
+      "kind": "normal",
+      "roughness": 0.6,
+      "clearcoat": 0.15
+    },
+    "mat-20": {
+      "hue": 0.62,
+      "sat": 0.2,
+      "value": 0.18,
+      "kind": "normal",
+      "roughness": 0.5
+    },
+    "mat-21": {
+      "hue": 0.55,
+      "sat": 0.62,
+      "value": 0.85,
+      "kind": "normal",
+      "roughness": 0.3,
+      "clearcoat": 0.45
+    },
+    "mat-22": {
+      "hue": 0.6100000000000001,
+      "sat": 0.7266666666666667,
+      "value": 0.65,
+      "kind": "normal",
+      "roughness": 0.3,
+      "clearcoat": 0.45
+    },
+    "mat-23": {
+      "hue": 0.64,
+      "sat": 0.78,
+      "value": 0.55,
+      "kind": "normal",
+      "roughness": 0.3,
+      "clearcoat": 0.45
+    },
+    "mat-24": {
+      "hue": 0.5650000000000001,
+      "sat": 0.6433333333333333,
+      "value": 0.7833333333333333,
+      "kind": "normal",
+      "roughness": 0.3,
+      "clearcoat": 0.45
+    },
+    "mat-25": {
+      "hue": 0.5800000000000001,
+      "sat": 0.6666666666666666,
+      "value": 0.7466666666666666,
+      "kind": "normal",
+      "roughness": 0.3,
+      "clearcoat": 0.45
+    },
+    "mat-26": {
+      "hue": 0.5950000000000001,
+      "sat": 0.69,
+      "value": 0.71,
+      "kind": "normal",
+      "roughness": 0.3,
+      "clearcoat": 0.45
+    },
+    "mat-27": {
+      "hue": 0.6100000000000001,
+      "sat": 0.7133333333333334,
+      "value": 0.6733333333333333,
+      "kind": "normal",
+      "roughness": 0.3,
+      "clearcoat": 0.45
+    },
+    "mat-28": {
+      "hue": 0.625,
+      "sat": 0.7366666666666667,
+      "value": 0.6366666666666666,
+      "kind": "normal",
+      "roughness": 0.3,
+      "clearcoat": 0.45
+    },
+    "mat-29": {
+      "hue": 0.11,
+      "sat": 0.78,
+      "value": 0.95,
+      "metal": 0,
+      "glow": 0.04,
+      "kind": "normal",
+      "roughness": 0.22,
+      "clearcoat": 0.6
+    },
+    "mat-30": {
+      "hue": 0.5950000000000001,
+      "sat": 0.7,
+      "value": 0.71,
+      "kind": "normal",
+      "roughness": 0.3,
+      "clearcoat": 0.45
+    },
+    "mat-31": {
+      "hue": 0.64,
+      "sat": 0.78,
+      "value": 0.57,
+      "kind": "normal",
+      "roughness": 0.3,
+      "clearcoat": 0.45
+    },
+    "mat-32": {
+      "hue": 0.62,
+      "sat": 0.3,
+      "value": 0.22,
+      "kind": "normal",
+      "roughness": 0.4,
+      "clearcoat": 0.3
+    },
+    "mat-33": {
+      "hue": 0.6,
+      "sat": 0.1,
+      "value": 0.3,
+      "kind": "normal",
+      "roughness": 0.7,
+      "clearcoat": 0.1
+    },
+    "mat-34": {
+      "hue": 0.57,
+      "sat": 0.55,
+      "value": 0.72,
+      "kind": "normal",
+      "roughness": 0.3,
+      "clearcoat": 0.45
+    },
+    "mat-35": {
+      "hue": 0.62,
+      "sat": 0.25,
+      "value": 0.14,
+      "metal": 0,
+      "glow": 0,
+      "kind": "normal",
+      "roughness": 0.5,
+      "clearcoat": 0.35
+    }
+  },
   "subjects": [
     {
       "id": "s0-mono-title",
@@ -12,14 +431,8 @@
       "transform": {
         "translate": [0, 2.7, -1.4]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.1,
-        "kind": "normal",
-        "roughness": 0.48,
-        "clearcoat": 0.45
-      }
+      "material": "mat-0",
+      "collection": "station-0"
     },
     {
       "id": "s0-forest-0-l0",
@@ -32,14 +445,8 @@
         "translate": [-3.4, 4, -6],
         "rotate": [0, -0.12, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.1,
-        "kind": "normal",
-        "roughness": 0.48,
-        "clearcoat": 0.45
-      }
+      "material": "mat-0",
+      "collection": "station-0"
     },
     {
       "id": "s0-forest-0-l1",
@@ -52,14 +459,8 @@
         "translate": [-6.4, 4, -8.2],
         "rotate": [0, -0.2, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.1,
-        "kind": "normal",
-        "roughness": 0.48,
-        "clearcoat": 0.45
-      }
+      "material": "mat-0",
+      "collection": "station-0"
     },
     {
       "id": "s0-forest-0-r0",
@@ -72,14 +473,8 @@
         "translate": [3.4, 4, -6],
         "rotate": [0, 0.12, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.1,
-        "kind": "normal",
-        "roughness": 0.48,
-        "clearcoat": 0.45
-      }
+      "material": "mat-0",
+      "collection": "station-0"
     },
     {
       "id": "s0-forest-0-r1",
@@ -92,14 +487,8 @@
         "translate": [6.4, 4, -8.2],
         "rotate": [0, 0.2, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.1,
-        "kind": "normal",
-        "roughness": 0.48,
-        "clearcoat": 0.45
-      }
+      "material": "mat-0",
+      "collection": "station-0"
     },
     {
       "id": "s0-forest-1-l0",
@@ -112,14 +501,8 @@
         "translate": [-4.5, 5.75, -12.5],
         "rotate": [0, -0.12, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.1,
-        "kind": "normal",
-        "roughness": 0.48,
-        "clearcoat": 0.45
-      }
+      "material": "mat-0",
+      "collection": "station-0"
     },
     {
       "id": "s0-forest-1-l1",
@@ -132,14 +515,8 @@
         "translate": [-7.5, 5.75, -14.7],
         "rotate": [0, -0.2, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.1,
-        "kind": "normal",
-        "roughness": 0.48,
-        "clearcoat": 0.45
-      }
+      "material": "mat-0",
+      "collection": "station-0"
     },
     {
       "id": "s0-forest-1-r0",
@@ -152,14 +529,8 @@
         "translate": [4.5, 5.75, -12.5],
         "rotate": [0, 0.12, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.1,
-        "kind": "normal",
-        "roughness": 0.48,
-        "clearcoat": 0.45
-      }
+      "material": "mat-0",
+      "collection": "station-0"
     },
     {
       "id": "s0-forest-1-r1",
@@ -172,14 +543,8 @@
         "translate": [7.5, 5.75, -14.7],
         "rotate": [0, 0.2, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.1,
-        "kind": "normal",
-        "roughness": 0.48,
-        "clearcoat": 0.45
-      }
+      "material": "mat-0",
+      "collection": "station-0"
     },
     {
       "id": "s0-forest-2-l0",
@@ -192,14 +557,8 @@
         "translate": [-5.6, 7.5, -19],
         "rotate": [0, -0.12, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.1,
-        "kind": "normal",
-        "roughness": 0.48,
-        "clearcoat": 0.45
-      }
+      "material": "mat-0",
+      "collection": "station-0"
     },
     {
       "id": "s0-forest-2-l1",
@@ -212,14 +571,8 @@
         "translate": [-8.600000000000001, 7.5, -21.2],
         "rotate": [0, -0.2, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.1,
-        "kind": "normal",
-        "roughness": 0.48,
-        "clearcoat": 0.45
-      }
+      "material": "mat-0",
+      "collection": "station-0"
     },
     {
       "id": "s0-forest-2-r0",
@@ -232,14 +585,8 @@
         "translate": [5.6, 7.5, -19],
         "rotate": [0, 0.12, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.1,
-        "kind": "normal",
-        "roughness": 0.48,
-        "clearcoat": 0.45
-      }
+      "material": "mat-0",
+      "collection": "station-0"
     },
     {
       "id": "s0-forest-2-r1",
@@ -252,14 +599,8 @@
         "translate": [8.600000000000001, 7.5, -21.2],
         "rotate": [0, 0.2, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.1,
-        "kind": "normal",
-        "roughness": 0.48,
-        "clearcoat": 0.45
-      }
+      "material": "mat-0",
+      "collection": "station-0"
     },
     {
       "id": "s0-forest-3-l0",
@@ -272,14 +613,8 @@
         "translate": [-6.7, 9.25, -25.5],
         "rotate": [0, -0.12, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.1,
-        "kind": "normal",
-        "roughness": 0.48,
-        "clearcoat": 0.45
-      }
+      "material": "mat-0",
+      "collection": "station-0"
     },
     {
       "id": "s0-forest-3-l1",
@@ -292,14 +627,8 @@
         "translate": [-9.700000000000001, 9.25, -27.7],
         "rotate": [0, -0.2, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.1,
-        "kind": "normal",
-        "roughness": 0.48,
-        "clearcoat": 0.45
-      }
+      "material": "mat-0",
+      "collection": "station-0"
     },
     {
       "id": "s0-forest-3-r0",
@@ -312,14 +641,8 @@
         "translate": [6.7, 9.25, -25.5],
         "rotate": [0, 0.12, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.1,
-        "kind": "normal",
-        "roughness": 0.48,
-        "clearcoat": 0.45
-      }
+      "material": "mat-0",
+      "collection": "station-0"
     },
     {
       "id": "s0-forest-3-r1",
@@ -332,14 +655,8 @@
         "translate": [9.700000000000001, 9.25, -27.7],
         "rotate": [0, 0.2, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.1,
-        "kind": "normal",
-        "roughness": 0.48,
-        "clearcoat": 0.45
-      }
+      "material": "mat-0",
+      "collection": "station-0"
     },
     {
       "id": "s0-floater-0",
@@ -352,20 +669,14 @@
         "translate": [-6.5, 3.4, -6],
         "rotate": [0, -1, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.1,
-        "kind": "normal",
-        "roughness": 0.48,
-        "clearcoat": 0.45
-      },
+      "material": "mat-0",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "3.400 - 0.000 * smoothstep(0.00, 1.00, t) + 0.07 * sin(0.35 * t + 0.00)"
         }
-      ]
+      ],
+      "collection": "station-0"
     },
     {
       "id": "s0-floater-1",
@@ -378,20 +689,14 @@
         "translate": [4.8, 2.6, -7.5],
         "rotate": [0, -0.5, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.1,
-        "kind": "normal",
-        "roughness": 0.48,
-        "clearcoat": 0.45
-      },
+      "material": "mat-0",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "2.600 - 0.000 * smoothstep(0.00, 1.00, t) + 0.09 * sin(0.43 * t + 2.10)"
         }
-      ]
+      ],
+      "collection": "station-0"
     },
     {
       "id": "s0-floater-2",
@@ -404,20 +709,14 @@
         "translate": [-3.2, 4.6, -9],
         "rotate": [0, 0, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.1,
-        "kind": "normal",
-        "roughness": 0.48,
-        "clearcoat": 0.45
-      },
+      "material": "mat-0",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "4.600 - 0.000 * smoothstep(0.00, 1.00, t) + 0.11 * sin(0.51 * t + 4.20)"
         }
-      ]
+      ],
+      "collection": "station-0"
     },
     {
       "id": "s0-floater-3",
@@ -430,20 +729,14 @@
         "translate": [7.2, 4, -5],
         "rotate": [0, 0.5, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.1,
-        "kind": "normal",
-        "roughness": 0.48,
-        "clearcoat": 0.45
-      },
+      "material": "mat-0",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "4.000 - 0.000 * smoothstep(0.00, 1.00, t) + 0.13 * sin(0.59 * t + 0.02)"
         }
-      ]
+      ],
+      "collection": "station-0"
     },
     {
       "id": "s0-floater-4",
@@ -456,20 +749,14 @@
         "translate": [-9.5, 5.8, -12],
         "rotate": [0, 1, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.1,
-        "kind": "normal",
-        "roughness": 0.48,
-        "clearcoat": 0.45
-      },
+      "material": "mat-0",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "5.800 - 0.000 * smoothstep(0.00, 1.00, t) + 0.15 * sin(0.67 * t + 2.12)"
         }
-      ]
+      ],
+      "collection": "station-0"
     },
     {
       "id": "s0-floater-5",
@@ -482,20 +769,14 @@
         "translate": [10.5, 5.2, -10],
         "rotate": [0, 1.5, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.1,
-        "kind": "normal",
-        "roughness": 0.48,
-        "clearcoat": 0.45
-      },
+      "material": "mat-0",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "5.200 - 0.000 * smoothstep(0.00, 1.00, t) + 0.17 * sin(0.75 * t + 4.22)"
         }
-      ]
+      ],
+      "collection": "station-0"
     },
     {
       "id": "s0-floater-6",
@@ -508,20 +789,14 @@
         "translate": [2.2, 7, -14],
         "rotate": [0, 2, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.1,
-        "kind": "normal",
-        "roughness": 0.48,
-        "clearcoat": 0.45
-      },
+      "material": "mat-0",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "7.000 - 0.000 * smoothstep(0.00, 1.00, t) + 0.19 * sin(0.83 * t + 0.04)"
         }
-      ]
+      ],
+      "collection": "station-0"
     },
     {
       "id": "s0-floater-7",
@@ -534,20 +809,14 @@
         "translate": [-5.8, 6.4, -16],
         "rotate": [0, 2.5, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.1,
-        "kind": "normal",
-        "roughness": 0.48,
-        "clearcoat": 0.45
-      },
+      "material": "mat-0",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "6.400 - 0.000 * smoothstep(0.00, 1.00, t) + 0.21 * sin(0.91 * t + 2.14)"
         }
-      ]
+      ],
+      "collection": "station-0"
     },
     {
       "id": "s0-floater-8",
@@ -560,20 +829,14 @@
         "translate": [6.8, 2, -13],
         "rotate": [0, 3, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.1,
-        "kind": "normal",
-        "roughness": 0.48,
-        "clearcoat": 0.45
-      },
+      "material": "mat-0",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "2.000 - 0.000 * smoothstep(0.00, 1.00, t) + 0.23 * sin(0.99 * t + 4.24)"
         }
-      ]
+      ],
+      "collection": "station-0"
     },
     {
       "id": "path-0-1",
@@ -585,15 +848,8 @@
         "translate": [2, 0.03, 0],
         "rotate": [0, 0, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-0"
     },
     {
       "id": "path-0-2",
@@ -605,15 +861,8 @@
         "translate": [4, 0.03, 0],
         "rotate": [0, 0, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-0"
     },
     {
       "id": "path-0-3",
@@ -625,15 +874,8 @@
         "translate": [6, 0.03, 0],
         "rotate": [0, 0, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-0"
     },
     {
       "id": "path-0-4",
@@ -645,15 +887,8 @@
         "translate": [8, 0.03, 0],
         "rotate": [0, 0, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-0"
     },
     {
       "id": "path-0-5",
@@ -665,15 +900,8 @@
         "translate": [10, 0.03, 0],
         "rotate": [0, 0, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-0"
     },
     {
       "id": "path-0-6",
@@ -685,15 +913,8 @@
         "translate": [12, 0.03, 0],
         "rotate": [0, 0, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-0"
     },
     {
       "id": "path-0-7",
@@ -705,15 +926,8 @@
         "translate": [14, 0.03, 0],
         "rotate": [0, 0, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-0"
     },
     {
       "id": "s1-dome",
@@ -724,14 +938,8 @@
       "transform": {
         "translate": [16, 0, -1.2]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.1,
-        "kind": "normal",
-        "roughness": 0.4,
-        "clearcoat": 0.45
-      }
+      "material": "mat-2",
+      "collection": "station-1"
     },
     {
       "id": "s1-orb-0",
@@ -742,21 +950,14 @@
       "transform": {
         "translate": [19.487901743725214, 2.2, -0.5534640548657206]
       },
-      "material": {
-        "hue": 0.995,
-        "sat": 0.85,
-        "value": 0.78,
-        "glow": 0.12,
-        "kind": "normal",
-        "roughness": 0.3,
-        "clearcoat": 0.5
-      },
+      "material": "mat-3",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "3.800 - 1.600 * smoothstep(9.45, 10.00, t) + 0.04 * sin(0.6 * t + -4.56)"
         }
-      ]
+      ],
+      "collection": "station-1"
     },
     {
       "id": "s1-orb-stem-0",
@@ -768,14 +969,8 @@
       "transform": {
         "translate": [19.487901743725214, 1.1, -0.5534640548657206]
       },
-      "material": {
-        "hue": 0.995,
-        "sat": 0.15,
-        "value": 0.8,
-        "glow": 0.5,
-        "kind": "normal",
-        "roughness": 0.4
-      }
+      "material": "mat-4",
+      "collection": "station-1"
     },
     {
       "id": "s1-orb-1",
@@ -786,21 +981,14 @@
       "transform": {
         "translate": [18.350094450939565, 2.2, -0.19211357462773826]
       },
-      "material": {
-        "hue": 0.11,
-        "sat": 0.78,
-        "value": 0.95,
-        "glow": 0.1,
-        "kind": "normal",
-        "roughness": 0.22,
-        "clearcoat": 0.6
-      },
+      "material": "mat-5",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "3.800 - 1.600 * smoothstep(10.45, 11.00, t) + 0.04 * sin(0.6 * t + -2.86)"
         }
-      ]
+      ],
+      "collection": "station-1"
     },
     {
       "id": "s1-orb-stem-1",
@@ -812,14 +1000,8 @@
       "transform": {
         "translate": [18.350094450939565, 1.1, -0.19211357462773826]
       },
-      "material": {
-        "hue": 0.995,
-        "sat": 0.15,
-        "value": 0.8,
-        "glow": 0.5,
-        "kind": "normal",
-        "roughness": 0.4
-      }
+      "material": "mat-4",
+      "collection": "station-1"
     },
     {
       "id": "s1-orb-2",
@@ -830,21 +1012,14 @@
       "transform": {
         "translate": [16.828466888570354, 2.2, 0.0046276749721592125]
       },
-      "material": {
-        "hue": 0.995,
-        "sat": 0.85,
-        "value": 0.78,
-        "glow": 0.12,
-        "kind": "normal",
-        "roughness": 0.3,
-        "clearcoat": 0.5
-      },
+      "material": "mat-3",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "3.800 - 1.600 * smoothstep(11.45, 12.00, t) + 0.04 * sin(0.6 * t + -1.16)"
         }
-      ]
+      ],
+      "collection": "station-1"
     },
     {
       "id": "s1-orb-stem-2",
@@ -856,14 +1031,8 @@
       "transform": {
         "translate": [16.828466888570354, 1.1, 0.0046276749721592125]
       },
-      "material": {
-        "hue": 0.995,
-        "sat": 0.15,
-        "value": 0.8,
-        "glow": 0.5,
-        "kind": "normal",
-        "roughness": 0.4
-      }
+      "material": "mat-4",
+      "collection": "station-1"
     },
     {
       "id": "s1-orb-3",
@@ -874,21 +1043,14 @@
       "transform": {
         "translate": [15.171533111429648, 2.2, 0.0046276749721592125]
       },
-      "material": {
-        "hue": 0.995,
-        "sat": 0.85,
-        "value": 0.78,
-        "glow": 0.12,
-        "kind": "normal",
-        "roughness": 0.3,
-        "clearcoat": 0.5
-      },
+      "material": "mat-3",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "3.800 - 1.600 * smoothstep(12.45, 13.00, t) + 0.04 * sin(0.6 * t + 0.54)"
         }
-      ]
+      ],
+      "collection": "station-1"
     },
     {
       "id": "s1-orb-stem-3",
@@ -900,14 +1062,8 @@
       "transform": {
         "translate": [15.171533111429648, 1.1, 0.0046276749721592125]
       },
-      "material": {
-        "hue": 0.995,
-        "sat": 0.15,
-        "value": 0.8,
-        "glow": 0.5,
-        "kind": "normal",
-        "roughness": 0.4
-      }
+      "material": "mat-4",
+      "collection": "station-1"
     },
     {
       "id": "s1-orb-4",
@@ -918,21 +1074,14 @@
       "transform": {
         "translate": [13.649905549060437, 2.2, -0.19211357462773782]
       },
-      "material": {
-        "hue": 0.995,
-        "sat": 0.85,
-        "value": 0.78,
-        "glow": 0.12,
-        "kind": "normal",
-        "roughness": 0.3,
-        "clearcoat": 0.5
-      },
+      "material": "mat-3",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "3.800 - 1.600 * smoothstep(13.45, 14.00, t) + 0.04 * sin(0.6 * t + -4.04)"
         }
-      ]
+      ],
+      "collection": "station-1"
     },
     {
       "id": "s1-orb-stem-4",
@@ -944,14 +1093,8 @@
       "transform": {
         "translate": [13.649905549060437, 1.1, -0.19211357462773782]
       },
-      "material": {
-        "hue": 0.995,
-        "sat": 0.15,
-        "value": 0.8,
-        "glow": 0.5,
-        "kind": "normal",
-        "roughness": 0.4
-      }
+      "material": "mat-4",
+      "collection": "station-1"
     },
     {
       "id": "s1-orb-5",
@@ -962,21 +1105,14 @@
       "transform": {
         "translate": [12.512098256274788, 2.2, -0.5534640548657205]
       },
-      "material": {
-        "hue": 0.995,
-        "sat": 0.85,
-        "value": 0.78,
-        "glow": 0.12,
-        "kind": "normal",
-        "roughness": 0.3,
-        "clearcoat": 0.5
-      },
+      "material": "mat-3",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "3.800 - 1.600 * smoothstep(14.45, 15.00, t) + 0.04 * sin(0.6 * t + -2.34)"
         }
-      ]
+      ],
+      "collection": "station-1"
     },
     {
       "id": "s1-orb-stem-5",
@@ -988,14 +1124,8 @@
       "transform": {
         "translate": [12.512098256274788, 1.1, -0.5534640548657205]
       },
-      "material": {
-        "hue": 0.995,
-        "sat": 0.15,
-        "value": 0.8,
-        "glow": 0.5,
-        "kind": "normal",
-        "roughness": 0.4
-      }
+      "material": "mat-4",
+      "collection": "station-1"
     },
     {
       "id": "path-1-1",
@@ -1007,15 +1137,8 @@
         "translate": [18, 0.03, 0],
         "rotate": [0, 0, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-1"
     },
     {
       "id": "path-1-2",
@@ -1027,15 +1150,8 @@
         "translate": [20, 0.03, 0],
         "rotate": [0, 0, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-1"
     },
     {
       "id": "path-1-3",
@@ -1047,15 +1163,8 @@
         "translate": [22, 0.03, 0],
         "rotate": [0, 0, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-1"
     },
     {
       "id": "path-1-4",
@@ -1067,15 +1176,8 @@
         "translate": [24, 0.03, 0],
         "rotate": [0, 0, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-1"
     },
     {
       "id": "path-1-5",
@@ -1087,15 +1189,8 @@
         "translate": [26, 0.03, 0],
         "rotate": [0, 0, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-1"
     },
     {
       "id": "path-1-6",
@@ -1107,15 +1202,8 @@
         "translate": [28, 0.03, 0],
         "rotate": [0, 0, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-1"
     },
     {
       "id": "path-1-7",
@@ -1127,15 +1215,8 @@
         "translate": [30, 0.03, 0],
         "rotate": [0, 0, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-1"
     },
     {
       "id": "s2-plinth-0",
@@ -1146,14 +1227,8 @@
       "transform": {
         "translate": [35.175, 0.06, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.1,
-        "value": 0.55,
-        "kind": "normal",
-        "roughness": 0.6,
-        "clearcoat": 0.1
-      }
+      "material": "mat-6",
+      "collection": "station-2"
     },
     {
       "id": "s2-mono-0",
@@ -1165,21 +1240,15 @@
       "transform": {
         "translate": [35.175, 0.9931034482758622, 0]
       },
-      "material": {
-        "hue": 0.55,
-        "sat": 0.62,
-        "value": 0.82,
-        "kind": "normal",
-        "roughness": 0.3,
-        "clearcoat": 0.45
-      },
+      "material": "mat-7",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "-1.293 + 2.286 * smoothstep(21.45, 22.05, t)"
         }
       ],
-      "pattern": "cracked"
+      "pattern": "cracked",
+      "collection": "station-2"
     },
     {
       "id": "s2-plinth-1",
@@ -1190,14 +1259,8 @@
       "transform": {
         "translate": [33.905, 0.06, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.1,
-        "value": 0.55,
-        "kind": "normal",
-        "roughness": 0.6,
-        "clearcoat": 0.1
-      }
+      "material": "mat-6",
+      "collection": "station-2"
     },
     {
       "id": "s2-mono-1",
@@ -1209,21 +1272,15 @@
       "transform": {
         "translate": [33.905, 1.2413793103448276, 0]
       },
-      "material": {
-        "hue": 0.5680000000000001,
-        "sat": 0.648,
-        "value": 0.7759999999999999,
-        "kind": "normal",
-        "roughness": 0.3,
-        "clearcoat": 0.45
-      },
+      "material": "mat-8",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "-1.541 + 2.783 * smoothstep(22.55, 23.15, t)"
         }
       ],
-      "pattern": "cracked"
+      "pattern": "cracked",
+      "collection": "station-2"
     },
     {
       "id": "s2-plinth-2",
@@ -1234,14 +1291,8 @@
       "transform": {
         "translate": [32.635, 0.06, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.1,
-        "value": 0.55,
-        "kind": "normal",
-        "roughness": 0.6,
-        "clearcoat": 0.1
-      }
+      "material": "mat-6",
+      "collection": "station-2"
     },
     {
       "id": "s2-mono-2",
@@ -1253,21 +1304,15 @@
       "transform": {
         "translate": [32.635, 1.6, 0]
       },
-      "material": {
-        "hue": 0.5860000000000001,
-        "sat": 0.676,
-        "value": 0.732,
-        "kind": "normal",
-        "roughness": 0.3,
-        "clearcoat": 0.45
-      },
+      "material": "mat-9",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "-1.900 + 3.500 * smoothstep(23.65, 24.25, t)"
         }
       ],
-      "pattern": "cracked"
+      "pattern": "cracked",
+      "collection": "station-2"
     },
     {
       "id": "s2-plinth-3",
@@ -1278,14 +1323,8 @@
       "transform": {
         "translate": [31.365, 0.06, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.1,
-        "value": 0.55,
-        "kind": "normal",
-        "roughness": 0.6,
-        "clearcoat": 0.1
-      }
+      "material": "mat-6",
+      "collection": "station-2"
     },
     {
       "id": "s2-mono-3",
@@ -1297,21 +1336,15 @@
       "transform": {
         "translate": [31.365, 1.9034482758620692, 0]
       },
-      "material": {
-        "hue": 0.6040000000000001,
-        "sat": 0.704,
-        "value": 0.688,
-        "kind": "normal",
-        "roughness": 0.3,
-        "clearcoat": 0.45
-      },
+      "material": "mat-10",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "-2.203 + 4.107 * smoothstep(24.75, 25.35, t)"
         }
       ],
-      "pattern": "cracked"
+      "pattern": "cracked",
+      "collection": "station-2"
     },
     {
       "id": "s2-plinth-4",
@@ -1322,14 +1355,8 @@
       "transform": {
         "translate": [30.095, 0.06, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.1,
-        "value": 0.55,
-        "kind": "normal",
-        "roughness": 0.6,
-        "clearcoat": 0.1
-      }
+      "material": "mat-6",
+      "collection": "station-2"
     },
     {
       "id": "s2-mono-4",
@@ -1341,21 +1368,15 @@
       "transform": {
         "translate": [30.095, 2.1517241379310343, 0]
       },
-      "material": {
-        "hue": 0.622,
-        "sat": 0.732,
-        "value": 0.6439999999999999,
-        "kind": "normal",
-        "roughness": 0.3,
-        "clearcoat": 0.45
-      },
+      "material": "mat-11",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "-2.452 + 4.603 * smoothstep(25.85, 26.45, t)"
         }
       ],
-      "pattern": "cracked"
+      "pattern": "cracked",
+      "collection": "station-2"
     },
     {
       "id": "s2-plinth-5",
@@ -1366,14 +1387,8 @@
       "transform": {
         "translate": [28.825, 0.06, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.1,
-        "value": 0.55,
-        "kind": "normal",
-        "roughness": 0.6,
-        "clearcoat": 0.1
-      }
+      "material": "mat-6",
+      "collection": "station-2"
     },
     {
       "id": "s2-mono-5",
@@ -1385,22 +1400,14 @@
       "transform": {
         "translate": [28.825, 2.4, 0]
       },
-      "material": {
-        "hue": 0.11,
-        "sat": 0.78,
-        "value": 0.95,
-        "metal": 0,
-        "glow": 0.1,
-        "kind": "normal",
-        "roughness": 0.22,
-        "clearcoat": 0.6
-      },
+      "material": "mat-12",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "-2.700 + 5.100 * smoothstep(26.95, 27.55, t)"
         }
-      ]
+      ],
+      "collection": "station-2"
     },
     {
       "id": "s2-guard-l-0",
@@ -1412,14 +1419,8 @@
         "translate": [23.865000000000002, 1.1, 1.2],
         "rotate": [0, -0.3, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-13",
+      "collection": "station-2"
     },
     {
       "id": "s2-guard-r-0",
@@ -1431,14 +1432,8 @@
         "translate": [40.135, 1.1, 1.2],
         "rotate": [0, 0.3, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-13",
+      "collection": "station-2"
     },
     {
       "id": "s2-guard-l-1",
@@ -1450,14 +1445,8 @@
         "translate": [24.465, 1.75, -4.6],
         "rotate": [0, -0.3, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-13",
+      "collection": "station-2"
     },
     {
       "id": "s2-guard-r-1",
@@ -1469,14 +1458,8 @@
         "translate": [39.535, 1.75, -4.6],
         "rotate": [0, 0.3, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-13",
+      "collection": "station-2"
     },
     {
       "id": "s2-guard-l-2",
@@ -1488,14 +1471,8 @@
         "translate": [23.064999999999998, 2.4000000000000004, -6.800000000000001],
         "rotate": [0, -0.3, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-13",
+      "collection": "station-2"
     },
     {
       "id": "s2-guard-r-2",
@@ -1507,14 +1484,8 @@
         "translate": [40.935, 2.4000000000000004, -6.800000000000001],
         "rotate": [0, 0.3, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-13",
+      "collection": "station-2"
     },
     {
       "id": "path-2-1",
@@ -1526,15 +1497,8 @@
         "translate": [34, 0.03, 0],
         "rotate": [0, 0, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-2"
     },
     {
       "id": "path-2-2",
@@ -1546,15 +1510,8 @@
         "translate": [36, 0.03, 0],
         "rotate": [0, 0, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-2"
     },
     {
       "id": "path-2-3",
@@ -1566,15 +1523,8 @@
         "translate": [38, 0.03, 0],
         "rotate": [0, 0, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-2"
     },
     {
       "id": "path-2-4",
@@ -1586,15 +1536,8 @@
         "translate": [40, 0.03, 0],
         "rotate": [0, 0, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-2"
     },
     {
       "id": "path-2-5",
@@ -1606,15 +1549,8 @@
         "translate": [42, 0.03, 0],
         "rotate": [0, 0, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-2"
     },
     {
       "id": "path-2-6",
@@ -1626,15 +1562,8 @@
         "translate": [44, 0.03, 0],
         "rotate": [0, 0, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-2"
     },
     {
       "id": "path-2-7",
@@ -1646,15 +1575,8 @@
         "translate": [46, 0.03, 0],
         "rotate": [0, 0, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-2"
     },
     {
       "id": "s3-plinth-0",
@@ -1665,14 +1587,8 @@
       "transform": {
         "translate": [51.175, 0.06, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.1,
-        "value": 0.55,
-        "kind": "normal",
-        "roughness": 0.6,
-        "clearcoat": 0.1
-      }
+      "material": "mat-6",
+      "collection": "station-3"
     },
     {
       "id": "s3-mono-0",
@@ -1684,21 +1600,15 @@
       "transform": {
         "translate": [51.175, 0.14464710547184773, 0]
       },
-      "material": {
-        "hue": 0.55,
-        "sat": 0.62,
-        "value": 0.82,
-        "kind": "normal",
-        "roughness": 0.3,
-        "clearcoat": 0.45
-      },
+      "material": "mat-7",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "-0.445 + 0.589 * smoothstep(34.75, 35.35, t)"
         }
       ],
-      "pattern": "cracked"
+      "pattern": "cracked",
+      "collection": "station-3"
     },
     {
       "id": "s3-plinth-1",
@@ -1709,14 +1619,8 @@
       "transform": {
         "translate": [49.905, 0.06, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.1,
-        "value": 0.55,
-        "kind": "normal",
-        "roughness": 0.6,
-        "clearcoat": 0.1
-      }
+      "material": "mat-6",
+      "collection": "station-3"
     },
     {
       "id": "s3-mono-1",
@@ -1728,21 +1632,15 @@
       "transform": {
         "translate": [49.905, 0.28263283108643933, 0]
       },
-      "material": {
-        "hue": 0.5680000000000001,
-        "sat": 0.648,
-        "value": 0.7759999999999999,
-        "kind": "normal",
-        "roughness": 0.3,
-        "clearcoat": 0.45
-      },
+      "material": "mat-8",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "-0.583 + 0.865 * smoothstep(35.85, 36.45, t)"
         }
       ],
-      "pattern": "cracked"
+      "pattern": "cracked",
+      "collection": "station-3"
     },
     {
       "id": "s3-plinth-2",
@@ -1753,14 +1651,8 @@
       "transform": {
         "translate": [48.635, 0.06, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.1,
-        "value": 0.55,
-        "kind": "normal",
-        "roughness": 0.6,
-        "clearcoat": 0.1
-      }
+      "material": "mat-6",
+      "collection": "station-3"
     },
     {
       "id": "s3-mono-2",
@@ -1772,21 +1664,15 @@
       "transform": {
         "translate": [48.635, 0.5443298969072166, 0]
       },
-      "material": {
-        "hue": 0.5860000000000001,
-        "sat": 0.676,
-        "value": 0.732,
-        "kind": "normal",
-        "roughness": 0.3,
-        "clearcoat": 0.45
-      },
+      "material": "mat-9",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "-0.844 + 1.389 * smoothstep(36.95, 37.55, t)"
         }
       ],
-      "pattern": "cracked"
+      "pattern": "cracked",
+      "collection": "station-3"
     },
     {
       "id": "s3-plinth-3",
@@ -1797,14 +1683,8 @@
       "transform": {
         "translate": [47.365, 0.06, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.1,
-        "value": 0.55,
-        "kind": "normal",
-        "roughness": 0.6,
-        "clearcoat": 0.1
-      }
+      "material": "mat-6",
+      "collection": "station-3"
     },
     {
       "id": "s3-mono-3",
@@ -1816,21 +1696,15 @@
       "transform": {
         "translate": [47.365, 0.9601903251387788, 0]
       },
-      "material": {
-        "hue": 0.6040000000000001,
-        "sat": 0.704,
-        "value": 0.688,
-        "kind": "normal",
-        "roughness": 0.3,
-        "clearcoat": 0.45
-      },
+      "material": "mat-10",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "-1.260 + 2.220 * smoothstep(38.05, 38.65, t)"
         }
       ],
-      "pattern": "cracked"
+      "pattern": "cracked",
+      "collection": "station-3"
     },
     {
       "id": "s3-plinth-4",
@@ -1841,14 +1715,8 @@
       "transform": {
         "translate": [46.095, 0.06, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.1,
-        "value": 0.55,
-        "kind": "normal",
-        "roughness": 0.6,
-        "clearcoat": 0.1
-      }
+      "material": "mat-6",
+      "collection": "station-3"
     },
     {
       "id": "s3-mono-4",
@@ -1860,21 +1728,15 @@
       "transform": {
         "translate": [46.095, 1.5501982553528946, 0]
       },
-      "material": {
-        "hue": 0.622,
-        "sat": 0.732,
-        "value": 0.6439999999999999,
-        "kind": "normal",
-        "roughness": 0.3,
-        "clearcoat": 0.45
-      },
+      "material": "mat-11",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "-1.850 + 3.400 * smoothstep(39.15, 39.75, t)"
         }
       ],
-      "pattern": "cracked"
+      "pattern": "cracked",
+      "collection": "station-3"
     },
     {
       "id": "s3-plinth-5",
@@ -1885,14 +1747,8 @@
       "transform": {
         "translate": [44.825, 0.06, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.1,
-        "value": 0.55,
-        "kind": "normal",
-        "roughness": 0.6,
-        "clearcoat": 0.1
-      }
+      "material": "mat-6",
+      "collection": "station-3"
     },
     {
       "id": "s3-mono-5",
@@ -1904,22 +1760,14 @@
       "transform": {
         "translate": [44.825, 2.4, 0]
       },
-      "material": {
-        "hue": 0.11,
-        "sat": 0.78,
-        "value": 0.95,
-        "metal": 0,
-        "glow": 0.1,
-        "kind": "normal",
-        "roughness": 0.22,
-        "clearcoat": 0.6
-      },
+      "material": "mat-12",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "-2.700 + 5.100 * smoothstep(40.25, 40.85, t)"
         }
-      ]
+      ],
+      "collection": "station-3"
     },
     {
       "id": "s3-guard-l-0",
@@ -1931,14 +1779,8 @@
         "translate": [39.865, 1.1, 1.2],
         "rotate": [0, -0.3, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-13",
+      "collection": "station-3"
     },
     {
       "id": "s3-guard-r-0",
@@ -1950,14 +1792,8 @@
         "translate": [56.135, 1.1, 1.2],
         "rotate": [0, 0.3, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-13",
+      "collection": "station-3"
     },
     {
       "id": "s3-guard-l-1",
@@ -1969,14 +1805,8 @@
         "translate": [40.465, 1.75, -4.6],
         "rotate": [0, -0.3, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-13",
+      "collection": "station-3"
     },
     {
       "id": "s3-guard-r-1",
@@ -1988,14 +1818,8 @@
         "translate": [55.535, 1.75, -4.6],
         "rotate": [0, 0.3, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-13",
+      "collection": "station-3"
     },
     {
       "id": "s3-guard-l-2",
@@ -2007,14 +1831,8 @@
         "translate": [39.065, 2.4000000000000004, -6.800000000000001],
         "rotate": [0, -0.3, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-13",
+      "collection": "station-3"
     },
     {
       "id": "s3-guard-r-2",
@@ -2026,14 +1844,8 @@
         "translate": [56.935, 2.4000000000000004, -6.800000000000001],
         "rotate": [0, 0.3, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-13",
+      "collection": "station-3"
     },
     {
       "id": "path-3-1",
@@ -2045,15 +1857,8 @@
         "translate": [42, 0.03, -2],
         "rotate": [0, 2.819842099193151, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-3"
     },
     {
       "id": "path-3-2",
@@ -2065,15 +1870,8 @@
         "translate": [36, 0.03, -4],
         "rotate": [0, 2.819842099193151, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-3"
     },
     {
       "id": "path-3-3",
@@ -2085,15 +1883,8 @@
         "translate": [30, 0.03, -6],
         "rotate": [0, 2.819842099193151, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-3"
     },
     {
       "id": "path-3-4",
@@ -2105,15 +1896,8 @@
         "translate": [24, 0.03, -8],
         "rotate": [0, 2.819842099193151, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-3"
     },
     {
       "id": "path-3-5",
@@ -2125,15 +1909,8 @@
         "translate": [18, 0.03, -10],
         "rotate": [0, 2.819842099193151, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-3"
     },
     {
       "id": "path-3-6",
@@ -2145,15 +1922,8 @@
         "translate": [12, 0.03, -12],
         "rotate": [0, 2.819842099193151, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-3"
     },
     {
       "id": "path-3-7",
@@ -2165,15 +1935,8 @@
         "translate": [6, 0.03, -14],
         "rotate": [0, 2.819842099193151, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-3"
     },
     {
       "id": "s4-plinth-0",
@@ -2184,14 +1947,8 @@
       "transform": {
         "translate": [3.175, 0.06, -16]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.1,
-        "value": 0.55,
-        "kind": "normal",
-        "roughness": 0.6,
-        "clearcoat": 0.1
-      }
+      "material": "mat-6",
+      "collection": "station-4"
     },
     {
       "id": "s4-mono-0",
@@ -2203,22 +1960,14 @@
       "transform": {
         "translate": [3.175, 2.4, -16]
       },
-      "material": {
-        "hue": 0.11,
-        "sat": 0.78,
-        "value": 0.95,
-        "metal": 0,
-        "glow": 0.1,
-        "kind": "normal",
-        "roughness": 0.22,
-        "clearcoat": 0.6
-      },
+      "material": "mat-12",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "-2.700 + 5.100 * smoothstep(48.05, 48.65, t)"
         }
-      ]
+      ],
+      "collection": "station-4"
     },
     {
       "id": "s4-plinth-1",
@@ -2229,14 +1978,8 @@
       "transform": {
         "translate": [1.905, 0.06, -16]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.1,
-        "value": 0.55,
-        "kind": "normal",
-        "roughness": 0.6,
-        "clearcoat": 0.1
-      }
+      "material": "mat-6",
+      "collection": "station-4"
     },
     {
       "id": "s4-mono-1",
@@ -2248,21 +1991,15 @@
       "transform": {
         "translate": [1.905, 2.2374501992031868, -16]
       },
-      "material": {
-        "hue": 0.5680000000000001,
-        "sat": 0.648,
-        "value": 0.7759999999999999,
-        "kind": "normal",
-        "roughness": 0.3,
-        "clearcoat": 0.45
-      },
+      "material": "mat-8",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "-2.537 + 4.775 * smoothstep(49.15, 49.75, t)"
         }
       ],
-      "pattern": "cracked"
+      "pattern": "cracked",
+      "collection": "station-4"
     },
     {
       "id": "s4-plinth-2",
@@ -2273,14 +2010,8 @@
       "transform": {
         "translate": [0.635, 0.06, -16]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.1,
-        "value": 0.55,
-        "kind": "normal",
-        "roughness": 0.6,
-        "clearcoat": 0.1
-      }
+      "material": "mat-6",
+      "collection": "station-4"
     },
     {
       "id": "s4-mono-2",
@@ -2292,21 +2023,15 @@
       "transform": {
         "translate": [0.635, 1.4151394422310757, -16]
       },
-      "material": {
-        "hue": 0.5860000000000001,
-        "sat": 0.676,
-        "value": 0.732,
-        "kind": "normal",
-        "roughness": 0.3,
-        "clearcoat": 0.45
-      },
+      "material": "mat-9",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "-1.715 + 3.130 * smoothstep(50.25, 50.85, t)"
         }
       ],
-      "pattern": "cracked"
+      "pattern": "cracked",
+      "collection": "station-4"
     },
     {
       "id": "s4-plinth-3",
@@ -2317,14 +2042,8 @@
       "transform": {
         "translate": [-0.635, 0.06, -16]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.1,
-        "value": 0.55,
-        "kind": "normal",
-        "roughness": 0.6,
-        "clearcoat": 0.1
-      }
+      "material": "mat-6",
+      "collection": "station-4"
     },
     {
       "id": "s4-mono-3",
@@ -2336,21 +2055,15 @@
       "transform": {
         "translate": [-0.635, 1.2430278884462151, -16]
       },
-      "material": {
-        "hue": 0.6040000000000001,
-        "sat": 0.704,
-        "value": 0.688,
-        "kind": "normal",
-        "roughness": 0.3,
-        "clearcoat": 0.45
-      },
+      "material": "mat-10",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "-1.543 + 2.786 * smoothstep(51.35, 51.95, t)"
         }
       ],
-      "pattern": "cracked"
+      "pattern": "cracked",
+      "collection": "station-4"
     },
     {
       "id": "s4-plinth-4",
@@ -2361,14 +2074,8 @@
       "transform": {
         "translate": [-1.905, 0.06, -16]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.1,
-        "value": 0.55,
-        "kind": "normal",
-        "roughness": 0.6,
-        "clearcoat": 0.1
-      }
+      "material": "mat-6",
+      "collection": "station-4"
     },
     {
       "id": "s4-mono-4",
@@ -2380,21 +2087,15 @@
       "transform": {
         "translate": [-1.905, 0.7362549800796813, -16]
       },
-      "material": {
-        "hue": 0.622,
-        "sat": 0.732,
-        "value": 0.6439999999999999,
-        "kind": "normal",
-        "roughness": 0.3,
-        "clearcoat": 0.45
-      },
+      "material": "mat-11",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "-1.036 + 1.773 * smoothstep(52.45, 53.05, t)"
         }
       ],
-      "pattern": "cracked"
+      "pattern": "cracked",
+      "collection": "station-4"
     },
     {
       "id": "s4-plinth-5",
@@ -2405,14 +2106,8 @@
       "transform": {
         "translate": [-3.175, 0.06, -16]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.1,
-        "value": 0.55,
-        "kind": "normal",
-        "roughness": 0.6,
-        "clearcoat": 0.1
-      }
+      "material": "mat-6",
+      "collection": "station-4"
     },
     {
       "id": "s4-mono-5",
@@ -2424,21 +2119,15 @@
       "transform": {
         "translate": [-3.175, 0.6501992031872509, -16]
       },
-      "material": {
-        "hue": 0.64,
-        "sat": 0.76,
-        "value": 0.6,
-        "kind": "normal",
-        "roughness": 0.3,
-        "clearcoat": 0.45
-      },
+      "material": "mat-14",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "-0.950 + 1.600 * smoothstep(53.55, 54.15, t)"
         }
       ],
-      "pattern": "cracked"
+      "pattern": "cracked",
+      "collection": "station-4"
     },
     {
       "id": "s4-guard-l-0",
@@ -2450,14 +2139,8 @@
         "translate": [-8.135, 1.1, -14.8],
         "rotate": [0, -0.3, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-13",
+      "collection": "station-4"
     },
     {
       "id": "s4-guard-r-0",
@@ -2469,14 +2152,8 @@
         "translate": [8.135, 1.1, -14.8],
         "rotate": [0, 0.3, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-13",
+      "collection": "station-4"
     },
     {
       "id": "s4-guard-l-1",
@@ -2488,14 +2165,8 @@
         "translate": [-7.535, 1.75, -20.6],
         "rotate": [0, -0.3, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-13",
+      "collection": "station-4"
     },
     {
       "id": "s4-guard-r-1",
@@ -2507,14 +2178,8 @@
         "translate": [7.535, 1.75, -20.6],
         "rotate": [0, 0.3, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-13",
+      "collection": "station-4"
     },
     {
       "id": "s4-guard-l-2",
@@ -2526,14 +2191,8 @@
         "translate": [-8.935, 2.4000000000000004, -22.8],
         "rotate": [0, -0.3, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-13",
+      "collection": "station-4"
     },
     {
       "id": "s4-guard-r-2",
@@ -2545,14 +2204,8 @@
         "translate": [8.935, 2.4000000000000004, -22.8],
         "rotate": [0, 0.3, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-13",
+      "collection": "station-4"
     },
     {
       "id": "path-4-1",
@@ -2564,15 +2217,8 @@
         "translate": [2, 0.03, -16],
         "rotate": [0, 0, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-4"
     },
     {
       "id": "path-4-2",
@@ -2584,15 +2230,8 @@
         "translate": [4, 0.03, -16],
         "rotate": [0, 0, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-4"
     },
     {
       "id": "path-4-3",
@@ -2604,15 +2243,8 @@
         "translate": [6, 0.03, -16],
         "rotate": [0, 0, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-4"
     },
     {
       "id": "path-4-4",
@@ -2624,15 +2256,8 @@
         "translate": [8, 0.03, -16],
         "rotate": [0, 0, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-4"
     },
     {
       "id": "path-4-5",
@@ -2644,15 +2269,8 @@
         "translate": [10, 0.03, -16],
         "rotate": [0, 0, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-4"
     },
     {
       "id": "path-4-6",
@@ -2664,15 +2282,8 @@
         "translate": [12, 0.03, -16],
         "rotate": [0, 0, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-4"
     },
     {
       "id": "path-4-7",
@@ -2684,15 +2295,8 @@
         "translate": [14, 0.03, -16],
         "rotate": [0, 0, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-4"
     },
     {
       "id": "s5-plinth-0",
@@ -2703,14 +2307,8 @@
       "transform": {
         "translate": [19.175, 0.06, -16]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.1,
-        "value": 0.55,
-        "kind": "normal",
-        "roughness": 0.6,
-        "clearcoat": 0.1
-      }
+      "material": "mat-6",
+      "collection": "station-5"
     },
     {
       "id": "s5-mono-0",
@@ -2722,22 +2320,14 @@
       "transform": {
         "translate": [19.175, 2.4, -16]
       },
-      "material": {
-        "hue": 0.11,
-        "sat": 0.78,
-        "value": 0.95,
-        "metal": 0,
-        "glow": 0.1,
-        "kind": "normal",
-        "roughness": 0.22,
-        "clearcoat": 0.6
-      },
+      "material": "mat-12",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "-2.700 + 5.100 * smoothstep(61.35, 61.95, t)"
         }
-      ]
+      ],
+      "collection": "station-5"
     },
     {
       "id": "s5-plinth-1",
@@ -2748,14 +2338,8 @@
       "transform": {
         "translate": [17.905, 0.06, -16]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.1,
-        "value": 0.55,
-        "kind": "normal",
-        "roughness": 0.6,
-        "clearcoat": 0.1
-      }
+      "material": "mat-6",
+      "collection": "station-5"
     },
     {
       "id": "s5-mono-1",
@@ -2767,21 +2351,15 @@
       "transform": {
         "translate": [17.905, 2.2072538860103625, -16]
       },
-      "material": {
-        "hue": 0.5680000000000001,
-        "sat": 0.648,
-        "value": 0.7759999999999999,
-        "kind": "normal",
-        "roughness": 0.3,
-        "clearcoat": 0.45
-      },
+      "material": "mat-8",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "-2.507 + 4.715 * smoothstep(62.45, 63.05, t)"
         }
       ],
-      "pattern": "cracked"
+      "pattern": "cracked",
+      "collection": "station-5"
     },
     {
       "id": "s5-plinth-2",
@@ -2792,14 +2370,8 @@
       "transform": {
         "translate": [16.635, 0.06, -16]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.1,
-        "value": 0.55,
-        "kind": "normal",
-        "roughness": 0.6,
-        "clearcoat": 0.1
-      }
+      "material": "mat-6",
+      "collection": "station-5"
     },
     {
       "id": "s5-mono-2",
@@ -2811,21 +2383,15 @@
       "transform": {
         "translate": [16.635, 1.5015544041450775, -16]
       },
-      "material": {
-        "hue": 0.5860000000000001,
-        "sat": 0.676,
-        "value": 0.732,
-        "kind": "normal",
-        "roughness": 0.3,
-        "clearcoat": 0.45
-      },
+      "material": "mat-9",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "-1.802 + 3.303 * smoothstep(63.55, 64.15, t)"
         }
       ],
-      "pattern": "cracked"
+      "pattern": "cracked",
+      "collection": "station-5"
     },
     {
       "id": "s5-plinth-3",
@@ -2836,14 +2402,8 @@
       "transform": {
         "translate": [15.365, 0.06, -16]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.1,
-        "value": 0.55,
-        "kind": "normal",
-        "roughness": 0.6,
-        "clearcoat": 0.1
-      }
+      "material": "mat-6",
+      "collection": "station-5"
     },
     {
       "id": "s5-mono-3",
@@ -2855,21 +2415,15 @@
       "transform": {
         "translate": [15.365, 1.2590673575129532, -16]
       },
-      "material": {
-        "hue": 0.6040000000000001,
-        "sat": 0.704,
-        "value": 0.688,
-        "kind": "normal",
-        "roughness": 0.3,
-        "clearcoat": 0.45
-      },
+      "material": "mat-10",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "-1.559 + 2.818 * smoothstep(64.65, 65.25, t)"
         }
       ],
-      "pattern": "cracked"
+      "pattern": "cracked",
+      "collection": "station-5"
     },
     {
       "id": "s5-plinth-4",
@@ -2880,14 +2434,8 @@
       "transform": {
         "translate": [14.095, 0.06, -16]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.1,
-        "value": 0.55,
-        "kind": "normal",
-        "roughness": 0.6,
-        "clearcoat": 0.1
-      }
+      "material": "mat-6",
+      "collection": "station-5"
     },
     {
       "id": "s5-mono-4",
@@ -2899,21 +2447,15 @@
       "transform": {
         "translate": [14.095, 1.0290155440414508, -16]
       },
-      "material": {
-        "hue": 0.622,
-        "sat": 0.732,
-        "value": 0.6439999999999999,
-        "kind": "normal",
-        "roughness": 0.3,
-        "clearcoat": 0.45
-      },
+      "material": "mat-11",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "-1.329 + 2.358 * smoothstep(65.75, 66.35, t)"
         }
       ],
-      "pattern": "cracked"
+      "pattern": "cracked",
+      "collection": "station-5"
     },
     {
       "id": "s5-plinth-5",
@@ -2924,14 +2466,8 @@
       "transform": {
         "translate": [12.825, 0.06, -16]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.1,
-        "value": 0.55,
-        "kind": "normal",
-        "roughness": 0.6,
-        "clearcoat": 0.1
-      }
+      "material": "mat-6",
+      "collection": "station-5"
     },
     {
       "id": "s5-mono-5",
@@ -2943,21 +2479,15 @@
       "transform": {
         "translate": [12.825, 0.9699481865284973, -16]
       },
-      "material": {
-        "hue": 0.64,
-        "sat": 0.76,
-        "value": 0.6,
-        "kind": "normal",
-        "roughness": 0.3,
-        "clearcoat": 0.45
-      },
+      "material": "mat-14",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "-1.270 + 2.240 * smoothstep(66.85, 67.45, t)"
         }
       ],
-      "pattern": "cracked"
+      "pattern": "cracked",
+      "collection": "station-5"
     },
     {
       "id": "s5-guard-l-0",
@@ -2969,14 +2499,8 @@
         "translate": [7.865, 1.1, -14.8],
         "rotate": [0, -0.3, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-13",
+      "collection": "station-5"
     },
     {
       "id": "s5-guard-r-0",
@@ -2988,14 +2512,8 @@
         "translate": [24.134999999999998, 1.1, -14.8],
         "rotate": [0, 0.3, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-13",
+      "collection": "station-5"
     },
     {
       "id": "s5-guard-l-1",
@@ -3007,14 +2525,8 @@
         "translate": [8.465, 1.75, -20.6],
         "rotate": [0, -0.3, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-13",
+      "collection": "station-5"
     },
     {
       "id": "s5-guard-r-1",
@@ -3026,14 +2538,8 @@
         "translate": [23.535, 1.75, -20.6],
         "rotate": [0, 0.3, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-13",
+      "collection": "station-5"
     },
     {
       "id": "s5-guard-l-2",
@@ -3045,14 +2551,8 @@
         "translate": [7.0649999999999995, 2.4000000000000004, -22.8],
         "rotate": [0, -0.3, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-13",
+      "collection": "station-5"
     },
     {
       "id": "s5-guard-r-2",
@@ -3064,14 +2564,8 @@
         "translate": [24.935000000000002, 2.4000000000000004, -22.8],
         "rotate": [0, 0.3, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-13",
+      "collection": "station-5"
     },
     {
       "id": "path-5-1",
@@ -3083,15 +2577,8 @@
         "translate": [18, 0.03, -16],
         "rotate": [0, 0, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-5"
     },
     {
       "id": "path-5-2",
@@ -3103,15 +2590,8 @@
         "translate": [20, 0.03, -16],
         "rotate": [0, 0, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-5"
     },
     {
       "id": "path-5-3",
@@ -3123,15 +2603,8 @@
         "translate": [22, 0.03, -16],
         "rotate": [0, 0, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-5"
     },
     {
       "id": "path-5-4",
@@ -3143,15 +2616,8 @@
         "translate": [24, 0.03, -16],
         "rotate": [0, 0, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-5"
     },
     {
       "id": "path-5-5",
@@ -3163,15 +2629,8 @@
         "translate": [26, 0.03, -16],
         "rotate": [0, 0, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-5"
     },
     {
       "id": "path-5-6",
@@ -3183,15 +2642,8 @@
         "translate": [28, 0.03, -16],
         "rotate": [0, 0, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-5"
     },
     {
       "id": "path-5-7",
@@ -3203,15 +2655,8 @@
         "translate": [30, 0.03, -16],
         "rotate": [0, 0, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-5"
     },
     {
       "id": "s6-past-0",
@@ -3223,14 +2668,8 @@
       "transform": {
         "translate": [35.4, 0.55, -16]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-13",
+      "collection": "station-6"
     },
     {
       "id": "s6-past-1",
@@ -3242,14 +2681,8 @@
       "transform": {
         "translate": [32, 0.55, -16]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-13",
+      "collection": "station-6"
     },
     {
       "id": "s6-past-2",
@@ -3261,14 +2694,8 @@
       "transform": {
         "translate": [28.6, 0.55, -16]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-13",
+      "collection": "station-6"
     },
     {
       "id": "s6-now-3",
@@ -3279,21 +2706,14 @@
       "transform": {
         "translate": [35.4, 3.6, -16]
       },
-      "material": {
-        "hue": 0.995,
-        "sat": 0.85,
-        "value": 0.78,
-        "glow": 0.24,
-        "kind": "normal",
-        "roughness": 0.3,
-        "clearcoat": 0.5
-      },
+      "material": "mat-15",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "1.100 + 2.500 * smoothstep(74.60, 75.40, t) + 0.06 * sin(0.5 * t + -36.50)"
         }
-      ]
+      ],
+      "collection": "station-6"
     },
     {
       "id": "s6-now-4",
@@ -3304,21 +2724,14 @@
       "transform": {
         "translate": [32, 3.6, -16]
       },
-      "material": {
-        "hue": 0.995,
-        "sat": 0.85,
-        "value": 0.78,
-        "glow": 0.12,
-        "kind": "normal",
-        "roughness": 0.3,
-        "clearcoat": 0.5
-      },
+      "material": "mat-3",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "1.100 + 2.500 * smoothstep(75.70, 76.50, t) + 0.06 * sin(0.5 * t + -34.40)"
         }
-      ]
+      ],
+      "collection": "station-6"
     },
     {
       "id": "s6-now-5",
@@ -3329,21 +2742,14 @@
       "transform": {
         "translate": [28.6, 3.6, -16]
       },
-      "material": {
-        "hue": 0.995,
-        "sat": 0.85,
-        "value": 0.78,
-        "glow": 0.12,
-        "kind": "normal",
-        "roughness": 0.3,
-        "clearcoat": 0.5
-      },
+      "material": "mat-3",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "1.100 + 2.500 * smoothstep(76.80, 77.60, t) + 0.06 * sin(0.5 * t + -32.30)"
         }
-      ]
+      ],
+      "collection": "station-6"
     },
     {
       "id": "s6-trail-0-0",
@@ -3355,14 +2761,8 @@
         "translate": [35.4, 1.5, -16],
         "rotate": [0, 0, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-13",
+      "collection": "station-6"
     },
     {
       "id": "s6-trail-0-1",
@@ -3374,14 +2774,8 @@
         "translate": [35.4, 2.2199999999999998, -16],
         "rotate": [0, 0.3, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-13",
+      "collection": "station-6"
     },
     {
       "id": "s6-trail-0-2",
@@ -3393,14 +2787,8 @@
         "translate": [35.4, 2.94, -16],
         "rotate": [0, 0.6, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-13",
+      "collection": "station-6"
     },
     {
       "id": "s6-trail-1-0",
@@ -3412,14 +2800,8 @@
         "translate": [32, 1.5, -16],
         "rotate": [0, 0, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-13",
+      "collection": "station-6"
     },
     {
       "id": "s6-trail-1-1",
@@ -3431,14 +2813,8 @@
         "translate": [32, 2.2199999999999998, -16],
         "rotate": [0, 0.3, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-13",
+      "collection": "station-6"
     },
     {
       "id": "s6-trail-1-2",
@@ -3450,14 +2826,8 @@
         "translate": [32, 2.94, -16],
         "rotate": [0, 0.6, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-13",
+      "collection": "station-6"
     },
     {
       "id": "s6-trail-2-0",
@@ -3469,14 +2839,8 @@
         "translate": [28.6, 1.5, -16],
         "rotate": [0, 0, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-13",
+      "collection": "station-6"
     },
     {
       "id": "s6-trail-2-1",
@@ -3488,14 +2852,8 @@
         "translate": [28.6, 2.2199999999999998, -16],
         "rotate": [0, 0.3, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-13",
+      "collection": "station-6"
     },
     {
       "id": "s6-trail-2-2",
@@ -3507,14 +2865,8 @@
         "translate": [28.6, 2.94, -16],
         "rotate": [0, 0.6, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-13",
+      "collection": "station-6"
     },
     {
       "id": "path-6-1",
@@ -3526,15 +2878,8 @@
         "translate": [34, 0.03, -16],
         "rotate": [0, 0, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-6"
     },
     {
       "id": "path-6-2",
@@ -3546,15 +2891,8 @@
         "translate": [36, 0.03, -16],
         "rotate": [0, 0, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-6"
     },
     {
       "id": "path-6-3",
@@ -3566,15 +2904,8 @@
         "translate": [38, 0.03, -16],
         "rotate": [0, 0, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-6"
     },
     {
       "id": "path-6-4",
@@ -3586,15 +2917,8 @@
         "translate": [40, 0.03, -16],
         "rotate": [0, 0, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-6"
     },
     {
       "id": "path-6-5",
@@ -3606,15 +2930,8 @@
         "translate": [42, 0.03, -16],
         "rotate": [0, 0, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-6"
     },
     {
       "id": "path-6-6",
@@ -3626,15 +2943,8 @@
         "translate": [44, 0.03, -16],
         "rotate": [0, 0, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-6"
     },
     {
       "id": "path-6-7",
@@ -3646,15 +2956,8 @@
         "translate": [46, 0.03, -16],
         "rotate": [0, 0, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-6"
     },
     {
       "id": "s7-net-node-0",
@@ -3665,22 +2968,14 @@
       "transform": {
         "translate": [48, 3.5204111503539433, -16]
       },
-      "material": {
-        "hue": 0.11,
-        "sat": 0.78,
-        "value": 0.95,
-        "metal": 0,
-        "glow": 0.1,
-        "kind": "normal",
-        "roughness": 0.22,
-        "clearcoat": 0.6
-      },
+      "material": "mat-12",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "4.620 - 1.1 * smoothstep(82.55, 83.05, t) + 0.018 * sin(1.3 * t + -106.99)"
         }
-      ]
+      ],
+      "collection": "station-7"
     },
     {
       "id": "s7-net-node-1",
@@ -3691,20 +2986,14 @@
       "transform": {
         "translate": [46.45370033299743, 5.980307652106461, -14.291291726614867]
       },
-      "material": {
-        "hue": 0.62875,
-        "sat": 0.76,
-        "value": 0.5875,
-        "kind": "normal",
-        "roughness": 0.55,
-        "clearcoat": 0.2
-      },
+      "material": "mat-16",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "7.080 - 1.1 * smoothstep(82.67, 83.17, t) + 0.018 * sin(1.3 * t + -104.89)"
         }
-      ]
+      ],
+      "collection": "station-7"
     },
     {
       "id": "s7-net-node-2",
@@ -3715,20 +3004,14 @@
       "transform": {
         "translate": [48.29161726142453, 5.250904506397122, -18.88519619245656]
       },
-      "material": {
-        "hue": 0.62875,
-        "sat": 0.76,
-        "value": 0.5875,
-        "kind": "normal",
-        "roughness": 0.55,
-        "clearcoat": 0.2
-      },
+      "material": "mat-16",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "6.351 - 1.1 * smoothstep(82.79, 83.29, t) + 0.018 * sin(1.3 * t + -102.79)"
         }
-      ]
+      ],
+      "collection": "station-7"
     },
     {
       "id": "s7-net-node-3",
@@ -3739,20 +3022,14 @@
       "transform": {
         "translate": [50.31650182833244, 4.3697567245487905, -13.630497577478971]
       },
-      "material": {
-        "hue": 0.62875,
-        "sat": 0.76,
-        "value": 0.5875,
-        "kind": "normal",
-        "roughness": 0.55,
-        "clearcoat": 0.2
-      },
+      "material": "mat-16",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "5.470 - 1.1 * smoothstep(82.91, 83.41, t) + 0.018 * sin(1.3 * t + -100.69)"
         }
-      ]
+      ],
+      "collection": "station-7"
     },
     {
       "id": "s7-net-node-4",
@@ -3763,20 +3040,14 @@
       "transform": {
         "translate": [44.66711706881019, 3.6213578719444897, -16.57036214719362]
       },
-      "material": {
-        "hue": 0.62875,
-        "sat": 0.76,
-        "value": 0.5875,
-        "kind": "normal",
-        "roughness": 0.55,
-        "clearcoat": 0.2
-      },
+      "material": "mat-16",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "4.721 - 1.1 * smoothstep(83.03, 83.53, t) + 0.018 * sin(1.3 * t + -98.59)"
         }
-      ]
+      ],
+      "collection": "station-7"
     },
     {
       "id": "s7-net-node-5",
@@ -3787,20 +3058,14 @@
       "transform": {
         "translate": [51.0462853596452, 2.9527771216598238, -17.444450357471]
       },
-      "material": {
-        "hue": 0.62875,
-        "sat": 0.76,
-        "value": 0.5875,
-        "kind": "normal",
-        "roughness": 0.55,
-        "clearcoat": 0.2
-      },
+      "material": "mat-16",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "4.053 - 1.1 * smoothstep(83.15, 83.65, t) + 0.018 * sin(1.3 * t + -96.49)"
         }
-      ]
+      ],
+      "collection": "station-7"
     },
     {
       "id": "s7-net-node-6",
@@ -3811,20 +3076,14 @@
       "transform": {
         "translate": [47.36335850348319, 1.819620731911172, -13.390219876800096]
       },
-      "material": {
-        "hue": 0.6175,
-        "sat": 0.74,
-        "value": 0.625,
-        "kind": "normal",
-        "roughness": 0.55,
-        "clearcoat": 0.2
-      },
+      "material": "mat-17",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "2.920 - 1.1 * smoothstep(83.27, 83.77, t) + 0.018 * sin(1.3 * t + -94.39)"
         }
-      ]
+      ],
+      "collection": "station-7"
     },
     {
       "id": "s7-net-node-7",
@@ -3835,20 +3094,14 @@
       "transform": {
         "translate": [47.19989911320728, 1.2095751500786114, -17.988536462099237]
       },
-      "material": {
-        "hue": 0.6175,
-        "sat": 0.74,
-        "value": 0.625,
-        "kind": "normal",
-        "roughness": 0.55,
-        "clearcoat": 0.2
-      },
+      "material": "mat-17",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "2.310 - 1.1 * smoothstep(83.39, 83.89, t) + 0.018 * sin(1.3 * t + -92.29)"
         }
-      ]
+      ],
+      "collection": "station-7"
     },
     {
       "id": "s7-net-node-8",
@@ -3859,20 +3112,14 @@
       "transform": {
         "translate": [48.124597636454034, 0.6000000000000001, -15.585334562779362]
       },
-      "material": {
-        "hue": 0.60625,
-        "sat": 0.72,
-        "value": 0.6625000000000001,
-        "kind": "normal",
-        "roughness": 0.55,
-        "clearcoat": 0.2
-      },
+      "material": "mat-18",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "1.700 - 1.1 * smoothstep(83.51, 84.01, t) + 0.018 * sin(1.3 * t + -90.19)"
         }
-      ]
+      ],
+      "collection": "station-7"
     },
     {
       "id": "s7-net-edge-0",
@@ -3885,21 +3132,14 @@
       "transform": {
         "translate": [46.45370033299743, 5.980307652106461, -14.291291726614867]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.55,
-        "glow": 0.08,
-        "kind": "normal",
-        "roughness": 0.6,
-        "clearcoat": 0.15
-      },
+      "material": "mat-19",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "7.080 - 1.1 * smoothstep(83.83, 84.28, t)"
         }
-      ]
+      ],
+      "collection": "station-7"
     },
     {
       "id": "s7-net-edge-1",
@@ -3912,21 +3152,14 @@
       "transform": {
         "translate": [48.29161726142453, 5.250904506397122, -18.88519619245656]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.55,
-        "glow": 0.08,
-        "kind": "normal",
-        "roughness": 0.6,
-        "clearcoat": 0.15
-      },
+      "material": "mat-19",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "6.351 - 1.1 * smoothstep(83.97, 84.42, t)"
         }
-      ]
+      ],
+      "collection": "station-7"
     },
     {
       "id": "s7-net-edge-2",
@@ -3939,21 +3172,14 @@
       "transform": {
         "translate": [50.31650182833244, 4.3697567245487905, -13.630497577478971]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.55,
-        "glow": 0.08,
-        "kind": "normal",
-        "roughness": 0.6,
-        "clearcoat": 0.15
-      },
+      "material": "mat-19",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "5.470 - 1.1 * smoothstep(84.11, 84.56, t)"
         }
-      ]
+      ],
+      "collection": "station-7"
     },
     {
       "id": "s7-net-edge-3",
@@ -3966,21 +3192,14 @@
       "transform": {
         "translate": [44.66711706881019, 3.6213578719444897, -16.57036214719362]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.55,
-        "glow": 0.08,
-        "kind": "normal",
-        "roughness": 0.6,
-        "clearcoat": 0.15
-      },
+      "material": "mat-19",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "4.721 - 1.1 * smoothstep(84.25, 84.70, t)"
         }
-      ]
+      ],
+      "collection": "station-7"
     },
     {
       "id": "s7-net-edge-4",
@@ -3993,21 +3212,14 @@
       "transform": {
         "translate": [51.0462853596452, 2.9527771216598238, -17.444450357471]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.55,
-        "glow": 0.08,
-        "kind": "normal",
-        "roughness": 0.6,
-        "clearcoat": 0.15
-      },
+      "material": "mat-19",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "4.053 - 1.1 * smoothstep(84.39, 84.84, t)"
         }
-      ]
+      ],
+      "collection": "station-7"
     },
     {
       "id": "s7-net-edge-5",
@@ -4020,21 +3232,14 @@
       "transform": {
         "translate": [48, 3.5204111503539433, -16]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.55,
-        "glow": 0.08,
-        "kind": "normal",
-        "roughness": 0.6,
-        "clearcoat": 0.15
-      },
+      "material": "mat-19",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "4.620 - 1.1 * smoothstep(84.53, 84.98, t)"
         }
-      ]
+      ],
+      "collection": "station-7"
     },
     {
       "id": "s7-net-edge-6",
@@ -4047,21 +3252,14 @@
       "transform": {
         "translate": [48, 3.5204111503539433, -16]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.55,
-        "glow": 0.08,
-        "kind": "normal",
-        "roughness": 0.6,
-        "clearcoat": 0.15
-      },
+      "material": "mat-19",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "4.620 - 1.1 * smoothstep(84.67, 85.12, t)"
         }
-      ]
+      ],
+      "collection": "station-7"
     },
     {
       "id": "s7-net-edge-7",
@@ -4074,21 +3272,14 @@
       "transform": {
         "translate": [47.36335850348319, 1.819620731911172, -13.390219876800096]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.55,
-        "glow": 0.08,
-        "kind": "normal",
-        "roughness": 0.6,
-        "clearcoat": 0.15
-      },
+      "material": "mat-19",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "2.920 - 1.1 * smoothstep(84.81, 85.26, t)"
         }
-      ]
+      ],
+      "collection": "station-7"
     },
     {
       "id": "s7-net-edge-8",
@@ -4101,21 +3292,14 @@
       "transform": {
         "translate": [47.19989911320728, 1.2095751500786114, -17.988536462099237]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.55,
-        "glow": 0.08,
-        "kind": "normal",
-        "roughness": 0.6,
-        "clearcoat": 0.15
-      },
+      "material": "mat-19",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "2.310 - 1.1 * smoothstep(84.95, 85.40, t)"
         }
-      ]
+      ],
+      "collection": "station-7"
     },
     {
       "id": "s7-net-edge-9",
@@ -4128,21 +3312,14 @@
       "transform": {
         "translate": [48.124597636454034, 0.6000000000000001, -15.585334562779362]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.55,
-        "glow": 0.08,
-        "kind": "normal",
-        "roughness": 0.6,
-        "clearcoat": 0.15
-      },
+      "material": "mat-19",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "1.700 - 1.1 * smoothstep(85.09, 85.54, t)"
         }
-      ]
+      ],
+      "collection": "station-7"
     },
     {
       "id": "s7-dust-0",
@@ -4154,19 +3331,14 @@
         "translate": [49.251874627366746, 4.405000000000001, -16],
         "rotate": [0, 0, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.2,
-        "value": 0.18,
-        "kind": "normal",
-        "roughness": 0.5
-      },
+      "material": "mat-20",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "4.405 - 0.000 * smoothstep(82.30, 83.30, t) + 0.05 * sin(0.30 * t + -24.69)"
         }
-      ]
+      ],
+      "collection": "station-7"
     },
     {
       "id": "s7-dust-1",
@@ -4178,19 +3350,14 @@
         "translate": [48.557092148492025, 4.399558176477956, -18.266932389155055],
         "rotate": [0, 0.9, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.2,
-        "value": 0.18,
-        "kind": "normal",
-        "roughness": 0.5
-      },
+      "material": "mat-20",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "4.400 - 0.000 * smoothstep(82.30, 83.30, t) + 0.07 * sin(0.35 * t + -27.51)"
         }
-      ]
+      ],
+      "collection": "station-7"
     },
     {
       "id": "s7-dust-2",
@@ -4202,19 +3369,14 @@
         "translate": [46.10811593736101, 3.629579332748476, -16.989614658959955],
         "rotate": [0, 1.8, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.2,
-        "value": 0.18,
-        "kind": "normal",
-        "roughness": 0.5
-      },
+      "material": "mat-20",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "3.630 - 0.000 * smoothstep(82.30, 83.30, t) + 0.09 * sin(0.40 * t + -30.32)"
         }
-      ]
+      ],
+      "collection": "station-7"
     },
     {
       "id": "s7-dust-3",
@@ -4226,19 +3388,14 @@
         "translate": [45.38985964677685, 4.222504230305474, -13.041462830146227],
         "rotate": [0, 2.7, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.2,
-        "value": 0.18,
-        "kind": "normal",
-        "roughness": 0.5
-      },
+      "material": "mat-20",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "4.223 - 0.000 * smoothstep(82.30, 83.30, t) + 0.05 * sin(0.45 * t + -33.14)"
         }
-      ]
+      ],
+      "collection": "station-7"
     },
     {
       "id": "s7-dust-4",
@@ -4250,19 +3407,14 @@
         "translate": [49.25099030296351, 3.0836452719433054, -14.198269146341225],
         "rotate": [0, 0.5, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.2,
-        "value": 0.18,
-        "kind": "normal",
-        "roughness": 0.5
-      },
+      "material": "mat-20",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "3.084 - 0.000 * smoothstep(82.30, 83.30, t) + 0.07 * sin(0.50 * t + -35.95)"
         }
-      ]
+      ],
+      "collection": "station-7"
     },
     {
       "id": "s7-dust-5",
@@ -4274,19 +3426,14 @@
         "translate": [52.75734157303818, 3.8177730524847187, -17.822992316403063],
         "rotate": [0, 1.4, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.2,
-        "value": 0.18,
-        "kind": "normal",
-        "roughness": 0.5
-      },
+      "material": "mat-20",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "3.818 - 0.000 * smoothstep(82.30, 83.30, t) + 0.09 * sin(0.30 * t + -24.47)"
         }
-      ]
+      ],
+      "collection": "station-7"
     },
     {
       "id": "s7-dust-6",
@@ -4298,19 +3445,14 @@
         "translate": [47.72553875943947, 2.742972950909394, -18.18487030155368],
         "rotate": [0, 2.3000000000000003, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.2,
-        "value": 0.18,
-        "kind": "normal",
-        "roughness": 0.5
-      },
+      "material": "mat-20",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "2.743 - 0.000 * smoothstep(82.30, 83.30, t) + 0.05 * sin(0.35 * t + -27.29)"
         }
-      ]
+      ],
+      "collection": "station-7"
     },
     {
       "id": "s7-dust-7",
@@ -4322,19 +3464,14 @@
         "translate": [42.362314705852384, 3.247721417838311, -16.656963786339638],
         "rotate": [0, 0.09999999999999964, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.2,
-        "value": 0.18,
-        "kind": "normal",
-        "roughness": 0.5
-      },
+      "material": "mat-20",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "3.248 - 0.000 * smoothstep(82.30, 83.30, t) + 0.07 * sin(0.40 * t + -30.10)"
         }
-      ]
+      ],
+      "collection": "station-7"
     },
     {
       "id": "s7-dust-8",
@@ -4346,19 +3483,14 @@
         "translate": [47.14359048881437, 2.514577769081229, -13.70373955156739],
         "rotate": [0, 1, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.2,
-        "value": 0.18,
-        "kind": "normal",
-        "roughness": 0.5
-      },
+      "material": "mat-20",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "2.515 - 0.000 * smoothstep(82.30, 83.30, t) + 0.09 * sin(0.45 * t + -32.92)"
         }
-      ]
+      ],
+      "collection": "station-7"
     },
     {
       "id": "s7-dust-9",
@@ -4370,19 +3502,14 @@
         "translate": [52.65225163462019, 2.626149955099641, -12.831194414845982],
         "rotate": [0, 1.8999999999999995, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.2,
-        "value": 0.18,
-        "kind": "normal",
-        "roughness": 0.5
-      },
+      "material": "mat-20",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "2.626 - 0.000 * smoothstep(82.30, 83.30, t) + 0.05 * sin(0.50 * t + -35.73)"
         }
-      ]
+      ],
+      "collection": "station-7"
     },
     {
       "id": "s7-dust-10",
@@ -4394,19 +3521,14 @@
         "translate": [50.2335226351827, 2.2751364752104166, -18.006364302126396],
         "rotate": [0, 2.8, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.2,
-        "value": 0.18,
-        "kind": "normal",
-        "roughness": 0.5
-      },
+      "material": "mat-20",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "2.275 - 0.000 * smoothstep(82.30, 83.30, t) + 0.07 * sin(0.30 * t + -24.25)"
         }
-      ]
+      ],
+      "collection": "station-7"
     },
     {
       "id": "s7-dust-11",
@@ -4418,19 +3540,14 @@
         "translate": [45.62757972031037, 2.074057518564027, -20.438197954760973],
         "rotate": [0, 0.6000000000000001, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.2,
-        "value": 0.18,
-        "kind": "normal",
-        "roughness": 0.5
-      },
+      "material": "mat-20",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "2.074 - 0.000 * smoothstep(82.30, 83.30, t) + 0.09 * sin(0.35 * t + -27.07)"
         }
-      ]
+      ],
+      "collection": "station-7"
     },
     {
       "id": "s7-dust-12",
@@ -4442,19 +3559,14 @@
         "translate": [44.38336837509747, 1.9174150657237594, -15.076796365522718],
         "rotate": [0, 1.5000000000000004, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.2,
-        "value": 0.18,
-        "kind": "normal",
-        "roughness": 0.5
-      },
+      "material": "mat-20",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "1.917 - 0.000 * smoothstep(82.30, 83.30, t) + 0.05 * sin(0.40 * t + -29.88)"
         }
-      ]
+      ],
+      "collection": "station-7"
     },
     {
       "id": "s7-dust-13",
@@ -4466,19 +3578,14 @@
         "translate": [48.036647923605095, 1.6748001647187152, -11.908516452868163],
         "rotate": [0, 2.400000000000001, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.2,
-        "value": 0.18,
-        "kind": "normal",
-        "roughness": 0.5
-      },
+      "material": "mat-20",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "1.675 - 0.000 * smoothstep(82.30, 83.30, t) + 0.07 * sin(0.45 * t + -32.70)"
         }
-      ]
+      ],
+      "collection": "station-7"
     },
     {
       "id": "s7-dust-14",
@@ -4490,19 +3597,14 @@
         "translate": [52.270930563835755, 1.3899081353990992, -14.990907488424414],
         "rotate": [0, 0.1999999999999993, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.2,
-        "value": 0.18,
-        "kind": "normal",
-        "roughness": 0.5
-      },
+      "material": "mat-20",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "1.390 - 0.000 * smoothstep(82.30, 83.30, t) + 0.09 * sin(0.50 * t + -35.51)"
         }
-      ]
+      ],
+      "collection": "station-7"
     },
     {
       "id": "s7-dust-15",
@@ -4514,19 +3616,14 @@
         "translate": [49.39883204644998, 1.44284528397345, -18.733538270572545],
         "rotate": [0, 1.0999999999999996, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.2,
-        "value": 0.18,
-        "kind": "normal",
-        "roughness": 0.5
-      },
+      "material": "mat-20",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "1.443 - 0.000 * smoothstep(82.30, 83.30, t) + 0.05 * sin(0.30 * t + -24.03)"
         }
-      ]
+      ],
+      "collection": "station-7"
     },
     {
       "id": "s7-dust-16",
@@ -4538,19 +3635,14 @@
         "translate": [44.470728519999355, 0.7171594937718098, -19.057888513618657],
         "rotate": [0, 2, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.2,
-        "value": 0.18,
-        "kind": "normal",
-        "roughness": 0.5
-      },
+      "material": "mat-20",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "0.717 - 0.000 * smoothstep(82.30, 83.30, t) + 0.07 * sin(0.35 * t + -26.85)"
         }
-      ]
+      ],
+      "collection": "station-7"
     },
     {
       "id": "s7-dust-17",
@@ -4562,19 +3654,14 @@
         "translate": [46.20894758465646, 1.3160592709780925, -14.732498536829059],
         "rotate": [0, 2.9000000000000004, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.2,
-        "value": 0.18,
-        "kind": "normal",
-        "roughness": 0.5
-      },
+      "material": "mat-20",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "1.316 - 0.000 * smoothstep(82.30, 83.30, t) + 0.09 * sin(0.40 * t + -29.66)"
         }
-      ]
+      ],
+      "collection": "station-7"
     },
     {
       "id": "s7-dust-18",
@@ -4586,19 +3673,14 @@
         "translate": [49.57563917106201, -0.005841134412181592, -11.995868450679282],
         "rotate": [0, 0.6999999999999988, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.2,
-        "value": 0.18,
-        "kind": "normal",
-        "roughness": 0.5
-      },
+      "material": "mat-20",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "-0.006 - 0.000 * smoothstep(82.30, 83.30, t) + 0.05 * sin(0.45 * t + -32.48)"
         }
-      ]
+      ],
+      "collection": "station-7"
     },
     {
       "id": "s7-dust-19",
@@ -4610,19 +3692,14 @@
         "translate": [49.51816511579864, 1.1743019526359513, -16.204538932927985],
         "rotate": [0, 1.600000000000001, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.2,
-        "value": 0.18,
-        "kind": "normal",
-        "roughness": 0.5
-      },
+      "material": "mat-20",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "1.174 - 0.000 * smoothstep(82.30, 83.30, t) + 0.07 * sin(0.50 * t + -35.29)"
         }
-      ]
+      ],
+      "collection": "station-7"
     },
     {
       "id": "s7-dust-20",
@@ -4634,19 +3711,14 @@
         "translate": [48.32248616067346, -0.6439061141122786, -19.000946679549862],
         "rotate": [0, 2.4999999999999996, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.2,
-        "value": 0.18,
-        "kind": "normal",
-        "roughness": 0.5
-      },
+      "material": "mat-20",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "-0.644 - 0.000 * smoothstep(82.30, 83.30, t) + 0.09 * sin(0.30 * t + -23.81)"
         }
-      ]
+      ],
+      "collection": "station-7"
     },
     {
       "id": "s7-dust-21",
@@ -4658,19 +3730,14 @@
         "translate": [47.29501086354327, 0.879070215106386, -16.255762502362927],
         "rotate": [0, 0.3000000000000016, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.2,
-        "value": 0.18,
-        "kind": "normal",
-        "roughness": 0.5
-      },
+      "material": "mat-20",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "0.879 - 0.000 * smoothstep(82.30, 83.30, t) + 0.05 * sin(0.35 * t + -26.63)"
         }
-      ]
+      ],
+      "collection": "station-7"
     },
     {
       "id": "path-7-1",
@@ -4682,15 +3749,8 @@
         "translate": [42, 0.03, -18],
         "rotate": [0, 2.819842099193151, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-7"
     },
     {
       "id": "path-7-2",
@@ -4702,15 +3762,8 @@
         "translate": [36, 0.03, -20],
         "rotate": [0, 2.819842099193151, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-7"
     },
     {
       "id": "path-7-3",
@@ -4722,15 +3775,8 @@
         "translate": [30, 0.03, -22],
         "rotate": [0, 2.819842099193151, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-7"
     },
     {
       "id": "path-7-4",
@@ -4742,15 +3788,8 @@
         "translate": [24, 0.03, -24],
         "rotate": [0, 2.819842099193151, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-7"
     },
     {
       "id": "path-7-5",
@@ -4762,15 +3801,8 @@
         "translate": [18, 0.03, -26],
         "rotate": [0, 2.819842099193151, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-7"
     },
     {
       "id": "path-7-6",
@@ -4782,15 +3814,8 @@
         "translate": [12, 0.03, -28],
         "rotate": [0, 2.819842099193151, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-7"
     },
     {
       "id": "path-7-7",
@@ -4802,15 +3827,8 @@
         "translate": [6, 0.03, -30],
         "rotate": [0, 2.819842099193151, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-7"
     },
     {
       "id": "s8-stage-0",
@@ -4824,20 +3842,14 @@
       "transform": {
         "translate": [0, 2.8000000000000003, -32]
       },
-      "material": {
-        "hue": 0.55,
-        "sat": 0.62,
-        "value": 0.85,
-        "kind": "normal",
-        "roughness": 0.3,
-        "clearcoat": 0.45
-      },
+      "material": "mat-21",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "3.700 - 0.9 * smoothstep(93.05, 93.65, t)"
         }
-      ]
+      ],
+      "collection": "station-8"
     },
     {
       "id": "s8-stage-1",
@@ -4851,22 +3863,14 @@
       "transform": {
         "translate": [0, 2, -32]
       },
-      "material": {
-        "hue": 0.11,
-        "sat": 0.78,
-        "value": 0.95,
-        "metal": 0,
-        "glow": 0.1,
-        "kind": "normal",
-        "roughness": 0.22,
-        "clearcoat": 0.6
-      },
+      "material": "mat-12",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "2.900 - 0.9 * smoothstep(93.40, 94.00, t)"
         }
-      ]
+      ],
+      "collection": "station-8"
     },
     {
       "id": "s8-stage-2",
@@ -4880,20 +3884,14 @@
       "transform": {
         "translate": [0, 1.2000000000000002, -32]
       },
-      "material": {
-        "hue": 0.6100000000000001,
-        "sat": 0.7266666666666667,
-        "value": 0.65,
-        "kind": "normal",
-        "roughness": 0.3,
-        "clearcoat": 0.45
-      },
+      "material": "mat-22",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "2.100 - 0.9 * smoothstep(93.75, 94.35, t)"
         }
-      ]
+      ],
+      "collection": "station-8"
     },
     {
       "id": "s8-stage-3",
@@ -4907,20 +3905,14 @@
       "transform": {
         "translate": [0, 0.3999999999999999, -32]
       },
-      "material": {
-        "hue": 0.64,
-        "sat": 0.78,
-        "value": 0.55,
-        "kind": "normal",
-        "roughness": 0.3,
-        "clearcoat": 0.45
-      },
+      "material": "mat-23",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "1.300 - 0.9 * smoothstep(94.10, 94.70, t)"
         }
-      ]
+      ],
+      "collection": "station-8"
     },
     {
       "id": "path-8-1",
@@ -4932,15 +3924,8 @@
         "translate": [2, 0.03, -32],
         "rotate": [0, 0, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-8"
     },
     {
       "id": "path-8-2",
@@ -4952,15 +3937,8 @@
         "translate": [4, 0.03, -32],
         "rotate": [0, 0, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-8"
     },
     {
       "id": "path-8-3",
@@ -4972,15 +3950,8 @@
         "translate": [6, 0.03, -32],
         "rotate": [0, 0, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-8"
     },
     {
       "id": "path-8-4",
@@ -4992,15 +3963,8 @@
         "translate": [8, 0.03, -32],
         "rotate": [0, 0, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-8"
     },
     {
       "id": "path-8-5",
@@ -5012,15 +3976,8 @@
         "translate": [10, 0.03, -32],
         "rotate": [0, 0, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-8"
     },
     {
       "id": "path-8-6",
@@ -5032,15 +3989,8 @@
         "translate": [12, 0.03, -32],
         "rotate": [0, 0, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-8"
     },
     {
       "id": "path-8-7",
@@ -5052,15 +4002,8 @@
         "translate": [14, 0.03, -32],
         "rotate": [0, 0, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-8"
     },
     {
       "id": "s9-plinth-0",
@@ -5071,14 +4014,8 @@
       "transform": {
         "translate": [19.81, 0.06, -32]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.1,
-        "value": 0.55,
-        "kind": "normal",
-        "roughness": 0.6,
-        "clearcoat": 0.1
-      }
+      "material": "mat-6",
+      "collection": "station-9"
     },
     {
       "id": "s9-mono-0",
@@ -5090,21 +4027,15 @@
       "transform": {
         "translate": [19.81, 2.4, -32]
       },
-      "material": {
-        "hue": 0.55,
-        "sat": 0.62,
-        "value": 0.82,
-        "kind": "normal",
-        "roughness": 0.3,
-        "clearcoat": 0.45
-      },
+      "material": "mat-7",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "-2.700 + 5.100 * smoothstep(106.05, 106.65, t)"
         }
       ],
-      "pattern": "cracked"
+      "pattern": "cracked",
+      "collection": "station-9"
     },
     {
       "id": "s9-plinth-1",
@@ -5115,14 +4046,8 @@
       "transform": {
         "translate": [18.54, 0.06, -32]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.1,
-        "value": 0.55,
-        "kind": "normal",
-        "roughness": 0.6,
-        "clearcoat": 0.1
-      }
+      "material": "mat-6",
+      "collection": "station-9"
     },
     {
       "id": "s9-mono-1",
@@ -5134,21 +4059,15 @@
       "transform": {
         "translate": [18.54, 2.3564356435643563, -32]
       },
-      "material": {
-        "hue": 0.5650000000000001,
-        "sat": 0.6433333333333333,
-        "value": 0.7833333333333333,
-        "kind": "normal",
-        "roughness": 0.3,
-        "clearcoat": 0.45
-      },
+      "material": "mat-24",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "-2.656 + 5.013 * smoothstep(107.15, 107.75, t)"
         }
       ],
-      "pattern": "cracked"
+      "pattern": "cracked",
+      "collection": "station-9"
     },
     {
       "id": "s9-plinth-2",
@@ -5159,14 +4078,8 @@
       "transform": {
         "translate": [17.27, 0.06, -32]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.1,
-        "value": 0.55,
-        "kind": "normal",
-        "roughness": 0.6,
-        "clearcoat": 0.1
-      }
+      "material": "mat-6",
+      "collection": "station-9"
     },
     {
       "id": "s9-mono-2",
@@ -5178,21 +4091,15 @@
       "transform": {
         "translate": [17.27, 2.2376237623762374, -32]
       },
-      "material": {
-        "hue": 0.5800000000000001,
-        "sat": 0.6666666666666666,
-        "value": 0.7466666666666666,
-        "kind": "normal",
-        "roughness": 0.3,
-        "clearcoat": 0.45
-      },
+      "material": "mat-25",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "-2.538 + 4.775 * smoothstep(108.25, 108.85, t)"
         }
       ],
-      "pattern": "cracked"
+      "pattern": "cracked",
+      "collection": "station-9"
     },
     {
       "id": "s9-plinth-3",
@@ -5203,14 +4110,8 @@
       "transform": {
         "translate": [16, 0.06, -32]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.1,
-        "value": 0.55,
-        "kind": "normal",
-        "roughness": 0.6,
-        "clearcoat": 0.1
-      }
+      "material": "mat-6",
+      "collection": "station-9"
     },
     {
       "id": "s9-mono-3",
@@ -5222,21 +4123,15 @@
       "transform": {
         "translate": [16, 2.1425742574257423, -32]
       },
-      "material": {
-        "hue": 0.5950000000000001,
-        "sat": 0.69,
-        "value": 0.71,
-        "kind": "normal",
-        "roughness": 0.3,
-        "clearcoat": 0.45
-      },
+      "material": "mat-26",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "-2.443 + 4.585 * smoothstep(109.35, 109.95, t)"
         }
       ],
-      "pattern": "cracked"
+      "pattern": "cracked",
+      "collection": "station-9"
     },
     {
       "id": "s9-plinth-4",
@@ -5247,14 +4142,8 @@
       "transform": {
         "translate": [14.73, 0.06, -32]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.1,
-        "value": 0.55,
-        "kind": "normal",
-        "roughness": 0.6,
-        "clearcoat": 0.1
-      }
+      "material": "mat-6",
+      "collection": "station-9"
     },
     {
       "id": "s9-mono-4",
@@ -5266,21 +4155,15 @@
       "transform": {
         "translate": [14.73, 2.023762376237624, -32]
       },
-      "material": {
-        "hue": 0.6100000000000001,
-        "sat": 0.7133333333333334,
-        "value": 0.6733333333333333,
-        "kind": "normal",
-        "roughness": 0.3,
-        "clearcoat": 0.45
-      },
+      "material": "mat-27",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "-2.324 + 4.348 * smoothstep(110.45, 111.05, t)"
         }
       ],
-      "pattern": "cracked"
+      "pattern": "cracked",
+      "collection": "station-9"
     },
     {
       "id": "s9-plinth-5",
@@ -5291,14 +4174,8 @@
       "transform": {
         "translate": [13.46, 0.06, -32]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.1,
-        "value": 0.55,
-        "kind": "normal",
-        "roughness": 0.6,
-        "clearcoat": 0.1
-      }
+      "material": "mat-6",
+      "collection": "station-9"
     },
     {
       "id": "s9-mono-5",
@@ -5310,21 +4187,15 @@
       "transform": {
         "translate": [13.46, 1.881188118811881, -32]
       },
-      "material": {
-        "hue": 0.625,
-        "sat": 0.7366666666666667,
-        "value": 0.6366666666666666,
-        "kind": "normal",
-        "roughness": 0.3,
-        "clearcoat": 0.45
-      },
+      "material": "mat-28",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "-2.181 + 4.062 * smoothstep(111.55, 112.15, t)"
         }
       ],
-      "pattern": "cracked"
+      "pattern": "cracked",
+      "collection": "station-9"
     },
     {
       "id": "s9-plinth-6",
@@ -5335,14 +4206,8 @@
       "transform": {
         "translate": [12.19, 0.06, -32]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.1,
-        "value": 0.55,
-        "kind": "normal",
-        "roughness": 0.6,
-        "clearcoat": 0.1
-      }
+      "material": "mat-6",
+      "collection": "station-9"
     },
     {
       "id": "s9-mono-6",
@@ -5354,22 +4219,14 @@
       "transform": {
         "translate": [12.19, 1.786138613861386, -32]
       },
-      "material": {
-        "hue": 0.11,
-        "sat": 0.78,
-        "value": 0.95,
-        "metal": 0,
-        "glow": 0.1,
-        "kind": "normal",
-        "roughness": 0.22,
-        "clearcoat": 0.6
-      },
+      "material": "mat-12",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "-2.086 + 3.872 * smoothstep(112.65, 113.25, t)"
         }
-      ]
+      ],
+      "collection": "station-9"
     },
     {
       "id": "s9-guard-l-0",
@@ -5381,14 +4238,8 @@
         "translate": [7.23, 1.1, -30.8],
         "rotate": [0, -0.3, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-13",
+      "collection": "station-9"
     },
     {
       "id": "s9-guard-r-0",
@@ -5400,14 +4251,8 @@
         "translate": [24.77, 1.1, -30.8],
         "rotate": [0, 0.3, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-13",
+      "collection": "station-9"
     },
     {
       "id": "s9-guard-l-1",
@@ -5419,14 +4264,8 @@
         "translate": [7.83, 1.75, -36.6],
         "rotate": [0, -0.3, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-13",
+      "collection": "station-9"
     },
     {
       "id": "s9-guard-r-1",
@@ -5438,14 +4277,8 @@
         "translate": [24.17, 1.75, -36.6],
         "rotate": [0, 0.3, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-13",
+      "collection": "station-9"
     },
     {
       "id": "s9-guard-l-2",
@@ -5457,14 +4290,8 @@
         "translate": [6.43, 2.4000000000000004, -38.8],
         "rotate": [0, -0.3, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-13",
+      "collection": "station-9"
     },
     {
       "id": "s9-guard-r-2",
@@ -5476,14 +4303,8 @@
         "translate": [25.57, 2.4000000000000004, -38.8],
         "rotate": [0, 0.3, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-13",
+      "collection": "station-9"
     },
     {
       "id": "path-9-1",
@@ -5495,15 +4316,8 @@
         "translate": [18, 0.03, -32],
         "rotate": [0, 0, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-9"
     },
     {
       "id": "path-9-2",
@@ -5515,15 +4329,8 @@
         "translate": [20, 0.03, -32],
         "rotate": [0, 0, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-9"
     },
     {
       "id": "path-9-3",
@@ -5535,15 +4342,8 @@
         "translate": [22, 0.03, -32],
         "rotate": [0, 0, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-9"
     },
     {
       "id": "path-9-4",
@@ -5555,15 +4355,8 @@
         "translate": [24, 0.03, -32],
         "rotate": [0, 0, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-9"
     },
     {
       "id": "path-9-5",
@@ -5575,15 +4368,8 @@
         "translate": [26, 0.03, -32],
         "rotate": [0, 0, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-9"
     },
     {
       "id": "path-9-6",
@@ -5595,15 +4381,8 @@
         "translate": [28, 0.03, -32],
         "rotate": [0, 0, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-9"
     },
     {
       "id": "path-9-7",
@@ -5615,15 +4394,8 @@
         "translate": [30, 0.03, -32],
         "rotate": [0, 0, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-9"
     },
     {
       "id": "s10-node-0",
@@ -5643,22 +4415,14 @@
       "transform": {
         "translate": [32, 3.15, -32]
       },
-      "material": {
-        "hue": 0.11,
-        "sat": 0.78,
-        "value": 0.95,
-        "metal": 0,
-        "glow": 0.04,
-        "kind": "normal",
-        "roughness": 0.22,
-        "clearcoat": 0.6
-      },
+      "material": "mat-29",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "4.150 - 1 * smoothstep(120.35, 120.90, t)"
         }
-      ]
+      ],
+      "collection": "station-10"
     },
     {
       "id": "s10-node-1",
@@ -5690,20 +4454,14 @@
       "transform": {
         "translate": [32, 2, -33.9]
       },
-      "material": {
-        "hue": 0.5950000000000001,
-        "sat": 0.7,
-        "value": 0.71,
-        "kind": "normal",
-        "roughness": 0.3,
-        "clearcoat": 0.45
-      },
+      "material": "mat-30",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "3.000 - 1 * smoothstep(121.85, 122.40, t)"
         }
-      ]
+      ],
+      "collection": "station-10"
     },
     {
       "id": "s10-node-2",
@@ -5735,20 +4493,14 @@
       "transform": {
         "translate": [33.64544826719043, 2, -31.05]
       },
-      "material": {
-        "hue": 0.5950000000000001,
-        "sat": 0.7,
-        "value": 0.71,
-        "kind": "normal",
-        "roughness": 0.3,
-        "clearcoat": 0.45
-      },
+      "material": "mat-30",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "3.000 - 1 * smoothstep(121.85, 122.40, t)"
         }
-      ]
+      ],
+      "collection": "station-10"
     },
     {
       "id": "s10-node-3",
@@ -5780,20 +4532,14 @@
       "transform": {
         "translate": [30.35455173280957, 2, -31.05]
       },
-      "material": {
-        "hue": 0.5950000000000001,
-        "sat": 0.7,
-        "value": 0.71,
-        "kind": "normal",
-        "roughness": 0.3,
-        "clearcoat": 0.45
-      },
+      "material": "mat-30",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "3.000 - 1 * smoothstep(121.85, 122.40, t)"
         }
-      ]
+      ],
+      "collection": "station-10"
     },
     {
       "id": "s10-node-4",
@@ -5825,20 +4571,14 @@
       "transform": {
         "translate": [33.14289187648037, 0.8500000000000001, -30.358290469809422]
       },
-      "material": {
-        "hue": 0.64,
-        "sat": 0.78,
-        "value": 0.57,
-        "kind": "normal",
-        "roughness": 0.3,
-        "clearcoat": 0.45
-      },
+      "material": "mat-31",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "1.850 - 1 * smoothstep(123.35, 123.90, t)"
         }
-      ]
+      ],
+      "collection": "station-10"
     },
     {
       "id": "path-10-1",
@@ -5850,15 +4590,8 @@
         "translate": [34, 0.03, -32],
         "rotate": [0, 0, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-10"
     },
     {
       "id": "path-10-2",
@@ -5870,15 +4603,8 @@
         "translate": [36, 0.03, -32],
         "rotate": [0, 0, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-10"
     },
     {
       "id": "path-10-3",
@@ -5890,15 +4616,8 @@
         "translate": [38, 0.03, -32],
         "rotate": [0, 0, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-10"
     },
     {
       "id": "path-10-4",
@@ -5910,15 +4629,8 @@
         "translate": [40, 0.03, -32],
         "rotate": [0, 0, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-10"
     },
     {
       "id": "path-10-5",
@@ -5930,15 +4642,8 @@
         "translate": [42, 0.03, -32],
         "rotate": [0, 0, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-10"
     },
     {
       "id": "path-10-6",
@@ -5950,15 +4655,8 @@
         "translate": [44, 0.03, -32],
         "rotate": [0, 0, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-10"
     },
     {
       "id": "path-10-7",
@@ -5970,15 +4668,8 @@
         "translate": [46, 0.03, -32],
         "rotate": [0, 0, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-10"
     },
     {
       "id": "s11-backboard",
@@ -5990,14 +4681,8 @@
       "transform": {
         "translate": [48, 2.51, -32.34]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.3,
-        "value": 0.22,
-        "kind": "normal",
-        "roughness": 0.4,
-        "clearcoat": 0.3
-      }
+      "material": "mat-32",
+      "collection": "station-11"
     },
     {
       "id": "s11-cell-0-0",
@@ -6009,14 +4694,8 @@
       "transform": {
         "translate": [48.91, 3.2199999999999998, -32]
       },
-      "material": {
-        "hue": 0.6,
-        "sat": 0.1,
-        "value": 0.3,
-        "kind": "normal",
-        "roughness": 0.7,
-        "clearcoat": 0.1
-      }
+      "material": "mat-33",
+      "collection": "station-11"
     },
     {
       "id": "s11-cell-1-0",
@@ -6028,14 +4707,8 @@
       "transform": {
         "translate": [47.09, 3.2199999999999998, -32]
       },
-      "material": {
-        "hue": 0.6,
-        "sat": 0.1,
-        "value": 0.3,
-        "kind": "normal",
-        "roughness": 0.7,
-        "clearcoat": 0.1
-      }
+      "material": "mat-33",
+      "collection": "station-11"
     },
     {
       "id": "s11-cell-0-1",
@@ -6047,14 +4720,8 @@
       "transform": {
         "translate": [48.91, 1.7999999999999998, -32]
       },
-      "material": {
-        "hue": 0.6,
-        "sat": 0.1,
-        "value": 0.3,
-        "kind": "normal",
-        "roughness": 0.7,
-        "clearcoat": 0.1
-      }
+      "material": "mat-33",
+      "collection": "station-11"
     },
     {
       "id": "s11-cell-1-1",
@@ -6066,14 +4733,8 @@
       "transform": {
         "translate": [47.09, 1.7999999999999998, -32]
       },
-      "material": {
-        "hue": 0.6,
-        "sat": 0.1,
-        "value": 0.3,
-        "kind": "normal",
-        "roughness": 0.7,
-        "clearcoat": 0.1
-      }
+      "material": "mat-33",
+      "collection": "station-11"
     },
     {
       "id": "s11-item-0",
@@ -6085,20 +4746,14 @@
       "transform": {
         "translate": [48.91, 3.2199999999999998, -31.66]
       },
-      "material": {
-        "hue": 0.57,
-        "sat": 0.55,
-        "value": 0.72,
-        "kind": "normal",
-        "roughness": 0.3,
-        "clearcoat": 0.45
-      },
+      "material": "mat-34",
       "animation": [
         {
           "channel": "transform.translate.z",
           "expr": "2.400 - 2.060 * smoothstep(131.25, 131.70, t)"
         }
-      ]
+      ],
+      "collection": "station-11"
     },
     {
       "id": "s11-item-1",
@@ -6110,20 +4765,14 @@
       "transform": {
         "translate": [48.91, 1.7999999999999998, -31.66]
       },
-      "material": {
-        "hue": 0.57,
-        "sat": 0.55,
-        "value": 0.72,
-        "kind": "normal",
-        "roughness": 0.3,
-        "clearcoat": 0.45
-      },
+      "material": "mat-34",
       "animation": [
         {
           "channel": "transform.translate.z",
           "expr": "2.400 - 2.060 * smoothstep(132.15, 132.60, t)"
         }
-      ]
+      ],
+      "collection": "station-11"
     },
     {
       "id": "s11-item-2",
@@ -6135,20 +4784,14 @@
       "transform": {
         "translate": [47.09, 3.2199999999999998, -31.66]
       },
-      "material": {
-        "hue": 0.57,
-        "sat": 0.55,
-        "value": 0.72,
-        "kind": "normal",
-        "roughness": 0.3,
-        "clearcoat": 0.45
-      },
+      "material": "mat-34",
       "animation": [
         {
           "channel": "transform.translate.z",
           "expr": "2.400 - 2.060 * smoothstep(133.05, 133.50, t)"
         }
-      ]
+      ],
+      "collection": "station-11"
     },
     {
       "id": "s11-item-3",
@@ -6160,21 +4803,14 @@
       "transform": {
         "translate": [47.09, 1.7999999999999998, -31.66]
       },
-      "material": {
-        "hue": 0.11,
-        "sat": 0.78,
-        "value": 0.95,
-        "glow": 0.1,
-        "kind": "normal",
-        "roughness": 0.22,
-        "clearcoat": 0.6
-      },
+      "material": "mat-5",
       "animation": [
         {
           "channel": "transform.translate.z",
           "expr": "2.400 - 2.060 * smoothstep(133.95, 134.40, t)"
         }
-      ]
+      ],
+      "collection": "station-11"
     },
     {
       "id": "s11-flank-0",
@@ -6186,20 +4822,14 @@
         "translate": [43.84, 3.3099999999999996, -34.2],
         "rotate": [0, -0.9, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      },
+      "material": "mat-13",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "3.310 - 0.000 * smoothstep(130.00, 131.00, t) + 0.06 * sin(0.30 * t + -39.00)"
         }
-      ]
+      ],
+      "collection": "station-11"
     },
     {
       "id": "s11-flank-1",
@@ -6211,20 +4841,14 @@
         "translate": [52.46, 2.11, -35],
         "rotate": [0, -0.4, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      },
+      "material": "mat-13",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "2.110 - 0.000 * smoothstep(130.00, 131.00, t) + 0.08 * sin(0.37 * t + -45.90)"
         }
-      ]
+      ],
+      "collection": "station-11"
     },
     {
       "id": "s11-flank-2",
@@ -6236,20 +4860,14 @@
         "translate": [42.04, 4.71, -37.5],
         "rotate": [0, 0.09999999999999998, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      },
+      "material": "mat-13",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "4.710 - 0.000 * smoothstep(130.00, 131.00, t) + 0.10 * sin(0.44 * t + -52.80)"
         }
-      ]
+      ],
+      "collection": "station-11"
     },
     {
       "id": "s11-flank-3",
@@ -6261,20 +4879,14 @@
         "translate": [54.56, 4.109999999999999, -38.5],
         "rotate": [0, 0.6, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      },
+      "material": "mat-13",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "4.110 - 0.000 * smoothstep(130.00, 131.00, t) + 0.12 * sin(0.51 * t + -65.98)"
         }
-      ]
+      ],
+      "collection": "station-11"
     },
     {
       "id": "path-11-1",
@@ -6286,15 +4898,8 @@
         "translate": [42, 0.03, -34],
         "rotate": [0, 2.819842099193151, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-11"
     },
     {
       "id": "path-11-2",
@@ -6306,15 +4911,8 @@
         "translate": [36, 0.03, -36],
         "rotate": [0, 2.819842099193151, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-11"
     },
     {
       "id": "path-11-3",
@@ -6326,15 +4924,8 @@
         "translate": [30, 0.03, -38],
         "rotate": [0, 2.819842099193151, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-11"
     },
     {
       "id": "path-11-4",
@@ -6346,15 +4937,8 @@
         "translate": [24, 0.03, -40],
         "rotate": [0, 2.819842099193151, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-11"
     },
     {
       "id": "path-11-5",
@@ -6366,15 +4950,8 @@
         "translate": [18, 0.03, -42],
         "rotate": [0, 2.819842099193151, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-11"
     },
     {
       "id": "path-11-6",
@@ -6386,15 +4963,8 @@
         "translate": [12, 0.03, -44],
         "rotate": [0, 2.819842099193151, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-11"
     },
     {
       "id": "path-11-7",
@@ -6406,15 +4976,8 @@
         "translate": [6, 0.03, -46],
         "rotate": [0, 2.819842099193151, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-11"
     },
     {
       "id": "s12-plinth-0",
@@ -6425,14 +4988,8 @@
       "transform": {
         "translate": [1.27, 0.06, -48]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.1,
-        "value": 0.55,
-        "kind": "normal",
-        "roughness": 0.6,
-        "clearcoat": 0.1
-      }
+      "material": "mat-6",
+      "collection": "station-12"
     },
     {
       "id": "s12-mono-0",
@@ -6444,21 +5001,15 @@
       "transform": {
         "translate": [1.27, 0.24, -48]
       },
-      "material": {
-        "hue": 0.55,
-        "sat": 0.62,
-        "value": 0.82,
-        "kind": "normal",
-        "roughness": 0.3,
-        "clearcoat": 0.45
-      },
+      "material": "mat-7",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "-0.540 + 0.780 * smoothstep(141.15, 141.75, t)"
         }
       ],
-      "pattern": "cracked"
+      "pattern": "cracked",
+      "collection": "station-12"
     },
     {
       "id": "s12-plinth-1",
@@ -6469,14 +5020,8 @@
       "transform": {
         "translate": [0, 0.06, -48]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.1,
-        "value": 0.55,
-        "kind": "normal",
-        "roughness": 0.6,
-        "clearcoat": 0.1
-      }
+      "material": "mat-6",
+      "collection": "station-12"
     },
     {
       "id": "s12-mono-1",
@@ -6488,21 +5033,15 @@
       "transform": {
         "translate": [0, 1.2, -48]
       },
-      "material": {
-        "hue": 0.5950000000000001,
-        "sat": 0.69,
-        "value": 0.71,
-        "kind": "normal",
-        "roughness": 0.3,
-        "clearcoat": 0.45
-      },
+      "material": "mat-26",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "-1.500 + 2.700 * smoothstep(142.25, 142.85, t)"
         }
       ],
-      "pattern": "cracked"
+      "pattern": "cracked",
+      "collection": "station-12"
     },
     {
       "id": "s12-plinth-2",
@@ -6513,14 +5052,8 @@
       "transform": {
         "translate": [-1.27, 0.06, -48]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.1,
-        "value": 0.55,
-        "kind": "normal",
-        "roughness": 0.6,
-        "clearcoat": 0.1
-      }
+      "material": "mat-6",
+      "collection": "station-12"
     },
     {
       "id": "s12-mono-2",
@@ -6532,22 +5065,14 @@
       "transform": {
         "translate": [-1.27, 2.4, -48]
       },
-      "material": {
-        "hue": 0.11,
-        "sat": 0.78,
-        "value": 0.95,
-        "metal": 0,
-        "glow": 0.1,
-        "kind": "normal",
-        "roughness": 0.22,
-        "clearcoat": 0.6
-      },
+      "material": "mat-12",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "-2.700 + 5.100 * smoothstep(143.35, 143.95, t)"
         }
-      ]
+      ],
+      "collection": "station-12"
     },
     {
       "id": "s12-guard-l-0",
@@ -6559,14 +5084,8 @@
         "translate": [-6.2299999999999995, 1.1, -46.8],
         "rotate": [0, -0.3, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-13",
+      "collection": "station-12"
     },
     {
       "id": "s12-guard-r-0",
@@ -6578,14 +5097,8 @@
         "translate": [6.2299999999999995, 1.1, -46.8],
         "rotate": [0, 0.3, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-13",
+      "collection": "station-12"
     },
     {
       "id": "s12-guard-l-1",
@@ -6597,14 +5110,8 @@
         "translate": [-5.63, 1.75, -52.6],
         "rotate": [0, -0.3, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-13",
+      "collection": "station-12"
     },
     {
       "id": "s12-guard-r-1",
@@ -6616,14 +5123,8 @@
         "translate": [5.63, 1.75, -52.6],
         "rotate": [0, 0.3, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-13",
+      "collection": "station-12"
     },
     {
       "id": "s12-guard-l-2",
@@ -6635,14 +5136,8 @@
         "translate": [-7.03, 2.4000000000000004, -54.8],
         "rotate": [0, -0.3, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-13",
+      "collection": "station-12"
     },
     {
       "id": "s12-guard-r-2",
@@ -6654,14 +5149,8 @@
         "translate": [7.03, 2.4000000000000004, -54.8],
         "rotate": [0, 0.3, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-13",
+      "collection": "station-12"
     },
     {
       "id": "horizon-0",
@@ -6673,16 +5162,8 @@
         "translate": [22.153846153846153, 7.016592952333921, 129.98604452013421],
         "rotate": [0, 0, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "metal": 0,
-        "glow": 0,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-35",
+      "collection": "horizon"
     },
     {
       "id": "horizon-1",
@@ -6694,16 +5175,8 @@
         "translate": [85.46046706914235, 7.62296579657653, 74.39555058828262],
         "rotate": [0, 0.34528374665954953, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "metal": 0,
-        "glow": 0,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-35",
+      "collection": "horizon"
     },
     {
       "id": "horizon-2",
@@ -6715,16 +5188,8 @@
         "translate": [64.32508054170378, 4.819555072083943, 39.72745735696862],
         "rotate": [0, -0.3486303089654353, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "metal": 0,
-        "glow": 0,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-35",
+      "collection": "horizon"
     },
     {
       "id": "horizon-3",
@@ -6736,16 +5201,8 @@
         "translate": [155.39376626395293, 4.842001421418689, -33.860401166753746],
         "rotate": [0, 0.006725560193740241, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "metal": 0,
-        "glow": 0,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-35",
+      "collection": "horizon"
     },
     {
       "id": "horizon-4",
@@ -6757,16 +5214,8 @@
         "translate": [155.59371759652714, 7.640377316314558, -2.516528086496381],
         "rotate": [0, 0.3418395632353122, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "metal": 0,
-        "glow": 0,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-35",
+      "collection": "horizon"
     },
     {
       "id": "horizon-5",
@@ -6778,16 +5227,8 @@
         "translate": [63.74443991943304, 6.990241111126378, -77.18060697097252],
         "rotate": [0, -0.35187830398866804, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "metal": 0,
-        "glow": 0,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-35",
+      "collection": "horizon"
     },
     {
       "id": "horizon-6",
@@ -6799,16 +5240,8 @@
         "translate": [86.73068803428151, 4.3376940527581525, -110.04572698856313],
         "rotate": [0, 0.01344921888845539, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "metal": 0,
-        "glow": 0,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-35",
+      "collection": "horizon"
     },
     {
       "id": "horizon-7",
@@ -6820,16 +5253,8 @@
         "translate": [19.53214682017555, 5.582809968766616, -167.001653812622],
         "rotate": [0, 0.33829873245717335, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "metal": 0,
-        "glow": 0,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-35",
+      "collection": "horizon"
     },
     {
       "id": "horizon-8",
@@ -6841,16 +5266,8 @@
         "translate": [-24.508283111604, 7.956071234520032, -89.3367931365888],
         "rotate": [0, -0.35502681343260184, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "metal": 0,
-        "glow": 0,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-35",
+      "collection": "horizon"
     },
     {
       "id": "horizon-9",
@@ -6862,16 +5279,8 @@
         "translate": [-31.227730323988688, 6.178620822448911, -90.35718043439542],
         "rotate": [0, 0.020169075122725907, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "metal": 0,
-        "glow": 0,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-35",
+      "collection": "horizon"
     },
     {
       "id": "horizon-10",
@@ -6883,16 +5292,8 @@
         "translate": [-127.15348055095802, 4.204050667126552, -1.9209760377709948],
         "rotate": [0, 0.33466225541442246, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "metal": 0,
-        "glow": 0,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-35",
+      "collection": "horizon"
     },
     {
       "id": "horizon-11",
@@ -6904,16 +5305,8 @@
         "translate": [-83.35728783635753, 6.424407144257572, -31.389683207356995],
         "rotate": [0, -0.35807494712787274, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "metal": 0,
-        "glow": 0,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-35",
+      "collection": "horizon"
     },
     {
       "id": "horizon-12",
@@ -6925,16 +5318,8 @@
         "translate": [-20.017140918251492, 7.900940120366205, 42.375717617013834],
         "rotate": [0, 0.02688322901019139, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "metal": 0,
-        "glow": 0,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-35",
+      "collection": "horizon"
     },
     {
       "id": "horizon-13",
@@ -6946,16 +5331,8 @@
         "translate": [-59.57036602380531, 5.34938983448815, 93.74535911170264],
         "rotate": [0, 0.3309311602381515, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "metal": 0,
-        "glow": 0,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-35",
+      "collection": "horizon"
     }
   ],
   "overlay": [

--- a/sdf-js/fixtures/golden/assemble-deck-line.json
+++ b/sdf-js/fixtures/golden/assemble-deck-line.json
@@ -1,6 +1,425 @@
 {
   "v": 1,
   "name": "(deck) 最懂你的头条 — 2013 管理层陈述",
+  "collections": {
+    "station-0": {
+      "kind": "station",
+      "station": 0
+    },
+    "path-0": {
+      "kind": "transit-path",
+      "from": 0
+    },
+    "station-1": {
+      "kind": "station",
+      "station": 1
+    },
+    "path-1": {
+      "kind": "transit-path",
+      "from": 1
+    },
+    "station-2": {
+      "kind": "station",
+      "station": 2
+    },
+    "path-2": {
+      "kind": "transit-path",
+      "from": 2
+    },
+    "station-3": {
+      "kind": "station",
+      "station": 3
+    },
+    "path-3": {
+      "kind": "transit-path",
+      "from": 3
+    },
+    "station-4": {
+      "kind": "station",
+      "station": 4
+    },
+    "path-4": {
+      "kind": "transit-path",
+      "from": 4
+    },
+    "station-5": {
+      "kind": "station",
+      "station": 5
+    },
+    "path-5": {
+      "kind": "transit-path",
+      "from": 5
+    },
+    "station-6": {
+      "kind": "station",
+      "station": 6
+    },
+    "path-6": {
+      "kind": "transit-path",
+      "from": 6
+    },
+    "station-7": {
+      "kind": "station",
+      "station": 7
+    },
+    "path-7": {
+      "kind": "transit-path",
+      "from": 7
+    },
+    "station-8": {
+      "kind": "station",
+      "station": 8
+    },
+    "path-8": {
+      "kind": "transit-path",
+      "from": 8
+    },
+    "station-9": {
+      "kind": "station",
+      "station": 9
+    },
+    "path-9": {
+      "kind": "transit-path",
+      "from": 9
+    },
+    "station-10": {
+      "kind": "station",
+      "station": 10
+    },
+    "path-10": {
+      "kind": "transit-path",
+      "from": 10
+    },
+    "station-11": {
+      "kind": "station",
+      "station": 11
+    },
+    "path-11": {
+      "kind": "transit-path",
+      "from": 11
+    },
+    "station-12": {
+      "kind": "station",
+      "station": 12
+    },
+    "massing": {
+      "kind": "dressing",
+      "cull": "never"
+    },
+    "horizon": {
+      "kind": "dressing",
+      "cull": "nearest",
+      "budget": {
+        "hero": 7,
+        "content": 3
+      },
+      "yieldTo": "massing"
+    },
+    "env": {
+      "kind": "dressing",
+      "cull": "never"
+    }
+  },
+  "materials": {
+    "mat-0": {
+      "hue": 0.62,
+      "sat": 0.25,
+      "value": 0.1,
+      "kind": "normal",
+      "roughness": 0.48,
+      "clearcoat": 0.45
+    },
+    "mat-1": {
+      "hue": 0.58,
+      "sat": 0.25,
+      "value": 0.85,
+      "glow": 0.45,
+      "kind": "normal",
+      "roughness": 0.5,
+      "clearcoat": 0.2
+    },
+    "mat-2": {
+      "hue": 0.62,
+      "sat": 0.25,
+      "value": 0.1,
+      "kind": "normal",
+      "roughness": 0.4,
+      "clearcoat": 0.45
+    },
+    "mat-3": {
+      "hue": 0.995,
+      "sat": 0.85,
+      "value": 0.78,
+      "glow": 0.12,
+      "kind": "normal",
+      "roughness": 0.3,
+      "clearcoat": 0.5
+    },
+    "mat-4": {
+      "hue": 0.995,
+      "sat": 0.15,
+      "value": 0.8,
+      "glow": 0.5,
+      "kind": "normal",
+      "roughness": 0.4
+    },
+    "mat-5": {
+      "hue": 0.11,
+      "sat": 0.78,
+      "value": 0.95,
+      "glow": 0.1,
+      "kind": "normal",
+      "roughness": 0.22,
+      "clearcoat": 0.6
+    },
+    "mat-6": {
+      "hue": 0.58,
+      "sat": 0.1,
+      "value": 0.55,
+      "kind": "normal",
+      "roughness": 0.6,
+      "clearcoat": 0.1
+    },
+    "mat-7": {
+      "hue": 0.55,
+      "sat": 0.62,
+      "value": 0.82,
+      "kind": "normal",
+      "roughness": 0.3,
+      "clearcoat": 0.45
+    },
+    "mat-8": {
+      "hue": 0.5680000000000001,
+      "sat": 0.648,
+      "value": 0.7759999999999999,
+      "kind": "normal",
+      "roughness": 0.3,
+      "clearcoat": 0.45
+    },
+    "mat-9": {
+      "hue": 0.5860000000000001,
+      "sat": 0.676,
+      "value": 0.732,
+      "kind": "normal",
+      "roughness": 0.3,
+      "clearcoat": 0.45
+    },
+    "mat-10": {
+      "hue": 0.6040000000000001,
+      "sat": 0.704,
+      "value": 0.688,
+      "kind": "normal",
+      "roughness": 0.3,
+      "clearcoat": 0.45
+    },
+    "mat-11": {
+      "hue": 0.622,
+      "sat": 0.732,
+      "value": 0.6439999999999999,
+      "kind": "normal",
+      "roughness": 0.3,
+      "clearcoat": 0.45
+    },
+    "mat-12": {
+      "hue": 0.11,
+      "sat": 0.78,
+      "value": 0.95,
+      "metal": 0,
+      "glow": 0.1,
+      "kind": "normal",
+      "roughness": 0.22,
+      "clearcoat": 0.6
+    },
+    "mat-13": {
+      "hue": 0.62,
+      "sat": 0.25,
+      "value": 0.14,
+      "kind": "normal",
+      "roughness": 0.5,
+      "clearcoat": 0.35
+    },
+    "mat-14": {
+      "hue": 0.64,
+      "sat": 0.76,
+      "value": 0.6,
+      "kind": "normal",
+      "roughness": 0.3,
+      "clearcoat": 0.45
+    },
+    "mat-15": {
+      "hue": 0.995,
+      "sat": 0.85,
+      "value": 0.78,
+      "glow": 0.24,
+      "kind": "normal",
+      "roughness": 0.3,
+      "clearcoat": 0.5
+    },
+    "mat-16": {
+      "hue": 0.62875,
+      "sat": 0.76,
+      "value": 0.5875,
+      "kind": "normal",
+      "roughness": 0.55,
+      "clearcoat": 0.2
+    },
+    "mat-17": {
+      "hue": 0.6175,
+      "sat": 0.74,
+      "value": 0.625,
+      "kind": "normal",
+      "roughness": 0.55,
+      "clearcoat": 0.2
+    },
+    "mat-18": {
+      "hue": 0.60625,
+      "sat": 0.72,
+      "value": 0.6625000000000001,
+      "kind": "normal",
+      "roughness": 0.55,
+      "clearcoat": 0.2
+    },
+    "mat-19": {
+      "hue": 0.58,
+      "sat": 0.25,
+      "value": 0.55,
+      "glow": 0.08,
+      "kind": "normal",
+      "roughness": 0.6,
+      "clearcoat": 0.15
+    },
+    "mat-20": {
+      "hue": 0.62,
+      "sat": 0.2,
+      "value": 0.18,
+      "kind": "normal",
+      "roughness": 0.5
+    },
+    "mat-21": {
+      "hue": 0.55,
+      "sat": 0.62,
+      "value": 0.85,
+      "kind": "normal",
+      "roughness": 0.3,
+      "clearcoat": 0.45
+    },
+    "mat-22": {
+      "hue": 0.6100000000000001,
+      "sat": 0.7266666666666667,
+      "value": 0.65,
+      "kind": "normal",
+      "roughness": 0.3,
+      "clearcoat": 0.45
+    },
+    "mat-23": {
+      "hue": 0.64,
+      "sat": 0.78,
+      "value": 0.55,
+      "kind": "normal",
+      "roughness": 0.3,
+      "clearcoat": 0.45
+    },
+    "mat-24": {
+      "hue": 0.5650000000000001,
+      "sat": 0.6433333333333333,
+      "value": 0.7833333333333333,
+      "kind": "normal",
+      "roughness": 0.3,
+      "clearcoat": 0.45
+    },
+    "mat-25": {
+      "hue": 0.5800000000000001,
+      "sat": 0.6666666666666666,
+      "value": 0.7466666666666666,
+      "kind": "normal",
+      "roughness": 0.3,
+      "clearcoat": 0.45
+    },
+    "mat-26": {
+      "hue": 0.5950000000000001,
+      "sat": 0.69,
+      "value": 0.71,
+      "kind": "normal",
+      "roughness": 0.3,
+      "clearcoat": 0.45
+    },
+    "mat-27": {
+      "hue": 0.6100000000000001,
+      "sat": 0.7133333333333334,
+      "value": 0.6733333333333333,
+      "kind": "normal",
+      "roughness": 0.3,
+      "clearcoat": 0.45
+    },
+    "mat-28": {
+      "hue": 0.625,
+      "sat": 0.7366666666666667,
+      "value": 0.6366666666666666,
+      "kind": "normal",
+      "roughness": 0.3,
+      "clearcoat": 0.45
+    },
+    "mat-29": {
+      "hue": 0.11,
+      "sat": 0.78,
+      "value": 0.95,
+      "metal": 0,
+      "glow": 0.04,
+      "kind": "normal",
+      "roughness": 0.22,
+      "clearcoat": 0.6
+    },
+    "mat-30": {
+      "hue": 0.5950000000000001,
+      "sat": 0.7,
+      "value": 0.71,
+      "kind": "normal",
+      "roughness": 0.3,
+      "clearcoat": 0.45
+    },
+    "mat-31": {
+      "hue": 0.64,
+      "sat": 0.78,
+      "value": 0.57,
+      "kind": "normal",
+      "roughness": 0.3,
+      "clearcoat": 0.45
+    },
+    "mat-32": {
+      "hue": 0.62,
+      "sat": 0.3,
+      "value": 0.22,
+      "kind": "normal",
+      "roughness": 0.4,
+      "clearcoat": 0.3
+    },
+    "mat-33": {
+      "hue": 0.6,
+      "sat": 0.1,
+      "value": 0.3,
+      "kind": "normal",
+      "roughness": 0.7,
+      "clearcoat": 0.1
+    },
+    "mat-34": {
+      "hue": 0.57,
+      "sat": 0.55,
+      "value": 0.72,
+      "kind": "normal",
+      "roughness": 0.3,
+      "clearcoat": 0.45
+    },
+    "mat-35": {
+      "hue": 0.62,
+      "sat": 0.25,
+      "value": 0.14,
+      "metal": 0,
+      "glow": 0,
+      "kind": "normal",
+      "roughness": 0.5,
+      "clearcoat": 0.35
+    }
+  },
   "subjects": [
     {
       "id": "s0-mono-title",
@@ -12,14 +431,8 @@
       "transform": {
         "translate": [0, 2.7, -1.4]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.1,
-        "kind": "normal",
-        "roughness": 0.48,
-        "clearcoat": 0.45
-      }
+      "material": "mat-0",
+      "collection": "station-0"
     },
     {
       "id": "s0-forest-0-l0",
@@ -32,14 +445,8 @@
         "translate": [-3.4, 4, -6],
         "rotate": [0, -0.12, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.1,
-        "kind": "normal",
-        "roughness": 0.48,
-        "clearcoat": 0.45
-      }
+      "material": "mat-0",
+      "collection": "station-0"
     },
     {
       "id": "s0-forest-0-l1",
@@ -52,14 +459,8 @@
         "translate": [-6.4, 4, -8.2],
         "rotate": [0, -0.2, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.1,
-        "kind": "normal",
-        "roughness": 0.48,
-        "clearcoat": 0.45
-      }
+      "material": "mat-0",
+      "collection": "station-0"
     },
     {
       "id": "s0-forest-0-r0",
@@ -72,14 +473,8 @@
         "translate": [3.4, 4, -6],
         "rotate": [0, 0.12, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.1,
-        "kind": "normal",
-        "roughness": 0.48,
-        "clearcoat": 0.45
-      }
+      "material": "mat-0",
+      "collection": "station-0"
     },
     {
       "id": "s0-forest-0-r1",
@@ -92,14 +487,8 @@
         "translate": [6.4, 4, -8.2],
         "rotate": [0, 0.2, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.1,
-        "kind": "normal",
-        "roughness": 0.48,
-        "clearcoat": 0.45
-      }
+      "material": "mat-0",
+      "collection": "station-0"
     },
     {
       "id": "s0-forest-1-l0",
@@ -112,14 +501,8 @@
         "translate": [-4.5, 5.75, -12.5],
         "rotate": [0, -0.12, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.1,
-        "kind": "normal",
-        "roughness": 0.48,
-        "clearcoat": 0.45
-      }
+      "material": "mat-0",
+      "collection": "station-0"
     },
     {
       "id": "s0-forest-1-l1",
@@ -132,14 +515,8 @@
         "translate": [-7.5, 5.75, -14.7],
         "rotate": [0, -0.2, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.1,
-        "kind": "normal",
-        "roughness": 0.48,
-        "clearcoat": 0.45
-      }
+      "material": "mat-0",
+      "collection": "station-0"
     },
     {
       "id": "s0-forest-1-r0",
@@ -152,14 +529,8 @@
         "translate": [4.5, 5.75, -12.5],
         "rotate": [0, 0.12, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.1,
-        "kind": "normal",
-        "roughness": 0.48,
-        "clearcoat": 0.45
-      }
+      "material": "mat-0",
+      "collection": "station-0"
     },
     {
       "id": "s0-forest-1-r1",
@@ -172,14 +543,8 @@
         "translate": [7.5, 5.75, -14.7],
         "rotate": [0, 0.2, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.1,
-        "kind": "normal",
-        "roughness": 0.48,
-        "clearcoat": 0.45
-      }
+      "material": "mat-0",
+      "collection": "station-0"
     },
     {
       "id": "s0-forest-2-l0",
@@ -192,14 +557,8 @@
         "translate": [-5.6, 7.5, -19],
         "rotate": [0, -0.12, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.1,
-        "kind": "normal",
-        "roughness": 0.48,
-        "clearcoat": 0.45
-      }
+      "material": "mat-0",
+      "collection": "station-0"
     },
     {
       "id": "s0-forest-2-l1",
@@ -212,14 +571,8 @@
         "translate": [-8.600000000000001, 7.5, -21.2],
         "rotate": [0, -0.2, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.1,
-        "kind": "normal",
-        "roughness": 0.48,
-        "clearcoat": 0.45
-      }
+      "material": "mat-0",
+      "collection": "station-0"
     },
     {
       "id": "s0-forest-2-r0",
@@ -232,14 +585,8 @@
         "translate": [5.6, 7.5, -19],
         "rotate": [0, 0.12, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.1,
-        "kind": "normal",
-        "roughness": 0.48,
-        "clearcoat": 0.45
-      }
+      "material": "mat-0",
+      "collection": "station-0"
     },
     {
       "id": "s0-forest-2-r1",
@@ -252,14 +599,8 @@
         "translate": [8.600000000000001, 7.5, -21.2],
         "rotate": [0, 0.2, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.1,
-        "kind": "normal",
-        "roughness": 0.48,
-        "clearcoat": 0.45
-      }
+      "material": "mat-0",
+      "collection": "station-0"
     },
     {
       "id": "s0-forest-3-l0",
@@ -272,14 +613,8 @@
         "translate": [-6.7, 9.25, -25.5],
         "rotate": [0, -0.12, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.1,
-        "kind": "normal",
-        "roughness": 0.48,
-        "clearcoat": 0.45
-      }
+      "material": "mat-0",
+      "collection": "station-0"
     },
     {
       "id": "s0-forest-3-l1",
@@ -292,14 +627,8 @@
         "translate": [-9.700000000000001, 9.25, -27.7],
         "rotate": [0, -0.2, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.1,
-        "kind": "normal",
-        "roughness": 0.48,
-        "clearcoat": 0.45
-      }
+      "material": "mat-0",
+      "collection": "station-0"
     },
     {
       "id": "s0-forest-3-r0",
@@ -312,14 +641,8 @@
         "translate": [6.7, 9.25, -25.5],
         "rotate": [0, 0.12, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.1,
-        "kind": "normal",
-        "roughness": 0.48,
-        "clearcoat": 0.45
-      }
+      "material": "mat-0",
+      "collection": "station-0"
     },
     {
       "id": "s0-forest-3-r1",
@@ -332,14 +655,8 @@
         "translate": [9.700000000000001, 9.25, -27.7],
         "rotate": [0, 0.2, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.1,
-        "kind": "normal",
-        "roughness": 0.48,
-        "clearcoat": 0.45
-      }
+      "material": "mat-0",
+      "collection": "station-0"
     },
     {
       "id": "s0-floater-0",
@@ -352,20 +669,14 @@
         "translate": [-6.5, 3.4, -6],
         "rotate": [0, -1, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.1,
-        "kind": "normal",
-        "roughness": 0.48,
-        "clearcoat": 0.45
-      },
+      "material": "mat-0",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "3.400 - 0.000 * smoothstep(0.00, 1.00, t) + 0.07 * sin(0.35 * t + 0.00)"
         }
-      ]
+      ],
+      "collection": "station-0"
     },
     {
       "id": "s0-floater-1",
@@ -378,20 +689,14 @@
         "translate": [4.8, 2.6, -7.5],
         "rotate": [0, -0.5, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.1,
-        "kind": "normal",
-        "roughness": 0.48,
-        "clearcoat": 0.45
-      },
+      "material": "mat-0",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "2.600 - 0.000 * smoothstep(0.00, 1.00, t) + 0.09 * sin(0.43 * t + 2.10)"
         }
-      ]
+      ],
+      "collection": "station-0"
     },
     {
       "id": "s0-floater-2",
@@ -404,20 +709,14 @@
         "translate": [-3.2, 4.6, -9],
         "rotate": [0, 0, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.1,
-        "kind": "normal",
-        "roughness": 0.48,
-        "clearcoat": 0.45
-      },
+      "material": "mat-0",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "4.600 - 0.000 * smoothstep(0.00, 1.00, t) + 0.11 * sin(0.51 * t + 4.20)"
         }
-      ]
+      ],
+      "collection": "station-0"
     },
     {
       "id": "s0-floater-3",
@@ -430,20 +729,14 @@
         "translate": [7.2, 4, -5],
         "rotate": [0, 0.5, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.1,
-        "kind": "normal",
-        "roughness": 0.48,
-        "clearcoat": 0.45
-      },
+      "material": "mat-0",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "4.000 - 0.000 * smoothstep(0.00, 1.00, t) + 0.13 * sin(0.59 * t + 0.02)"
         }
-      ]
+      ],
+      "collection": "station-0"
     },
     {
       "id": "s0-floater-4",
@@ -456,20 +749,14 @@
         "translate": [-9.5, 5.8, -12],
         "rotate": [0, 1, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.1,
-        "kind": "normal",
-        "roughness": 0.48,
-        "clearcoat": 0.45
-      },
+      "material": "mat-0",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "5.800 - 0.000 * smoothstep(0.00, 1.00, t) + 0.15 * sin(0.67 * t + 2.12)"
         }
-      ]
+      ],
+      "collection": "station-0"
     },
     {
       "id": "s0-floater-5",
@@ -482,20 +769,14 @@
         "translate": [10.5, 5.2, -10],
         "rotate": [0, 1.5, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.1,
-        "kind": "normal",
-        "roughness": 0.48,
-        "clearcoat": 0.45
-      },
+      "material": "mat-0",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "5.200 - 0.000 * smoothstep(0.00, 1.00, t) + 0.17 * sin(0.75 * t + 4.22)"
         }
-      ]
+      ],
+      "collection": "station-0"
     },
     {
       "id": "s0-floater-6",
@@ -508,20 +789,14 @@
         "translate": [2.2, 7, -14],
         "rotate": [0, 2, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.1,
-        "kind": "normal",
-        "roughness": 0.48,
-        "clearcoat": 0.45
-      },
+      "material": "mat-0",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "7.000 - 0.000 * smoothstep(0.00, 1.00, t) + 0.19 * sin(0.83 * t + 0.04)"
         }
-      ]
+      ],
+      "collection": "station-0"
     },
     {
       "id": "s0-floater-7",
@@ -534,20 +809,14 @@
         "translate": [-5.8, 6.4, -16],
         "rotate": [0, 2.5, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.1,
-        "kind": "normal",
-        "roughness": 0.48,
-        "clearcoat": 0.45
-      },
+      "material": "mat-0",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "6.400 - 0.000 * smoothstep(0.00, 1.00, t) + 0.21 * sin(0.91 * t + 2.14)"
         }
-      ]
+      ],
+      "collection": "station-0"
     },
     {
       "id": "s0-floater-8",
@@ -560,20 +829,14 @@
         "translate": [6.8, 2, -13],
         "rotate": [0, 3, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.1,
-        "kind": "normal",
-        "roughness": 0.48,
-        "clearcoat": 0.45
-      },
+      "material": "mat-0",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "2.000 - 0.000 * smoothstep(0.00, 1.00, t) + 0.23 * sin(0.99 * t + 4.24)"
         }
-      ]
+      ],
+      "collection": "station-0"
     },
     {
       "id": "path-0-1",
@@ -585,15 +848,8 @@
         "translate": [2, 0.03, 0],
         "rotate": [0, 0, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-0"
     },
     {
       "id": "path-0-2",
@@ -605,15 +861,8 @@
         "translate": [4, 0.03, 0],
         "rotate": [0, 0, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-0"
     },
     {
       "id": "path-0-3",
@@ -625,15 +874,8 @@
         "translate": [6, 0.03, 0],
         "rotate": [0, 0, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-0"
     },
     {
       "id": "path-0-4",
@@ -645,15 +887,8 @@
         "translate": [8, 0.03, 0],
         "rotate": [0, 0, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-0"
     },
     {
       "id": "path-0-5",
@@ -665,15 +900,8 @@
         "translate": [10, 0.03, 0],
         "rotate": [0, 0, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-0"
     },
     {
       "id": "path-0-6",
@@ -685,15 +913,8 @@
         "translate": [12, 0.03, 0],
         "rotate": [0, 0, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-0"
     },
     {
       "id": "path-0-7",
@@ -705,15 +926,8 @@
         "translate": [14, 0.03, 0],
         "rotate": [0, 0, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-0"
     },
     {
       "id": "s1-dome",
@@ -724,14 +938,8 @@
       "transform": {
         "translate": [16, 0, -1.2]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.1,
-        "kind": "normal",
-        "roughness": 0.4,
-        "clearcoat": 0.45
-      }
+      "material": "mat-2",
+      "collection": "station-1"
     },
     {
       "id": "s1-orb-0",
@@ -742,21 +950,14 @@
       "transform": {
         "translate": [19.487901743725214, 2.2, -0.5534640548657206]
       },
-      "material": {
-        "hue": 0.995,
-        "sat": 0.85,
-        "value": 0.78,
-        "glow": 0.12,
-        "kind": "normal",
-        "roughness": 0.3,
-        "clearcoat": 0.5
-      },
+      "material": "mat-3",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "3.800 - 1.600 * smoothstep(9.45, 10.00, t) + 0.04 * sin(0.6 * t + -4.56)"
         }
-      ]
+      ],
+      "collection": "station-1"
     },
     {
       "id": "s1-orb-stem-0",
@@ -768,14 +969,8 @@
       "transform": {
         "translate": [19.487901743725214, 1.1, -0.5534640548657206]
       },
-      "material": {
-        "hue": 0.995,
-        "sat": 0.15,
-        "value": 0.8,
-        "glow": 0.5,
-        "kind": "normal",
-        "roughness": 0.4
-      }
+      "material": "mat-4",
+      "collection": "station-1"
     },
     {
       "id": "s1-orb-1",
@@ -786,21 +981,14 @@
       "transform": {
         "translate": [18.350094450939565, 2.2, -0.19211357462773826]
       },
-      "material": {
-        "hue": 0.11,
-        "sat": 0.78,
-        "value": 0.95,
-        "glow": 0.1,
-        "kind": "normal",
-        "roughness": 0.22,
-        "clearcoat": 0.6
-      },
+      "material": "mat-5",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "3.800 - 1.600 * smoothstep(10.45, 11.00, t) + 0.04 * sin(0.6 * t + -2.86)"
         }
-      ]
+      ],
+      "collection": "station-1"
     },
     {
       "id": "s1-orb-stem-1",
@@ -812,14 +1000,8 @@
       "transform": {
         "translate": [18.350094450939565, 1.1, -0.19211357462773826]
       },
-      "material": {
-        "hue": 0.995,
-        "sat": 0.15,
-        "value": 0.8,
-        "glow": 0.5,
-        "kind": "normal",
-        "roughness": 0.4
-      }
+      "material": "mat-4",
+      "collection": "station-1"
     },
     {
       "id": "s1-orb-2",
@@ -830,21 +1012,14 @@
       "transform": {
         "translate": [16.828466888570354, 2.2, 0.0046276749721592125]
       },
-      "material": {
-        "hue": 0.995,
-        "sat": 0.85,
-        "value": 0.78,
-        "glow": 0.12,
-        "kind": "normal",
-        "roughness": 0.3,
-        "clearcoat": 0.5
-      },
+      "material": "mat-3",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "3.800 - 1.600 * smoothstep(11.45, 12.00, t) + 0.04 * sin(0.6 * t + -1.16)"
         }
-      ]
+      ],
+      "collection": "station-1"
     },
     {
       "id": "s1-orb-stem-2",
@@ -856,14 +1031,8 @@
       "transform": {
         "translate": [16.828466888570354, 1.1, 0.0046276749721592125]
       },
-      "material": {
-        "hue": 0.995,
-        "sat": 0.15,
-        "value": 0.8,
-        "glow": 0.5,
-        "kind": "normal",
-        "roughness": 0.4
-      }
+      "material": "mat-4",
+      "collection": "station-1"
     },
     {
       "id": "s1-orb-3",
@@ -874,21 +1043,14 @@
       "transform": {
         "translate": [15.171533111429648, 2.2, 0.0046276749721592125]
       },
-      "material": {
-        "hue": 0.995,
-        "sat": 0.85,
-        "value": 0.78,
-        "glow": 0.12,
-        "kind": "normal",
-        "roughness": 0.3,
-        "clearcoat": 0.5
-      },
+      "material": "mat-3",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "3.800 - 1.600 * smoothstep(12.45, 13.00, t) + 0.04 * sin(0.6 * t + 0.54)"
         }
-      ]
+      ],
+      "collection": "station-1"
     },
     {
       "id": "s1-orb-stem-3",
@@ -900,14 +1062,8 @@
       "transform": {
         "translate": [15.171533111429648, 1.1, 0.0046276749721592125]
       },
-      "material": {
-        "hue": 0.995,
-        "sat": 0.15,
-        "value": 0.8,
-        "glow": 0.5,
-        "kind": "normal",
-        "roughness": 0.4
-      }
+      "material": "mat-4",
+      "collection": "station-1"
     },
     {
       "id": "s1-orb-4",
@@ -918,21 +1074,14 @@
       "transform": {
         "translate": [13.649905549060437, 2.2, -0.19211357462773782]
       },
-      "material": {
-        "hue": 0.995,
-        "sat": 0.85,
-        "value": 0.78,
-        "glow": 0.12,
-        "kind": "normal",
-        "roughness": 0.3,
-        "clearcoat": 0.5
-      },
+      "material": "mat-3",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "3.800 - 1.600 * smoothstep(13.45, 14.00, t) + 0.04 * sin(0.6 * t + -4.04)"
         }
-      ]
+      ],
+      "collection": "station-1"
     },
     {
       "id": "s1-orb-stem-4",
@@ -944,14 +1093,8 @@
       "transform": {
         "translate": [13.649905549060437, 1.1, -0.19211357462773782]
       },
-      "material": {
-        "hue": 0.995,
-        "sat": 0.15,
-        "value": 0.8,
-        "glow": 0.5,
-        "kind": "normal",
-        "roughness": 0.4
-      }
+      "material": "mat-4",
+      "collection": "station-1"
     },
     {
       "id": "s1-orb-5",
@@ -962,21 +1105,14 @@
       "transform": {
         "translate": [12.512098256274788, 2.2, -0.5534640548657205]
       },
-      "material": {
-        "hue": 0.995,
-        "sat": 0.85,
-        "value": 0.78,
-        "glow": 0.12,
-        "kind": "normal",
-        "roughness": 0.3,
-        "clearcoat": 0.5
-      },
+      "material": "mat-3",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "3.800 - 1.600 * smoothstep(14.45, 15.00, t) + 0.04 * sin(0.6 * t + -2.34)"
         }
-      ]
+      ],
+      "collection": "station-1"
     },
     {
       "id": "s1-orb-stem-5",
@@ -988,14 +1124,8 @@
       "transform": {
         "translate": [12.512098256274788, 1.1, -0.5534640548657205]
       },
-      "material": {
-        "hue": 0.995,
-        "sat": 0.15,
-        "value": 0.8,
-        "glow": 0.5,
-        "kind": "normal",
-        "roughness": 0.4
-      }
+      "material": "mat-4",
+      "collection": "station-1"
     },
     {
       "id": "path-1-1",
@@ -1007,15 +1137,8 @@
         "translate": [18, 0.03, 0],
         "rotate": [0, 0, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-1"
     },
     {
       "id": "path-1-2",
@@ -1027,15 +1150,8 @@
         "translate": [20, 0.03, 0],
         "rotate": [0, 0, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-1"
     },
     {
       "id": "path-1-3",
@@ -1047,15 +1163,8 @@
         "translate": [22, 0.03, 0],
         "rotate": [0, 0, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-1"
     },
     {
       "id": "path-1-4",
@@ -1067,15 +1176,8 @@
         "translate": [24, 0.03, 0],
         "rotate": [0, 0, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-1"
     },
     {
       "id": "path-1-5",
@@ -1087,15 +1189,8 @@
         "translate": [26, 0.03, 0],
         "rotate": [0, 0, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-1"
     },
     {
       "id": "path-1-6",
@@ -1107,15 +1202,8 @@
         "translate": [28, 0.03, 0],
         "rotate": [0, 0, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-1"
     },
     {
       "id": "path-1-7",
@@ -1127,15 +1215,8 @@
         "translate": [30, 0.03, 0],
         "rotate": [0, 0, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-1"
     },
     {
       "id": "s2-plinth-0",
@@ -1146,14 +1227,8 @@
       "transform": {
         "translate": [35.175, 0.06, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.1,
-        "value": 0.55,
-        "kind": "normal",
-        "roughness": 0.6,
-        "clearcoat": 0.1
-      }
+      "material": "mat-6",
+      "collection": "station-2"
     },
     {
       "id": "s2-mono-0",
@@ -1165,21 +1240,15 @@
       "transform": {
         "translate": [35.175, 0.9931034482758622, 0]
       },
-      "material": {
-        "hue": 0.55,
-        "sat": 0.62,
-        "value": 0.82,
-        "kind": "normal",
-        "roughness": 0.3,
-        "clearcoat": 0.45
-      },
+      "material": "mat-7",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "-1.293 + 2.286 * smoothstep(21.45, 22.05, t)"
         }
       ],
-      "pattern": "cracked"
+      "pattern": "cracked",
+      "collection": "station-2"
     },
     {
       "id": "s2-plinth-1",
@@ -1190,14 +1259,8 @@
       "transform": {
         "translate": [33.905, 0.06, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.1,
-        "value": 0.55,
-        "kind": "normal",
-        "roughness": 0.6,
-        "clearcoat": 0.1
-      }
+      "material": "mat-6",
+      "collection": "station-2"
     },
     {
       "id": "s2-mono-1",
@@ -1209,21 +1272,15 @@
       "transform": {
         "translate": [33.905, 1.2413793103448276, 0]
       },
-      "material": {
-        "hue": 0.5680000000000001,
-        "sat": 0.648,
-        "value": 0.7759999999999999,
-        "kind": "normal",
-        "roughness": 0.3,
-        "clearcoat": 0.45
-      },
+      "material": "mat-8",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "-1.541 + 2.783 * smoothstep(22.55, 23.15, t)"
         }
       ],
-      "pattern": "cracked"
+      "pattern": "cracked",
+      "collection": "station-2"
     },
     {
       "id": "s2-plinth-2",
@@ -1234,14 +1291,8 @@
       "transform": {
         "translate": [32.635, 0.06, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.1,
-        "value": 0.55,
-        "kind": "normal",
-        "roughness": 0.6,
-        "clearcoat": 0.1
-      }
+      "material": "mat-6",
+      "collection": "station-2"
     },
     {
       "id": "s2-mono-2",
@@ -1253,21 +1304,15 @@
       "transform": {
         "translate": [32.635, 1.6, 0]
       },
-      "material": {
-        "hue": 0.5860000000000001,
-        "sat": 0.676,
-        "value": 0.732,
-        "kind": "normal",
-        "roughness": 0.3,
-        "clearcoat": 0.45
-      },
+      "material": "mat-9",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "-1.900 + 3.500 * smoothstep(23.65, 24.25, t)"
         }
       ],
-      "pattern": "cracked"
+      "pattern": "cracked",
+      "collection": "station-2"
     },
     {
       "id": "s2-plinth-3",
@@ -1278,14 +1323,8 @@
       "transform": {
         "translate": [31.365, 0.06, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.1,
-        "value": 0.55,
-        "kind": "normal",
-        "roughness": 0.6,
-        "clearcoat": 0.1
-      }
+      "material": "mat-6",
+      "collection": "station-2"
     },
     {
       "id": "s2-mono-3",
@@ -1297,21 +1336,15 @@
       "transform": {
         "translate": [31.365, 1.9034482758620692, 0]
       },
-      "material": {
-        "hue": 0.6040000000000001,
-        "sat": 0.704,
-        "value": 0.688,
-        "kind": "normal",
-        "roughness": 0.3,
-        "clearcoat": 0.45
-      },
+      "material": "mat-10",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "-2.203 + 4.107 * smoothstep(24.75, 25.35, t)"
         }
       ],
-      "pattern": "cracked"
+      "pattern": "cracked",
+      "collection": "station-2"
     },
     {
       "id": "s2-plinth-4",
@@ -1322,14 +1355,8 @@
       "transform": {
         "translate": [30.095, 0.06, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.1,
-        "value": 0.55,
-        "kind": "normal",
-        "roughness": 0.6,
-        "clearcoat": 0.1
-      }
+      "material": "mat-6",
+      "collection": "station-2"
     },
     {
       "id": "s2-mono-4",
@@ -1341,21 +1368,15 @@
       "transform": {
         "translate": [30.095, 2.1517241379310343, 0]
       },
-      "material": {
-        "hue": 0.622,
-        "sat": 0.732,
-        "value": 0.6439999999999999,
-        "kind": "normal",
-        "roughness": 0.3,
-        "clearcoat": 0.45
-      },
+      "material": "mat-11",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "-2.452 + 4.603 * smoothstep(25.85, 26.45, t)"
         }
       ],
-      "pattern": "cracked"
+      "pattern": "cracked",
+      "collection": "station-2"
     },
     {
       "id": "s2-plinth-5",
@@ -1366,14 +1387,8 @@
       "transform": {
         "translate": [28.825, 0.06, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.1,
-        "value": 0.55,
-        "kind": "normal",
-        "roughness": 0.6,
-        "clearcoat": 0.1
-      }
+      "material": "mat-6",
+      "collection": "station-2"
     },
     {
       "id": "s2-mono-5",
@@ -1385,22 +1400,14 @@
       "transform": {
         "translate": [28.825, 2.4, 0]
       },
-      "material": {
-        "hue": 0.11,
-        "sat": 0.78,
-        "value": 0.95,
-        "metal": 0,
-        "glow": 0.1,
-        "kind": "normal",
-        "roughness": 0.22,
-        "clearcoat": 0.6
-      },
+      "material": "mat-12",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "-2.700 + 5.100 * smoothstep(26.95, 27.55, t)"
         }
-      ]
+      ],
+      "collection": "station-2"
     },
     {
       "id": "s2-guard-l-0",
@@ -1412,14 +1419,8 @@
         "translate": [23.865000000000002, 1.1, 1.2],
         "rotate": [0, -0.3, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-13",
+      "collection": "station-2"
     },
     {
       "id": "s2-guard-r-0",
@@ -1431,14 +1432,8 @@
         "translate": [40.135, 1.1, 1.2],
         "rotate": [0, 0.3, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-13",
+      "collection": "station-2"
     },
     {
       "id": "s2-guard-l-1",
@@ -1450,14 +1445,8 @@
         "translate": [24.465, 1.75, -4.6],
         "rotate": [0, -0.3, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-13",
+      "collection": "station-2"
     },
     {
       "id": "s2-guard-r-1",
@@ -1469,14 +1458,8 @@
         "translate": [39.535, 1.75, -4.6],
         "rotate": [0, 0.3, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-13",
+      "collection": "station-2"
     },
     {
       "id": "s2-guard-l-2",
@@ -1488,14 +1471,8 @@
         "translate": [23.064999999999998, 2.4000000000000004, -6.800000000000001],
         "rotate": [0, -0.3, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-13",
+      "collection": "station-2"
     },
     {
       "id": "s2-guard-r-2",
@@ -1507,14 +1484,8 @@
         "translate": [40.935, 2.4000000000000004, -6.800000000000001],
         "rotate": [0, 0.3, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-13",
+      "collection": "station-2"
     },
     {
       "id": "path-2-1",
@@ -1526,15 +1497,8 @@
         "translate": [34, 0.03, 0],
         "rotate": [0, 0, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-2"
     },
     {
       "id": "path-2-2",
@@ -1546,15 +1510,8 @@
         "translate": [36, 0.03, 0],
         "rotate": [0, 0, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-2"
     },
     {
       "id": "path-2-3",
@@ -1566,15 +1523,8 @@
         "translate": [38, 0.03, 0],
         "rotate": [0, 0, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-2"
     },
     {
       "id": "path-2-4",
@@ -1586,15 +1536,8 @@
         "translate": [40, 0.03, 0],
         "rotate": [0, 0, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-2"
     },
     {
       "id": "path-2-5",
@@ -1606,15 +1549,8 @@
         "translate": [42, 0.03, 0],
         "rotate": [0, 0, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-2"
     },
     {
       "id": "path-2-6",
@@ -1626,15 +1562,8 @@
         "translate": [44, 0.03, 0],
         "rotate": [0, 0, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-2"
     },
     {
       "id": "path-2-7",
@@ -1646,15 +1575,8 @@
         "translate": [46, 0.03, 0],
         "rotate": [0, 0, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-2"
     },
     {
       "id": "s3-plinth-0",
@@ -1665,14 +1587,8 @@
       "transform": {
         "translate": [51.175, 0.06, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.1,
-        "value": 0.55,
-        "kind": "normal",
-        "roughness": 0.6,
-        "clearcoat": 0.1
-      }
+      "material": "mat-6",
+      "collection": "station-3"
     },
     {
       "id": "s3-mono-0",
@@ -1684,21 +1600,15 @@
       "transform": {
         "translate": [51.175, 0.14464710547184773, 0]
       },
-      "material": {
-        "hue": 0.55,
-        "sat": 0.62,
-        "value": 0.82,
-        "kind": "normal",
-        "roughness": 0.3,
-        "clearcoat": 0.45
-      },
+      "material": "mat-7",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "-0.445 + 0.589 * smoothstep(34.75, 35.35, t)"
         }
       ],
-      "pattern": "cracked"
+      "pattern": "cracked",
+      "collection": "station-3"
     },
     {
       "id": "s3-plinth-1",
@@ -1709,14 +1619,8 @@
       "transform": {
         "translate": [49.905, 0.06, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.1,
-        "value": 0.55,
-        "kind": "normal",
-        "roughness": 0.6,
-        "clearcoat": 0.1
-      }
+      "material": "mat-6",
+      "collection": "station-3"
     },
     {
       "id": "s3-mono-1",
@@ -1728,21 +1632,15 @@
       "transform": {
         "translate": [49.905, 0.28263283108643933, 0]
       },
-      "material": {
-        "hue": 0.5680000000000001,
-        "sat": 0.648,
-        "value": 0.7759999999999999,
-        "kind": "normal",
-        "roughness": 0.3,
-        "clearcoat": 0.45
-      },
+      "material": "mat-8",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "-0.583 + 0.865 * smoothstep(35.85, 36.45, t)"
         }
       ],
-      "pattern": "cracked"
+      "pattern": "cracked",
+      "collection": "station-3"
     },
     {
       "id": "s3-plinth-2",
@@ -1753,14 +1651,8 @@
       "transform": {
         "translate": [48.635, 0.06, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.1,
-        "value": 0.55,
-        "kind": "normal",
-        "roughness": 0.6,
-        "clearcoat": 0.1
-      }
+      "material": "mat-6",
+      "collection": "station-3"
     },
     {
       "id": "s3-mono-2",
@@ -1772,21 +1664,15 @@
       "transform": {
         "translate": [48.635, 0.5443298969072166, 0]
       },
-      "material": {
-        "hue": 0.5860000000000001,
-        "sat": 0.676,
-        "value": 0.732,
-        "kind": "normal",
-        "roughness": 0.3,
-        "clearcoat": 0.45
-      },
+      "material": "mat-9",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "-0.844 + 1.389 * smoothstep(36.95, 37.55, t)"
         }
       ],
-      "pattern": "cracked"
+      "pattern": "cracked",
+      "collection": "station-3"
     },
     {
       "id": "s3-plinth-3",
@@ -1797,14 +1683,8 @@
       "transform": {
         "translate": [47.365, 0.06, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.1,
-        "value": 0.55,
-        "kind": "normal",
-        "roughness": 0.6,
-        "clearcoat": 0.1
-      }
+      "material": "mat-6",
+      "collection": "station-3"
     },
     {
       "id": "s3-mono-3",
@@ -1816,21 +1696,15 @@
       "transform": {
         "translate": [47.365, 0.9601903251387788, 0]
       },
-      "material": {
-        "hue": 0.6040000000000001,
-        "sat": 0.704,
-        "value": 0.688,
-        "kind": "normal",
-        "roughness": 0.3,
-        "clearcoat": 0.45
-      },
+      "material": "mat-10",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "-1.260 + 2.220 * smoothstep(38.05, 38.65, t)"
         }
       ],
-      "pattern": "cracked"
+      "pattern": "cracked",
+      "collection": "station-3"
     },
     {
       "id": "s3-plinth-4",
@@ -1841,14 +1715,8 @@
       "transform": {
         "translate": [46.095, 0.06, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.1,
-        "value": 0.55,
-        "kind": "normal",
-        "roughness": 0.6,
-        "clearcoat": 0.1
-      }
+      "material": "mat-6",
+      "collection": "station-3"
     },
     {
       "id": "s3-mono-4",
@@ -1860,21 +1728,15 @@
       "transform": {
         "translate": [46.095, 1.5501982553528946, 0]
       },
-      "material": {
-        "hue": 0.622,
-        "sat": 0.732,
-        "value": 0.6439999999999999,
-        "kind": "normal",
-        "roughness": 0.3,
-        "clearcoat": 0.45
-      },
+      "material": "mat-11",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "-1.850 + 3.400 * smoothstep(39.15, 39.75, t)"
         }
       ],
-      "pattern": "cracked"
+      "pattern": "cracked",
+      "collection": "station-3"
     },
     {
       "id": "s3-plinth-5",
@@ -1885,14 +1747,8 @@
       "transform": {
         "translate": [44.825, 0.06, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.1,
-        "value": 0.55,
-        "kind": "normal",
-        "roughness": 0.6,
-        "clearcoat": 0.1
-      }
+      "material": "mat-6",
+      "collection": "station-3"
     },
     {
       "id": "s3-mono-5",
@@ -1904,22 +1760,14 @@
       "transform": {
         "translate": [44.825, 2.4, 0]
       },
-      "material": {
-        "hue": 0.11,
-        "sat": 0.78,
-        "value": 0.95,
-        "metal": 0,
-        "glow": 0.1,
-        "kind": "normal",
-        "roughness": 0.22,
-        "clearcoat": 0.6
-      },
+      "material": "mat-12",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "-2.700 + 5.100 * smoothstep(40.25, 40.85, t)"
         }
-      ]
+      ],
+      "collection": "station-3"
     },
     {
       "id": "s3-guard-l-0",
@@ -1931,14 +1779,8 @@
         "translate": [39.865, 1.1, 1.2],
         "rotate": [0, -0.3, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-13",
+      "collection": "station-3"
     },
     {
       "id": "s3-guard-r-0",
@@ -1950,14 +1792,8 @@
         "translate": [56.135, 1.1, 1.2],
         "rotate": [0, 0.3, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-13",
+      "collection": "station-3"
     },
     {
       "id": "s3-guard-l-1",
@@ -1969,14 +1805,8 @@
         "translate": [40.465, 1.75, -4.6],
         "rotate": [0, -0.3, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-13",
+      "collection": "station-3"
     },
     {
       "id": "s3-guard-r-1",
@@ -1988,14 +1818,8 @@
         "translate": [55.535, 1.75, -4.6],
         "rotate": [0, 0.3, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-13",
+      "collection": "station-3"
     },
     {
       "id": "s3-guard-l-2",
@@ -2007,14 +1831,8 @@
         "translate": [39.065, 2.4000000000000004, -6.800000000000001],
         "rotate": [0, -0.3, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-13",
+      "collection": "station-3"
     },
     {
       "id": "s3-guard-r-2",
@@ -2026,14 +1844,8 @@
         "translate": [56.935, 2.4000000000000004, -6.800000000000001],
         "rotate": [0, 0.3, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-13",
+      "collection": "station-3"
     },
     {
       "id": "path-3-1",
@@ -2045,15 +1857,8 @@
         "translate": [50, 0.03, 0],
         "rotate": [0, 0, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-3"
     },
     {
       "id": "path-3-2",
@@ -2065,15 +1870,8 @@
         "translate": [52, 0.03, 0],
         "rotate": [0, 0, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-3"
     },
     {
       "id": "path-3-3",
@@ -2085,15 +1883,8 @@
         "translate": [54, 0.03, 0],
         "rotate": [0, 0, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-3"
     },
     {
       "id": "path-3-4",
@@ -2105,15 +1896,8 @@
         "translate": [56, 0.03, 0],
         "rotate": [0, 0, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-3"
     },
     {
       "id": "path-3-5",
@@ -2125,15 +1909,8 @@
         "translate": [58, 0.03, 0],
         "rotate": [0, 0, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-3"
     },
     {
       "id": "path-3-6",
@@ -2145,15 +1922,8 @@
         "translate": [60, 0.03, 0],
         "rotate": [0, 0, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-3"
     },
     {
       "id": "path-3-7",
@@ -2165,15 +1935,8 @@
         "translate": [62, 0.03, 0],
         "rotate": [0, 0, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-3"
     },
     {
       "id": "s4-plinth-0",
@@ -2184,14 +1947,8 @@
       "transform": {
         "translate": [67.175, 0.06, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.1,
-        "value": 0.55,
-        "kind": "normal",
-        "roughness": 0.6,
-        "clearcoat": 0.1
-      }
+      "material": "mat-6",
+      "collection": "station-4"
     },
     {
       "id": "s4-mono-0",
@@ -2203,22 +1960,14 @@
       "transform": {
         "translate": [67.175, 2.4, 0]
       },
-      "material": {
-        "hue": 0.11,
-        "sat": 0.78,
-        "value": 0.95,
-        "metal": 0,
-        "glow": 0.1,
-        "kind": "normal",
-        "roughness": 0.22,
-        "clearcoat": 0.6
-      },
+      "material": "mat-12",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "-2.700 + 5.100 * smoothstep(48.05, 48.65, t)"
         }
-      ]
+      ],
+      "collection": "station-4"
     },
     {
       "id": "s4-plinth-1",
@@ -2229,14 +1978,8 @@
       "transform": {
         "translate": [65.905, 0.06, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.1,
-        "value": 0.55,
-        "kind": "normal",
-        "roughness": 0.6,
-        "clearcoat": 0.1
-      }
+      "material": "mat-6",
+      "collection": "station-4"
     },
     {
       "id": "s4-mono-1",
@@ -2248,21 +1991,15 @@
       "transform": {
         "translate": [65.905, 2.2374501992031868, 0]
       },
-      "material": {
-        "hue": 0.5680000000000001,
-        "sat": 0.648,
-        "value": 0.7759999999999999,
-        "kind": "normal",
-        "roughness": 0.3,
-        "clearcoat": 0.45
-      },
+      "material": "mat-8",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "-2.537 + 4.775 * smoothstep(49.15, 49.75, t)"
         }
       ],
-      "pattern": "cracked"
+      "pattern": "cracked",
+      "collection": "station-4"
     },
     {
       "id": "s4-plinth-2",
@@ -2273,14 +2010,8 @@
       "transform": {
         "translate": [64.635, 0.06, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.1,
-        "value": 0.55,
-        "kind": "normal",
-        "roughness": 0.6,
-        "clearcoat": 0.1
-      }
+      "material": "mat-6",
+      "collection": "station-4"
     },
     {
       "id": "s4-mono-2",
@@ -2292,21 +2023,15 @@
       "transform": {
         "translate": [64.635, 1.4151394422310757, 0]
       },
-      "material": {
-        "hue": 0.5860000000000001,
-        "sat": 0.676,
-        "value": 0.732,
-        "kind": "normal",
-        "roughness": 0.3,
-        "clearcoat": 0.45
-      },
+      "material": "mat-9",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "-1.715 + 3.130 * smoothstep(50.25, 50.85, t)"
         }
       ],
-      "pattern": "cracked"
+      "pattern": "cracked",
+      "collection": "station-4"
     },
     {
       "id": "s4-plinth-3",
@@ -2317,14 +2042,8 @@
       "transform": {
         "translate": [63.365, 0.06, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.1,
-        "value": 0.55,
-        "kind": "normal",
-        "roughness": 0.6,
-        "clearcoat": 0.1
-      }
+      "material": "mat-6",
+      "collection": "station-4"
     },
     {
       "id": "s4-mono-3",
@@ -2336,21 +2055,15 @@
       "transform": {
         "translate": [63.365, 1.2430278884462151, 0]
       },
-      "material": {
-        "hue": 0.6040000000000001,
-        "sat": 0.704,
-        "value": 0.688,
-        "kind": "normal",
-        "roughness": 0.3,
-        "clearcoat": 0.45
-      },
+      "material": "mat-10",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "-1.543 + 2.786 * smoothstep(51.35, 51.95, t)"
         }
       ],
-      "pattern": "cracked"
+      "pattern": "cracked",
+      "collection": "station-4"
     },
     {
       "id": "s4-plinth-4",
@@ -2361,14 +2074,8 @@
       "transform": {
         "translate": [62.095, 0.06, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.1,
-        "value": 0.55,
-        "kind": "normal",
-        "roughness": 0.6,
-        "clearcoat": 0.1
-      }
+      "material": "mat-6",
+      "collection": "station-4"
     },
     {
       "id": "s4-mono-4",
@@ -2380,21 +2087,15 @@
       "transform": {
         "translate": [62.095, 0.7362549800796813, 0]
       },
-      "material": {
-        "hue": 0.622,
-        "sat": 0.732,
-        "value": 0.6439999999999999,
-        "kind": "normal",
-        "roughness": 0.3,
-        "clearcoat": 0.45
-      },
+      "material": "mat-11",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "-1.036 + 1.773 * smoothstep(52.45, 53.05, t)"
         }
       ],
-      "pattern": "cracked"
+      "pattern": "cracked",
+      "collection": "station-4"
     },
     {
       "id": "s4-plinth-5",
@@ -2405,14 +2106,8 @@
       "transform": {
         "translate": [60.825, 0.06, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.1,
-        "value": 0.55,
-        "kind": "normal",
-        "roughness": 0.6,
-        "clearcoat": 0.1
-      }
+      "material": "mat-6",
+      "collection": "station-4"
     },
     {
       "id": "s4-mono-5",
@@ -2424,21 +2119,15 @@
       "transform": {
         "translate": [60.825, 0.6501992031872509, 0]
       },
-      "material": {
-        "hue": 0.64,
-        "sat": 0.76,
-        "value": 0.6,
-        "kind": "normal",
-        "roughness": 0.3,
-        "clearcoat": 0.45
-      },
+      "material": "mat-14",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "-0.950 + 1.600 * smoothstep(53.55, 54.15, t)"
         }
       ],
-      "pattern": "cracked"
+      "pattern": "cracked",
+      "collection": "station-4"
     },
     {
       "id": "s4-guard-l-0",
@@ -2450,14 +2139,8 @@
         "translate": [55.865, 1.1, 1.2],
         "rotate": [0, -0.3, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-13",
+      "collection": "station-4"
     },
     {
       "id": "s4-guard-r-0",
@@ -2469,14 +2152,8 @@
         "translate": [72.135, 1.1, 1.2],
         "rotate": [0, 0.3, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-13",
+      "collection": "station-4"
     },
     {
       "id": "s4-guard-l-1",
@@ -2488,14 +2165,8 @@
         "translate": [56.465, 1.75, -4.6],
         "rotate": [0, -0.3, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-13",
+      "collection": "station-4"
     },
     {
       "id": "s4-guard-r-1",
@@ -2507,14 +2178,8 @@
         "translate": [71.535, 1.75, -4.6],
         "rotate": [0, 0.3, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-13",
+      "collection": "station-4"
     },
     {
       "id": "s4-guard-l-2",
@@ -2526,14 +2191,8 @@
         "translate": [55.065, 2.4000000000000004, -6.800000000000001],
         "rotate": [0, -0.3, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-13",
+      "collection": "station-4"
     },
     {
       "id": "s4-guard-r-2",
@@ -2545,14 +2204,8 @@
         "translate": [72.935, 2.4000000000000004, -6.800000000000001],
         "rotate": [0, 0.3, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-13",
+      "collection": "station-4"
     },
     {
       "id": "path-4-1",
@@ -2564,15 +2217,8 @@
         "translate": [66, 0.03, 0],
         "rotate": [0, 0, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-4"
     },
     {
       "id": "path-4-2",
@@ -2584,15 +2230,8 @@
         "translate": [68, 0.03, 0],
         "rotate": [0, 0, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-4"
     },
     {
       "id": "path-4-3",
@@ -2604,15 +2243,8 @@
         "translate": [70, 0.03, 0],
         "rotate": [0, 0, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-4"
     },
     {
       "id": "path-4-4",
@@ -2624,15 +2256,8 @@
         "translate": [72, 0.03, 0],
         "rotate": [0, 0, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-4"
     },
     {
       "id": "path-4-5",
@@ -2644,15 +2269,8 @@
         "translate": [74, 0.03, 0],
         "rotate": [0, 0, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-4"
     },
     {
       "id": "path-4-6",
@@ -2664,15 +2282,8 @@
         "translate": [76, 0.03, 0],
         "rotate": [0, 0, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-4"
     },
     {
       "id": "path-4-7",
@@ -2684,15 +2295,8 @@
         "translate": [78, 0.03, 0],
         "rotate": [0, 0, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-4"
     },
     {
       "id": "s5-plinth-0",
@@ -2703,14 +2307,8 @@
       "transform": {
         "translate": [83.175, 0.06, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.1,
-        "value": 0.55,
-        "kind": "normal",
-        "roughness": 0.6,
-        "clearcoat": 0.1
-      }
+      "material": "mat-6",
+      "collection": "station-5"
     },
     {
       "id": "s5-mono-0",
@@ -2722,22 +2320,14 @@
       "transform": {
         "translate": [83.175, 2.4, 0]
       },
-      "material": {
-        "hue": 0.11,
-        "sat": 0.78,
-        "value": 0.95,
-        "metal": 0,
-        "glow": 0.1,
-        "kind": "normal",
-        "roughness": 0.22,
-        "clearcoat": 0.6
-      },
+      "material": "mat-12",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "-2.700 + 5.100 * smoothstep(61.35, 61.95, t)"
         }
-      ]
+      ],
+      "collection": "station-5"
     },
     {
       "id": "s5-plinth-1",
@@ -2748,14 +2338,8 @@
       "transform": {
         "translate": [81.905, 0.06, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.1,
-        "value": 0.55,
-        "kind": "normal",
-        "roughness": 0.6,
-        "clearcoat": 0.1
-      }
+      "material": "mat-6",
+      "collection": "station-5"
     },
     {
       "id": "s5-mono-1",
@@ -2767,21 +2351,15 @@
       "transform": {
         "translate": [81.905, 2.2072538860103625, 0]
       },
-      "material": {
-        "hue": 0.5680000000000001,
-        "sat": 0.648,
-        "value": 0.7759999999999999,
-        "kind": "normal",
-        "roughness": 0.3,
-        "clearcoat": 0.45
-      },
+      "material": "mat-8",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "-2.507 + 4.715 * smoothstep(62.45, 63.05, t)"
         }
       ],
-      "pattern": "cracked"
+      "pattern": "cracked",
+      "collection": "station-5"
     },
     {
       "id": "s5-plinth-2",
@@ -2792,14 +2370,8 @@
       "transform": {
         "translate": [80.635, 0.06, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.1,
-        "value": 0.55,
-        "kind": "normal",
-        "roughness": 0.6,
-        "clearcoat": 0.1
-      }
+      "material": "mat-6",
+      "collection": "station-5"
     },
     {
       "id": "s5-mono-2",
@@ -2811,21 +2383,15 @@
       "transform": {
         "translate": [80.635, 1.5015544041450775, 0]
       },
-      "material": {
-        "hue": 0.5860000000000001,
-        "sat": 0.676,
-        "value": 0.732,
-        "kind": "normal",
-        "roughness": 0.3,
-        "clearcoat": 0.45
-      },
+      "material": "mat-9",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "-1.802 + 3.303 * smoothstep(63.55, 64.15, t)"
         }
       ],
-      "pattern": "cracked"
+      "pattern": "cracked",
+      "collection": "station-5"
     },
     {
       "id": "s5-plinth-3",
@@ -2836,14 +2402,8 @@
       "transform": {
         "translate": [79.365, 0.06, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.1,
-        "value": 0.55,
-        "kind": "normal",
-        "roughness": 0.6,
-        "clearcoat": 0.1
-      }
+      "material": "mat-6",
+      "collection": "station-5"
     },
     {
       "id": "s5-mono-3",
@@ -2855,21 +2415,15 @@
       "transform": {
         "translate": [79.365, 1.2590673575129532, 0]
       },
-      "material": {
-        "hue": 0.6040000000000001,
-        "sat": 0.704,
-        "value": 0.688,
-        "kind": "normal",
-        "roughness": 0.3,
-        "clearcoat": 0.45
-      },
+      "material": "mat-10",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "-1.559 + 2.818 * smoothstep(64.65, 65.25, t)"
         }
       ],
-      "pattern": "cracked"
+      "pattern": "cracked",
+      "collection": "station-5"
     },
     {
       "id": "s5-plinth-4",
@@ -2880,14 +2434,8 @@
       "transform": {
         "translate": [78.095, 0.06, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.1,
-        "value": 0.55,
-        "kind": "normal",
-        "roughness": 0.6,
-        "clearcoat": 0.1
-      }
+      "material": "mat-6",
+      "collection": "station-5"
     },
     {
       "id": "s5-mono-4",
@@ -2899,21 +2447,15 @@
       "transform": {
         "translate": [78.095, 1.0290155440414508, 0]
       },
-      "material": {
-        "hue": 0.622,
-        "sat": 0.732,
-        "value": 0.6439999999999999,
-        "kind": "normal",
-        "roughness": 0.3,
-        "clearcoat": 0.45
-      },
+      "material": "mat-11",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "-1.329 + 2.358 * smoothstep(65.75, 66.35, t)"
         }
       ],
-      "pattern": "cracked"
+      "pattern": "cracked",
+      "collection": "station-5"
     },
     {
       "id": "s5-plinth-5",
@@ -2924,14 +2466,8 @@
       "transform": {
         "translate": [76.825, 0.06, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.1,
-        "value": 0.55,
-        "kind": "normal",
-        "roughness": 0.6,
-        "clearcoat": 0.1
-      }
+      "material": "mat-6",
+      "collection": "station-5"
     },
     {
       "id": "s5-mono-5",
@@ -2943,21 +2479,15 @@
       "transform": {
         "translate": [76.825, 0.9699481865284973, 0]
       },
-      "material": {
-        "hue": 0.64,
-        "sat": 0.76,
-        "value": 0.6,
-        "kind": "normal",
-        "roughness": 0.3,
-        "clearcoat": 0.45
-      },
+      "material": "mat-14",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "-1.270 + 2.240 * smoothstep(66.85, 67.45, t)"
         }
       ],
-      "pattern": "cracked"
+      "pattern": "cracked",
+      "collection": "station-5"
     },
     {
       "id": "s5-guard-l-0",
@@ -2969,14 +2499,8 @@
         "translate": [71.865, 1.1, 1.2],
         "rotate": [0, -0.3, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-13",
+      "collection": "station-5"
     },
     {
       "id": "s5-guard-r-0",
@@ -2988,14 +2512,8 @@
         "translate": [88.135, 1.1, 1.2],
         "rotate": [0, 0.3, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-13",
+      "collection": "station-5"
     },
     {
       "id": "s5-guard-l-1",
@@ -3007,14 +2525,8 @@
         "translate": [72.465, 1.75, -4.6],
         "rotate": [0, -0.3, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-13",
+      "collection": "station-5"
     },
     {
       "id": "s5-guard-r-1",
@@ -3026,14 +2538,8 @@
         "translate": [87.535, 1.75, -4.6],
         "rotate": [0, 0.3, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-13",
+      "collection": "station-5"
     },
     {
       "id": "s5-guard-l-2",
@@ -3045,14 +2551,8 @@
         "translate": [71.065, 2.4000000000000004, -6.800000000000001],
         "rotate": [0, -0.3, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-13",
+      "collection": "station-5"
     },
     {
       "id": "s5-guard-r-2",
@@ -3064,14 +2564,8 @@
         "translate": [88.935, 2.4000000000000004, -6.800000000000001],
         "rotate": [0, 0.3, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-13",
+      "collection": "station-5"
     },
     {
       "id": "path-5-1",
@@ -3083,15 +2577,8 @@
         "translate": [82, 0.03, 0],
         "rotate": [0, 0, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-5"
     },
     {
       "id": "path-5-2",
@@ -3103,15 +2590,8 @@
         "translate": [84, 0.03, 0],
         "rotate": [0, 0, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-5"
     },
     {
       "id": "path-5-3",
@@ -3123,15 +2603,8 @@
         "translate": [86, 0.03, 0],
         "rotate": [0, 0, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-5"
     },
     {
       "id": "path-5-4",
@@ -3143,15 +2616,8 @@
         "translate": [88, 0.03, 0],
         "rotate": [0, 0, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-5"
     },
     {
       "id": "path-5-5",
@@ -3163,15 +2629,8 @@
         "translate": [90, 0.03, 0],
         "rotate": [0, 0, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-5"
     },
     {
       "id": "path-5-6",
@@ -3183,15 +2642,8 @@
         "translate": [92, 0.03, 0],
         "rotate": [0, 0, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-5"
     },
     {
       "id": "path-5-7",
@@ -3203,15 +2655,8 @@
         "translate": [94, 0.03, 0],
         "rotate": [0, 0, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-5"
     },
     {
       "id": "s6-past-0",
@@ -3223,14 +2668,8 @@
       "transform": {
         "translate": [99.4, 0.55, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-13",
+      "collection": "station-6"
     },
     {
       "id": "s6-past-1",
@@ -3242,14 +2681,8 @@
       "transform": {
         "translate": [96, 0.55, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-13",
+      "collection": "station-6"
     },
     {
       "id": "s6-past-2",
@@ -3261,14 +2694,8 @@
       "transform": {
         "translate": [92.6, 0.55, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-13",
+      "collection": "station-6"
     },
     {
       "id": "s6-now-3",
@@ -3279,21 +2706,14 @@
       "transform": {
         "translate": [99.4, 3.6, 0]
       },
-      "material": {
-        "hue": 0.995,
-        "sat": 0.85,
-        "value": 0.78,
-        "glow": 0.24,
-        "kind": "normal",
-        "roughness": 0.3,
-        "clearcoat": 0.5
-      },
+      "material": "mat-15",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "1.100 + 2.500 * smoothstep(74.60, 75.40, t) + 0.06 * sin(0.5 * t + -36.50)"
         }
-      ]
+      ],
+      "collection": "station-6"
     },
     {
       "id": "s6-now-4",
@@ -3304,21 +2724,14 @@
       "transform": {
         "translate": [96, 3.6, 0]
       },
-      "material": {
-        "hue": 0.995,
-        "sat": 0.85,
-        "value": 0.78,
-        "glow": 0.12,
-        "kind": "normal",
-        "roughness": 0.3,
-        "clearcoat": 0.5
-      },
+      "material": "mat-3",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "1.100 + 2.500 * smoothstep(75.70, 76.50, t) + 0.06 * sin(0.5 * t + -34.40)"
         }
-      ]
+      ],
+      "collection": "station-6"
     },
     {
       "id": "s6-now-5",
@@ -3329,21 +2742,14 @@
       "transform": {
         "translate": [92.6, 3.6, 0]
       },
-      "material": {
-        "hue": 0.995,
-        "sat": 0.85,
-        "value": 0.78,
-        "glow": 0.12,
-        "kind": "normal",
-        "roughness": 0.3,
-        "clearcoat": 0.5
-      },
+      "material": "mat-3",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "1.100 + 2.500 * smoothstep(76.80, 77.60, t) + 0.06 * sin(0.5 * t + -32.30)"
         }
-      ]
+      ],
+      "collection": "station-6"
     },
     {
       "id": "s6-trail-0-0",
@@ -3355,14 +2761,8 @@
         "translate": [99.4, 1.5, 0],
         "rotate": [0, 0, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-13",
+      "collection": "station-6"
     },
     {
       "id": "s6-trail-0-1",
@@ -3374,14 +2774,8 @@
         "translate": [99.4, 2.2199999999999998, 0],
         "rotate": [0, 0.3, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-13",
+      "collection": "station-6"
     },
     {
       "id": "s6-trail-0-2",
@@ -3393,14 +2787,8 @@
         "translate": [99.4, 2.94, 0],
         "rotate": [0, 0.6, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-13",
+      "collection": "station-6"
     },
     {
       "id": "s6-trail-1-0",
@@ -3412,14 +2800,8 @@
         "translate": [96, 1.5, 0],
         "rotate": [0, 0, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-13",
+      "collection": "station-6"
     },
     {
       "id": "s6-trail-1-1",
@@ -3431,14 +2813,8 @@
         "translate": [96, 2.2199999999999998, 0],
         "rotate": [0, 0.3, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-13",
+      "collection": "station-6"
     },
     {
       "id": "s6-trail-1-2",
@@ -3450,14 +2826,8 @@
         "translate": [96, 2.94, 0],
         "rotate": [0, 0.6, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-13",
+      "collection": "station-6"
     },
     {
       "id": "s6-trail-2-0",
@@ -3469,14 +2839,8 @@
         "translate": [92.6, 1.5, 0],
         "rotate": [0, 0, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-13",
+      "collection": "station-6"
     },
     {
       "id": "s6-trail-2-1",
@@ -3488,14 +2852,8 @@
         "translate": [92.6, 2.2199999999999998, 0],
         "rotate": [0, 0.3, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-13",
+      "collection": "station-6"
     },
     {
       "id": "s6-trail-2-2",
@@ -3507,14 +2865,8 @@
         "translate": [92.6, 2.94, 0],
         "rotate": [0, 0.6, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-13",
+      "collection": "station-6"
     },
     {
       "id": "path-6-1",
@@ -3526,15 +2878,8 @@
         "translate": [98, 0.03, 0],
         "rotate": [0, 0, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-6"
     },
     {
       "id": "path-6-2",
@@ -3546,15 +2891,8 @@
         "translate": [100, 0.03, 0],
         "rotate": [0, 0, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-6"
     },
     {
       "id": "path-6-3",
@@ -3566,15 +2904,8 @@
         "translate": [102, 0.03, 0],
         "rotate": [0, 0, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-6"
     },
     {
       "id": "path-6-4",
@@ -3586,15 +2917,8 @@
         "translate": [104, 0.03, 0],
         "rotate": [0, 0, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-6"
     },
     {
       "id": "path-6-5",
@@ -3606,15 +2930,8 @@
         "translate": [106, 0.03, 0],
         "rotate": [0, 0, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-6"
     },
     {
       "id": "path-6-6",
@@ -3626,15 +2943,8 @@
         "translate": [108, 0.03, 0],
         "rotate": [0, 0, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-6"
     },
     {
       "id": "path-6-7",
@@ -3646,15 +2956,8 @@
         "translate": [110, 0.03, 0],
         "rotate": [0, 0, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-6"
     },
     {
       "id": "s7-net-node-0",
@@ -3665,22 +2968,14 @@
       "transform": {
         "translate": [112, 3.5204111503539433, 0]
       },
-      "material": {
-        "hue": 0.11,
-        "sat": 0.78,
-        "value": 0.95,
-        "metal": 0,
-        "glow": 0.1,
-        "kind": "normal",
-        "roughness": 0.22,
-        "clearcoat": 0.6
-      },
+      "material": "mat-12",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "4.620 - 1.1 * smoothstep(82.55, 83.05, t) + 0.018 * sin(1.3 * t + -106.99)"
         }
-      ]
+      ],
+      "collection": "station-7"
     },
     {
       "id": "s7-net-node-1",
@@ -3691,20 +2986,14 @@
       "transform": {
         "translate": [110.45370033299743, 5.980307652106461, 1.7087082733851329]
       },
-      "material": {
-        "hue": 0.62875,
-        "sat": 0.76,
-        "value": 0.5875,
-        "kind": "normal",
-        "roughness": 0.55,
-        "clearcoat": 0.2
-      },
+      "material": "mat-16",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "7.080 - 1.1 * smoothstep(82.67, 83.17, t) + 0.018 * sin(1.3 * t + -104.89)"
         }
-      ]
+      ],
+      "collection": "station-7"
     },
     {
       "id": "s7-net-node-2",
@@ -3715,20 +3004,14 @@
       "transform": {
         "translate": [112.29161726142452, 5.250904506397122, -2.8851961924565597]
       },
-      "material": {
-        "hue": 0.62875,
-        "sat": 0.76,
-        "value": 0.5875,
-        "kind": "normal",
-        "roughness": 0.55,
-        "clearcoat": 0.2
-      },
+      "material": "mat-16",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "6.351 - 1.1 * smoothstep(82.79, 83.29, t) + 0.018 * sin(1.3 * t + -102.79)"
         }
-      ]
+      ],
+      "collection": "station-7"
     },
     {
       "id": "s7-net-node-3",
@@ -3739,20 +3022,14 @@
       "transform": {
         "translate": [114.31650182833245, 4.3697567245487905, 2.3695024225210286]
       },
-      "material": {
-        "hue": 0.62875,
-        "sat": 0.76,
-        "value": 0.5875,
-        "kind": "normal",
-        "roughness": 0.55,
-        "clearcoat": 0.2
-      },
+      "material": "mat-16",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "5.470 - 1.1 * smoothstep(82.91, 83.41, t) + 0.018 * sin(1.3 * t + -100.69)"
         }
-      ]
+      ],
+      "collection": "station-7"
     },
     {
       "id": "s7-net-node-4",
@@ -3763,20 +3040,14 @@
       "transform": {
         "translate": [108.66711706881019, 3.6213578719444897, -0.5703621471936202]
       },
-      "material": {
-        "hue": 0.62875,
-        "sat": 0.76,
-        "value": 0.5875,
-        "kind": "normal",
-        "roughness": 0.55,
-        "clearcoat": 0.2
-      },
+      "material": "mat-16",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "4.721 - 1.1 * smoothstep(83.03, 83.53, t) + 0.018 * sin(1.3 * t + -98.59)"
         }
-      ]
+      ],
+      "collection": "station-7"
     },
     {
       "id": "s7-net-node-5",
@@ -3787,20 +3058,14 @@
       "transform": {
         "translate": [115.04628535964521, 2.9527771216598238, -1.444450357470997]
       },
-      "material": {
-        "hue": 0.62875,
-        "sat": 0.76,
-        "value": 0.5875,
-        "kind": "normal",
-        "roughness": 0.55,
-        "clearcoat": 0.2
-      },
+      "material": "mat-16",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "4.053 - 1.1 * smoothstep(83.15, 83.65, t) + 0.018 * sin(1.3 * t + -96.49)"
         }
-      ]
+      ],
+      "collection": "station-7"
     },
     {
       "id": "s7-net-node-6",
@@ -3811,20 +3076,14 @@
       "transform": {
         "translate": [111.3633585034832, 1.819620731911172, 2.6097801231999034]
       },
-      "material": {
-        "hue": 0.6175,
-        "sat": 0.74,
-        "value": 0.625,
-        "kind": "normal",
-        "roughness": 0.55,
-        "clearcoat": 0.2
-      },
+      "material": "mat-17",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "2.920 - 1.1 * smoothstep(83.27, 83.77, t) + 0.018 * sin(1.3 * t + -94.39)"
         }
-      ]
+      ],
+      "collection": "station-7"
     },
     {
       "id": "s7-net-node-7",
@@ -3835,20 +3094,14 @@
       "transform": {
         "translate": [111.19989911320728, 1.2095751500786114, -1.9885364620992363]
       },
-      "material": {
-        "hue": 0.6175,
-        "sat": 0.74,
-        "value": 0.625,
-        "kind": "normal",
-        "roughness": 0.55,
-        "clearcoat": 0.2
-      },
+      "material": "mat-17",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "2.310 - 1.1 * smoothstep(83.39, 83.89, t) + 0.018 * sin(1.3 * t + -92.29)"
         }
-      ]
+      ],
+      "collection": "station-7"
     },
     {
       "id": "s7-net-node-8",
@@ -3859,20 +3112,14 @@
       "transform": {
         "translate": [112.12459763645404, 0.6000000000000001, 0.41466543722063837]
       },
-      "material": {
-        "hue": 0.60625,
-        "sat": 0.72,
-        "value": 0.6625000000000001,
-        "kind": "normal",
-        "roughness": 0.55,
-        "clearcoat": 0.2
-      },
+      "material": "mat-18",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "1.700 - 1.1 * smoothstep(83.51, 84.01, t) + 0.018 * sin(1.3 * t + -90.19)"
         }
-      ]
+      ],
+      "collection": "station-7"
     },
     {
       "id": "s7-net-edge-0",
@@ -3885,21 +3132,14 @@
       "transform": {
         "translate": [110.45370033299743, 5.980307652106461, 1.7087082733851329]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.55,
-        "glow": 0.08,
-        "kind": "normal",
-        "roughness": 0.6,
-        "clearcoat": 0.15
-      },
+      "material": "mat-19",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "7.080 - 1.1 * smoothstep(83.83, 84.28, t)"
         }
-      ]
+      ],
+      "collection": "station-7"
     },
     {
       "id": "s7-net-edge-1",
@@ -3912,21 +3152,14 @@
       "transform": {
         "translate": [112.29161726142452, 5.250904506397122, -2.8851961924565597]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.55,
-        "glow": 0.08,
-        "kind": "normal",
-        "roughness": 0.6,
-        "clearcoat": 0.15
-      },
+      "material": "mat-19",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "6.351 - 1.1 * smoothstep(83.97, 84.42, t)"
         }
-      ]
+      ],
+      "collection": "station-7"
     },
     {
       "id": "s7-net-edge-2",
@@ -3939,21 +3172,14 @@
       "transform": {
         "translate": [114.31650182833245, 4.3697567245487905, 2.3695024225210286]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.55,
-        "glow": 0.08,
-        "kind": "normal",
-        "roughness": 0.6,
-        "clearcoat": 0.15
-      },
+      "material": "mat-19",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "5.470 - 1.1 * smoothstep(84.11, 84.56, t)"
         }
-      ]
+      ],
+      "collection": "station-7"
     },
     {
       "id": "s7-net-edge-3",
@@ -3966,21 +3192,14 @@
       "transform": {
         "translate": [108.66711706881019, 3.6213578719444897, -0.5703621471936202]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.55,
-        "glow": 0.08,
-        "kind": "normal",
-        "roughness": 0.6,
-        "clearcoat": 0.15
-      },
+      "material": "mat-19",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "4.721 - 1.1 * smoothstep(84.25, 84.70, t)"
         }
-      ]
+      ],
+      "collection": "station-7"
     },
     {
       "id": "s7-net-edge-4",
@@ -3993,21 +3212,14 @@
       "transform": {
         "translate": [115.04628535964521, 2.9527771216598238, -1.444450357470997]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.55,
-        "glow": 0.08,
-        "kind": "normal",
-        "roughness": 0.6,
-        "clearcoat": 0.15
-      },
+      "material": "mat-19",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "4.053 - 1.1 * smoothstep(84.39, 84.84, t)"
         }
-      ]
+      ],
+      "collection": "station-7"
     },
     {
       "id": "s7-net-edge-5",
@@ -4020,21 +3232,14 @@
       "transform": {
         "translate": [112, 3.5204111503539433, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.55,
-        "glow": 0.08,
-        "kind": "normal",
-        "roughness": 0.6,
-        "clearcoat": 0.15
-      },
+      "material": "mat-19",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "4.620 - 1.1 * smoothstep(84.53, 84.98, t)"
         }
-      ]
+      ],
+      "collection": "station-7"
     },
     {
       "id": "s7-net-edge-6",
@@ -4047,21 +3252,14 @@
       "transform": {
         "translate": [112, 3.5204111503539433, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.55,
-        "glow": 0.08,
-        "kind": "normal",
-        "roughness": 0.6,
-        "clearcoat": 0.15
-      },
+      "material": "mat-19",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "4.620 - 1.1 * smoothstep(84.67, 85.12, t)"
         }
-      ]
+      ],
+      "collection": "station-7"
     },
     {
       "id": "s7-net-edge-7",
@@ -4074,21 +3272,14 @@
       "transform": {
         "translate": [111.3633585034832, 1.819620731911172, 2.6097801231999034]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.55,
-        "glow": 0.08,
-        "kind": "normal",
-        "roughness": 0.6,
-        "clearcoat": 0.15
-      },
+      "material": "mat-19",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "2.920 - 1.1 * smoothstep(84.81, 85.26, t)"
         }
-      ]
+      ],
+      "collection": "station-7"
     },
     {
       "id": "s7-net-edge-8",
@@ -4101,21 +3292,14 @@
       "transform": {
         "translate": [111.19989911320728, 1.2095751500786114, -1.9885364620992363]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.55,
-        "glow": 0.08,
-        "kind": "normal",
-        "roughness": 0.6,
-        "clearcoat": 0.15
-      },
+      "material": "mat-19",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "2.310 - 1.1 * smoothstep(84.95, 85.40, t)"
         }
-      ]
+      ],
+      "collection": "station-7"
     },
     {
       "id": "s7-net-edge-9",
@@ -4128,21 +3312,14 @@
       "transform": {
         "translate": [112.12459763645404, 0.6000000000000001, 0.41466543722063837]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.55,
-        "glow": 0.08,
-        "kind": "normal",
-        "roughness": 0.6,
-        "clearcoat": 0.15
-      },
+      "material": "mat-19",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "1.700 - 1.1 * smoothstep(85.09, 85.54, t)"
         }
-      ]
+      ],
+      "collection": "station-7"
     },
     {
       "id": "s7-dust-0",
@@ -4154,19 +3331,14 @@
         "translate": [113.25187462736675, 4.405000000000001, 0],
         "rotate": [0, 0, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.2,
-        "value": 0.18,
-        "kind": "normal",
-        "roughness": 0.5
-      },
+      "material": "mat-20",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "4.405 - 0.000 * smoothstep(82.30, 83.30, t) + 0.05 * sin(0.30 * t + -24.69)"
         }
-      ]
+      ],
+      "collection": "station-7"
     },
     {
       "id": "s7-dust-1",
@@ -4178,19 +3350,14 @@
         "translate": [112.55709214849203, 4.399558176477956, -2.2669323891550555],
         "rotate": [0, 0.9, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.2,
-        "value": 0.18,
-        "kind": "normal",
-        "roughness": 0.5
-      },
+      "material": "mat-20",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "4.400 - 0.000 * smoothstep(82.30, 83.30, t) + 0.07 * sin(0.35 * t + -27.51)"
         }
-      ]
+      ],
+      "collection": "station-7"
     },
     {
       "id": "s7-dust-2",
@@ -4202,19 +3369,14 @@
         "translate": [110.10811593736102, 3.629579332748476, -0.989614658959953],
         "rotate": [0, 1.8, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.2,
-        "value": 0.18,
-        "kind": "normal",
-        "roughness": 0.5
-      },
+      "material": "mat-20",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "3.630 - 0.000 * smoothstep(82.30, 83.30, t) + 0.09 * sin(0.40 * t + -30.32)"
         }
-      ]
+      ],
+      "collection": "station-7"
     },
     {
       "id": "s7-dust-3",
@@ -4226,19 +3388,14 @@
         "translate": [109.38985964677684, 4.222504230305474, 2.958537169853774],
         "rotate": [0, 2.7, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.2,
-        "value": 0.18,
-        "kind": "normal",
-        "roughness": 0.5
-      },
+      "material": "mat-20",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "4.223 - 0.000 * smoothstep(82.30, 83.30, t) + 0.05 * sin(0.45 * t + -33.14)"
         }
-      ]
+      ],
+      "collection": "station-7"
     },
     {
       "id": "s7-dust-4",
@@ -4250,19 +3407,14 @@
         "translate": [113.2509903029635, 3.0836452719433054, 1.8017308536587748],
         "rotate": [0, 0.5, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.2,
-        "value": 0.18,
-        "kind": "normal",
-        "roughness": 0.5
-      },
+      "material": "mat-20",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "3.084 - 0.000 * smoothstep(82.30, 83.30, t) + 0.07 * sin(0.50 * t + -35.95)"
         }
-      ]
+      ],
+      "collection": "station-7"
     },
     {
       "id": "s7-dust-5",
@@ -4274,19 +3426,14 @@
         "translate": [116.75734157303819, 3.8177730524847187, -1.822992316403063],
         "rotate": [0, 1.4, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.2,
-        "value": 0.18,
-        "kind": "normal",
-        "roughness": 0.5
-      },
+      "material": "mat-20",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "3.818 - 0.000 * smoothstep(82.30, 83.30, t) + 0.09 * sin(0.30 * t + -24.47)"
         }
-      ]
+      ],
+      "collection": "station-7"
     },
     {
       "id": "s7-dust-6",
@@ -4298,19 +3445,14 @@
         "translate": [111.72553875943947, 2.742972950909394, -2.1848703015536812],
         "rotate": [0, 2.3000000000000003, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.2,
-        "value": 0.18,
-        "kind": "normal",
-        "roughness": 0.5
-      },
+      "material": "mat-20",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "2.743 - 0.000 * smoothstep(82.30, 83.30, t) + 0.05 * sin(0.35 * t + -27.29)"
         }
-      ]
+      ],
+      "collection": "station-7"
     },
     {
       "id": "s7-dust-7",
@@ -4322,19 +3464,14 @@
         "translate": [106.36231470585238, 3.247721417838311, -0.6569637863396396],
         "rotate": [0, 0.09999999999999964, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.2,
-        "value": 0.18,
-        "kind": "normal",
-        "roughness": 0.5
-      },
+      "material": "mat-20",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "3.248 - 0.000 * smoothstep(82.30, 83.30, t) + 0.07 * sin(0.40 * t + -30.10)"
         }
-      ]
+      ],
+      "collection": "station-7"
     },
     {
       "id": "s7-dust-8",
@@ -4346,19 +3483,14 @@
         "translate": [111.14359048881437, 2.514577769081229, 2.2962604484326103],
         "rotate": [0, 1, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.2,
-        "value": 0.18,
-        "kind": "normal",
-        "roughness": 0.5
-      },
+      "material": "mat-20",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "2.515 - 0.000 * smoothstep(82.30, 83.30, t) + 0.09 * sin(0.45 * t + -32.92)"
         }
-      ]
+      ],
+      "collection": "station-7"
     },
     {
       "id": "s7-dust-9",
@@ -4370,19 +3502,14 @@
         "translate": [116.6522516346202, 2.626149955099641, 3.1688055851540176],
         "rotate": [0, 1.8999999999999995, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.2,
-        "value": 0.18,
-        "kind": "normal",
-        "roughness": 0.5
-      },
+      "material": "mat-20",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "2.626 - 0.000 * smoothstep(82.30, 83.30, t) + 0.05 * sin(0.50 * t + -35.73)"
         }
-      ]
+      ],
+      "collection": "station-7"
     },
     {
       "id": "s7-dust-10",
@@ -4394,19 +3521,14 @@
         "translate": [114.23352263518271, 2.2751364752104166, -2.006364302126396],
         "rotate": [0, 2.8, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.2,
-        "value": 0.18,
-        "kind": "normal",
-        "roughness": 0.5
-      },
+      "material": "mat-20",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "2.275 - 0.000 * smoothstep(82.30, 83.30, t) + 0.07 * sin(0.30 * t + -24.25)"
         }
-      ]
+      ],
+      "collection": "station-7"
     },
     {
       "id": "s7-dust-11",
@@ -4418,19 +3540,14 @@
         "translate": [109.62757972031038, 2.074057518564027, -4.438197954760972],
         "rotate": [0, 0.6000000000000001, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.2,
-        "value": 0.18,
-        "kind": "normal",
-        "roughness": 0.5
-      },
+      "material": "mat-20",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "2.074 - 0.000 * smoothstep(82.30, 83.30, t) + 0.09 * sin(0.35 * t + -27.07)"
         }
-      ]
+      ],
+      "collection": "station-7"
     },
     {
       "id": "s7-dust-12",
@@ -4442,19 +3559,14 @@
         "translate": [108.38336837509748, 1.9174150657237594, 0.9232036344772824],
         "rotate": [0, 1.5000000000000004, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.2,
-        "value": 0.18,
-        "kind": "normal",
-        "roughness": 0.5
-      },
+      "material": "mat-20",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "1.917 - 0.000 * smoothstep(82.30, 83.30, t) + 0.05 * sin(0.40 * t + -29.88)"
         }
-      ]
+      ],
+      "collection": "station-7"
     },
     {
       "id": "s7-dust-13",
@@ -4466,19 +3578,14 @@
         "translate": [112.03664792360509, 1.6748001647187152, 4.091483547131837],
         "rotate": [0, 2.400000000000001, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.2,
-        "value": 0.18,
-        "kind": "normal",
-        "roughness": 0.5
-      },
+      "material": "mat-20",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "1.675 - 0.000 * smoothstep(82.30, 83.30, t) + 0.07 * sin(0.45 * t + -32.70)"
         }
-      ]
+      ],
+      "collection": "station-7"
     },
     {
       "id": "s7-dust-14",
@@ -4490,19 +3597,14 @@
         "translate": [116.27093056383576, 1.3899081353990992, 1.0090925115755864],
         "rotate": [0, 0.1999999999999993, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.2,
-        "value": 0.18,
-        "kind": "normal",
-        "roughness": 0.5
-      },
+      "material": "mat-20",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "1.390 - 0.000 * smoothstep(82.30, 83.30, t) + 0.09 * sin(0.50 * t + -35.51)"
         }
-      ]
+      ],
+      "collection": "station-7"
     },
     {
       "id": "s7-dust-15",
@@ -4514,19 +3616,14 @@
         "translate": [113.39883204644998, 1.44284528397345, -2.7335382705725464],
         "rotate": [0, 1.0999999999999996, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.2,
-        "value": 0.18,
-        "kind": "normal",
-        "roughness": 0.5
-      },
+      "material": "mat-20",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "1.443 - 0.000 * smoothstep(82.30, 83.30, t) + 0.05 * sin(0.30 * t + -24.03)"
         }
-      ]
+      ],
+      "collection": "station-7"
     },
     {
       "id": "s7-dust-16",
@@ -4538,19 +3635,14 @@
         "translate": [108.47072851999935, 0.7171594937718098, -3.057888513618657],
         "rotate": [0, 2, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.2,
-        "value": 0.18,
-        "kind": "normal",
-        "roughness": 0.5
-      },
+      "material": "mat-20",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "0.717 - 0.000 * smoothstep(82.30, 83.30, t) + 0.07 * sin(0.35 * t + -26.85)"
         }
-      ]
+      ],
+      "collection": "station-7"
     },
     {
       "id": "s7-dust-17",
@@ -4562,19 +3654,14 @@
         "translate": [110.20894758465646, 1.3160592709780925, 1.2675014631709414],
         "rotate": [0, 2.9000000000000004, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.2,
-        "value": 0.18,
-        "kind": "normal",
-        "roughness": 0.5
-      },
+      "material": "mat-20",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "1.316 - 0.000 * smoothstep(82.30, 83.30, t) + 0.09 * sin(0.40 * t + -29.66)"
         }
-      ]
+      ],
+      "collection": "station-7"
     },
     {
       "id": "s7-dust-18",
@@ -4586,19 +3673,14 @@
         "translate": [113.57563917106201, -0.005841134412181592, 4.004131549320719],
         "rotate": [0, 0.6999999999999988, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.2,
-        "value": 0.18,
-        "kind": "normal",
-        "roughness": 0.5
-      },
+      "material": "mat-20",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "-0.006 - 0.000 * smoothstep(82.30, 83.30, t) + 0.05 * sin(0.45 * t + -32.48)"
         }
-      ]
+      ],
+      "collection": "station-7"
     },
     {
       "id": "s7-dust-19",
@@ -4610,19 +3692,14 @@
         "translate": [113.51816511579864, 1.1743019526359513, -0.20453893292798464],
         "rotate": [0, 1.600000000000001, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.2,
-        "value": 0.18,
-        "kind": "normal",
-        "roughness": 0.5
-      },
+      "material": "mat-20",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "1.174 - 0.000 * smoothstep(82.30, 83.30, t) + 0.07 * sin(0.50 * t + -35.29)"
         }
-      ]
+      ],
+      "collection": "station-7"
     },
     {
       "id": "s7-dust-20",
@@ -4634,19 +3711,14 @@
         "translate": [112.32248616067346, -0.6439061141122786, -3.000946679549864],
         "rotate": [0, 2.4999999999999996, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.2,
-        "value": 0.18,
-        "kind": "normal",
-        "roughness": 0.5
-      },
+      "material": "mat-20",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "-0.644 - 0.000 * smoothstep(82.30, 83.30, t) + 0.09 * sin(0.30 * t + -23.81)"
         }
-      ]
+      ],
+      "collection": "station-7"
     },
     {
       "id": "s7-dust-21",
@@ -4658,19 +3730,14 @@
         "translate": [111.29501086354327, 0.879070215106386, -0.2557625023629266],
         "rotate": [0, 0.3000000000000016, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.2,
-        "value": 0.18,
-        "kind": "normal",
-        "roughness": 0.5
-      },
+      "material": "mat-20",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "0.879 - 0.000 * smoothstep(82.30, 83.30, t) + 0.05 * sin(0.35 * t + -26.63)"
         }
-      ]
+      ],
+      "collection": "station-7"
     },
     {
       "id": "path-7-1",
@@ -4682,15 +3749,8 @@
         "translate": [114, 0.03, 0],
         "rotate": [0, 0, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-7"
     },
     {
       "id": "path-7-2",
@@ -4702,15 +3762,8 @@
         "translate": [116, 0.03, 0],
         "rotate": [0, 0, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-7"
     },
     {
       "id": "path-7-3",
@@ -4722,15 +3775,8 @@
         "translate": [118, 0.03, 0],
         "rotate": [0, 0, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-7"
     },
     {
       "id": "path-7-4",
@@ -4742,15 +3788,8 @@
         "translate": [120, 0.03, 0],
         "rotate": [0, 0, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-7"
     },
     {
       "id": "path-7-5",
@@ -4762,15 +3801,8 @@
         "translate": [122, 0.03, 0],
         "rotate": [0, 0, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-7"
     },
     {
       "id": "path-7-6",
@@ -4782,15 +3814,8 @@
         "translate": [124, 0.03, 0],
         "rotate": [0, 0, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-7"
     },
     {
       "id": "path-7-7",
@@ -4802,15 +3827,8 @@
         "translate": [126, 0.03, 0],
         "rotate": [0, 0, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-7"
     },
     {
       "id": "s8-stage-0",
@@ -4824,20 +3842,14 @@
       "transform": {
         "translate": [128, 2.8000000000000003, 0]
       },
-      "material": {
-        "hue": 0.55,
-        "sat": 0.62,
-        "value": 0.85,
-        "kind": "normal",
-        "roughness": 0.3,
-        "clearcoat": 0.45
-      },
+      "material": "mat-21",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "3.700 - 0.9 * smoothstep(93.05, 93.65, t)"
         }
-      ]
+      ],
+      "collection": "station-8"
     },
     {
       "id": "s8-stage-1",
@@ -4851,22 +3863,14 @@
       "transform": {
         "translate": [128, 2, 0]
       },
-      "material": {
-        "hue": 0.11,
-        "sat": 0.78,
-        "value": 0.95,
-        "metal": 0,
-        "glow": 0.1,
-        "kind": "normal",
-        "roughness": 0.22,
-        "clearcoat": 0.6
-      },
+      "material": "mat-12",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "2.900 - 0.9 * smoothstep(93.40, 94.00, t)"
         }
-      ]
+      ],
+      "collection": "station-8"
     },
     {
       "id": "s8-stage-2",
@@ -4880,20 +3884,14 @@
       "transform": {
         "translate": [128, 1.2000000000000002, 0]
       },
-      "material": {
-        "hue": 0.6100000000000001,
-        "sat": 0.7266666666666667,
-        "value": 0.65,
-        "kind": "normal",
-        "roughness": 0.3,
-        "clearcoat": 0.45
-      },
+      "material": "mat-22",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "2.100 - 0.9 * smoothstep(93.75, 94.35, t)"
         }
-      ]
+      ],
+      "collection": "station-8"
     },
     {
       "id": "s8-stage-3",
@@ -4907,20 +3905,14 @@
       "transform": {
         "translate": [128, 0.3999999999999999, 0]
       },
-      "material": {
-        "hue": 0.64,
-        "sat": 0.78,
-        "value": 0.55,
-        "kind": "normal",
-        "roughness": 0.3,
-        "clearcoat": 0.45
-      },
+      "material": "mat-23",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "1.300 - 0.9 * smoothstep(94.10, 94.70, t)"
         }
-      ]
+      ],
+      "collection": "station-8"
     },
     {
       "id": "path-8-1",
@@ -4932,15 +3924,8 @@
         "translate": [130, 0.03, 0],
         "rotate": [0, 0, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-8"
     },
     {
       "id": "path-8-2",
@@ -4952,15 +3937,8 @@
         "translate": [132, 0.03, 0],
         "rotate": [0, 0, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-8"
     },
     {
       "id": "path-8-3",
@@ -4972,15 +3950,8 @@
         "translate": [134, 0.03, 0],
         "rotate": [0, 0, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-8"
     },
     {
       "id": "path-8-4",
@@ -4992,15 +3963,8 @@
         "translate": [136, 0.03, 0],
         "rotate": [0, 0, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-8"
     },
     {
       "id": "path-8-5",
@@ -5012,15 +3976,8 @@
         "translate": [138, 0.03, 0],
         "rotate": [0, 0, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-8"
     },
     {
       "id": "path-8-6",
@@ -5032,15 +3989,8 @@
         "translate": [140, 0.03, 0],
         "rotate": [0, 0, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-8"
     },
     {
       "id": "path-8-7",
@@ -5052,15 +4002,8 @@
         "translate": [142, 0.03, 0],
         "rotate": [0, 0, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-8"
     },
     {
       "id": "s9-plinth-0",
@@ -5071,14 +4014,8 @@
       "transform": {
         "translate": [147.81, 0.06, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.1,
-        "value": 0.55,
-        "kind": "normal",
-        "roughness": 0.6,
-        "clearcoat": 0.1
-      }
+      "material": "mat-6",
+      "collection": "station-9"
     },
     {
       "id": "s9-mono-0",
@@ -5090,21 +4027,15 @@
       "transform": {
         "translate": [147.81, 2.4, 0]
       },
-      "material": {
-        "hue": 0.55,
-        "sat": 0.62,
-        "value": 0.82,
-        "kind": "normal",
-        "roughness": 0.3,
-        "clearcoat": 0.45
-      },
+      "material": "mat-7",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "-2.700 + 5.100 * smoothstep(106.05, 106.65, t)"
         }
       ],
-      "pattern": "cracked"
+      "pattern": "cracked",
+      "collection": "station-9"
     },
     {
       "id": "s9-plinth-1",
@@ -5115,14 +4046,8 @@
       "transform": {
         "translate": [146.54, 0.06, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.1,
-        "value": 0.55,
-        "kind": "normal",
-        "roughness": 0.6,
-        "clearcoat": 0.1
-      }
+      "material": "mat-6",
+      "collection": "station-9"
     },
     {
       "id": "s9-mono-1",
@@ -5134,21 +4059,15 @@
       "transform": {
         "translate": [146.54, 2.3564356435643563, 0]
       },
-      "material": {
-        "hue": 0.5650000000000001,
-        "sat": 0.6433333333333333,
-        "value": 0.7833333333333333,
-        "kind": "normal",
-        "roughness": 0.3,
-        "clearcoat": 0.45
-      },
+      "material": "mat-24",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "-2.656 + 5.013 * smoothstep(107.15, 107.75, t)"
         }
       ],
-      "pattern": "cracked"
+      "pattern": "cracked",
+      "collection": "station-9"
     },
     {
       "id": "s9-plinth-2",
@@ -5159,14 +4078,8 @@
       "transform": {
         "translate": [145.27, 0.06, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.1,
-        "value": 0.55,
-        "kind": "normal",
-        "roughness": 0.6,
-        "clearcoat": 0.1
-      }
+      "material": "mat-6",
+      "collection": "station-9"
     },
     {
       "id": "s9-mono-2",
@@ -5178,21 +4091,15 @@
       "transform": {
         "translate": [145.27, 2.2376237623762374, 0]
       },
-      "material": {
-        "hue": 0.5800000000000001,
-        "sat": 0.6666666666666666,
-        "value": 0.7466666666666666,
-        "kind": "normal",
-        "roughness": 0.3,
-        "clearcoat": 0.45
-      },
+      "material": "mat-25",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "-2.538 + 4.775 * smoothstep(108.25, 108.85, t)"
         }
       ],
-      "pattern": "cracked"
+      "pattern": "cracked",
+      "collection": "station-9"
     },
     {
       "id": "s9-plinth-3",
@@ -5203,14 +4110,8 @@
       "transform": {
         "translate": [144, 0.06, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.1,
-        "value": 0.55,
-        "kind": "normal",
-        "roughness": 0.6,
-        "clearcoat": 0.1
-      }
+      "material": "mat-6",
+      "collection": "station-9"
     },
     {
       "id": "s9-mono-3",
@@ -5222,21 +4123,15 @@
       "transform": {
         "translate": [144, 2.1425742574257423, 0]
       },
-      "material": {
-        "hue": 0.5950000000000001,
-        "sat": 0.69,
-        "value": 0.71,
-        "kind": "normal",
-        "roughness": 0.3,
-        "clearcoat": 0.45
-      },
+      "material": "mat-26",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "-2.443 + 4.585 * smoothstep(109.35, 109.95, t)"
         }
       ],
-      "pattern": "cracked"
+      "pattern": "cracked",
+      "collection": "station-9"
     },
     {
       "id": "s9-plinth-4",
@@ -5247,14 +4142,8 @@
       "transform": {
         "translate": [142.73, 0.06, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.1,
-        "value": 0.55,
-        "kind": "normal",
-        "roughness": 0.6,
-        "clearcoat": 0.1
-      }
+      "material": "mat-6",
+      "collection": "station-9"
     },
     {
       "id": "s9-mono-4",
@@ -5266,21 +4155,15 @@
       "transform": {
         "translate": [142.73, 2.023762376237624, 0]
       },
-      "material": {
-        "hue": 0.6100000000000001,
-        "sat": 0.7133333333333334,
-        "value": 0.6733333333333333,
-        "kind": "normal",
-        "roughness": 0.3,
-        "clearcoat": 0.45
-      },
+      "material": "mat-27",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "-2.324 + 4.348 * smoothstep(110.45, 111.05, t)"
         }
       ],
-      "pattern": "cracked"
+      "pattern": "cracked",
+      "collection": "station-9"
     },
     {
       "id": "s9-plinth-5",
@@ -5291,14 +4174,8 @@
       "transform": {
         "translate": [141.46, 0.06, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.1,
-        "value": 0.55,
-        "kind": "normal",
-        "roughness": 0.6,
-        "clearcoat": 0.1
-      }
+      "material": "mat-6",
+      "collection": "station-9"
     },
     {
       "id": "s9-mono-5",
@@ -5310,21 +4187,15 @@
       "transform": {
         "translate": [141.46, 1.881188118811881, 0]
       },
-      "material": {
-        "hue": 0.625,
-        "sat": 0.7366666666666667,
-        "value": 0.6366666666666666,
-        "kind": "normal",
-        "roughness": 0.3,
-        "clearcoat": 0.45
-      },
+      "material": "mat-28",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "-2.181 + 4.062 * smoothstep(111.55, 112.15, t)"
         }
       ],
-      "pattern": "cracked"
+      "pattern": "cracked",
+      "collection": "station-9"
     },
     {
       "id": "s9-plinth-6",
@@ -5335,14 +4206,8 @@
       "transform": {
         "translate": [140.19, 0.06, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.1,
-        "value": 0.55,
-        "kind": "normal",
-        "roughness": 0.6,
-        "clearcoat": 0.1
-      }
+      "material": "mat-6",
+      "collection": "station-9"
     },
     {
       "id": "s9-mono-6",
@@ -5354,22 +4219,14 @@
       "transform": {
         "translate": [140.19, 1.786138613861386, 0]
       },
-      "material": {
-        "hue": 0.11,
-        "sat": 0.78,
-        "value": 0.95,
-        "metal": 0,
-        "glow": 0.1,
-        "kind": "normal",
-        "roughness": 0.22,
-        "clearcoat": 0.6
-      },
+      "material": "mat-12",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "-2.086 + 3.872 * smoothstep(112.65, 113.25, t)"
         }
-      ]
+      ],
+      "collection": "station-9"
     },
     {
       "id": "s9-guard-l-0",
@@ -5381,14 +4238,8 @@
         "translate": [135.23, 1.1, 1.2],
         "rotate": [0, -0.3, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-13",
+      "collection": "station-9"
     },
     {
       "id": "s9-guard-r-0",
@@ -5400,14 +4251,8 @@
         "translate": [152.77, 1.1, 1.2],
         "rotate": [0, 0.3, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-13",
+      "collection": "station-9"
     },
     {
       "id": "s9-guard-l-1",
@@ -5419,14 +4264,8 @@
         "translate": [135.83, 1.75, -4.6],
         "rotate": [0, -0.3, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-13",
+      "collection": "station-9"
     },
     {
       "id": "s9-guard-r-1",
@@ -5438,14 +4277,8 @@
         "translate": [152.17, 1.75, -4.6],
         "rotate": [0, 0.3, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-13",
+      "collection": "station-9"
     },
     {
       "id": "s9-guard-l-2",
@@ -5457,14 +4290,8 @@
         "translate": [134.43, 2.4000000000000004, -6.800000000000001],
         "rotate": [0, -0.3, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-13",
+      "collection": "station-9"
     },
     {
       "id": "s9-guard-r-2",
@@ -5476,14 +4303,8 @@
         "translate": [153.57, 2.4000000000000004, -6.800000000000001],
         "rotate": [0, 0.3, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-13",
+      "collection": "station-9"
     },
     {
       "id": "path-9-1",
@@ -5495,15 +4316,8 @@
         "translate": [146, 0.03, 0],
         "rotate": [0, 0, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-9"
     },
     {
       "id": "path-9-2",
@@ -5515,15 +4329,8 @@
         "translate": [148, 0.03, 0],
         "rotate": [0, 0, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-9"
     },
     {
       "id": "path-9-3",
@@ -5535,15 +4342,8 @@
         "translate": [150, 0.03, 0],
         "rotate": [0, 0, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-9"
     },
     {
       "id": "path-9-4",
@@ -5555,15 +4355,8 @@
         "translate": [152, 0.03, 0],
         "rotate": [0, 0, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-9"
     },
     {
       "id": "path-9-5",
@@ -5575,15 +4368,8 @@
         "translate": [154, 0.03, 0],
         "rotate": [0, 0, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-9"
     },
     {
       "id": "path-9-6",
@@ -5595,15 +4381,8 @@
         "translate": [156, 0.03, 0],
         "rotate": [0, 0, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-9"
     },
     {
       "id": "path-9-7",
@@ -5615,15 +4394,8 @@
         "translate": [158, 0.03, 0],
         "rotate": [0, 0, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-9"
     },
     {
       "id": "s10-node-0",
@@ -5643,22 +4415,14 @@
       "transform": {
         "translate": [160, 3.15, 0]
       },
-      "material": {
-        "hue": 0.11,
-        "sat": 0.78,
-        "value": 0.95,
-        "metal": 0,
-        "glow": 0.04,
-        "kind": "normal",
-        "roughness": 0.22,
-        "clearcoat": 0.6
-      },
+      "material": "mat-29",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "4.150 - 1 * smoothstep(120.35, 120.90, t)"
         }
-      ]
+      ],
+      "collection": "station-10"
     },
     {
       "id": "s10-node-1",
@@ -5690,20 +4454,14 @@
       "transform": {
         "translate": [160, 2, -1.9]
       },
-      "material": {
-        "hue": 0.5950000000000001,
-        "sat": 0.7,
-        "value": 0.71,
-        "kind": "normal",
-        "roughness": 0.3,
-        "clearcoat": 0.45
-      },
+      "material": "mat-30",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "3.000 - 1 * smoothstep(121.85, 122.40, t)"
         }
-      ]
+      ],
+      "collection": "station-10"
     },
     {
       "id": "s10-node-2",
@@ -5735,20 +4493,14 @@
       "transform": {
         "translate": [161.64544826719043, 2, 0.9499999999999996]
       },
-      "material": {
-        "hue": 0.5950000000000001,
-        "sat": 0.7,
-        "value": 0.71,
-        "kind": "normal",
-        "roughness": 0.3,
-        "clearcoat": 0.45
-      },
+      "material": "mat-30",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "3.000 - 1 * smoothstep(121.85, 122.40, t)"
         }
-      ]
+      ],
+      "collection": "station-10"
     },
     {
       "id": "s10-node-3",
@@ -5780,20 +4532,14 @@
       "transform": {
         "translate": [158.35455173280957, 2, 0.9500000000000006]
       },
-      "material": {
-        "hue": 0.5950000000000001,
-        "sat": 0.7,
-        "value": 0.71,
-        "kind": "normal",
-        "roughness": 0.3,
-        "clearcoat": 0.45
-      },
+      "material": "mat-30",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "3.000 - 1 * smoothstep(121.85, 122.40, t)"
         }
-      ]
+      ],
+      "collection": "station-10"
     },
     {
       "id": "s10-node-4",
@@ -5825,20 +4571,14 @@
       "transform": {
         "translate": [161.14289187648038, 0.8500000000000001, 1.6417095301905795]
       },
-      "material": {
-        "hue": 0.64,
-        "sat": 0.78,
-        "value": 0.57,
-        "kind": "normal",
-        "roughness": 0.3,
-        "clearcoat": 0.45
-      },
+      "material": "mat-31",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "1.850 - 1 * smoothstep(123.35, 123.90, t)"
         }
-      ]
+      ],
+      "collection": "station-10"
     },
     {
       "id": "path-10-1",
@@ -5850,15 +4590,8 @@
         "translate": [162, 0.03, 0],
         "rotate": [0, 0, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-10"
     },
     {
       "id": "path-10-2",
@@ -5870,15 +4603,8 @@
         "translate": [164, 0.03, 0],
         "rotate": [0, 0, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-10"
     },
     {
       "id": "path-10-3",
@@ -5890,15 +4616,8 @@
         "translate": [166, 0.03, 0],
         "rotate": [0, 0, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-10"
     },
     {
       "id": "path-10-4",
@@ -5910,15 +4629,8 @@
         "translate": [168, 0.03, 0],
         "rotate": [0, 0, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-10"
     },
     {
       "id": "path-10-5",
@@ -5930,15 +4642,8 @@
         "translate": [170, 0.03, 0],
         "rotate": [0, 0, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-10"
     },
     {
       "id": "path-10-6",
@@ -5950,15 +4655,8 @@
         "translate": [172, 0.03, 0],
         "rotate": [0, 0, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-10"
     },
     {
       "id": "path-10-7",
@@ -5970,15 +4668,8 @@
         "translate": [174, 0.03, 0],
         "rotate": [0, 0, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-10"
     },
     {
       "id": "s11-backboard",
@@ -5990,14 +4681,8 @@
       "transform": {
         "translate": [176, 2.51, -0.34]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.3,
-        "value": 0.22,
-        "kind": "normal",
-        "roughness": 0.4,
-        "clearcoat": 0.3
-      }
+      "material": "mat-32",
+      "collection": "station-11"
     },
     {
       "id": "s11-cell-0-0",
@@ -6009,14 +4694,8 @@
       "transform": {
         "translate": [176.91, 3.2199999999999998, 0]
       },
-      "material": {
-        "hue": 0.6,
-        "sat": 0.1,
-        "value": 0.3,
-        "kind": "normal",
-        "roughness": 0.7,
-        "clearcoat": 0.1
-      }
+      "material": "mat-33",
+      "collection": "station-11"
     },
     {
       "id": "s11-cell-1-0",
@@ -6028,14 +4707,8 @@
       "transform": {
         "translate": [175.09, 3.2199999999999998, 0]
       },
-      "material": {
-        "hue": 0.6,
-        "sat": 0.1,
-        "value": 0.3,
-        "kind": "normal",
-        "roughness": 0.7,
-        "clearcoat": 0.1
-      }
+      "material": "mat-33",
+      "collection": "station-11"
     },
     {
       "id": "s11-cell-0-1",
@@ -6047,14 +4720,8 @@
       "transform": {
         "translate": [176.91, 1.7999999999999998, 0]
       },
-      "material": {
-        "hue": 0.6,
-        "sat": 0.1,
-        "value": 0.3,
-        "kind": "normal",
-        "roughness": 0.7,
-        "clearcoat": 0.1
-      }
+      "material": "mat-33",
+      "collection": "station-11"
     },
     {
       "id": "s11-cell-1-1",
@@ -6066,14 +4733,8 @@
       "transform": {
         "translate": [175.09, 1.7999999999999998, 0]
       },
-      "material": {
-        "hue": 0.6,
-        "sat": 0.1,
-        "value": 0.3,
-        "kind": "normal",
-        "roughness": 0.7,
-        "clearcoat": 0.1
-      }
+      "material": "mat-33",
+      "collection": "station-11"
     },
     {
       "id": "s11-item-0",
@@ -6085,20 +4746,14 @@
       "transform": {
         "translate": [176.91, 3.2199999999999998, 0.34]
       },
-      "material": {
-        "hue": 0.57,
-        "sat": 0.55,
-        "value": 0.72,
-        "kind": "normal",
-        "roughness": 0.3,
-        "clearcoat": 0.45
-      },
+      "material": "mat-34",
       "animation": [
         {
           "channel": "transform.translate.z",
           "expr": "2.400 - 2.060 * smoothstep(131.25, 131.70, t)"
         }
-      ]
+      ],
+      "collection": "station-11"
     },
     {
       "id": "s11-item-1",
@@ -6110,20 +4765,14 @@
       "transform": {
         "translate": [176.91, 1.7999999999999998, 0.34]
       },
-      "material": {
-        "hue": 0.57,
-        "sat": 0.55,
-        "value": 0.72,
-        "kind": "normal",
-        "roughness": 0.3,
-        "clearcoat": 0.45
-      },
+      "material": "mat-34",
       "animation": [
         {
           "channel": "transform.translate.z",
           "expr": "2.400 - 2.060 * smoothstep(132.15, 132.60, t)"
         }
-      ]
+      ],
+      "collection": "station-11"
     },
     {
       "id": "s11-item-2",
@@ -6135,20 +4784,14 @@
       "transform": {
         "translate": [175.09, 3.2199999999999998, 0.34]
       },
-      "material": {
-        "hue": 0.57,
-        "sat": 0.55,
-        "value": 0.72,
-        "kind": "normal",
-        "roughness": 0.3,
-        "clearcoat": 0.45
-      },
+      "material": "mat-34",
       "animation": [
         {
           "channel": "transform.translate.z",
           "expr": "2.400 - 2.060 * smoothstep(133.05, 133.50, t)"
         }
-      ]
+      ],
+      "collection": "station-11"
     },
     {
       "id": "s11-item-3",
@@ -6160,21 +4803,14 @@
       "transform": {
         "translate": [175.09, 1.7999999999999998, 0.34]
       },
-      "material": {
-        "hue": 0.11,
-        "sat": 0.78,
-        "value": 0.95,
-        "glow": 0.1,
-        "kind": "normal",
-        "roughness": 0.22,
-        "clearcoat": 0.6
-      },
+      "material": "mat-5",
       "animation": [
         {
           "channel": "transform.translate.z",
           "expr": "2.400 - 2.060 * smoothstep(133.95, 134.40, t)"
         }
-      ]
+      ],
+      "collection": "station-11"
     },
     {
       "id": "s11-flank-0",
@@ -6186,20 +4822,14 @@
         "translate": [171.84, 3.3099999999999996, -2.2],
         "rotate": [0, -0.9, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      },
+      "material": "mat-13",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "3.310 - 0.000 * smoothstep(130.00, 131.00, t) + 0.06 * sin(0.30 * t + -39.00)"
         }
-      ]
+      ],
+      "collection": "station-11"
     },
     {
       "id": "s11-flank-1",
@@ -6211,20 +4841,14 @@
         "translate": [180.46, 2.11, -3],
         "rotate": [0, -0.4, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      },
+      "material": "mat-13",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "2.110 - 0.000 * smoothstep(130.00, 131.00, t) + 0.08 * sin(0.37 * t + -45.90)"
         }
-      ]
+      ],
+      "collection": "station-11"
     },
     {
       "id": "s11-flank-2",
@@ -6236,20 +4860,14 @@
         "translate": [170.04, 4.71, -5.5],
         "rotate": [0, 0.09999999999999998, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      },
+      "material": "mat-13",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "4.710 - 0.000 * smoothstep(130.00, 131.00, t) + 0.10 * sin(0.44 * t + -52.80)"
         }
-      ]
+      ],
+      "collection": "station-11"
     },
     {
       "id": "s11-flank-3",
@@ -6261,20 +4879,14 @@
         "translate": [182.56, 4.109999999999999, -6.5],
         "rotate": [0, 0.6, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      },
+      "material": "mat-13",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "4.110 - 0.000 * smoothstep(130.00, 131.00, t) + 0.12 * sin(0.51 * t + -65.98)"
         }
-      ]
+      ],
+      "collection": "station-11"
     },
     {
       "id": "path-11-1",
@@ -6286,15 +4898,8 @@
         "translate": [178, 0.03, 0],
         "rotate": [0, 0, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-11"
     },
     {
       "id": "path-11-2",
@@ -6306,15 +4911,8 @@
         "translate": [180, 0.03, 0],
         "rotate": [0, 0, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-11"
     },
     {
       "id": "path-11-3",
@@ -6326,15 +4924,8 @@
         "translate": [182, 0.03, 0],
         "rotate": [0, 0, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-11"
     },
     {
       "id": "path-11-4",
@@ -6346,15 +4937,8 @@
         "translate": [184, 0.03, 0],
         "rotate": [0, 0, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-11"
     },
     {
       "id": "path-11-5",
@@ -6366,15 +4950,8 @@
         "translate": [186, 0.03, 0],
         "rotate": [0, 0, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-11"
     },
     {
       "id": "path-11-6",
@@ -6386,15 +4963,8 @@
         "translate": [188, 0.03, 0],
         "rotate": [0, 0, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-11"
     },
     {
       "id": "path-11-7",
@@ -6406,15 +4976,8 @@
         "translate": [190, 0.03, 0],
         "rotate": [0, 0, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-11"
     },
     {
       "id": "s12-plinth-0",
@@ -6425,14 +4988,8 @@
       "transform": {
         "translate": [193.27, 0.06, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.1,
-        "value": 0.55,
-        "kind": "normal",
-        "roughness": 0.6,
-        "clearcoat": 0.1
-      }
+      "material": "mat-6",
+      "collection": "station-12"
     },
     {
       "id": "s12-mono-0",
@@ -6444,21 +5001,15 @@
       "transform": {
         "translate": [193.27, 0.24, 0]
       },
-      "material": {
-        "hue": 0.55,
-        "sat": 0.62,
-        "value": 0.82,
-        "kind": "normal",
-        "roughness": 0.3,
-        "clearcoat": 0.45
-      },
+      "material": "mat-7",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "-0.540 + 0.780 * smoothstep(141.15, 141.75, t)"
         }
       ],
-      "pattern": "cracked"
+      "pattern": "cracked",
+      "collection": "station-12"
     },
     {
       "id": "s12-plinth-1",
@@ -6469,14 +5020,8 @@
       "transform": {
         "translate": [192, 0.06, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.1,
-        "value": 0.55,
-        "kind": "normal",
-        "roughness": 0.6,
-        "clearcoat": 0.1
-      }
+      "material": "mat-6",
+      "collection": "station-12"
     },
     {
       "id": "s12-mono-1",
@@ -6488,21 +5033,15 @@
       "transform": {
         "translate": [192, 1.2, 0]
       },
-      "material": {
-        "hue": 0.5950000000000001,
-        "sat": 0.69,
-        "value": 0.71,
-        "kind": "normal",
-        "roughness": 0.3,
-        "clearcoat": 0.45
-      },
+      "material": "mat-26",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "-1.500 + 2.700 * smoothstep(142.25, 142.85, t)"
         }
       ],
-      "pattern": "cracked"
+      "pattern": "cracked",
+      "collection": "station-12"
     },
     {
       "id": "s12-plinth-2",
@@ -6513,14 +5052,8 @@
       "transform": {
         "translate": [190.73, 0.06, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.1,
-        "value": 0.55,
-        "kind": "normal",
-        "roughness": 0.6,
-        "clearcoat": 0.1
-      }
+      "material": "mat-6",
+      "collection": "station-12"
     },
     {
       "id": "s12-mono-2",
@@ -6532,22 +5065,14 @@
       "transform": {
         "translate": [190.73, 2.4, 0]
       },
-      "material": {
-        "hue": 0.11,
-        "sat": 0.78,
-        "value": 0.95,
-        "metal": 0,
-        "glow": 0.1,
-        "kind": "normal",
-        "roughness": 0.22,
-        "clearcoat": 0.6
-      },
+      "material": "mat-12",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "-2.700 + 5.100 * smoothstep(143.35, 143.95, t)"
         }
-      ]
+      ],
+      "collection": "station-12"
     },
     {
       "id": "s12-guard-l-0",
@@ -6559,14 +5084,8 @@
         "translate": [185.77, 1.1, 1.2],
         "rotate": [0, -0.3, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-13",
+      "collection": "station-12"
     },
     {
       "id": "s12-guard-r-0",
@@ -6578,14 +5097,8 @@
         "translate": [198.23, 1.1, 1.2],
         "rotate": [0, 0.3, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-13",
+      "collection": "station-12"
     },
     {
       "id": "s12-guard-l-1",
@@ -6597,14 +5110,8 @@
         "translate": [186.37, 1.75, -4.6],
         "rotate": [0, -0.3, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-13",
+      "collection": "station-12"
     },
     {
       "id": "s12-guard-r-1",
@@ -6616,14 +5123,8 @@
         "translate": [197.63, 1.75, -4.6],
         "rotate": [0, 0.3, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-13",
+      "collection": "station-12"
     },
     {
       "id": "s12-guard-l-2",
@@ -6635,14 +5136,8 @@
         "translate": [184.97, 2.4000000000000004, -6.800000000000001],
         "rotate": [0, -0.3, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-13",
+      "collection": "station-12"
     },
     {
       "id": "s12-guard-r-2",
@@ -6654,14 +5149,8 @@
         "translate": [199.03, 2.4000000000000004, -6.800000000000001],
         "rotate": [0, 0.3, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-13",
+      "collection": "station-12"
     },
     {
       "id": "horizon-0",
@@ -6673,16 +5162,8 @@
         "translate": [96, 7.016592952333921, 148.44758298167267],
         "rotate": [0, 0, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "metal": 0,
-        "glow": 0,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-35",
+      "collection": "horizon"
     },
     {
       "id": "horizon-1",
@@ -6694,16 +5175,8 @@
         "translate": [159.3066209152962, 7.62296579657653, 92.85708904982108],
         "rotate": [0, 0.34528374665954953, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "metal": 0,
-        "glow": 0,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-35",
+      "collection": "horizon"
     },
     {
       "id": "horizon-2",
@@ -6715,16 +5188,8 @@
         "translate": [138.17123438785762, 4.819555072083943, 58.18899581850708],
         "rotate": [0, -0.3486303089654353, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "metal": 0,
-        "glow": 0,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-35",
+      "collection": "horizon"
     },
     {
       "id": "horizon-3",
@@ -6736,16 +5201,8 @@
         "translate": [229.23992011010677, 4.842001421418689, -15.398862705215285],
         "rotate": [0, 0.006725560193740241, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "metal": 0,
-        "glow": 0,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-35",
+      "collection": "horizon"
     },
     {
       "id": "horizon-4",
@@ -6757,16 +5214,8 @@
         "translate": [229.43987144268098, 7.640377316314558, 15.945010375042079],
         "rotate": [0, 0.3418395632353122, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "metal": 0,
-        "glow": 0,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-35",
+      "collection": "horizon"
     },
     {
       "id": "horizon-5",
@@ -6778,16 +5227,8 @@
         "translate": [137.5905937655869, 6.990241111126378, -58.71906850943405],
         "rotate": [0, -0.35187830398866804, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "metal": 0,
-        "glow": 0,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-35",
+      "collection": "horizon"
     },
     {
       "id": "horizon-6",
@@ -6799,16 +5240,8 @@
         "translate": [160.57684188043538, 4.3376940527581525, -91.58418852702466],
         "rotate": [0, 0.01344921888845539, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "metal": 0,
-        "glow": 0,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-35",
+      "collection": "horizon"
     },
     {
       "id": "horizon-7",
@@ -6820,16 +5253,8 @@
         "translate": [93.3783006663294, 5.582809968766616, -148.54011535108356],
         "rotate": [0, 0.33829873245717335, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "metal": 0,
-        "glow": 0,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-35",
+      "collection": "horizon"
     },
     {
       "id": "horizon-8",
@@ -6841,16 +5266,8 @@
         "translate": [49.337870734549846, 7.956071234520032, -70.87525467505033],
         "rotate": [0, -0.35502681343260184, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "metal": 0,
-        "glow": 0,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-35",
+      "collection": "horizon"
     },
     {
       "id": "horizon-9",
@@ -6862,16 +5279,8 @@
         "translate": [42.61842352216516, 6.178620822448911, -71.89564197285696],
         "rotate": [0, 0.020169075122725907, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "metal": 0,
-        "glow": 0,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-35",
+      "collection": "horizon"
     },
     {
       "id": "horizon-10",
@@ -6883,16 +5292,8 @@
         "translate": [-53.30732670480418, 4.204050667126552, 16.540562423767465],
         "rotate": [0, 0.33466225541442246, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "metal": 0,
-        "glow": 0,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-35",
+      "collection": "horizon"
     },
     {
       "id": "horizon-11",
@@ -6904,16 +5305,8 @@
         "translate": [-9.511133990203675, 6.424407144257572, -12.928144745818537],
         "rotate": [0, -0.35807494712787274, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "metal": 0,
-        "glow": 0,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-35",
+      "collection": "horizon"
     },
     {
       "id": "horizon-12",
@@ -6925,16 +5318,8 @@
         "translate": [53.829012927902355, 7.900940120366205, 60.837256078552294],
         "rotate": [0, 0.02688322901019139, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "metal": 0,
-        "glow": 0,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-35",
+      "collection": "horizon"
     },
     {
       "id": "horizon-13",
@@ -6946,16 +5331,8 @@
         "translate": [14.275787822348533, 5.34938983448815, 112.20689757324111],
         "rotate": [0, 0.3309311602381515, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "metal": 0,
-        "glow": 0,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-35",
+      "collection": "horizon"
     }
   ],
   "overlay": [

--- a/sdf-js/fixtures/golden/assemble-deck-radial.json
+++ b/sdf-js/fixtures/golden/assemble-deck-radial.json
@@ -1,6 +1,425 @@
 {
   "v": 1,
   "name": "(deck) 最懂你的头条 — 2013 管理层陈述",
+  "collections": {
+    "station-0": {
+      "kind": "station",
+      "station": 0
+    },
+    "path-0": {
+      "kind": "transit-path",
+      "from": 0
+    },
+    "station-1": {
+      "kind": "station",
+      "station": 1
+    },
+    "path-1": {
+      "kind": "transit-path",
+      "from": 1
+    },
+    "station-2": {
+      "kind": "station",
+      "station": 2
+    },
+    "path-2": {
+      "kind": "transit-path",
+      "from": 2
+    },
+    "station-3": {
+      "kind": "station",
+      "station": 3
+    },
+    "path-3": {
+      "kind": "transit-path",
+      "from": 3
+    },
+    "station-4": {
+      "kind": "station",
+      "station": 4
+    },
+    "path-4": {
+      "kind": "transit-path",
+      "from": 4
+    },
+    "station-5": {
+      "kind": "station",
+      "station": 5
+    },
+    "path-5": {
+      "kind": "transit-path",
+      "from": 5
+    },
+    "station-6": {
+      "kind": "station",
+      "station": 6
+    },
+    "path-6": {
+      "kind": "transit-path",
+      "from": 6
+    },
+    "station-7": {
+      "kind": "station",
+      "station": 7
+    },
+    "path-7": {
+      "kind": "transit-path",
+      "from": 7
+    },
+    "station-8": {
+      "kind": "station",
+      "station": 8
+    },
+    "path-8": {
+      "kind": "transit-path",
+      "from": 8
+    },
+    "station-9": {
+      "kind": "station",
+      "station": 9
+    },
+    "path-9": {
+      "kind": "transit-path",
+      "from": 9
+    },
+    "station-10": {
+      "kind": "station",
+      "station": 10
+    },
+    "path-10": {
+      "kind": "transit-path",
+      "from": 10
+    },
+    "station-11": {
+      "kind": "station",
+      "station": 11
+    },
+    "path-11": {
+      "kind": "transit-path",
+      "from": 11
+    },
+    "station-12": {
+      "kind": "station",
+      "station": 12
+    },
+    "massing": {
+      "kind": "dressing",
+      "cull": "never"
+    },
+    "horizon": {
+      "kind": "dressing",
+      "cull": "nearest",
+      "budget": {
+        "hero": 7,
+        "content": 3
+      },
+      "yieldTo": "massing"
+    },
+    "env": {
+      "kind": "dressing",
+      "cull": "never"
+    }
+  },
+  "materials": {
+    "mat-0": {
+      "hue": 0.62,
+      "sat": 0.25,
+      "value": 0.1,
+      "kind": "normal",
+      "roughness": 0.48,
+      "clearcoat": 0.45
+    },
+    "mat-1": {
+      "hue": 0.58,
+      "sat": 0.25,
+      "value": 0.85,
+      "glow": 0.45,
+      "kind": "normal",
+      "roughness": 0.5,
+      "clearcoat": 0.2
+    },
+    "mat-2": {
+      "hue": 0.62,
+      "sat": 0.25,
+      "value": 0.1,
+      "kind": "normal",
+      "roughness": 0.4,
+      "clearcoat": 0.45
+    },
+    "mat-3": {
+      "hue": 0.995,
+      "sat": 0.85,
+      "value": 0.78,
+      "glow": 0.12,
+      "kind": "normal",
+      "roughness": 0.3,
+      "clearcoat": 0.5
+    },
+    "mat-4": {
+      "hue": 0.995,
+      "sat": 0.15,
+      "value": 0.8,
+      "glow": 0.5,
+      "kind": "normal",
+      "roughness": 0.4
+    },
+    "mat-5": {
+      "hue": 0.11,
+      "sat": 0.78,
+      "value": 0.95,
+      "glow": 0.1,
+      "kind": "normal",
+      "roughness": 0.22,
+      "clearcoat": 0.6
+    },
+    "mat-6": {
+      "hue": 0.58,
+      "sat": 0.1,
+      "value": 0.55,
+      "kind": "normal",
+      "roughness": 0.6,
+      "clearcoat": 0.1
+    },
+    "mat-7": {
+      "hue": 0.55,
+      "sat": 0.62,
+      "value": 0.82,
+      "kind": "normal",
+      "roughness": 0.3,
+      "clearcoat": 0.45
+    },
+    "mat-8": {
+      "hue": 0.5680000000000001,
+      "sat": 0.648,
+      "value": 0.7759999999999999,
+      "kind": "normal",
+      "roughness": 0.3,
+      "clearcoat": 0.45
+    },
+    "mat-9": {
+      "hue": 0.5860000000000001,
+      "sat": 0.676,
+      "value": 0.732,
+      "kind": "normal",
+      "roughness": 0.3,
+      "clearcoat": 0.45
+    },
+    "mat-10": {
+      "hue": 0.6040000000000001,
+      "sat": 0.704,
+      "value": 0.688,
+      "kind": "normal",
+      "roughness": 0.3,
+      "clearcoat": 0.45
+    },
+    "mat-11": {
+      "hue": 0.622,
+      "sat": 0.732,
+      "value": 0.6439999999999999,
+      "kind": "normal",
+      "roughness": 0.3,
+      "clearcoat": 0.45
+    },
+    "mat-12": {
+      "hue": 0.11,
+      "sat": 0.78,
+      "value": 0.95,
+      "metal": 0,
+      "glow": 0.1,
+      "kind": "normal",
+      "roughness": 0.22,
+      "clearcoat": 0.6
+    },
+    "mat-13": {
+      "hue": 0.62,
+      "sat": 0.25,
+      "value": 0.14,
+      "kind": "normal",
+      "roughness": 0.5,
+      "clearcoat": 0.35
+    },
+    "mat-14": {
+      "hue": 0.64,
+      "sat": 0.76,
+      "value": 0.6,
+      "kind": "normal",
+      "roughness": 0.3,
+      "clearcoat": 0.45
+    },
+    "mat-15": {
+      "hue": 0.995,
+      "sat": 0.85,
+      "value": 0.78,
+      "glow": 0.24,
+      "kind": "normal",
+      "roughness": 0.3,
+      "clearcoat": 0.5
+    },
+    "mat-16": {
+      "hue": 0.62875,
+      "sat": 0.76,
+      "value": 0.5875,
+      "kind": "normal",
+      "roughness": 0.55,
+      "clearcoat": 0.2
+    },
+    "mat-17": {
+      "hue": 0.6175,
+      "sat": 0.74,
+      "value": 0.625,
+      "kind": "normal",
+      "roughness": 0.55,
+      "clearcoat": 0.2
+    },
+    "mat-18": {
+      "hue": 0.60625,
+      "sat": 0.72,
+      "value": 0.6625000000000001,
+      "kind": "normal",
+      "roughness": 0.55,
+      "clearcoat": 0.2
+    },
+    "mat-19": {
+      "hue": 0.58,
+      "sat": 0.25,
+      "value": 0.55,
+      "glow": 0.08,
+      "kind": "normal",
+      "roughness": 0.6,
+      "clearcoat": 0.15
+    },
+    "mat-20": {
+      "hue": 0.62,
+      "sat": 0.2,
+      "value": 0.18,
+      "kind": "normal",
+      "roughness": 0.5
+    },
+    "mat-21": {
+      "hue": 0.55,
+      "sat": 0.62,
+      "value": 0.85,
+      "kind": "normal",
+      "roughness": 0.3,
+      "clearcoat": 0.45
+    },
+    "mat-22": {
+      "hue": 0.6100000000000001,
+      "sat": 0.7266666666666667,
+      "value": 0.65,
+      "kind": "normal",
+      "roughness": 0.3,
+      "clearcoat": 0.45
+    },
+    "mat-23": {
+      "hue": 0.64,
+      "sat": 0.78,
+      "value": 0.55,
+      "kind": "normal",
+      "roughness": 0.3,
+      "clearcoat": 0.45
+    },
+    "mat-24": {
+      "hue": 0.5650000000000001,
+      "sat": 0.6433333333333333,
+      "value": 0.7833333333333333,
+      "kind": "normal",
+      "roughness": 0.3,
+      "clearcoat": 0.45
+    },
+    "mat-25": {
+      "hue": 0.5800000000000001,
+      "sat": 0.6666666666666666,
+      "value": 0.7466666666666666,
+      "kind": "normal",
+      "roughness": 0.3,
+      "clearcoat": 0.45
+    },
+    "mat-26": {
+      "hue": 0.5950000000000001,
+      "sat": 0.69,
+      "value": 0.71,
+      "kind": "normal",
+      "roughness": 0.3,
+      "clearcoat": 0.45
+    },
+    "mat-27": {
+      "hue": 0.6100000000000001,
+      "sat": 0.7133333333333334,
+      "value": 0.6733333333333333,
+      "kind": "normal",
+      "roughness": 0.3,
+      "clearcoat": 0.45
+    },
+    "mat-28": {
+      "hue": 0.625,
+      "sat": 0.7366666666666667,
+      "value": 0.6366666666666666,
+      "kind": "normal",
+      "roughness": 0.3,
+      "clearcoat": 0.45
+    },
+    "mat-29": {
+      "hue": 0.11,
+      "sat": 0.78,
+      "value": 0.95,
+      "metal": 0,
+      "glow": 0.04,
+      "kind": "normal",
+      "roughness": 0.22,
+      "clearcoat": 0.6
+    },
+    "mat-30": {
+      "hue": 0.5950000000000001,
+      "sat": 0.7,
+      "value": 0.71,
+      "kind": "normal",
+      "roughness": 0.3,
+      "clearcoat": 0.45
+    },
+    "mat-31": {
+      "hue": 0.64,
+      "sat": 0.78,
+      "value": 0.57,
+      "kind": "normal",
+      "roughness": 0.3,
+      "clearcoat": 0.45
+    },
+    "mat-32": {
+      "hue": 0.62,
+      "sat": 0.3,
+      "value": 0.22,
+      "kind": "normal",
+      "roughness": 0.4,
+      "clearcoat": 0.3
+    },
+    "mat-33": {
+      "hue": 0.6,
+      "sat": 0.1,
+      "value": 0.3,
+      "kind": "normal",
+      "roughness": 0.7,
+      "clearcoat": 0.1
+    },
+    "mat-34": {
+      "hue": 0.57,
+      "sat": 0.55,
+      "value": 0.72,
+      "kind": "normal",
+      "roughness": 0.3,
+      "clearcoat": 0.45
+    },
+    "mat-35": {
+      "hue": 0.62,
+      "sat": 0.25,
+      "value": 0.14,
+      "metal": 0,
+      "glow": 0,
+      "kind": "normal",
+      "roughness": 0.5,
+      "clearcoat": 0.35
+    }
+  },
   "subjects": [
     {
       "id": "s0-mono-title",
@@ -12,14 +431,8 @@
       "transform": {
         "translate": [0, 2.7, 31.70422816311423]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.1,
-        "kind": "normal",
-        "roughness": 0.48,
-        "clearcoat": 0.45
-      }
+      "material": "mat-0",
+      "collection": "station-0"
     },
     {
       "id": "s0-forest-0-l0",
@@ -32,14 +445,8 @@
         "translate": [-3.4, 4, 27.10422816311423],
         "rotate": [0, -0.12, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.1,
-        "kind": "normal",
-        "roughness": 0.48,
-        "clearcoat": 0.45
-      }
+      "material": "mat-0",
+      "collection": "station-0"
     },
     {
       "id": "s0-forest-0-l1",
@@ -52,14 +459,8 @@
         "translate": [-6.4, 4, 24.90422816311423],
         "rotate": [0, -0.2, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.1,
-        "kind": "normal",
-        "roughness": 0.48,
-        "clearcoat": 0.45
-      }
+      "material": "mat-0",
+      "collection": "station-0"
     },
     {
       "id": "s0-forest-0-r0",
@@ -72,14 +473,8 @@
         "translate": [3.4, 4, 27.10422816311423],
         "rotate": [0, 0.12, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.1,
-        "kind": "normal",
-        "roughness": 0.48,
-        "clearcoat": 0.45
-      }
+      "material": "mat-0",
+      "collection": "station-0"
     },
     {
       "id": "s0-forest-0-r1",
@@ -92,14 +487,8 @@
         "translate": [6.4, 4, 24.90422816311423],
         "rotate": [0, 0.2, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.1,
-        "kind": "normal",
-        "roughness": 0.48,
-        "clearcoat": 0.45
-      }
+      "material": "mat-0",
+      "collection": "station-0"
     },
     {
       "id": "s0-forest-1-l0",
@@ -112,14 +501,8 @@
         "translate": [-4.5, 5.75, 20.60422816311423],
         "rotate": [0, -0.12, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.1,
-        "kind": "normal",
-        "roughness": 0.48,
-        "clearcoat": 0.45
-      }
+      "material": "mat-0",
+      "collection": "station-0"
     },
     {
       "id": "s0-forest-1-l1",
@@ -132,14 +515,8 @@
         "translate": [-7.5, 5.75, 18.40422816311423],
         "rotate": [0, -0.2, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.1,
-        "kind": "normal",
-        "roughness": 0.48,
-        "clearcoat": 0.45
-      }
+      "material": "mat-0",
+      "collection": "station-0"
     },
     {
       "id": "s0-forest-1-r0",
@@ -152,14 +529,8 @@
         "translate": [4.5, 5.75, 20.60422816311423],
         "rotate": [0, 0.12, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.1,
-        "kind": "normal",
-        "roughness": 0.48,
-        "clearcoat": 0.45
-      }
+      "material": "mat-0",
+      "collection": "station-0"
     },
     {
       "id": "s0-forest-1-r1",
@@ -172,14 +543,8 @@
         "translate": [7.5, 5.75, 18.40422816311423],
         "rotate": [0, 0.2, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.1,
-        "kind": "normal",
-        "roughness": 0.48,
-        "clearcoat": 0.45
-      }
+      "material": "mat-0",
+      "collection": "station-0"
     },
     {
       "id": "s0-forest-2-l0",
@@ -192,14 +557,8 @@
         "translate": [-5.6, 7.5, 14.104228163114229],
         "rotate": [0, -0.12, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.1,
-        "kind": "normal",
-        "roughness": 0.48,
-        "clearcoat": 0.45
-      }
+      "material": "mat-0",
+      "collection": "station-0"
     },
     {
       "id": "s0-forest-2-l1",
@@ -212,14 +571,8 @@
         "translate": [-8.600000000000001, 7.5, 11.90422816311423],
         "rotate": [0, -0.2, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.1,
-        "kind": "normal",
-        "roughness": 0.48,
-        "clearcoat": 0.45
-      }
+      "material": "mat-0",
+      "collection": "station-0"
     },
     {
       "id": "s0-forest-2-r0",
@@ -232,14 +585,8 @@
         "translate": [5.6, 7.5, 14.104228163114229],
         "rotate": [0, 0.12, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.1,
-        "kind": "normal",
-        "roughness": 0.48,
-        "clearcoat": 0.45
-      }
+      "material": "mat-0",
+      "collection": "station-0"
     },
     {
       "id": "s0-forest-2-r1",
@@ -252,14 +599,8 @@
         "translate": [8.600000000000001, 7.5, 11.90422816311423],
         "rotate": [0, 0.2, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.1,
-        "kind": "normal",
-        "roughness": 0.48,
-        "clearcoat": 0.45
-      }
+      "material": "mat-0",
+      "collection": "station-0"
     },
     {
       "id": "s0-forest-3-l0",
@@ -272,14 +613,8 @@
         "translate": [-6.7, 9.25, 7.604228163114229],
         "rotate": [0, -0.12, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.1,
-        "kind": "normal",
-        "roughness": 0.48,
-        "clearcoat": 0.45
-      }
+      "material": "mat-0",
+      "collection": "station-0"
     },
     {
       "id": "s0-forest-3-l1",
@@ -292,14 +627,8 @@
         "translate": [-9.700000000000001, 9.25, 5.4042281631142295],
         "rotate": [0, -0.2, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.1,
-        "kind": "normal",
-        "roughness": 0.48,
-        "clearcoat": 0.45
-      }
+      "material": "mat-0",
+      "collection": "station-0"
     },
     {
       "id": "s0-forest-3-r0",
@@ -312,14 +641,8 @@
         "translate": [6.7, 9.25, 7.604228163114229],
         "rotate": [0, 0.12, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.1,
-        "kind": "normal",
-        "roughness": 0.48,
-        "clearcoat": 0.45
-      }
+      "material": "mat-0",
+      "collection": "station-0"
     },
     {
       "id": "s0-forest-3-r1",
@@ -332,14 +655,8 @@
         "translate": [9.700000000000001, 9.25, 5.4042281631142295],
         "rotate": [0, 0.2, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.1,
-        "kind": "normal",
-        "roughness": 0.48,
-        "clearcoat": 0.45
-      }
+      "material": "mat-0",
+      "collection": "station-0"
     },
     {
       "id": "s0-floater-0",
@@ -352,20 +669,14 @@
         "translate": [-6.5, 3.4, 27.10422816311423],
         "rotate": [0, -1, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.1,
-        "kind": "normal",
-        "roughness": 0.48,
-        "clearcoat": 0.45
-      },
+      "material": "mat-0",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "3.400 - 0.000 * smoothstep(0.00, 1.00, t) + 0.07 * sin(0.35 * t + 0.00)"
         }
-      ]
+      ],
+      "collection": "station-0"
     },
     {
       "id": "s0-floater-1",
@@ -378,20 +689,14 @@
         "translate": [4.8, 2.6, 25.60422816311423],
         "rotate": [0, -0.5, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.1,
-        "kind": "normal",
-        "roughness": 0.48,
-        "clearcoat": 0.45
-      },
+      "material": "mat-0",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "2.600 - 0.000 * smoothstep(0.00, 1.00, t) + 0.09 * sin(0.43 * t + 2.10)"
         }
-      ]
+      ],
+      "collection": "station-0"
     },
     {
       "id": "s0-floater-2",
@@ -404,20 +709,14 @@
         "translate": [-3.2, 4.6, 24.10422816311423],
         "rotate": [0, 0, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.1,
-        "kind": "normal",
-        "roughness": 0.48,
-        "clearcoat": 0.45
-      },
+      "material": "mat-0",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "4.600 - 0.000 * smoothstep(0.00, 1.00, t) + 0.11 * sin(0.51 * t + 4.20)"
         }
-      ]
+      ],
+      "collection": "station-0"
     },
     {
       "id": "s0-floater-3",
@@ -430,20 +729,14 @@
         "translate": [7.2, 4, 28.10422816311423],
         "rotate": [0, 0.5, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.1,
-        "kind": "normal",
-        "roughness": 0.48,
-        "clearcoat": 0.45
-      },
+      "material": "mat-0",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "4.000 - 0.000 * smoothstep(0.00, 1.00, t) + 0.13 * sin(0.59 * t + 0.02)"
         }
-      ]
+      ],
+      "collection": "station-0"
     },
     {
       "id": "s0-floater-4",
@@ -456,20 +749,14 @@
         "translate": [-9.5, 5.8, 21.10422816311423],
         "rotate": [0, 1, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.1,
-        "kind": "normal",
-        "roughness": 0.48,
-        "clearcoat": 0.45
-      },
+      "material": "mat-0",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "5.800 - 0.000 * smoothstep(0.00, 1.00, t) + 0.15 * sin(0.67 * t + 2.12)"
         }
-      ]
+      ],
+      "collection": "station-0"
     },
     {
       "id": "s0-floater-5",
@@ -482,20 +769,14 @@
         "translate": [10.5, 5.2, 23.10422816311423],
         "rotate": [0, 1.5, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.1,
-        "kind": "normal",
-        "roughness": 0.48,
-        "clearcoat": 0.45
-      },
+      "material": "mat-0",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "5.200 - 0.000 * smoothstep(0.00, 1.00, t) + 0.17 * sin(0.75 * t + 4.22)"
         }
-      ]
+      ],
+      "collection": "station-0"
     },
     {
       "id": "s0-floater-6",
@@ -508,20 +789,14 @@
         "translate": [2.2, 7, 19.10422816311423],
         "rotate": [0, 2, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.1,
-        "kind": "normal",
-        "roughness": 0.48,
-        "clearcoat": 0.45
-      },
+      "material": "mat-0",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "7.000 - 0.000 * smoothstep(0.00, 1.00, t) + 0.19 * sin(0.83 * t + 0.04)"
         }
-      ]
+      ],
+      "collection": "station-0"
     },
     {
       "id": "s0-floater-7",
@@ -534,20 +809,14 @@
         "translate": [-5.8, 6.4, 17.10422816311423],
         "rotate": [0, 2.5, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.1,
-        "kind": "normal",
-        "roughness": 0.48,
-        "clearcoat": 0.45
-      },
+      "material": "mat-0",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "6.400 - 0.000 * smoothstep(0.00, 1.00, t) + 0.21 * sin(0.91 * t + 2.14)"
         }
-      ]
+      ],
+      "collection": "station-0"
     },
     {
       "id": "s0-floater-8",
@@ -560,20 +829,14 @@
         "translate": [6.8, 2, 20.10422816311423],
         "rotate": [0, 3, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.1,
-        "kind": "normal",
-        "roughness": 0.48,
-        "clearcoat": 0.45
-      },
+      "material": "mat-0",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "2.000 - 0.000 * smoothstep(0.00, 1.00, t) + 0.23 * sin(0.99 * t + 4.24)"
         }
-      ]
+      ],
+      "collection": "station-0"
     },
     {
       "id": "path-0-1",
@@ -585,15 +848,8 @@
         "translate": [1.9230377400028875, 0.03, 32.630241930428475],
         "rotate": [0, 0.24166097335306091, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-0"
     },
     {
       "id": "path-0-2",
@@ -605,15 +861,8 @@
         "translate": [3.846075480005775, 0.03, 32.15625569774272],
         "rotate": [0, 0.24166097335306091, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-0"
     },
     {
       "id": "path-0-3",
@@ -625,15 +874,8 @@
         "translate": [5.769113220008663, 0.03, 31.68226946505696],
         "rotate": [0, 0.24166097335306091, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-0"
     },
     {
       "id": "path-0-4",
@@ -645,15 +887,8 @@
         "translate": [7.69215096001155, 0.03, 31.20828323237121],
         "rotate": [0, 0.24166097335306091, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-0"
     },
     {
       "id": "path-0-5",
@@ -665,15 +900,8 @@
         "translate": [9.615188700014437, 0.03, 30.734296999685455],
         "rotate": [0, 0.24166097335306091, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-0"
     },
     {
       "id": "path-0-6",
@@ -685,15 +913,8 @@
         "translate": [11.538226440017326, 0.03, 30.260310766999698],
         "rotate": [0, 0.24166097335306091, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-0"
     },
     {
       "id": "path-0-7",
@@ -705,15 +926,8 @@
         "translate": [13.461264180020212, 0.03, 29.78632453431394],
         "rotate": [0, 0.24166097335306091, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-0"
     },
     {
       "id": "s1-dome",
@@ -724,14 +938,8 @@
       "transform": {
         "translate": [15.3843019200231, 0, 28.11233830162819]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.1,
-        "kind": "normal",
-        "roughness": 0.4,
-        "clearcoat": 0.45
-      }
+      "material": "mat-2",
+      "collection": "station-1"
     },
     {
       "id": "s1-orb-0",
@@ -742,21 +950,14 @@
       "transform": {
         "translate": [18.872203663748312, 2.2, 28.758874246762467]
       },
-      "material": {
-        "hue": 0.995,
-        "sat": 0.85,
-        "value": 0.78,
-        "glow": 0.12,
-        "kind": "normal",
-        "roughness": 0.3,
-        "clearcoat": 0.5
-      },
+      "material": "mat-3",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "3.800 - 1.600 * smoothstep(9.45, 10.00, t) + 0.04 * sin(0.6 * t + -4.56)"
         }
-      ]
+      ],
+      "collection": "station-1"
     },
     {
       "id": "s1-orb-stem-0",
@@ -768,14 +969,8 @@
       "transform": {
         "translate": [18.872203663748312, 1.1, 28.758874246762467]
       },
-      "material": {
-        "hue": 0.995,
-        "sat": 0.15,
-        "value": 0.8,
-        "glow": 0.5,
-        "kind": "normal",
-        "roughness": 0.4
-      }
+      "material": "mat-4",
+      "collection": "station-1"
     },
     {
       "id": "s1-orb-1",
@@ -786,21 +981,14 @@
       "transform": {
         "translate": [17.734396370962664, 2.2, 29.120224727000448]
       },
-      "material": {
-        "hue": 0.11,
-        "sat": 0.78,
-        "value": 0.95,
-        "glow": 0.1,
-        "kind": "normal",
-        "roughness": 0.22,
-        "clearcoat": 0.6
-      },
+      "material": "mat-5",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "3.800 - 1.600 * smoothstep(10.45, 11.00, t) + 0.04 * sin(0.6 * t + -2.86)"
         }
-      ]
+      ],
+      "collection": "station-1"
     },
     {
       "id": "s1-orb-stem-1",
@@ -812,14 +1000,8 @@
       "transform": {
         "translate": [17.734396370962664, 1.1, 29.120224727000448]
       },
-      "material": {
-        "hue": 0.995,
-        "sat": 0.15,
-        "value": 0.8,
-        "glow": 0.5,
-        "kind": "normal",
-        "roughness": 0.4
-      }
+      "material": "mat-4",
+      "collection": "station-1"
     },
     {
       "id": "s1-orb-2",
@@ -830,21 +1012,14 @@
       "transform": {
         "translate": [16.212768808593452, 2.2, 29.316965976600347]
       },
-      "material": {
-        "hue": 0.995,
-        "sat": 0.85,
-        "value": 0.78,
-        "glow": 0.12,
-        "kind": "normal",
-        "roughness": 0.3,
-        "clearcoat": 0.5
-      },
+      "material": "mat-3",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "3.800 - 1.600 * smoothstep(11.45, 12.00, t) + 0.04 * sin(0.6 * t + -1.16)"
         }
-      ]
+      ],
+      "collection": "station-1"
     },
     {
       "id": "s1-orb-stem-2",
@@ -856,14 +1031,8 @@
       "transform": {
         "translate": [16.212768808593452, 1.1, 29.316965976600347]
       },
-      "material": {
-        "hue": 0.995,
-        "sat": 0.15,
-        "value": 0.8,
-        "glow": 0.5,
-        "kind": "normal",
-        "roughness": 0.4
-      }
+      "material": "mat-4",
+      "collection": "station-1"
     },
     {
       "id": "s1-orb-3",
@@ -874,21 +1043,14 @@
       "transform": {
         "translate": [14.555835031452748, 2.2, 29.316965976600347]
       },
-      "material": {
-        "hue": 0.995,
-        "sat": 0.85,
-        "value": 0.78,
-        "glow": 0.12,
-        "kind": "normal",
-        "roughness": 0.3,
-        "clearcoat": 0.5
-      },
+      "material": "mat-3",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "3.800 - 1.600 * smoothstep(12.45, 13.00, t) + 0.04 * sin(0.6 * t + 0.54)"
         }
-      ]
+      ],
+      "collection": "station-1"
     },
     {
       "id": "s1-orb-stem-3",
@@ -900,14 +1062,8 @@
       "transform": {
         "translate": [14.555835031452748, 1.1, 29.316965976600347]
       },
-      "material": {
-        "hue": 0.995,
-        "sat": 0.15,
-        "value": 0.8,
-        "glow": 0.5,
-        "kind": "normal",
-        "roughness": 0.4
-      }
+      "material": "mat-4",
+      "collection": "station-1"
     },
     {
       "id": "s1-orb-4",
@@ -918,21 +1074,14 @@
       "transform": {
         "translate": [13.034207469083537, 2.2, 29.12022472700045]
       },
-      "material": {
-        "hue": 0.995,
-        "sat": 0.85,
-        "value": 0.78,
-        "glow": 0.12,
-        "kind": "normal",
-        "roughness": 0.3,
-        "clearcoat": 0.5
-      },
+      "material": "mat-3",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "3.800 - 1.600 * smoothstep(13.45, 14.00, t) + 0.04 * sin(0.6 * t + -4.04)"
         }
-      ]
+      ],
+      "collection": "station-1"
     },
     {
       "id": "s1-orb-stem-4",
@@ -944,14 +1093,8 @@
       "transform": {
         "translate": [13.034207469083537, 1.1, 29.12022472700045]
       },
-      "material": {
-        "hue": 0.995,
-        "sat": 0.15,
-        "value": 0.8,
-        "glow": 0.5,
-        "kind": "normal",
-        "roughness": 0.4
-      }
+      "material": "mat-4",
+      "collection": "station-1"
     },
     {
       "id": "s1-orb-5",
@@ -962,21 +1105,14 @@
       "transform": {
         "translate": [11.896400176297888, 2.2, 28.758874246762467]
       },
-      "material": {
-        "hue": 0.995,
-        "sat": 0.85,
-        "value": 0.78,
-        "glow": 0.12,
-        "kind": "normal",
-        "roughness": 0.3,
-        "clearcoat": 0.5
-      },
+      "material": "mat-3",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "3.800 - 1.600 * smoothstep(14.45, 15.00, t) + 0.04 * sin(0.6 * t + -2.34)"
         }
-      ]
+      ],
+      "collection": "station-1"
     },
     {
       "id": "s1-orb-stem-5",
@@ -988,14 +1124,8 @@
       "transform": {
         "translate": [11.896400176297888, 1.1, 28.758874246762467]
       },
-      "material": {
-        "hue": 0.995,
-        "sat": 0.15,
-        "value": 0.8,
-        "glow": 0.5,
-        "kind": "normal",
-        "roughness": 0.4
-      }
+      "material": "mat-4",
+      "collection": "station-1"
     },
     {
       "id": "path-1-1",
@@ -1007,15 +1137,8 @@
         "translate": [16.866794888908387, 0.03, 27.9989641373259],
         "rotate": [0, 0.724982920059183, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-1"
     },
     {
       "id": "path-1-2",
@@ -1027,15 +1150,8 @@
         "translate": [18.349287857793676, 0.03, 26.68558997302361],
         "rotate": [0, 0.724982920059183, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-1"
     },
     {
       "id": "path-1-3",
@@ -1047,15 +1163,8 @@
         "translate": [19.831780826678965, 0.03, 25.37221580872132],
         "rotate": [0, 0.724982920059183, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-1"
     },
     {
       "id": "path-1-4",
@@ -1067,15 +1176,8 @@
         "translate": [21.31427379556425, 0.03, 24.058841644419033],
         "rotate": [0, 0.724982920059183, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-1"
     },
     {
       "id": "path-1-5",
@@ -1087,15 +1189,8 @@
         "translate": [22.79676676444954, 0.03, 22.745467480116744],
         "rotate": [0, 0.724982920059183, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-1"
     },
     {
       "id": "path-1-6",
@@ -1107,15 +1202,8 @@
         "translate": [24.279259733334825, 0.03, 21.43209331581446],
         "rotate": [0, 0.724982920059183, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-1"
     },
     {
       "id": "path-1-7",
@@ -1127,15 +1215,8 @@
         "translate": [25.761752702220114, 0.03, 20.11871915151217],
         "rotate": [0, 0.724982920059183, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-1"
     },
     {
       "id": "s2-plinth-0",
@@ -1146,14 +1227,8 @@
       "transform": {
         "translate": [30.419245671105404, 0.06, 18.80534498720988]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.1,
-        "value": 0.55,
-        "kind": "normal",
-        "roughness": 0.6,
-        "clearcoat": 0.1
-      }
+      "material": "mat-6",
+      "collection": "station-2"
     },
     {
       "id": "s2-mono-0",
@@ -1165,21 +1240,15 @@
       "transform": {
         "translate": [30.419245671105404, 0.9931034482758622, 18.80534498720988]
       },
-      "material": {
-        "hue": 0.55,
-        "sat": 0.62,
-        "value": 0.82,
-        "kind": "normal",
-        "roughness": 0.3,
-        "clearcoat": 0.45
-      },
+      "material": "mat-7",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "-1.293 + 2.286 * smoothstep(21.45, 22.05, t)"
         }
       ],
-      "pattern": "cracked"
+      "pattern": "cracked",
+      "collection": "station-2"
     },
     {
       "id": "s2-plinth-1",
@@ -1190,14 +1259,8 @@
       "transform": {
         "translate": [29.149245671105405, 0.06, 18.80534498720988]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.1,
-        "value": 0.55,
-        "kind": "normal",
-        "roughness": 0.6,
-        "clearcoat": 0.1
-      }
+      "material": "mat-6",
+      "collection": "station-2"
     },
     {
       "id": "s2-mono-1",
@@ -1209,21 +1272,15 @@
       "transform": {
         "translate": [29.149245671105405, 1.2413793103448276, 18.80534498720988]
       },
-      "material": {
-        "hue": 0.5680000000000001,
-        "sat": 0.648,
-        "value": 0.7759999999999999,
-        "kind": "normal",
-        "roughness": 0.3,
-        "clearcoat": 0.45
-      },
+      "material": "mat-8",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "-1.541 + 2.783 * smoothstep(22.55, 23.15, t)"
         }
       ],
-      "pattern": "cracked"
+      "pattern": "cracked",
+      "collection": "station-2"
     },
     {
       "id": "s2-plinth-2",
@@ -1234,14 +1291,8 @@
       "transform": {
         "translate": [27.879245671105405, 0.06, 18.80534498720988]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.1,
-        "value": 0.55,
-        "kind": "normal",
-        "roughness": 0.6,
-        "clearcoat": 0.1
-      }
+      "material": "mat-6",
+      "collection": "station-2"
     },
     {
       "id": "s2-mono-2",
@@ -1253,21 +1304,15 @@
       "transform": {
         "translate": [27.879245671105405, 1.6, 18.80534498720988]
       },
-      "material": {
-        "hue": 0.5860000000000001,
-        "sat": 0.676,
-        "value": 0.732,
-        "kind": "normal",
-        "roughness": 0.3,
-        "clearcoat": 0.45
-      },
+      "material": "mat-9",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "-1.900 + 3.500 * smoothstep(23.65, 24.25, t)"
         }
       ],
-      "pattern": "cracked"
+      "pattern": "cracked",
+      "collection": "station-2"
     },
     {
       "id": "s2-plinth-3",
@@ -1278,14 +1323,8 @@
       "transform": {
         "translate": [26.609245671105402, 0.06, 18.80534498720988]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.1,
-        "value": 0.55,
-        "kind": "normal",
-        "roughness": 0.6,
-        "clearcoat": 0.1
-      }
+      "material": "mat-6",
+      "collection": "station-2"
     },
     {
       "id": "s2-mono-3",
@@ -1297,21 +1336,15 @@
       "transform": {
         "translate": [26.609245671105402, 1.9034482758620692, 18.80534498720988]
       },
-      "material": {
-        "hue": 0.6040000000000001,
-        "sat": 0.704,
-        "value": 0.688,
-        "kind": "normal",
-        "roughness": 0.3,
-        "clearcoat": 0.45
-      },
+      "material": "mat-10",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "-2.203 + 4.107 * smoothstep(24.75, 25.35, t)"
         }
       ],
-      "pattern": "cracked"
+      "pattern": "cracked",
+      "collection": "station-2"
     },
     {
       "id": "s2-plinth-4",
@@ -1322,14 +1355,8 @@
       "transform": {
         "translate": [25.339245671105402, 0.06, 18.80534498720988]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.1,
-        "value": 0.55,
-        "kind": "normal",
-        "roughness": 0.6,
-        "clearcoat": 0.1
-      }
+      "material": "mat-6",
+      "collection": "station-2"
     },
     {
       "id": "s2-mono-4",
@@ -1341,21 +1368,15 @@
       "transform": {
         "translate": [25.339245671105402, 2.1517241379310343, 18.80534498720988]
       },
-      "material": {
-        "hue": 0.622,
-        "sat": 0.732,
-        "value": 0.6439999999999999,
-        "kind": "normal",
-        "roughness": 0.3,
-        "clearcoat": 0.45
-      },
+      "material": "mat-11",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "-2.452 + 4.603 * smoothstep(25.85, 26.45, t)"
         }
       ],
-      "pattern": "cracked"
+      "pattern": "cracked",
+      "collection": "station-2"
     },
     {
       "id": "s2-plinth-5",
@@ -1366,14 +1387,8 @@
       "transform": {
         "translate": [24.069245671105403, 0.06, 18.80534498720988]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.1,
-        "value": 0.55,
-        "kind": "normal",
-        "roughness": 0.6,
-        "clearcoat": 0.1
-      }
+      "material": "mat-6",
+      "collection": "station-2"
     },
     {
       "id": "s2-mono-5",
@@ -1385,22 +1400,14 @@
       "transform": {
         "translate": [24.069245671105403, 2.4, 18.80534498720988]
       },
-      "material": {
-        "hue": 0.11,
-        "sat": 0.78,
-        "value": 0.95,
-        "metal": 0,
-        "glow": 0.1,
-        "kind": "normal",
-        "roughness": 0.22,
-        "clearcoat": 0.6
-      },
+      "material": "mat-12",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "-2.700 + 5.100 * smoothstep(26.95, 27.55, t)"
         }
-      ]
+      ],
+      "collection": "station-2"
     },
     {
       "id": "s2-guard-l-0",
@@ -1412,14 +1419,8 @@
         "translate": [19.109245671105406, 1.1, 20.00534498720988],
         "rotate": [0, -0.3, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-13",
+      "collection": "station-2"
     },
     {
       "id": "s2-guard-r-0",
@@ -1431,14 +1432,8 @@
         "translate": [35.3792456711054, 1.1, 20.00534498720988],
         "rotate": [0, 0.3, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-13",
+      "collection": "station-2"
     },
     {
       "id": "s2-guard-l-1",
@@ -1450,14 +1445,8 @@
         "translate": [19.709245671105403, 1.75, 14.205344987209882],
         "rotate": [0, -0.3, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-13",
+      "collection": "station-2"
     },
     {
       "id": "s2-guard-r-1",
@@ -1469,14 +1458,8 @@
         "translate": [34.7792456711054, 1.75, 14.205344987209882],
         "rotate": [0, 0.3, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-13",
+      "collection": "station-2"
     },
     {
       "id": "s2-guard-l-2",
@@ -1488,14 +1471,8 @@
         "translate": [18.3092456711054, 2.4000000000000004, 12.005344987209881],
         "rotate": [0, -0.3, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-13",
+      "collection": "station-2"
     },
     {
       "id": "s2-guard-r-2",
@@ -1507,14 +1484,8 @@
         "translate": [36.179245671105406, 2.4000000000000004, 12.005344987209881],
         "rotate": [0, 0.3, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-13",
+      "collection": "station-2"
     },
     {
       "id": "path-2-1",
@@ -1526,15 +1497,8 @@
         "translate": [27.946572595678504, 0.03, 16.953461084458215],
         "rotate": [0, 1.208304866765305, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-2"
     },
     {
       "id": "path-2-2",
@@ -1546,15 +1510,8 @@
         "translate": [28.648899520251607, 0.03, 15.101577181706551],
         "rotate": [0, 1.208304866765305, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-2"
     },
     {
       "id": "path-2-3",
@@ -1566,15 +1523,8 @@
         "translate": [29.35122644482471, 0.03, 13.249693278954886],
         "rotate": [0, 1.208304866765305, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-2"
     },
     {
       "id": "path-2-4",
@@ -1586,15 +1536,8 @@
         "translate": [30.05355336939781, 0.03, 11.39780937620322],
         "rotate": [0, 1.208304866765305, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-2"
     },
     {
       "id": "path-2-5",
@@ -1606,15 +1549,8 @@
         "translate": [30.75588029397091, 0.03, 9.545925473451554],
         "rotate": [0, 1.208304866765305, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-2"
     },
     {
       "id": "path-2-6",
@@ -1626,15 +1562,8 @@
         "translate": [31.458207218544015, 0.03, 7.6940415706998895],
         "rotate": [0, 1.208304866765305, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-2"
     },
     {
       "id": "path-2-7",
@@ -1646,15 +1575,8 @@
         "translate": [32.16053414311712, 0.03, 5.842157667948225],
         "rotate": [0, 1.208304866765305, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-2"
     },
     {
       "id": "s3-plinth-0",
@@ -1665,14 +1587,8 @@
       "transform": {
         "translate": [36.037861067690216, 0.06, 3.9902737651965587]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.1,
-        "value": 0.55,
-        "kind": "normal",
-        "roughness": 0.6,
-        "clearcoat": 0.1
-      }
+      "material": "mat-6",
+      "collection": "station-3"
     },
     {
       "id": "s3-mono-0",
@@ -1684,21 +1600,15 @@
       "transform": {
         "translate": [36.037861067690216, 0.14464710547184773, 3.9902737651965587]
       },
-      "material": {
-        "hue": 0.55,
-        "sat": 0.62,
-        "value": 0.82,
-        "kind": "normal",
-        "roughness": 0.3,
-        "clearcoat": 0.45
-      },
+      "material": "mat-7",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "-0.445 + 0.589 * smoothstep(34.75, 35.35, t)"
         }
       ],
-      "pattern": "cracked"
+      "pattern": "cracked",
+      "collection": "station-3"
     },
     {
       "id": "s3-plinth-1",
@@ -1709,14 +1619,8 @@
       "transform": {
         "translate": [34.76786106769022, 0.06, 3.9902737651965587]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.1,
-        "value": 0.55,
-        "kind": "normal",
-        "roughness": 0.6,
-        "clearcoat": 0.1
-      }
+      "material": "mat-6",
+      "collection": "station-3"
     },
     {
       "id": "s3-mono-1",
@@ -1728,21 +1632,15 @@
       "transform": {
         "translate": [34.76786106769022, 0.28263283108643933, 3.9902737651965587]
       },
-      "material": {
-        "hue": 0.5680000000000001,
-        "sat": 0.648,
-        "value": 0.7759999999999999,
-        "kind": "normal",
-        "roughness": 0.3,
-        "clearcoat": 0.45
-      },
+      "material": "mat-8",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "-0.583 + 0.865 * smoothstep(35.85, 36.45, t)"
         }
       ],
-      "pattern": "cracked"
+      "pattern": "cracked",
+      "collection": "station-3"
     },
     {
       "id": "s3-plinth-2",
@@ -1753,14 +1651,8 @@
       "transform": {
         "translate": [33.497861067690216, 0.06, 3.9902737651965587]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.1,
-        "value": 0.55,
-        "kind": "normal",
-        "roughness": 0.6,
-        "clearcoat": 0.1
-      }
+      "material": "mat-6",
+      "collection": "station-3"
     },
     {
       "id": "s3-mono-2",
@@ -1772,21 +1664,15 @@
       "transform": {
         "translate": [33.497861067690216, 0.5443298969072166, 3.9902737651965587]
       },
-      "material": {
-        "hue": 0.5860000000000001,
-        "sat": 0.676,
-        "value": 0.732,
-        "kind": "normal",
-        "roughness": 0.3,
-        "clearcoat": 0.45
-      },
+      "material": "mat-9",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "-0.844 + 1.389 * smoothstep(36.95, 37.55, t)"
         }
       ],
-      "pattern": "cracked"
+      "pattern": "cracked",
+      "collection": "station-3"
     },
     {
       "id": "s3-plinth-3",
@@ -1797,14 +1683,8 @@
       "transform": {
         "translate": [32.22786106769022, 0.06, 3.9902737651965587]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.1,
-        "value": 0.55,
-        "kind": "normal",
-        "roughness": 0.6,
-        "clearcoat": 0.1
-      }
+      "material": "mat-6",
+      "collection": "station-3"
     },
     {
       "id": "s3-mono-3",
@@ -1816,21 +1696,15 @@
       "transform": {
         "translate": [32.22786106769022, 0.9601903251387788, 3.9902737651965587]
       },
-      "material": {
-        "hue": 0.6040000000000001,
-        "sat": 0.704,
-        "value": 0.688,
-        "kind": "normal",
-        "roughness": 0.3,
-        "clearcoat": 0.45
-      },
+      "material": "mat-10",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "-1.260 + 2.220 * smoothstep(38.05, 38.65, t)"
         }
       ],
-      "pattern": "cracked"
+      "pattern": "cracked",
+      "collection": "station-3"
     },
     {
       "id": "s3-plinth-4",
@@ -1841,14 +1715,8 @@
       "transform": {
         "translate": [30.957861067690217, 0.06, 3.9902737651965587]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.1,
-        "value": 0.55,
-        "kind": "normal",
-        "roughness": 0.6,
-        "clearcoat": 0.1
-      }
+      "material": "mat-6",
+      "collection": "station-3"
     },
     {
       "id": "s3-mono-4",
@@ -1860,21 +1728,15 @@
       "transform": {
         "translate": [30.957861067690217, 1.5501982553528946, 3.9902737651965587]
       },
-      "material": {
-        "hue": 0.622,
-        "sat": 0.732,
-        "value": 0.6439999999999999,
-        "kind": "normal",
-        "roughness": 0.3,
-        "clearcoat": 0.45
-      },
+      "material": "mat-11",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "-1.850 + 3.400 * smoothstep(39.15, 39.75, t)"
         }
       ],
-      "pattern": "cracked"
+      "pattern": "cracked",
+      "collection": "station-3"
     },
     {
       "id": "s3-plinth-5",
@@ -1885,14 +1747,8 @@
       "transform": {
         "translate": [29.687861067690218, 0.06, 3.9902737651965587]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.1,
-        "value": 0.55,
-        "kind": "normal",
-        "roughness": 0.6,
-        "clearcoat": 0.1
-      }
+      "material": "mat-6",
+      "collection": "station-3"
     },
     {
       "id": "s3-mono-5",
@@ -1904,22 +1760,14 @@
       "transform": {
         "translate": [29.687861067690218, 2.4, 3.9902737651965587]
       },
-      "material": {
-        "hue": 0.11,
-        "sat": 0.78,
-        "value": 0.95,
-        "metal": 0,
-        "glow": 0.1,
-        "kind": "normal",
-        "roughness": 0.22,
-        "clearcoat": 0.6
-      },
+      "material": "mat-12",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "-2.700 + 5.100 * smoothstep(40.25, 40.85, t)"
         }
-      ]
+      ],
+      "collection": "station-3"
     },
     {
       "id": "s3-guard-l-0",
@@ -1931,14 +1779,8 @@
         "translate": [24.72786106769022, 1.1, 5.190273765196559],
         "rotate": [0, -0.3, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-13",
+      "collection": "station-3"
     },
     {
       "id": "s3-guard-r-0",
@@ -1950,14 +1792,8 @@
         "translate": [40.997861067690216, 1.1, 5.190273765196559],
         "rotate": [0, 0.3, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-13",
+      "collection": "station-3"
     },
     {
       "id": "s3-guard-l-1",
@@ -1969,14 +1805,8 @@
         "translate": [25.32786106769022, 1.75, -0.6097262348034409],
         "rotate": [0, -0.3, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-13",
+      "collection": "station-3"
     },
     {
       "id": "s3-guard-r-1",
@@ -1988,14 +1818,8 @@
         "translate": [40.397861067690215, 1.75, -0.6097262348034409],
         "rotate": [0, 0.3, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-13",
+      "collection": "station-3"
     },
     {
       "id": "s3-guard-l-2",
@@ -2007,14 +1831,8 @@
         "translate": [23.927861067690216, 2.4000000000000004, -2.809726234803442],
         "rotate": [0, -0.3, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-13",
+      "collection": "station-3"
     },
     {
       "id": "s3-guard-r-2",
@@ -2026,14 +1844,8 @@
         "translate": [41.79786106769022, 2.4000000000000004, -2.809726234803442],
         "rotate": [0, 0.3, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-13",
+      "collection": "station-3"
     },
     {
       "id": "path-3-1",
@@ -2045,15 +1857,8 @@
         "translate": [32.62412731348841, 0.03, 2.0241244084955587],
         "rotate": [0, 1.6916268134714274, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-3"
     },
     {
       "id": "path-3-2",
@@ -2065,15 +1870,8 @@
         "translate": [32.385393559286605, 0.03, 0.05797505179455875],
         "rotate": [0, 1.6916268134714274, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-3"
     },
     {
       "id": "path-3-3",
@@ -2085,15 +1883,8 @@
         "translate": [32.146659805084795, 0.03, -1.9081743049064412],
         "rotate": [0, 1.6916268134714274, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-3"
     },
     {
       "id": "path-3-4",
@@ -2105,15 +1896,8 @@
         "translate": [31.90792605088299, 0.03, -3.8743236616074412],
         "rotate": [0, 1.6916268134714274, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-3"
     },
     {
       "id": "path-3-5",
@@ -2125,15 +1909,8 @@
         "translate": [31.66919229668118, 0.03, -5.84047301830844],
         "rotate": [0, 1.6916268134714274, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-3"
     },
     {
       "id": "path-3-6",
@@ -2145,15 +1922,8 @@
         "translate": [31.43045854247937, 0.03, -7.806622375009441],
         "rotate": [0, 1.6916268134714274, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-3"
     },
     {
       "id": "path-3-7",
@@ -2165,15 +1935,8 @@
         "translate": [31.191724788277565, 0.03, -9.772771731710442],
         "rotate": [0, 1.6916268134714274, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-3"
     },
     {
       "id": "s4-plinth-0",
@@ -2184,14 +1947,8 @@
       "transform": {
         "translate": [34.127991034075755, 0.06, -11.738921088411441]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.1,
-        "value": 0.55,
-        "kind": "normal",
-        "roughness": 0.6,
-        "clearcoat": 0.1
-      }
+      "material": "mat-6",
+      "collection": "station-4"
     },
     {
       "id": "s4-mono-0",
@@ -2203,22 +1960,14 @@
       "transform": {
         "translate": [34.127991034075755, 2.4, -11.738921088411441]
       },
-      "material": {
-        "hue": 0.11,
-        "sat": 0.78,
-        "value": 0.95,
-        "metal": 0,
-        "glow": 0.1,
-        "kind": "normal",
-        "roughness": 0.22,
-        "clearcoat": 0.6
-      },
+      "material": "mat-12",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "-2.700 + 5.100 * smoothstep(48.05, 48.65, t)"
         }
-      ]
+      ],
+      "collection": "station-4"
     },
     {
       "id": "s4-plinth-1",
@@ -2229,14 +1978,8 @@
       "transform": {
         "translate": [32.85799103407576, 0.06, -11.738921088411441]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.1,
-        "value": 0.55,
-        "kind": "normal",
-        "roughness": 0.6,
-        "clearcoat": 0.1
-      }
+      "material": "mat-6",
+      "collection": "station-4"
     },
     {
       "id": "s4-mono-1",
@@ -2248,21 +1991,15 @@
       "transform": {
         "translate": [32.85799103407576, 2.2374501992031868, -11.738921088411441]
       },
-      "material": {
-        "hue": 0.5680000000000001,
-        "sat": 0.648,
-        "value": 0.7759999999999999,
-        "kind": "normal",
-        "roughness": 0.3,
-        "clearcoat": 0.45
-      },
+      "material": "mat-8",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "-2.537 + 4.775 * smoothstep(49.15, 49.75, t)"
         }
       ],
-      "pattern": "cracked"
+      "pattern": "cracked",
+      "collection": "station-4"
     },
     {
       "id": "s4-plinth-2",
@@ -2273,14 +2010,8 @@
       "transform": {
         "translate": [31.58799103407576, 0.06, -11.738921088411441]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.1,
-        "value": 0.55,
-        "kind": "normal",
-        "roughness": 0.6,
-        "clearcoat": 0.1
-      }
+      "material": "mat-6",
+      "collection": "station-4"
     },
     {
       "id": "s4-mono-2",
@@ -2292,21 +2023,15 @@
       "transform": {
         "translate": [31.58799103407576, 1.4151394422310757, -11.738921088411441]
       },
-      "material": {
-        "hue": 0.5860000000000001,
-        "sat": 0.676,
-        "value": 0.732,
-        "kind": "normal",
-        "roughness": 0.3,
-        "clearcoat": 0.45
-      },
+      "material": "mat-9",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "-1.715 + 3.130 * smoothstep(50.25, 50.85, t)"
         }
       ],
-      "pattern": "cracked"
+      "pattern": "cracked",
+      "collection": "station-4"
     },
     {
       "id": "s4-plinth-3",
@@ -2317,14 +2042,8 @@
       "transform": {
         "translate": [30.317991034075757, 0.06, -11.738921088411441]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.1,
-        "value": 0.55,
-        "kind": "normal",
-        "roughness": 0.6,
-        "clearcoat": 0.1
-      }
+      "material": "mat-6",
+      "collection": "station-4"
     },
     {
       "id": "s4-mono-3",
@@ -2336,21 +2055,15 @@
       "transform": {
         "translate": [30.317991034075757, 1.2430278884462151, -11.738921088411441]
       },
-      "material": {
-        "hue": 0.6040000000000001,
-        "sat": 0.704,
-        "value": 0.688,
-        "kind": "normal",
-        "roughness": 0.3,
-        "clearcoat": 0.45
-      },
+      "material": "mat-10",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "-1.543 + 2.786 * smoothstep(51.35, 51.95, t)"
         }
       ],
-      "pattern": "cracked"
+      "pattern": "cracked",
+      "collection": "station-4"
     },
     {
       "id": "s4-plinth-4",
@@ -2361,14 +2074,8 @@
       "transform": {
         "translate": [29.047991034075757, 0.06, -11.738921088411441]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.1,
-        "value": 0.55,
-        "kind": "normal",
-        "roughness": 0.6,
-        "clearcoat": 0.1
-      }
+      "material": "mat-6",
+      "collection": "station-4"
     },
     {
       "id": "s4-mono-4",
@@ -2380,21 +2087,15 @@
       "transform": {
         "translate": [29.047991034075757, 0.7362549800796813, -11.738921088411441]
       },
-      "material": {
-        "hue": 0.622,
-        "sat": 0.732,
-        "value": 0.6439999999999999,
-        "kind": "normal",
-        "roughness": 0.3,
-        "clearcoat": 0.45
-      },
+      "material": "mat-11",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "-1.036 + 1.773 * smoothstep(52.45, 53.05, t)"
         }
       ],
-      "pattern": "cracked"
+      "pattern": "cracked",
+      "collection": "station-4"
     },
     {
       "id": "s4-plinth-5",
@@ -2405,14 +2106,8 @@
       "transform": {
         "translate": [27.777991034075757, 0.06, -11.738921088411441]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.1,
-        "value": 0.55,
-        "kind": "normal",
-        "roughness": 0.6,
-        "clearcoat": 0.1
-      }
+      "material": "mat-6",
+      "collection": "station-4"
     },
     {
       "id": "s4-mono-5",
@@ -2424,21 +2119,15 @@
       "transform": {
         "translate": [27.777991034075757, 0.6501992031872509, -11.738921088411441]
       },
-      "material": {
-        "hue": 0.64,
-        "sat": 0.76,
-        "value": 0.6,
-        "kind": "normal",
-        "roughness": 0.3,
-        "clearcoat": 0.45
-      },
+      "material": "mat-14",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "-0.950 + 1.600 * smoothstep(53.55, 54.15, t)"
         }
       ],
-      "pattern": "cracked"
+      "pattern": "cracked",
+      "collection": "station-4"
     },
     {
       "id": "s4-guard-l-0",
@@ -2450,14 +2139,8 @@
         "translate": [22.81799103407576, 1.1, -10.538921088411442],
         "rotate": [0, -0.3, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-13",
+      "collection": "station-4"
     },
     {
       "id": "s4-guard-r-0",
@@ -2469,14 +2152,8 @@
         "translate": [39.087991034075756, 1.1, -10.538921088411442],
         "rotate": [0, 0.3, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-13",
+      "collection": "station-4"
     },
     {
       "id": "s4-guard-l-1",
@@ -2488,14 +2165,8 @@
         "translate": [23.417991034075758, 1.75, -16.33892108841144],
         "rotate": [0, -0.3, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-13",
+      "collection": "station-4"
     },
     {
       "id": "s4-guard-r-1",
@@ -2507,14 +2178,8 @@
         "translate": [38.48799103407576, 1.75, -16.33892108841144],
         "rotate": [0, 0.3, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-13",
+      "collection": "station-4"
     },
     {
       "id": "s4-guard-l-2",
@@ -2526,14 +2191,8 @@
         "translate": [22.017991034075756, 2.4000000000000004, -18.538921088411442],
         "rotate": [0, -0.3, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-13",
+      "collection": "station-4"
     },
     {
       "id": "s4-guard-r-2",
@@ -2545,14 +2204,8 @@
         "translate": [39.88799103407576, 2.4000000000000004, -18.538921088411442],
         "rotate": [0, 0.3, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-13",
+      "collection": "station-4"
     },
     {
       "id": "path-4-1",
@@ -2564,15 +2217,8 @@
         "translate": [29.82788762713305, 0.03, -13.368914776109944],
         "rotate": [0, 2.174948760177549, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-4"
     },
     {
       "id": "path-4-2",
@@ -2584,15 +2230,8 @@
         "translate": [28.702784220190345, 0.03, -14.998908463808448],
         "rotate": [0, 2.174948760177549, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-4"
     },
     {
       "id": "path-4-3",
@@ -2604,15 +2243,8 @@
         "translate": [27.57768081324764, 0.03, -16.628902151506953],
         "rotate": [0, 2.174948760177549, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-4"
     },
     {
       "id": "path-4-4",
@@ -2624,15 +2256,8 @@
         "translate": [26.452577406304933, 0.03, -18.258895839205458],
         "rotate": [0, 2.174948760177549, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-4"
     },
     {
       "id": "path-4-5",
@@ -2644,15 +2269,8 @@
         "translate": [25.327473999362226, 0.03, -19.88888952690396],
         "rotate": [0, 2.174948760177549, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-4"
     },
     {
       "id": "path-4-6",
@@ -2664,15 +2282,8 @@
         "translate": [24.202370592419516, 0.03, -21.518883214602464],
         "rotate": [0, 2.174948760177549, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-4"
     },
     {
       "id": "path-4-7",
@@ -2684,15 +2295,8 @@
         "translate": [23.07726718547681, 0.03, -23.14887690230097],
         "rotate": [0, 2.174948760177549, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-4"
     },
     {
       "id": "s5-plinth-0",
@@ -2703,14 +2307,8 @@
       "transform": {
         "translate": [25.127163778534104, 0.06, -24.77887058999947]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.1,
-        "value": 0.55,
-        "kind": "normal",
-        "roughness": 0.6,
-        "clearcoat": 0.1
-      }
+      "material": "mat-6",
+      "collection": "station-5"
     },
     {
       "id": "s5-mono-0",
@@ -2722,22 +2320,14 @@
       "transform": {
         "translate": [25.127163778534104, 2.4, -24.77887058999947]
       },
-      "material": {
-        "hue": 0.11,
-        "sat": 0.78,
-        "value": 0.95,
-        "metal": 0,
-        "glow": 0.1,
-        "kind": "normal",
-        "roughness": 0.22,
-        "clearcoat": 0.6
-      },
+      "material": "mat-12",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "-2.700 + 5.100 * smoothstep(61.35, 61.95, t)"
         }
-      ]
+      ],
+      "collection": "station-5"
     },
     {
       "id": "s5-plinth-1",
@@ -2748,14 +2338,8 @@
       "transform": {
         "translate": [23.857163778534105, 0.06, -24.77887058999947]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.1,
-        "value": 0.55,
-        "kind": "normal",
-        "roughness": 0.6,
-        "clearcoat": 0.1
-      }
+      "material": "mat-6",
+      "collection": "station-5"
     },
     {
       "id": "s5-mono-1",
@@ -2767,21 +2351,15 @@
       "transform": {
         "translate": [23.857163778534105, 2.2072538860103625, -24.77887058999947]
       },
-      "material": {
-        "hue": 0.5680000000000001,
-        "sat": 0.648,
-        "value": 0.7759999999999999,
-        "kind": "normal",
-        "roughness": 0.3,
-        "clearcoat": 0.45
-      },
+      "material": "mat-8",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "-2.507 + 4.715 * smoothstep(62.45, 63.05, t)"
         }
       ],
-      "pattern": "cracked"
+      "pattern": "cracked",
+      "collection": "station-5"
     },
     {
       "id": "s5-plinth-2",
@@ -2792,14 +2370,8 @@
       "transform": {
         "translate": [22.587163778534105, 0.06, -24.77887058999947]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.1,
-        "value": 0.55,
-        "kind": "normal",
-        "roughness": 0.6,
-        "clearcoat": 0.1
-      }
+      "material": "mat-6",
+      "collection": "station-5"
     },
     {
       "id": "s5-mono-2",
@@ -2811,21 +2383,15 @@
       "transform": {
         "translate": [22.587163778534105, 1.5015544041450775, -24.77887058999947]
       },
-      "material": {
-        "hue": 0.5860000000000001,
-        "sat": 0.676,
-        "value": 0.732,
-        "kind": "normal",
-        "roughness": 0.3,
-        "clearcoat": 0.45
-      },
+      "material": "mat-9",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "-1.802 + 3.303 * smoothstep(63.55, 64.15, t)"
         }
       ],
-      "pattern": "cracked"
+      "pattern": "cracked",
+      "collection": "station-5"
     },
     {
       "id": "s5-plinth-3",
@@ -2836,14 +2402,8 @@
       "transform": {
         "translate": [21.317163778534102, 0.06, -24.77887058999947]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.1,
-        "value": 0.55,
-        "kind": "normal",
-        "roughness": 0.6,
-        "clearcoat": 0.1
-      }
+      "material": "mat-6",
+      "collection": "station-5"
     },
     {
       "id": "s5-mono-3",
@@ -2855,21 +2415,15 @@
       "transform": {
         "translate": [21.317163778534102, 1.2590673575129532, -24.77887058999947]
       },
-      "material": {
-        "hue": 0.6040000000000001,
-        "sat": 0.704,
-        "value": 0.688,
-        "kind": "normal",
-        "roughness": 0.3,
-        "clearcoat": 0.45
-      },
+      "material": "mat-10",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "-1.559 + 2.818 * smoothstep(64.65, 65.25, t)"
         }
       ],
-      "pattern": "cracked"
+      "pattern": "cracked",
+      "collection": "station-5"
     },
     {
       "id": "s5-plinth-4",
@@ -2880,14 +2434,8 @@
       "transform": {
         "translate": [20.047163778534102, 0.06, -24.77887058999947]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.1,
-        "value": 0.55,
-        "kind": "normal",
-        "roughness": 0.6,
-        "clearcoat": 0.1
-      }
+      "material": "mat-6",
+      "collection": "station-5"
     },
     {
       "id": "s5-mono-4",
@@ -2899,21 +2447,15 @@
       "transform": {
         "translate": [20.047163778534102, 1.0290155440414508, -24.77887058999947]
       },
-      "material": {
-        "hue": 0.622,
-        "sat": 0.732,
-        "value": 0.6439999999999999,
-        "kind": "normal",
-        "roughness": 0.3,
-        "clearcoat": 0.45
-      },
+      "material": "mat-11",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "-1.329 + 2.358 * smoothstep(65.75, 66.35, t)"
         }
       ],
-      "pattern": "cracked"
+      "pattern": "cracked",
+      "collection": "station-5"
     },
     {
       "id": "s5-plinth-5",
@@ -2924,14 +2466,8 @@
       "transform": {
         "translate": [18.777163778534103, 0.06, -24.77887058999947]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.1,
-        "value": 0.55,
-        "kind": "normal",
-        "roughness": 0.6,
-        "clearcoat": 0.1
-      }
+      "material": "mat-6",
+      "collection": "station-5"
     },
     {
       "id": "s5-mono-5",
@@ -2943,21 +2479,15 @@
       "transform": {
         "translate": [18.777163778534103, 0.9699481865284973, -24.77887058999947]
       },
-      "material": {
-        "hue": 0.64,
-        "sat": 0.76,
-        "value": 0.6,
-        "kind": "normal",
-        "roughness": 0.3,
-        "clearcoat": 0.45
-      },
+      "material": "mat-14",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "-1.270 + 2.240 * smoothstep(66.85, 67.45, t)"
         }
       ],
-      "pattern": "cracked"
+      "pattern": "cracked",
+      "collection": "station-5"
     },
     {
       "id": "s5-guard-l-0",
@@ -2969,14 +2499,8 @@
         "translate": [13.817163778534104, 1.1, -23.57887058999947],
         "rotate": [0, -0.3, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-13",
+      "collection": "station-5"
     },
     {
       "id": "s5-guard-r-0",
@@ -2988,14 +2512,8 @@
         "translate": [30.087163778534105, 1.1, -23.57887058999947],
         "rotate": [0, 0.3, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-13",
+      "collection": "station-5"
     },
     {
       "id": "s5-guard-l-1",
@@ -3007,14 +2525,8 @@
         "translate": [14.417163778534103, 1.75, -29.378870589999472],
         "rotate": [0, -0.3, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-13",
+      "collection": "station-5"
     },
     {
       "id": "s5-guard-r-1",
@@ -3026,14 +2538,8 @@
         "translate": [29.487163778534104, 1.75, -29.378870589999472],
         "rotate": [0, 0.3, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-13",
+      "collection": "station-5"
     },
     {
       "id": "s5-guard-l-2",
@@ -3045,14 +2551,8 @@
         "translate": [13.017163778534103, 2.4000000000000004, -31.57887058999947],
         "rotate": [0, -0.3, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-13",
+      "collection": "station-5"
     },
     {
       "id": "s5-guard-r-2",
@@ -3064,14 +2564,8 @@
         "translate": [30.887163778534102, 2.4000000000000004, -31.57887058999947],
         "rotate": [0, 0.3, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-13",
+      "collection": "station-5"
     },
     {
       "id": "path-5-1",
@@ -3083,15 +2577,8 @@
         "translate": [20.19843835041516, 0.03, -25.69929669839714],
         "rotate": [0, 2.6582707068836715, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-5"
     },
     {
       "id": "path-5-2",
@@ -3103,15 +2590,8 @@
         "translate": [18.44471292229622, 0.03, -26.61972280679481],
         "rotate": [0, 2.6582707068836715, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-5"
     },
     {
       "id": "path-5-3",
@@ -3123,15 +2603,8 @@
         "translate": [16.690987494177275, 0.03, -27.54014891519248],
         "rotate": [0, 2.6582707068836715, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-5"
     },
     {
       "id": "path-5-4",
@@ -3143,15 +2616,8 @@
         "translate": [14.93726206605833, 0.03, -28.46057502359015],
         "rotate": [0, 2.6582707068836715, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-5"
     },
     {
       "id": "path-5-5",
@@ -3163,15 +2629,8 @@
         "translate": [13.183536637939387, 0.03, -29.38100113198782],
         "rotate": [0, 2.6582707068836715, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-5"
     },
     {
       "id": "path-5-6",
@@ -3183,15 +2642,8 @@
         "translate": [11.429811209820445, 0.03, -30.301427240385486],
         "rotate": [0, 2.6582707068836715, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-5"
     },
     {
       "id": "path-5-7",
@@ -3203,15 +2655,8 @@
         "translate": [9.676085781701502, 0.03, -31.221853348783156],
         "rotate": [0, 2.6582707068836715, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-5"
     },
     {
       "id": "s6-past-0",
@@ -3223,14 +2668,8 @@
       "transform": {
         "translate": [11.322360353582557, 0.55, -32.14227945718083]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-13",
+      "collection": "station-6"
     },
     {
       "id": "s6-past-1",
@@ -3242,14 +2681,8 @@
       "transform": {
         "translate": [7.922360353582557, 0.55, -32.14227945718083]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-13",
+      "collection": "station-6"
     },
     {
       "id": "s6-past-2",
@@ -3261,14 +2694,8 @@
       "transform": {
         "translate": [4.522360353582558, 0.55, -32.14227945718083]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-13",
+      "collection": "station-6"
     },
     {
       "id": "s6-now-3",
@@ -3279,21 +2706,14 @@
       "transform": {
         "translate": [11.322360353582557, 3.6, -32.14227945718083]
       },
-      "material": {
-        "hue": 0.995,
-        "sat": 0.85,
-        "value": 0.78,
-        "glow": 0.24,
-        "kind": "normal",
-        "roughness": 0.3,
-        "clearcoat": 0.5
-      },
+      "material": "mat-15",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "1.100 + 2.500 * smoothstep(74.60, 75.40, t) + 0.06 * sin(0.5 * t + -36.50)"
         }
-      ]
+      ],
+      "collection": "station-6"
     },
     {
       "id": "s6-now-4",
@@ -3304,21 +2724,14 @@
       "transform": {
         "translate": [7.922360353582557, 3.6, -32.14227945718083]
       },
-      "material": {
-        "hue": 0.995,
-        "sat": 0.85,
-        "value": 0.78,
-        "glow": 0.12,
-        "kind": "normal",
-        "roughness": 0.3,
-        "clearcoat": 0.5
-      },
+      "material": "mat-3",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "1.100 + 2.500 * smoothstep(75.70, 76.50, t) + 0.06 * sin(0.5 * t + -34.40)"
         }
-      ]
+      ],
+      "collection": "station-6"
     },
     {
       "id": "s6-now-5",
@@ -3329,21 +2742,14 @@
       "transform": {
         "translate": [4.522360353582558, 3.6, -32.14227945718083]
       },
-      "material": {
-        "hue": 0.995,
-        "sat": 0.85,
-        "value": 0.78,
-        "glow": 0.12,
-        "kind": "normal",
-        "roughness": 0.3,
-        "clearcoat": 0.5
-      },
+      "material": "mat-3",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "1.100 + 2.500 * smoothstep(76.80, 77.60, t) + 0.06 * sin(0.5 * t + -32.30)"
         }
-      ]
+      ],
+      "collection": "station-6"
     },
     {
       "id": "s6-trail-0-0",
@@ -3355,14 +2761,8 @@
         "translate": [11.322360353582557, 1.5, -32.14227945718083],
         "rotate": [0, 0, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-13",
+      "collection": "station-6"
     },
     {
       "id": "s6-trail-0-1",
@@ -3374,14 +2774,8 @@
         "translate": [11.322360353582557, 2.2199999999999998, -32.14227945718083],
         "rotate": [0, 0.3, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-13",
+      "collection": "station-6"
     },
     {
       "id": "s6-trail-0-2",
@@ -3393,14 +2787,8 @@
         "translate": [11.322360353582557, 2.94, -32.14227945718083],
         "rotate": [0, 0.6, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-13",
+      "collection": "station-6"
     },
     {
       "id": "s6-trail-1-0",
@@ -3412,14 +2800,8 @@
         "translate": [7.922360353582557, 1.5, -32.14227945718083],
         "rotate": [0, 0, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-13",
+      "collection": "station-6"
     },
     {
       "id": "s6-trail-1-1",
@@ -3431,14 +2813,8 @@
         "translate": [7.922360353582557, 2.2199999999999998, -32.14227945718083],
         "rotate": [0, 0.3, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-13",
+      "collection": "station-6"
     },
     {
       "id": "s6-trail-1-2",
@@ -3450,14 +2826,8 @@
         "translate": [7.922360353582557, 2.94, -32.14227945718083],
         "rotate": [0, 0.6, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-13",
+      "collection": "station-6"
     },
     {
       "id": "s6-trail-2-0",
@@ -3469,14 +2839,8 @@
         "translate": [4.522360353582558, 1.5, -32.14227945718083],
         "rotate": [0, 0, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-13",
+      "collection": "station-6"
     },
     {
       "id": "s6-trail-2-1",
@@ -3488,14 +2852,8 @@
         "translate": [4.522360353582558, 2.2199999999999998, -32.14227945718083],
         "rotate": [0, 0.3, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-13",
+      "collection": "station-6"
     },
     {
       "id": "s6-trail-2-2",
@@ -3507,14 +2865,8 @@
         "translate": [4.522360353582558, 2.94, -32.14227945718083],
         "rotate": [0, 0.6, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-13",
+      "collection": "station-6"
     },
     {
       "id": "path-6-1",
@@ -3526,15 +2878,8 @@
         "translate": [5.9417702651869195, 0.03, -32.14227945718083],
         "rotate": [0, -3.141592653589793, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-6"
     },
     {
       "id": "path-6-2",
@@ -3546,15 +2891,8 @@
         "translate": [3.961180176791281, 0.03, -32.14227945718083],
         "rotate": [0, -3.141592653589793, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-6"
     },
     {
       "id": "path-6-3",
@@ -3566,15 +2904,8 @@
         "translate": [1.980590088395643, 0.03, -32.14227945718083],
         "rotate": [0, -3.141592653589793, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-6"
     },
     {
       "id": "path-6-4",
@@ -3586,15 +2917,8 @@
         "translate": [4.440892098500626e-15, 0.03, -32.14227945718083],
         "rotate": [0, -3.141592653589793, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-6"
     },
     {
       "id": "path-6-5",
@@ -3606,15 +2930,8 @@
         "translate": [-1.9805900883956342, 0.03, -32.14227945718083],
         "rotate": [0, -3.141592653589793, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-6"
     },
     {
       "id": "path-6-6",
@@ -3626,15 +2943,8 @@
         "translate": [-3.961180176791271, 0.03, -32.14227945718083],
         "rotate": [0, -3.141592653589793, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-6"
     },
     {
       "id": "path-6-7",
@@ -3646,15 +2956,8 @@
         "translate": [-5.94177026518691, 0.03, -32.14227945718083],
         "rotate": [0, -3.141592653589793, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-6"
     },
     {
       "id": "s7-net-node-0",
@@ -3665,22 +2968,14 @@
       "transform": {
         "translate": [-7.922360353582548, 3.5204111503539433, -32.14227945718083]
       },
-      "material": {
-        "hue": 0.11,
-        "sat": 0.78,
-        "value": 0.95,
-        "metal": 0,
-        "glow": 0.1,
-        "kind": "normal",
-        "roughness": 0.22,
-        "clearcoat": 0.6
-      },
+      "material": "mat-12",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "4.620 - 1.1 * smoothstep(82.55, 83.05, t) + 0.018 * sin(1.3 * t + -106.99)"
         }
-      ]
+      ],
+      "collection": "station-7"
     },
     {
       "id": "s7-net-node-1",
@@ -3691,20 +2986,14 @@
       "transform": {
         "translate": [-9.46866002058512, 5.980307652106461, -30.433571183795692]
       },
-      "material": {
-        "hue": 0.62875,
-        "sat": 0.76,
-        "value": 0.5875,
-        "kind": "normal",
-        "roughness": 0.55,
-        "clearcoat": 0.2
-      },
+      "material": "mat-16",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "7.080 - 1.1 * smoothstep(82.67, 83.17, t) + 0.018 * sin(1.3 * t + -104.89)"
         }
-      ]
+      ],
+      "collection": "station-7"
     },
     {
       "id": "s7-net-node-2",
@@ -3715,20 +3004,14 @@
       "transform": {
         "translate": [-7.630743092158022, 5.250904506397122, -35.02747564963739]
       },
-      "material": {
-        "hue": 0.62875,
-        "sat": 0.76,
-        "value": 0.5875,
-        "kind": "normal",
-        "roughness": 0.55,
-        "clearcoat": 0.2
-      },
+      "material": "mat-16",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "6.351 - 1.1 * smoothstep(82.79, 83.29, t) + 0.018 * sin(1.3 * t + -102.79)"
         }
-      ]
+      ],
+      "collection": "station-7"
     },
     {
       "id": "s7-net-node-3",
@@ -3739,20 +3022,14 @@
       "transform": {
         "translate": [-5.605858525250104, 4.3697567245487905, -29.772777034659796]
       },
-      "material": {
-        "hue": 0.62875,
-        "sat": 0.76,
-        "value": 0.5875,
-        "kind": "normal",
-        "roughness": 0.55,
-        "clearcoat": 0.2
-      },
+      "material": "mat-16",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "5.470 - 1.1 * smoothstep(82.91, 83.41, t) + 0.018 * sin(1.3 * t + -100.69)"
         }
-      ]
+      ],
+      "collection": "station-7"
     },
     {
       "id": "s7-net-node-4",
@@ -3763,20 +3040,14 @@
       "transform": {
         "translate": [-11.255243284772359, 3.6213578719444897, -32.71264160437445]
       },
-      "material": {
-        "hue": 0.62875,
-        "sat": 0.76,
-        "value": 0.5875,
-        "kind": "normal",
-        "roughness": 0.55,
-        "clearcoat": 0.2
-      },
+      "material": "mat-16",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "4.721 - 1.1 * smoothstep(83.03, 83.53, t) + 0.018 * sin(1.3 * t + -98.59)"
         }
-      ]
+      ],
+      "collection": "station-7"
     },
     {
       "id": "s7-net-node-5",
@@ -3787,20 +3058,14 @@
       "transform": {
         "translate": [-4.876074993937342, 2.9527771216598238, -33.586729814651825]
       },
-      "material": {
-        "hue": 0.62875,
-        "sat": 0.76,
-        "value": 0.5875,
-        "kind": "normal",
-        "roughness": 0.55,
-        "clearcoat": 0.2
-      },
+      "material": "mat-16",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "4.053 - 1.1 * smoothstep(83.15, 83.65, t) + 0.018 * sin(1.3 * t + -96.49)"
         }
-      ]
+      ],
+      "collection": "station-7"
     },
     {
       "id": "s7-net-node-6",
@@ -3811,20 +3076,14 @@
       "transform": {
         "translate": [-8.559001850099355, 1.819620731911172, -29.532499333980923]
       },
-      "material": {
-        "hue": 0.6175,
-        "sat": 0.74,
-        "value": 0.625,
-        "kind": "normal",
-        "roughness": 0.55,
-        "clearcoat": 0.2
-      },
+      "material": "mat-17",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "2.920 - 1.1 * smoothstep(83.27, 83.77, t) + 0.018 * sin(1.3 * t + -94.39)"
         }
-      ]
+      ],
+      "collection": "station-7"
     },
     {
       "id": "s7-net-node-7",
@@ -3835,20 +3094,14 @@
       "transform": {
         "translate": [-8.72246124037527, 1.2095751500786114, -34.13081591928006]
       },
-      "material": {
-        "hue": 0.6175,
-        "sat": 0.74,
-        "value": 0.625,
-        "kind": "normal",
-        "roughness": 0.55,
-        "clearcoat": 0.2
-      },
+      "material": "mat-17",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "2.310 - 1.1 * smoothstep(83.39, 83.89, t) + 0.018 * sin(1.3 * t + -92.29)"
         }
-      ]
+      ],
+      "collection": "station-7"
     },
     {
       "id": "s7-net-node-8",
@@ -3859,20 +3112,14 @@
       "transform": {
         "translate": [-7.797762717128511, 0.6000000000000001, -31.72761401996019]
       },
-      "material": {
-        "hue": 0.60625,
-        "sat": 0.72,
-        "value": 0.6625000000000001,
-        "kind": "normal",
-        "roughness": 0.55,
-        "clearcoat": 0.2
-      },
+      "material": "mat-18",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "1.700 - 1.1 * smoothstep(83.51, 84.01, t) + 0.018 * sin(1.3 * t + -90.19)"
         }
-      ]
+      ],
+      "collection": "station-7"
     },
     {
       "id": "s7-net-edge-0",
@@ -3885,21 +3132,14 @@
       "transform": {
         "translate": [-9.46866002058512, 5.980307652106461, -30.433571183795692]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.55,
-        "glow": 0.08,
-        "kind": "normal",
-        "roughness": 0.6,
-        "clearcoat": 0.15
-      },
+      "material": "mat-19",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "7.080 - 1.1 * smoothstep(83.83, 84.28, t)"
         }
-      ]
+      ],
+      "collection": "station-7"
     },
     {
       "id": "s7-net-edge-1",
@@ -3912,21 +3152,14 @@
       "transform": {
         "translate": [-7.630743092158022, 5.250904506397122, -35.02747564963739]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.55,
-        "glow": 0.08,
-        "kind": "normal",
-        "roughness": 0.6,
-        "clearcoat": 0.15
-      },
+      "material": "mat-19",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "6.351 - 1.1 * smoothstep(83.97, 84.42, t)"
         }
-      ]
+      ],
+      "collection": "station-7"
     },
     {
       "id": "s7-net-edge-2",
@@ -3939,21 +3172,14 @@
       "transform": {
         "translate": [-5.605858525250104, 4.3697567245487905, -29.772777034659796]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.55,
-        "glow": 0.08,
-        "kind": "normal",
-        "roughness": 0.6,
-        "clearcoat": 0.15
-      },
+      "material": "mat-19",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "5.470 - 1.1 * smoothstep(84.11, 84.56, t)"
         }
-      ]
+      ],
+      "collection": "station-7"
     },
     {
       "id": "s7-net-edge-3",
@@ -3966,21 +3192,14 @@
       "transform": {
         "translate": [-11.255243284772359, 3.6213578719444897, -32.71264160437445]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.55,
-        "glow": 0.08,
-        "kind": "normal",
-        "roughness": 0.6,
-        "clearcoat": 0.15
-      },
+      "material": "mat-19",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "4.721 - 1.1 * smoothstep(84.25, 84.70, t)"
         }
-      ]
+      ],
+      "collection": "station-7"
     },
     {
       "id": "s7-net-edge-4",
@@ -3993,21 +3212,14 @@
       "transform": {
         "translate": [-4.876074993937342, 2.9527771216598238, -33.586729814651825]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.55,
-        "glow": 0.08,
-        "kind": "normal",
-        "roughness": 0.6,
-        "clearcoat": 0.15
-      },
+      "material": "mat-19",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "4.053 - 1.1 * smoothstep(84.39, 84.84, t)"
         }
-      ]
+      ],
+      "collection": "station-7"
     },
     {
       "id": "s7-net-edge-5",
@@ -4020,21 +3232,14 @@
       "transform": {
         "translate": [-7.922360353582548, 3.5204111503539433, -32.14227945718083]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.55,
-        "glow": 0.08,
-        "kind": "normal",
-        "roughness": 0.6,
-        "clearcoat": 0.15
-      },
+      "material": "mat-19",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "4.620 - 1.1 * smoothstep(84.53, 84.98, t)"
         }
-      ]
+      ],
+      "collection": "station-7"
     },
     {
       "id": "s7-net-edge-6",
@@ -4047,21 +3252,14 @@
       "transform": {
         "translate": [-7.922360353582548, 3.5204111503539433, -32.14227945718083]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.55,
-        "glow": 0.08,
-        "kind": "normal",
-        "roughness": 0.6,
-        "clearcoat": 0.15
-      },
+      "material": "mat-19",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "4.620 - 1.1 * smoothstep(84.67, 85.12, t)"
         }
-      ]
+      ],
+      "collection": "station-7"
     },
     {
       "id": "s7-net-edge-7",
@@ -4074,21 +3272,14 @@
       "transform": {
         "translate": [-8.559001850099355, 1.819620731911172, -29.532499333980923]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.55,
-        "glow": 0.08,
-        "kind": "normal",
-        "roughness": 0.6,
-        "clearcoat": 0.15
-      },
+      "material": "mat-19",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "2.920 - 1.1 * smoothstep(84.81, 85.26, t)"
         }
-      ]
+      ],
+      "collection": "station-7"
     },
     {
       "id": "s7-net-edge-8",
@@ -4101,21 +3292,14 @@
       "transform": {
         "translate": [-8.72246124037527, 1.2095751500786114, -34.13081591928006]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.55,
-        "glow": 0.08,
-        "kind": "normal",
-        "roughness": 0.6,
-        "clearcoat": 0.15
-      },
+      "material": "mat-19",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "2.310 - 1.1 * smoothstep(84.95, 85.40, t)"
         }
-      ]
+      ],
+      "collection": "station-7"
     },
     {
       "id": "s7-net-edge-9",
@@ -4128,21 +3312,14 @@
       "transform": {
         "translate": [-7.797762717128511, 0.6000000000000001, -31.72761401996019]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.55,
-        "glow": 0.08,
-        "kind": "normal",
-        "roughness": 0.6,
-        "clearcoat": 0.15
-      },
+      "material": "mat-19",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "1.700 - 1.1 * smoothstep(85.09, 85.54, t)"
         }
-      ]
+      ],
+      "collection": "station-7"
     },
     {
       "id": "s7-dust-0",
@@ -4154,19 +3331,14 @@
         "translate": [-6.670485726215803, 4.405000000000001, -32.14227945718083],
         "rotate": [0, 0, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.2,
-        "value": 0.18,
-        "kind": "normal",
-        "roughness": 0.5
-      },
+      "material": "mat-20",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "4.405 - 0.000 * smoothstep(82.30, 83.30, t) + 0.05 * sin(0.30 * t + -24.69)"
         }
-      ]
+      ],
+      "collection": "station-7"
     },
     {
       "id": "s7-dust-1",
@@ -4178,19 +3350,14 @@
         "translate": [-7.36526820509052, 4.399558176477956, -34.40921184633588],
         "rotate": [0, 0.9, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.2,
-        "value": 0.18,
-        "kind": "normal",
-        "roughness": 0.5
-      },
+      "material": "mat-20",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "4.400 - 0.000 * smoothstep(82.30, 83.30, t) + 0.07 * sin(0.35 * t + -27.51)"
         }
-      ]
+      ],
+      "collection": "station-7"
     },
     {
       "id": "s7-dust-2",
@@ -4202,19 +3369,14 @@
         "translate": [-9.814244416221534, 3.629579332748476, -33.13189411614078],
         "rotate": [0, 1.8, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.2,
-        "value": 0.18,
-        "kind": "normal",
-        "roughness": 0.5
-      },
+      "material": "mat-20",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "3.630 - 0.000 * smoothstep(82.30, 83.30, t) + 0.09 * sin(0.40 * t + -30.32)"
         }
-      ]
+      ],
+      "collection": "station-7"
     },
     {
       "id": "s7-dust-3",
@@ -4226,19 +3388,14 @@
         "translate": [-10.5325007068057, 4.222504230305474, -29.183742287327053],
         "rotate": [0, 2.7, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.2,
-        "value": 0.18,
-        "kind": "normal",
-        "roughness": 0.5
-      },
+      "material": "mat-20",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "4.223 - 0.000 * smoothstep(82.30, 83.30, t) + 0.05 * sin(0.45 * t + -33.14)"
         }
-      ]
+      ],
+      "collection": "station-7"
     },
     {
       "id": "s7-dust-4",
@@ -4250,19 +3407,14 @@
         "translate": [-6.671370050619043, 3.0836452719433054, -30.340548603522052],
         "rotate": [0, 0.5, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.2,
-        "value": 0.18,
-        "kind": "normal",
-        "roughness": 0.5
-      },
+      "material": "mat-20",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "3.084 - 0.000 * smoothstep(82.30, 83.30, t) + 0.07 * sin(0.50 * t + -35.95)"
         }
-      ]
+      ],
+      "collection": "station-7"
     },
     {
       "id": "s7-dust-5",
@@ -4274,19 +3426,14 @@
         "translate": [-3.1650187805443633, 3.8177730524847187, -33.96527177358389],
         "rotate": [0, 1.4, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.2,
-        "value": 0.18,
-        "kind": "normal",
-        "roughness": 0.5
-      },
+      "material": "mat-20",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "3.818 - 0.000 * smoothstep(82.30, 83.30, t) + 0.09 * sin(0.30 * t + -24.47)"
         }
-      ]
+      ],
+      "collection": "station-7"
     },
     {
       "id": "s7-dust-6",
@@ -4298,19 +3445,14 @@
         "translate": [-8.196821594143072, 2.742972950909394, -34.32714975873451],
         "rotate": [0, 2.3000000000000003, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.2,
-        "value": 0.18,
-        "kind": "normal",
-        "roughness": 0.5
-      },
+      "material": "mat-20",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "2.743 - 0.000 * smoothstep(82.30, 83.30, t) + 0.05 * sin(0.35 * t + -27.29)"
         }
-      ]
+      ],
+      "collection": "station-7"
     },
     {
       "id": "s7-dust-7",
@@ -4322,19 +3464,14 @@
         "translate": [-13.560045647730163, 3.247721417838311, -32.799243243520465],
         "rotate": [0, 0.09999999999999964, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.2,
-        "value": 0.18,
-        "kind": "normal",
-        "roughness": 0.5
-      },
+      "material": "mat-20",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "3.248 - 0.000 * smoothstep(82.30, 83.30, t) + 0.07 * sin(0.40 * t + -30.10)"
         }
-      ]
+      ],
+      "collection": "station-7"
     },
     {
       "id": "s7-dust-8",
@@ -4346,19 +3483,14 @@
         "translate": [-8.778769864768181, 2.514577769081229, -29.846019008748215],
         "rotate": [0, 1, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.2,
-        "value": 0.18,
-        "kind": "normal",
-        "roughness": 0.5
-      },
+      "material": "mat-20",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "2.515 - 0.000 * smoothstep(82.30, 83.30, t) + 0.09 * sin(0.45 * t + -32.92)"
         }
-      ]
+      ],
+      "collection": "station-7"
     },
     {
       "id": "s7-dust-9",
@@ -4370,19 +3502,14 @@
         "translate": [-3.270108718962354, 2.626149955099641, -28.97347387202681],
         "rotate": [0, 1.8999999999999995, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.2,
-        "value": 0.18,
-        "kind": "normal",
-        "roughness": 0.5
-      },
+      "material": "mat-20",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "2.626 - 0.000 * smoothstep(82.30, 83.30, t) + 0.05 * sin(0.50 * t + -35.73)"
         }
-      ]
+      ],
+      "collection": "station-7"
     },
     {
       "id": "s7-dust-10",
@@ -4394,19 +3521,14 @@
         "translate": [-5.688837718399845, 2.2751364752104166, -34.14864375930722],
         "rotate": [0, 2.8, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.2,
-        "value": 0.18,
-        "kind": "normal",
-        "roughness": 0.5
-      },
+      "material": "mat-20",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "2.275 - 0.000 * smoothstep(82.30, 83.30, t) + 0.07 * sin(0.30 * t + -24.25)"
         }
-      ]
+      ],
+      "collection": "station-7"
     },
     {
       "id": "s7-dust-11",
@@ -4418,19 +3540,14 @@
         "translate": [-10.294780633272175, 2.074057518564027, -36.5804774119418],
         "rotate": [0, 0.6000000000000001, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.2,
-        "value": 0.18,
-        "kind": "normal",
-        "roughness": 0.5
-      },
+      "material": "mat-20",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "2.074 - 0.000 * smoothstep(82.30, 83.30, t) + 0.09 * sin(0.35 * t + -27.07)"
         }
-      ]
+      ],
+      "collection": "station-7"
     },
     {
       "id": "s7-dust-12",
@@ -4442,19 +3559,14 @@
         "translate": [-11.538991978485077, 1.9174150657237594, -31.219075822703545],
         "rotate": [0, 1.5000000000000004, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.2,
-        "value": 0.18,
-        "kind": "normal",
-        "roughness": 0.5
-      },
+      "material": "mat-20",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "1.917 - 0.000 * smoothstep(82.30, 83.30, t) + 0.05 * sin(0.40 * t + -29.88)"
         }
-      ]
+      ],
+      "collection": "station-7"
     },
     {
       "id": "s7-dust-13",
@@ -4466,19 +3578,14 @@
         "translate": [-7.885712429977456, 1.6748001647187152, -28.05079591004899],
         "rotate": [0, 2.400000000000001, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.2,
-        "value": 0.18,
-        "kind": "normal",
-        "roughness": 0.5
-      },
+      "material": "mat-20",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "1.675 - 0.000 * smoothstep(82.30, 83.30, t) + 0.07 * sin(0.45 * t + -32.70)"
         }
-      ]
+      ],
+      "collection": "station-7"
     },
     {
       "id": "s7-dust-14",
@@ -4490,19 +3597,14 @@
         "translate": [-3.6514297897467927, 1.3899081353990992, -31.13318694560524],
         "rotate": [0, 0.1999999999999993, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.2,
-        "value": 0.18,
-        "kind": "normal",
-        "roughness": 0.5
-      },
+      "material": "mat-20",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "1.390 - 0.000 * smoothstep(82.30, 83.30, t) + 0.09 * sin(0.50 * t + -35.51)"
         }
-      ]
+      ],
+      "collection": "station-7"
     },
     {
       "id": "s7-dust-15",
@@ -4514,19 +3616,14 @@
         "translate": [-6.5235283071325645, 1.44284528397345, -34.87581772775337],
         "rotate": [0, 1.0999999999999996, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.2,
-        "value": 0.18,
-        "kind": "normal",
-        "roughness": 0.5
-      },
+      "material": "mat-20",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "1.443 - 0.000 * smoothstep(82.30, 83.30, t) + 0.05 * sin(0.30 * t + -24.03)"
         }
-      ]
+      ],
+      "collection": "station-7"
     },
     {
       "id": "s7-dust-16",
@@ -4538,19 +3635,14 @@
         "translate": [-11.451631833583193, 0.7171594937718098, -35.200167970799484],
         "rotate": [0, 2, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.2,
-        "value": 0.18,
-        "kind": "normal",
-        "roughness": 0.5
-      },
+      "material": "mat-20",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "0.717 - 0.000 * smoothstep(82.30, 83.30, t) + 0.07 * sin(0.35 * t + -26.85)"
         }
-      ]
+      ],
+      "collection": "station-7"
     },
     {
       "id": "s7-dust-17",
@@ -4562,19 +3654,14 @@
         "translate": [-9.713412768926093, 1.3160592709780925, -30.874777994009886],
         "rotate": [0, 2.9000000000000004, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.2,
-        "value": 0.18,
-        "kind": "normal",
-        "roughness": 0.5
-      },
+      "material": "mat-20",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "1.316 - 0.000 * smoothstep(82.30, 83.30, t) + 0.09 * sin(0.40 * t + -29.66)"
         }
-      ]
+      ],
+      "collection": "station-7"
     },
     {
       "id": "s7-dust-18",
@@ -4586,19 +3673,14 @@
         "translate": [-6.34672118252054, -0.005841134412181592, -28.13814790786011],
         "rotate": [0, 0.6999999999999988, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.2,
-        "value": 0.18,
-        "kind": "normal",
-        "roughness": 0.5
-      },
+      "material": "mat-20",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "-0.006 - 0.000 * smoothstep(82.30, 83.30, t) + 0.05 * sin(0.45 * t + -32.48)"
         }
-      ]
+      ],
+      "collection": "station-7"
     },
     {
       "id": "s7-dust-19",
@@ -4610,19 +3692,14 @@
         "translate": [-6.404195237783911, 1.1743019526359513, -32.34681839010881],
         "rotate": [0, 1.600000000000001, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.2,
-        "value": 0.18,
-        "kind": "normal",
-        "roughness": 0.5
-      },
+      "material": "mat-20",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "1.174 - 0.000 * smoothstep(82.30, 83.30, t) + 0.07 * sin(0.50 * t + -35.29)"
         }
-      ]
+      ],
+      "collection": "station-7"
     },
     {
       "id": "s7-dust-20",
@@ -4634,19 +3711,14 @@
         "translate": [-7.599874192909084, -0.6439061141122786, -35.14322613673069],
         "rotate": [0, 2.4999999999999996, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.2,
-        "value": 0.18,
-        "kind": "normal",
-        "roughness": 0.5
-      },
+      "material": "mat-20",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "-0.644 - 0.000 * smoothstep(82.30, 83.30, t) + 0.09 * sin(0.30 * t + -23.81)"
         }
-      ]
+      ],
+      "collection": "station-7"
     },
     {
       "id": "s7-dust-21",
@@ -4658,19 +3730,14 @@
         "translate": [-8.627349490039283, 0.879070215106386, -32.398041959543754],
         "rotate": [0, 0.3000000000000016, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.2,
-        "value": 0.18,
-        "kind": "normal",
-        "roughness": 0.5
-      },
+      "material": "mat-20",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "0.879 - 0.000 * smoothstep(82.30, 83.30, t) + 0.05 * sin(0.35 * t + -26.63)"
         }
-      ]
+      ],
+      "collection": "station-7"
     },
     {
       "id": "path-7-1",
@@ -4682,15 +3749,8 @@
         "translate": [-9.676085781701492, 0.03, -31.221853348783156],
         "rotate": [0, -2.6582707068836715, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-7"
     },
     {
       "id": "path-7-2",
@@ -4702,15 +3762,8 @@
         "translate": [-11.429811209820436, 0.03, -30.30142724038549],
         "rotate": [0, -2.6582707068836715, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-7"
     },
     {
       "id": "path-7-3",
@@ -4722,15 +3775,8 @@
         "translate": [-13.18353663793938, 0.03, -29.38100113198782],
         "rotate": [0, -2.6582707068836715, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-7"
     },
     {
       "id": "path-7-4",
@@ -4742,15 +3788,8 @@
         "translate": [-14.937262066058324, 0.03, -28.460575023590152],
         "rotate": [0, -2.6582707068836715, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-7"
     },
     {
       "id": "path-7-5",
@@ -4762,15 +3801,8 @@
         "translate": [-16.690987494177268, 0.03, -27.540148915192482],
         "rotate": [0, -2.6582707068836715, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-7"
     },
     {
       "id": "path-7-6",
@@ -4782,15 +3814,8 @@
         "translate": [-18.44471292229621, 0.03, -26.61972280679481],
         "rotate": [0, -2.6582707068836715, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-7"
     },
     {
       "id": "path-7-7",
@@ -4802,15 +3827,8 @@
         "translate": [-20.198438350415152, 0.03, -25.69929669839714],
         "rotate": [0, -2.6582707068836715, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-7"
     },
     {
       "id": "s8-stage-0",
@@ -4824,20 +3842,14 @@
       "transform": {
         "translate": [-21.952163778534096, 2.8000000000000003, -24.778870589999475]
       },
-      "material": {
-        "hue": 0.55,
-        "sat": 0.62,
-        "value": 0.85,
-        "kind": "normal",
-        "roughness": 0.3,
-        "clearcoat": 0.45
-      },
+      "material": "mat-21",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "3.700 - 0.9 * smoothstep(93.05, 93.65, t)"
         }
-      ]
+      ],
+      "collection": "station-8"
     },
     {
       "id": "s8-stage-1",
@@ -4851,22 +3863,14 @@
       "transform": {
         "translate": [-21.952163778534096, 2, -24.778870589999475]
       },
-      "material": {
-        "hue": 0.11,
-        "sat": 0.78,
-        "value": 0.95,
-        "metal": 0,
-        "glow": 0.1,
-        "kind": "normal",
-        "roughness": 0.22,
-        "clearcoat": 0.6
-      },
+      "material": "mat-12",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "2.900 - 0.9 * smoothstep(93.40, 94.00, t)"
         }
-      ]
+      ],
+      "collection": "station-8"
     },
     {
       "id": "s8-stage-2",
@@ -4880,20 +3884,14 @@
       "transform": {
         "translate": [-21.952163778534096, 1.2000000000000002, -24.778870589999475]
       },
-      "material": {
-        "hue": 0.6100000000000001,
-        "sat": 0.7266666666666667,
-        "value": 0.65,
-        "kind": "normal",
-        "roughness": 0.3,
-        "clearcoat": 0.45
-      },
+      "material": "mat-22",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "2.100 - 0.9 * smoothstep(93.75, 94.35, t)"
         }
-      ]
+      ],
+      "collection": "station-8"
     },
     {
       "id": "s8-stage-3",
@@ -4907,20 +3905,14 @@
       "transform": {
         "translate": [-21.952163778534096, 0.3999999999999999, -24.778870589999475]
       },
-      "material": {
-        "hue": 0.64,
-        "sat": 0.78,
-        "value": 0.55,
-        "kind": "normal",
-        "roughness": 0.3,
-        "clearcoat": 0.45
-      },
+      "material": "mat-23",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "1.300 - 0.9 * smoothstep(94.10, 94.70, t)"
         }
-      ]
+      ],
+      "collection": "station-8"
     },
     {
       "id": "path-8-1",
@@ -4932,15 +3924,8 @@
         "translate": [-23.077267185476803, 0.03, -23.148876902300973],
         "rotate": [0, -2.1749487601775495, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-8"
     },
     {
       "id": "path-8-2",
@@ -4952,15 +3937,8 @@
         "translate": [-24.202370592419513, 0.03, -21.51888321460247],
         "rotate": [0, -2.1749487601775495, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-8"
     },
     {
       "id": "path-8-3",
@@ -4972,15 +3950,8 @@
         "translate": [-25.32747399936222, 0.03, -19.888889526903966],
         "rotate": [0, -2.1749487601775495, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-8"
     },
     {
       "id": "path-8-4",
@@ -4992,15 +3963,8 @@
         "translate": [-26.452577406304925, 0.03, -18.258895839205465],
         "rotate": [0, -2.1749487601775495, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-8"
     },
     {
       "id": "path-8-5",
@@ -5012,15 +3976,8 @@
         "translate": [-27.577680813247632, 0.03, -16.628902151506963],
         "rotate": [0, -2.1749487601775495, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-8"
     },
     {
       "id": "path-8-6",
@@ -5032,15 +3989,8 @@
         "translate": [-28.70278422019034, 0.03, -14.998908463808462],
         "rotate": [0, -2.1749487601775495, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-8"
     },
     {
       "id": "path-8-7",
@@ -5052,15 +4002,8 @@
         "translate": [-29.827887627133048, 0.03, -13.368914776109959],
         "rotate": [0, -2.1749487601775495, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-8"
     },
     {
       "id": "s9-plinth-0",
@@ -5071,14 +4014,8 @@
       "transform": {
         "translate": [-27.142991034075756, 0.06, -11.738921088411457]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.1,
-        "value": 0.55,
-        "kind": "normal",
-        "roughness": 0.6,
-        "clearcoat": 0.1
-      }
+      "material": "mat-6",
+      "collection": "station-9"
     },
     {
       "id": "s9-mono-0",
@@ -5090,21 +4027,15 @@
       "transform": {
         "translate": [-27.142991034075756, 2.4, -11.738921088411457]
       },
-      "material": {
-        "hue": 0.55,
-        "sat": 0.62,
-        "value": 0.82,
-        "kind": "normal",
-        "roughness": 0.3,
-        "clearcoat": 0.45
-      },
+      "material": "mat-7",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "-2.700 + 5.100 * smoothstep(106.05, 106.65, t)"
         }
       ],
-      "pattern": "cracked"
+      "pattern": "cracked",
+      "collection": "station-9"
     },
     {
       "id": "s9-plinth-1",
@@ -5115,14 +4046,8 @@
       "transform": {
         "translate": [-28.412991034075755, 0.06, -11.738921088411457]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.1,
-        "value": 0.55,
-        "kind": "normal",
-        "roughness": 0.6,
-        "clearcoat": 0.1
-      }
+      "material": "mat-6",
+      "collection": "station-9"
     },
     {
       "id": "s9-mono-1",
@@ -5134,21 +4059,15 @@
       "transform": {
         "translate": [-28.412991034075755, 2.3564356435643563, -11.738921088411457]
       },
-      "material": {
-        "hue": 0.5650000000000001,
-        "sat": 0.6433333333333333,
-        "value": 0.7833333333333333,
-        "kind": "normal",
-        "roughness": 0.3,
-        "clearcoat": 0.45
-      },
+      "material": "mat-24",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "-2.656 + 5.013 * smoothstep(107.15, 107.75, t)"
         }
       ],
-      "pattern": "cracked"
+      "pattern": "cracked",
+      "collection": "station-9"
     },
     {
       "id": "s9-plinth-2",
@@ -5159,14 +4078,8 @@
       "transform": {
         "translate": [-29.682991034075755, 0.06, -11.738921088411457]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.1,
-        "value": 0.55,
-        "kind": "normal",
-        "roughness": 0.6,
-        "clearcoat": 0.1
-      }
+      "material": "mat-6",
+      "collection": "station-9"
     },
     {
       "id": "s9-mono-2",
@@ -5178,21 +4091,15 @@
       "transform": {
         "translate": [-29.682991034075755, 2.2376237623762374, -11.738921088411457]
       },
-      "material": {
-        "hue": 0.5800000000000001,
-        "sat": 0.6666666666666666,
-        "value": 0.7466666666666666,
-        "kind": "normal",
-        "roughness": 0.3,
-        "clearcoat": 0.45
-      },
+      "material": "mat-25",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "-2.538 + 4.775 * smoothstep(108.25, 108.85, t)"
         }
       ],
-      "pattern": "cracked"
+      "pattern": "cracked",
+      "collection": "station-9"
     },
     {
       "id": "s9-plinth-3",
@@ -5203,14 +4110,8 @@
       "transform": {
         "translate": [-30.952991034075755, 0.06, -11.738921088411457]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.1,
-        "value": 0.55,
-        "kind": "normal",
-        "roughness": 0.6,
-        "clearcoat": 0.1
-      }
+      "material": "mat-6",
+      "collection": "station-9"
     },
     {
       "id": "s9-mono-3",
@@ -5222,21 +4123,15 @@
       "transform": {
         "translate": [-30.952991034075755, 2.1425742574257423, -11.738921088411457]
       },
-      "material": {
-        "hue": 0.5950000000000001,
-        "sat": 0.69,
-        "value": 0.71,
-        "kind": "normal",
-        "roughness": 0.3,
-        "clearcoat": 0.45
-      },
+      "material": "mat-26",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "-2.443 + 4.585 * smoothstep(109.35, 109.95, t)"
         }
       ],
-      "pattern": "cracked"
+      "pattern": "cracked",
+      "collection": "station-9"
     },
     {
       "id": "s9-plinth-4",
@@ -5247,14 +4142,8 @@
       "transform": {
         "translate": [-32.222991034075754, 0.06, -11.738921088411457]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.1,
-        "value": 0.55,
-        "kind": "normal",
-        "roughness": 0.6,
-        "clearcoat": 0.1
-      }
+      "material": "mat-6",
+      "collection": "station-9"
     },
     {
       "id": "s9-mono-4",
@@ -5266,21 +4155,15 @@
       "transform": {
         "translate": [-32.222991034075754, 2.023762376237624, -11.738921088411457]
       },
-      "material": {
-        "hue": 0.6100000000000001,
-        "sat": 0.7133333333333334,
-        "value": 0.6733333333333333,
-        "kind": "normal",
-        "roughness": 0.3,
-        "clearcoat": 0.45
-      },
+      "material": "mat-27",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "-2.324 + 4.348 * smoothstep(110.45, 111.05, t)"
         }
       ],
-      "pattern": "cracked"
+      "pattern": "cracked",
+      "collection": "station-9"
     },
     {
       "id": "s9-plinth-5",
@@ -5291,14 +4174,8 @@
       "transform": {
         "translate": [-33.49299103407576, 0.06, -11.738921088411457]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.1,
-        "value": 0.55,
-        "kind": "normal",
-        "roughness": 0.6,
-        "clearcoat": 0.1
-      }
+      "material": "mat-6",
+      "collection": "station-9"
     },
     {
       "id": "s9-mono-5",
@@ -5310,21 +4187,15 @@
       "transform": {
         "translate": [-33.49299103407576, 1.881188118811881, -11.738921088411457]
       },
-      "material": {
-        "hue": 0.625,
-        "sat": 0.7366666666666667,
-        "value": 0.6366666666666666,
-        "kind": "normal",
-        "roughness": 0.3,
-        "clearcoat": 0.45
-      },
+      "material": "mat-28",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "-2.181 + 4.062 * smoothstep(111.55, 112.15, t)"
         }
       ],
-      "pattern": "cracked"
+      "pattern": "cracked",
+      "collection": "station-9"
     },
     {
       "id": "s9-plinth-6",
@@ -5335,14 +4206,8 @@
       "transform": {
         "translate": [-34.76299103407575, 0.06, -11.738921088411457]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.1,
-        "value": 0.55,
-        "kind": "normal",
-        "roughness": 0.6,
-        "clearcoat": 0.1
-      }
+      "material": "mat-6",
+      "collection": "station-9"
     },
     {
       "id": "s9-mono-6",
@@ -5354,22 +4219,14 @@
       "transform": {
         "translate": [-34.76299103407575, 1.786138613861386, -11.738921088411457]
       },
-      "material": {
-        "hue": 0.11,
-        "sat": 0.78,
-        "value": 0.95,
-        "metal": 0,
-        "glow": 0.1,
-        "kind": "normal",
-        "roughness": 0.22,
-        "clearcoat": 0.6
-      },
+      "material": "mat-12",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "-2.086 + 3.872 * smoothstep(112.65, 113.25, t)"
         }
-      ]
+      ],
+      "collection": "station-9"
     },
     {
       "id": "s9-guard-l-0",
@@ -5381,14 +4238,8 @@
         "translate": [-39.722991034075754, 1.1, -10.538921088411458],
         "rotate": [0, -0.3, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-13",
+      "collection": "station-9"
     },
     {
       "id": "s9-guard-r-0",
@@ -5400,14 +4251,8 @@
         "translate": [-22.182991034075755, 1.1, -10.538921088411458],
         "rotate": [0, 0.3, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-13",
+      "collection": "station-9"
     },
     {
       "id": "s9-guard-l-1",
@@ -5419,14 +4264,8 @@
         "translate": [-39.12299103407575, 1.75, -16.338921088411457],
         "rotate": [0, -0.3, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-13",
+      "collection": "station-9"
     },
     {
       "id": "s9-guard-r-1",
@@ -5438,14 +4277,8 @@
         "translate": [-22.782991034075756, 1.75, -16.338921088411457],
         "rotate": [0, 0.3, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-13",
+      "collection": "station-9"
     },
     {
       "id": "s9-guard-l-2",
@@ -5457,14 +4290,8 @@
         "translate": [-40.52299103407576, 2.4000000000000004, -18.538921088411456],
         "rotate": [0, -0.3, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-13",
+      "collection": "station-9"
     },
     {
       "id": "s9-guard-r-2",
@@ -5476,14 +4303,8 @@
         "translate": [-21.382991034075754, 2.4000000000000004, -18.538921088411456],
         "rotate": [0, 0.3, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-13",
+      "collection": "station-9"
     },
     {
       "id": "path-9-1",
@@ -5495,15 +4316,8 @@
         "translate": [-31.19172478827756, 0.03, -9.772771731710455],
         "rotate": [0, -1.6916268134714274, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-9"
     },
     {
       "id": "path-9-2",
@@ -5515,15 +4329,8 @@
         "translate": [-31.43045854247937, 0.03, -7.806622375009452],
         "rotate": [0, -1.6916268134714274, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-9"
     },
     {
       "id": "path-9-3",
@@ -5535,15 +4342,8 @@
         "translate": [-31.669192296681178, 0.03, -5.840473018308449],
         "rotate": [0, -1.6916268134714274, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-9"
     },
     {
       "id": "path-9-4",
@@ -5555,15 +4355,8 @@
         "translate": [-31.907926050882985, 0.03, -3.8743236616074466],
         "rotate": [0, -1.6916268134714274, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-9"
     },
     {
       "id": "path-9-5",
@@ -5575,15 +4368,8 @@
         "translate": [-32.146659805084795, 0.03, -1.908174304906444],
         "rotate": [0, -1.6916268134714274, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-9"
     },
     {
       "id": "path-9-6",
@@ -5595,15 +4381,8 @@
         "translate": [-32.385393559286605, 0.03, 0.05797505179455875],
         "rotate": [0, -1.6916268134714274, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-9"
     },
     {
       "id": "path-9-7",
@@ -5615,15 +4394,8 @@
         "translate": [-32.62412731348841, 0.03, 2.0241244084955614],
         "rotate": [0, -1.6916268134714274, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-9"
     },
     {
       "id": "s10-node-0",
@@ -5643,22 +4415,14 @@
       "transform": {
         "translate": [-32.86286106769022, 3.15, 3.990273765196565]
       },
-      "material": {
-        "hue": 0.11,
-        "sat": 0.78,
-        "value": 0.95,
-        "metal": 0,
-        "glow": 0.04,
-        "kind": "normal",
-        "roughness": 0.22,
-        "clearcoat": 0.6
-      },
+      "material": "mat-29",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "4.150 - 1 * smoothstep(120.35, 120.90, t)"
         }
-      ]
+      ],
+      "collection": "station-10"
     },
     {
       "id": "s10-node-1",
@@ -5690,20 +4454,14 @@
       "transform": {
         "translate": [-32.86286106769022, 2, 2.090273765196565]
       },
-      "material": {
-        "hue": 0.5950000000000001,
-        "sat": 0.7,
-        "value": 0.71,
-        "kind": "normal",
-        "roughness": 0.3,
-        "clearcoat": 0.45
-      },
+      "material": "mat-30",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "3.000 - 1 * smoothstep(121.85, 122.40, t)"
         }
-      ]
+      ],
+      "collection": "station-10"
     },
     {
       "id": "s10-node-2",
@@ -5735,20 +4493,14 @@
       "transform": {
         "translate": [-31.217412800499783, 2, 4.940273765196564]
       },
-      "material": {
-        "hue": 0.5950000000000001,
-        "sat": 0.7,
-        "value": 0.71,
-        "kind": "normal",
-        "roughness": 0.3,
-        "clearcoat": 0.45
-      },
+      "material": "mat-30",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "3.000 - 1 * smoothstep(121.85, 122.40, t)"
         }
-      ]
+      ],
+      "collection": "station-10"
     },
     {
       "id": "s10-node-3",
@@ -5780,20 +4532,14 @@
       "transform": {
         "translate": [-34.50830933488065, 2, 4.940273765196565]
       },
-      "material": {
-        "hue": 0.5950000000000001,
-        "sat": 0.7,
-        "value": 0.71,
-        "kind": "normal",
-        "roughness": 0.3,
-        "clearcoat": 0.45
-      },
+      "material": "mat-30",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "3.000 - 1 * smoothstep(121.85, 122.40, t)"
         }
-      ]
+      ],
+      "collection": "station-10"
     },
     {
       "id": "s10-node-4",
@@ -5825,20 +4571,14 @@
       "transform": {
         "translate": [-31.71996919120985, 0.8500000000000001, 5.631983295387144]
       },
-      "material": {
-        "hue": 0.64,
-        "sat": 0.78,
-        "value": 0.57,
-        "kind": "normal",
-        "roughness": 0.3,
-        "clearcoat": 0.45
-      },
+      "material": "mat-31",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "1.850 - 1 * smoothstep(123.35, 123.90, t)"
         }
-      ]
+      ],
+      "collection": "station-10"
     },
     {
       "id": "path-10-1",
@@ -5850,15 +4590,8 @@
         "translate": [-32.16053414311712, 0.03, 5.842157667948225],
         "rotate": [0, -1.2083048667653054, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-10"
     },
     {
       "id": "path-10-2",
@@ -5870,15 +4603,8 @@
         "translate": [-31.45820721854402, 0.03, 7.694041570699885],
         "rotate": [0, -1.2083048667653054, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-10"
     },
     {
       "id": "path-10-3",
@@ -5890,15 +4616,8 @@
         "translate": [-30.75588029397092, 0.03, 9.545925473451545],
         "rotate": [0, -1.2083048667653054, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-10"
     },
     {
       "id": "path-10-4",
@@ -5910,15 +4629,8 @@
         "translate": [-30.05355336939782, 0.03, 11.397809376203206],
         "rotate": [0, -1.2083048667653054, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-10"
     },
     {
       "id": "path-10-5",
@@ -5930,15 +4642,8 @@
         "translate": [-29.35122644482472, 0.03, 13.249693278954865],
         "rotate": [0, -1.2083048667653054, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-10"
     },
     {
       "id": "path-10-6",
@@ -5950,15 +4655,8 @@
         "translate": [-28.648899520251625, 0.03, 15.101577181706524],
         "rotate": [0, -1.2083048667653054, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-10"
     },
     {
       "id": "path-10-7",
@@ -5970,15 +4668,8 @@
         "translate": [-27.946572595678525, 0.03, 16.953461084458187],
         "rotate": [0, -1.2083048667653054, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-10"
     },
     {
       "id": "s11-backboard",
@@ -5990,14 +4681,8 @@
       "transform": {
         "translate": [-27.244245671105425, 2.51, 18.465344987209846]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.3,
-        "value": 0.22,
-        "kind": "normal",
-        "roughness": 0.4,
-        "clearcoat": 0.3
-      }
+      "material": "mat-32",
+      "collection": "station-11"
     },
     {
       "id": "s11-cell-0-0",
@@ -6009,14 +4694,8 @@
       "transform": {
         "translate": [-26.334245671105425, 3.2199999999999998, 18.805344987209846]
       },
-      "material": {
-        "hue": 0.6,
-        "sat": 0.1,
-        "value": 0.3,
-        "kind": "normal",
-        "roughness": 0.7,
-        "clearcoat": 0.1
-      }
+      "material": "mat-33",
+      "collection": "station-11"
     },
     {
       "id": "s11-cell-1-0",
@@ -6028,14 +4707,8 @@
       "transform": {
         "translate": [-28.154245671105425, 3.2199999999999998, 18.805344987209846]
       },
-      "material": {
-        "hue": 0.6,
-        "sat": 0.1,
-        "value": 0.3,
-        "kind": "normal",
-        "roughness": 0.7,
-        "clearcoat": 0.1
-      }
+      "material": "mat-33",
+      "collection": "station-11"
     },
     {
       "id": "s11-cell-0-1",
@@ -6047,14 +4720,8 @@
       "transform": {
         "translate": [-26.334245671105425, 1.7999999999999998, 18.805344987209846]
       },
-      "material": {
-        "hue": 0.6,
-        "sat": 0.1,
-        "value": 0.3,
-        "kind": "normal",
-        "roughness": 0.7,
-        "clearcoat": 0.1
-      }
+      "material": "mat-33",
+      "collection": "station-11"
     },
     {
       "id": "s11-cell-1-1",
@@ -6066,14 +4733,8 @@
       "transform": {
         "translate": [-28.154245671105425, 1.7999999999999998, 18.805344987209846]
       },
-      "material": {
-        "hue": 0.6,
-        "sat": 0.1,
-        "value": 0.3,
-        "kind": "normal",
-        "roughness": 0.7,
-        "clearcoat": 0.1
-      }
+      "material": "mat-33",
+      "collection": "station-11"
     },
     {
       "id": "s11-item-0",
@@ -6085,20 +4746,14 @@
       "transform": {
         "translate": [-26.334245671105425, 3.2199999999999998, 19.145344987209846]
       },
-      "material": {
-        "hue": 0.57,
-        "sat": 0.55,
-        "value": 0.72,
-        "kind": "normal",
-        "roughness": 0.3,
-        "clearcoat": 0.45
-      },
+      "material": "mat-34",
       "animation": [
         {
           "channel": "transform.translate.z",
           "expr": "2.400 - 2.060 * smoothstep(131.25, 131.70, t)"
         }
-      ]
+      ],
+      "collection": "station-11"
     },
     {
       "id": "s11-item-1",
@@ -6110,20 +4765,14 @@
       "transform": {
         "translate": [-26.334245671105425, 1.7999999999999998, 19.145344987209846]
       },
-      "material": {
-        "hue": 0.57,
-        "sat": 0.55,
-        "value": 0.72,
-        "kind": "normal",
-        "roughness": 0.3,
-        "clearcoat": 0.45
-      },
+      "material": "mat-34",
       "animation": [
         {
           "channel": "transform.translate.z",
           "expr": "2.400 - 2.060 * smoothstep(132.15, 132.60, t)"
         }
-      ]
+      ],
+      "collection": "station-11"
     },
     {
       "id": "s11-item-2",
@@ -6135,20 +4784,14 @@
       "transform": {
         "translate": [-28.154245671105425, 3.2199999999999998, 19.145344987209846]
       },
-      "material": {
-        "hue": 0.57,
-        "sat": 0.55,
-        "value": 0.72,
-        "kind": "normal",
-        "roughness": 0.3,
-        "clearcoat": 0.45
-      },
+      "material": "mat-34",
       "animation": [
         {
           "channel": "transform.translate.z",
           "expr": "2.400 - 2.060 * smoothstep(133.05, 133.50, t)"
         }
-      ]
+      ],
+      "collection": "station-11"
     },
     {
       "id": "s11-item-3",
@@ -6160,21 +4803,14 @@
       "transform": {
         "translate": [-28.154245671105425, 1.7999999999999998, 19.145344987209846]
       },
-      "material": {
-        "hue": 0.11,
-        "sat": 0.78,
-        "value": 0.95,
-        "glow": 0.1,
-        "kind": "normal",
-        "roughness": 0.22,
-        "clearcoat": 0.6
-      },
+      "material": "mat-5",
       "animation": [
         {
           "channel": "transform.translate.z",
           "expr": "2.400 - 2.060 * smoothstep(133.95, 134.40, t)"
         }
-      ]
+      ],
+      "collection": "station-11"
     },
     {
       "id": "s11-flank-0",
@@ -6186,20 +4822,14 @@
         "translate": [-31.404245671105425, 3.3099999999999996, 16.605344987209847],
         "rotate": [0, -0.9, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      },
+      "material": "mat-13",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "3.310 - 0.000 * smoothstep(130.00, 131.00, t) + 0.06 * sin(0.30 * t + -39.00)"
         }
-      ]
+      ],
+      "collection": "station-11"
     },
     {
       "id": "s11-flank-1",
@@ -6211,20 +4841,14 @@
         "translate": [-22.784245671105424, 2.11, 15.805344987209846],
         "rotate": [0, -0.4, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      },
+      "material": "mat-13",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "2.110 - 0.000 * smoothstep(130.00, 131.00, t) + 0.08 * sin(0.37 * t + -45.90)"
         }
-      ]
+      ],
+      "collection": "station-11"
     },
     {
       "id": "s11-flank-2",
@@ -6236,20 +4860,14 @@
         "translate": [-33.204245671105426, 4.71, 13.305344987209846],
         "rotate": [0, 0.09999999999999998, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      },
+      "material": "mat-13",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "4.710 - 0.000 * smoothstep(130.00, 131.00, t) + 0.10 * sin(0.44 * t + -52.80)"
         }
-      ]
+      ],
+      "collection": "station-11"
     },
     {
       "id": "s11-flank-3",
@@ -6261,20 +4879,14 @@
         "translate": [-20.684245671105426, 4.109999999999999, 12.305344987209846],
         "rotate": [0, 0.6, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      },
+      "material": "mat-13",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "4.110 - 0.000 * smoothstep(130.00, 131.00, t) + 0.12 * sin(0.51 * t + -65.98)"
         }
-      ]
+      ],
+      "collection": "station-11"
     },
     {
       "id": "path-11-1",
@@ -6286,15 +4898,8 @@
         "translate": [-25.761752702220132, 0.03, 20.11871915151214],
         "rotate": [0, -0.7249829200591837, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-11"
     },
     {
       "id": "path-11-2",
@@ -6306,15 +4911,8 @@
         "translate": [-24.279259733334843, 0.03, 21.432093315814434],
         "rotate": [0, -0.7249829200591837, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-11"
     },
     {
       "id": "path-11-3",
@@ -6326,15 +4924,8 @@
         "translate": [-22.79676676444955, 0.03, 22.745467480116726],
         "rotate": [0, -0.7249829200591837, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-11"
     },
     {
       "id": "path-11-4",
@@ -6346,15 +4937,8 @@
         "translate": [-21.31427379556426, 0.03, 24.05884164441902],
         "rotate": [0, -0.7249829200591837, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-11"
     },
     {
       "id": "path-11-5",
@@ -6366,15 +4950,8 @@
         "translate": [-19.83178082667897, 0.03, 25.37221580872131],
         "rotate": [0, -0.7249829200591837, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-11"
     },
     {
       "id": "path-11-6",
@@ -6386,15 +4963,8 @@
         "translate": [-18.349287857793676, 0.03, 26.685589973023603],
         "rotate": [0, -0.7249829200591837, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-11"
     },
     {
       "id": "path-11-7",
@@ -6406,15 +4976,8 @@
         "translate": [-16.866794888908387, 0.03, 27.9989641373259],
         "rotate": [0, -0.7249829200591837, 0]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.25,
-        "value": 0.85,
-        "glow": 0.45,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.2
-      }
+      "material": "mat-1",
+      "collection": "path-11"
     },
     {
       "id": "s12-plinth-0",
@@ -6425,14 +4988,8 @@
       "transform": {
         "translate": [-14.114301920023097, 0.06, 29.31233830162819]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.1,
-        "value": 0.55,
-        "kind": "normal",
-        "roughness": 0.6,
-        "clearcoat": 0.1
-      }
+      "material": "mat-6",
+      "collection": "station-12"
     },
     {
       "id": "s12-mono-0",
@@ -6444,21 +5001,15 @@
       "transform": {
         "translate": [-14.114301920023097, 0.24, 29.31233830162819]
       },
-      "material": {
-        "hue": 0.55,
-        "sat": 0.62,
-        "value": 0.82,
-        "kind": "normal",
-        "roughness": 0.3,
-        "clearcoat": 0.45
-      },
+      "material": "mat-7",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "-0.540 + 0.780 * smoothstep(141.15, 141.75, t)"
         }
       ],
-      "pattern": "cracked"
+      "pattern": "cracked",
+      "collection": "station-12"
     },
     {
       "id": "s12-plinth-1",
@@ -6469,14 +5020,8 @@
       "transform": {
         "translate": [-15.384301920023097, 0.06, 29.31233830162819]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.1,
-        "value": 0.55,
-        "kind": "normal",
-        "roughness": 0.6,
-        "clearcoat": 0.1
-      }
+      "material": "mat-6",
+      "collection": "station-12"
     },
     {
       "id": "s12-mono-1",
@@ -6488,21 +5033,15 @@
       "transform": {
         "translate": [-15.384301920023097, 1.2, 29.31233830162819]
       },
-      "material": {
-        "hue": 0.5950000000000001,
-        "sat": 0.69,
-        "value": 0.71,
-        "kind": "normal",
-        "roughness": 0.3,
-        "clearcoat": 0.45
-      },
+      "material": "mat-26",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "-1.500 + 2.700 * smoothstep(142.25, 142.85, t)"
         }
       ],
-      "pattern": "cracked"
+      "pattern": "cracked",
+      "collection": "station-12"
     },
     {
       "id": "s12-plinth-2",
@@ -6513,14 +5052,8 @@
       "transform": {
         "translate": [-16.654301920023098, 0.06, 29.31233830162819]
       },
-      "material": {
-        "hue": 0.58,
-        "sat": 0.1,
-        "value": 0.55,
-        "kind": "normal",
-        "roughness": 0.6,
-        "clearcoat": 0.1
-      }
+      "material": "mat-6",
+      "collection": "station-12"
     },
     {
       "id": "s12-mono-2",
@@ -6532,22 +5065,14 @@
       "transform": {
         "translate": [-16.654301920023098, 2.4, 29.31233830162819]
       },
-      "material": {
-        "hue": 0.11,
-        "sat": 0.78,
-        "value": 0.95,
-        "metal": 0,
-        "glow": 0.1,
-        "kind": "normal",
-        "roughness": 0.22,
-        "clearcoat": 0.6
-      },
+      "material": "mat-12",
       "animation": [
         {
           "channel": "transform.translate.y",
           "expr": "-2.700 + 5.100 * smoothstep(143.35, 143.95, t)"
         }
-      ]
+      ],
+      "collection": "station-12"
     },
     {
       "id": "s12-guard-l-0",
@@ -6559,14 +5084,8 @@
         "translate": [-21.614301920023095, 1.1, 30.51233830162819],
         "rotate": [0, -0.3, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-13",
+      "collection": "station-12"
     },
     {
       "id": "s12-guard-r-0",
@@ -6578,14 +5097,8 @@
         "translate": [-9.154301920023098, 1.1, 30.51233830162819],
         "rotate": [0, 0.3, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-13",
+      "collection": "station-12"
     },
     {
       "id": "s12-guard-l-1",
@@ -6597,14 +5110,8 @@
         "translate": [-21.014301920023097, 1.75, 24.712338301628193],
         "rotate": [0, -0.3, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-13",
+      "collection": "station-12"
     },
     {
       "id": "s12-guard-r-1",
@@ -6616,14 +5123,8 @@
         "translate": [-9.754301920023096, 1.75, 24.712338301628193],
         "rotate": [0, 0.3, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-13",
+      "collection": "station-12"
     },
     {
       "id": "s12-guard-l-2",
@@ -6635,14 +5136,8 @@
         "translate": [-22.414301920023096, 2.4000000000000004, 22.51233830162819],
         "rotate": [0, -0.3, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-13",
+      "collection": "station-12"
     },
     {
       "id": "s12-guard-r-2",
@@ -6654,14 +5149,8 @@
         "translate": [-8.354301920023097, 2.4000000000000004, 22.51233830162819],
         "rotate": [0, 0.3, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-13",
+      "collection": "station-12"
     },
     {
       "id": "horizon-0",
@@ -6673,16 +5162,8 @@
         "translate": [-9.564998366001348e-16, 7.016592952333921, 148.44758298167267],
         "rotate": [0, 0, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "metal": 0,
-        "glow": 0,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-35",
+      "collection": "horizon"
     },
     {
       "id": "horizon-1",
@@ -6694,16 +5175,8 @@
         "translate": [63.3066209152962, 7.62296579657653, 92.85708904982108],
         "rotate": [0, 0.34528374665954953, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "metal": 0,
-        "glow": 0,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-35",
+      "collection": "horizon"
     },
     {
       "id": "horizon-2",
@@ -6715,16 +5188,8 @@
         "translate": [42.17123438785764, 4.819555072083943, 58.18899581850708],
         "rotate": [0, -0.3486303089654353, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "metal": 0,
-        "glow": 0,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-35",
+      "collection": "horizon"
     },
     {
       "id": "horizon-3",
@@ -6736,16 +5201,8 @@
         "translate": [133.23992011010677, 4.842001421418689, -15.398862705215288],
         "rotate": [0, 0.006725560193740241, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "metal": 0,
-        "glow": 0,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-35",
+      "collection": "horizon"
     },
     {
       "id": "horizon-4",
@@ -6757,16 +5214,8 @@
         "translate": [133.43987144268098, 7.640377316314558, 15.945010375042076],
         "rotate": [0, 0.3418395632353122, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "metal": 0,
-        "glow": 0,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-35",
+      "collection": "horizon"
     },
     {
       "id": "horizon-5",
@@ -6778,16 +5227,8 @@
         "translate": [41.59059376558689, 6.990241111126378, -58.71906850943405],
         "rotate": [0, -0.35187830398866804, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "metal": 0,
-        "glow": 0,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-35",
+      "collection": "horizon"
     },
     {
       "id": "horizon-6",
@@ -6799,16 +5240,8 @@
         "translate": [64.57684188043537, 4.3376940527581525, -91.58418852702466],
         "rotate": [0, 0.01344921888845539, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "metal": 0,
-        "glow": 0,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-35",
+      "collection": "horizon"
     },
     {
       "id": "horizon-7",
@@ -6820,16 +5253,8 @@
         "translate": [-2.621699333670603, 5.582809968766616, -148.54011535108356],
         "rotate": [0, 0.33829873245717335, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "metal": 0,
-        "glow": 0,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-35",
+      "collection": "horizon"
     },
     {
       "id": "horizon-8",
@@ -6841,16 +5266,8 @@
         "translate": [-46.662129265450154, 7.956071234520032, -70.87525467505033],
         "rotate": [0, -0.35502681343260184, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "metal": 0,
-        "glow": 0,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-35",
+      "collection": "horizon"
     },
     {
       "id": "horizon-9",
@@ -6862,16 +5279,8 @@
         "translate": [-53.38157647783484, 6.178620822448911, -71.89564197285696],
         "rotate": [0, 0.020169075122725907, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "metal": 0,
-        "glow": 0,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-35",
+      "collection": "horizon"
     },
     {
       "id": "horizon-10",
@@ -6883,16 +5292,8 @@
         "translate": [-149.30732670480418, 4.204050667126552, 16.54056242376746],
         "rotate": [0, 0.33466225541442246, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "metal": 0,
-        "glow": 0,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-35",
+      "collection": "horizon"
     },
     {
       "id": "horizon-11",
@@ -6904,16 +5305,8 @@
         "translate": [-105.51113399020367, 6.424407144257572, -12.92814474581854],
         "rotate": [0, -0.35807494712787274, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "metal": 0,
-        "glow": 0,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-35",
+      "collection": "horizon"
     },
     {
       "id": "horizon-12",
@@ -6925,16 +5318,8 @@
         "translate": [-42.170987072097645, 7.900940120366205, 60.837256078552294],
         "rotate": [0, 0.02688322901019139, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "metal": 0,
-        "glow": 0,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-35",
+      "collection": "horizon"
     },
     {
       "id": "horizon-13",
@@ -6946,16 +5331,8 @@
         "translate": [-81.72421217765147, 5.34938983448815, 112.20689757324111],
         "rotate": [0, 0.3309311602381515, 0]
       },
-      "material": {
-        "hue": 0.62,
-        "sat": 0.25,
-        "value": 0.14,
-        "metal": 0,
-        "glow": 0,
-        "kind": "normal",
-        "roughness": 0.5,
-        "clearcoat": 0.35
-      }
+      "material": "mat-35",
+      "collection": "horizon"
     }
   ],
   "overlay": [

--- a/sdf-js/scripts/test-courtyard.mjs
+++ b/sdf-js/scripts/test-courtyard.mjs
@@ -110,7 +110,9 @@ const stations = new Map(
   const hills = sliced.subjects.filter((s) => s.id.startsWith('horizon-'));
   ok(hills.length === 0, `slab quota yields to massing (slabs=${hills.length}, conservation)`);
   ok(
-    massing.every((s) => s.material.value <= 0.35 && s.material.glow === 0),
+    massing
+      .map((s) => (typeof s.material === 'string' ? scene.materials[s.material] : s.material))
+      .every((m) => m.value <= 0.35 && m.glow === 0),
     'massing stays silhouette-dark (subtle discipline)',
   );
 }

--- a/sdf-js/scripts/test-deck-decor.mjs
+++ b/sdf-js/scripts/test-deck-decor.mjs
@@ -56,7 +56,9 @@ const ANALYTIC_TYPES = new Set(['box', 'sphere', 'capsule', 'ellipsoid', 'cylind
   const scene = assembleDeck(DECK, { layout: 'radial', decorSeed: 'hash-A' });
   const decor = scene.subjects.filter((x) => /-decor-/.test(x.id));
   ok(
-    decor.every((s) => s.material.value <= DECOR_VALUE_CAP && s.material.glow === 0),
+    decor
+      .map((s) => (typeof s.material === 'string' ? scene.materials[s.material] : s.material))
+      .every((m) => m.value <= DECOR_VALUE_CAP && m.glow === 0),
     `all decor under brightness cap ${DECOR_VALUE_CAP}, zero glow`,
   );
   ok(

--- a/sdf-js/scripts/test-deck-windows.mjs
+++ b/sdf-js/scripts/test-deck-windows.mjs
@@ -117,7 +117,12 @@ for (let i = 0; i < wins.length; i++) {
 {
   const palette = {
     anchor: [241, 70, 22],
-    colors: [[241, 70, 22], [43, 154, 233], [168, 124, 42], [1, 119, 86]],
+    colors: [
+      [241, 70, 22],
+      [43, 154, 233],
+      [168, 124, 42],
+      [1, 119, 86],
+    ],
   };
   const deck2 = {
     title: 'c',
@@ -130,18 +135,24 @@ for (let i = 0; i < wins.length; i++) {
     ],
   };
   const sc = assembleDeck(deck2, { stage: true, palette });
+  // Wave A: assembled decks carry material REFS — deref via the registry
+  const matOf = (scene, s) =>
+    typeof s.material === 'string' ? scene.materials[s.material] : s.material;
   const chips = sc.overlay.filter((o) => o.role === 'value' && o.accentColor);
   ok(chips.length > 0, 'value chips carry the station accent color');
   const stationHues = new Set();
   for (const sub of sc.subjects) {
     const m = /^s(\d+)-mono-1$/.exec(sub.id || '');
-    if (m) stationHues.add(`${m[1]}:${sub.material.hue.toFixed(3)}`);
+    if (m) stationHues.add(`${m[1]}:${matOf(sc, sub).hue.toFixed(3)}`);
   }
   const hues = [...stationHues].map((x) => x.split(':')[1]);
   ok(new Set(hues).size >= 2, `content stations rotate hues (${[...stationHues].join(' ')})`);
   const noPal = assembleDeck(deck2, { stage: true });
   const blue = noPal.subjects.find((x) => /^s1-mono-1$/.test(x.id));
-  ok(Math.abs(blue.material.hue - 0.595) < 0.02, 'no palette → classic blue family (back-compat)');
+  ok(
+    Math.abs(matOf(noPal, blue).hue - 0.595) < 0.02,
+    'no palette → classic blue family (back-compat)',
+  );
 }
 
 // ---- windowIndexAt ------------------------------------------------------------

--- a/sdf-js/scripts/test-scene-collections.mjs
+++ b/sdf-js/scripts/test-scene-collections.mjs
@@ -1,0 +1,111 @@
+// sdf-js/scripts/test-scene-collections.mjs — Blender-borrow Wave A.
+// The load-bearing claim: collection-driven slicing is SEMANTICALLY IDENTICAL
+// to the legacy id-regex slicing, for every window of every layout. Plus the
+// material registry round-trip (dedup → refs → resolveMaterialRefs inflates
+// back) and the validator's dangling-reference errors.
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+import { assembleDeck, sliceDeckWindow } from '../src/scene/assemble-deck.js';
+import { validate, resolveMaterialRefs } from '../src/scene/spec.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const DECK = JSON.parse(readFileSync(resolve(__dirname, '../scenes/ir/bytedance-bp.json'), 'utf8'));
+
+let pass = 0,
+  fail = 0;
+const ok = (c, n) => (c ? (pass++, console.log(`  ✓ ${n}`)) : (fail++, console.log(`  ✗ ${n}`)));
+console.log('=== scene collections + material registry (Wave A) ===\n');
+
+// ---- semantic equivalence: collections vs legacy regex --------------------------
+for (const layout of ['radial', 'courtyard']) {
+  const scene = assembleDeck(DECK, { layout });
+  ok(!!scene.collections && !!scene.materials, `${layout}: collections + materials emitted`);
+  ok(
+    scene.subjects.every(
+      (s) => typeof s.collection === 'string' && scene.collections[s.collection],
+    ),
+    `${layout}: every subject carries a registered collection`,
+  );
+  // strip collections/tags → the slicer falls back to the legacy regex path
+  const legacy = {
+    ...scene,
+    collections: undefined,
+    subjects: scene.subjects.map((s) => ({ ...s, collection: undefined })),
+  };
+  let identical = true;
+  for (const win of scene.deckWindows) {
+    const a = sliceDeckWindow(scene, win)
+      .subjects.map((s) => s.id)
+      .join('|');
+    const b = sliceDeckWindow(legacy, win)
+      .subjects.map((s) => s.id)
+      .join('|');
+    if (a !== b) {
+      identical = false;
+      console.log(`    ✗ window ${win.kind}[${win.stations}] diverges`);
+      break;
+    }
+  }
+  ok(identical, `${layout}: collection slicing ≡ legacy regex slicing (every window)`);
+}
+
+// ---- material registry round-trip ------------------------------------------------
+{
+  const scene = assembleDeck(DECK, { layout: 'radial' });
+  const refs = scene.subjects.filter((s) => typeof s.material === 'string');
+  ok(
+    refs.length > 200,
+    `materials dedup'd to refs (${refs.length} refs, ${Object.keys(scene.materials).length} entries)`,
+  );
+  ok(
+    Object.keys(scene.materials).length < 60,
+    `registry stays small (${Object.keys(scene.materials).length} unique materials)`,
+  );
+  const inflated = resolveMaterialRefs(scene);
+  ok(
+    inflated.subjects.every((s) => s.material == null || typeof s.material === 'object'),
+    'resolveMaterialRefs inflates every ref back to an object',
+  );
+  // registry name that shadows nothing → untouched preset strings still work
+  const v = validate(scene);
+  ok(v.ok, `assembled deck validates with registry (${v.errors[0] || 'no errors'})`);
+}
+
+// ---- validator: dangling references are ERRORS -----------------------------------
+{
+  const bad = {
+    v: 1,
+    materials: { good: { hue: 0.5 } },
+    subjects: [{ id: 'a', type: 'sphere', args: { radius: 1 }, material: 'nope' }],
+  };
+  const v = validate(bad);
+  ok(
+    !v.ok && v.errors.some((e) => e.includes('not in scene.materials')),
+    'dangling material ref = ERROR when registry present',
+  );
+  const badCol = {
+    v: 1,
+    collections: { real: { kind: 'dressing' } },
+    subjects: [{ id: 'a', type: 'sphere', args: { radius: 1 }, collection: 'ghost' }],
+  };
+  const v2 = validate(badCol);
+  ok(
+    !v2.ok && v2.errors.some((e) => e.includes('not in scene.collections')),
+    'dangling collection ref = ERROR when registry present',
+  );
+  // no registry → preset warning path unchanged (forward compat)
+  const legacy = {
+    v: 1,
+    defaults: {
+      camera: { yaw: 0, pitch: -0.1, distance: 8, focal: 1.2, targetX: 0, targetY: 1, targetZ: 0 },
+      light: { azimuth: 0.5, altitude: 0.7, distance: 30, intensity: 1 },
+    },
+    subjects: [{ id: 'a', type: 'sphere', args: { radius: 1 }, material: 'gold' }],
+  };
+  const vLegacy = validate(legacy);
+  ok(vLegacy.ok, `preset strings without registry keep working (${vLegacy.errors[0] || ''})`);
+}
+
+console.log(`\n${pass}/${pass + fail} passed`);
+process.exit(fail ? 1 : 0);

--- a/sdf-js/src/runtime/apply-studio-scene.js
+++ b/sdf-js/src/runtime/apply-studio-scene.js
@@ -26,6 +26,7 @@ import { compile as compileSceneData } from '../scene/index.js';
 import { expandVariants } from '../scene/generator-s.js';
 import { expandChartLabels } from '../scene/chart-labels.js';
 import { expandStage } from '../scene/stage.js';
+import { resolveMaterialRefs } from '../scene/spec.js';
 import { union as sdfUnion } from '../sdf/dn.js';
 
 // Does the scene change pixels on its own (no input)? Drives studio's idle-stop:
@@ -76,7 +77,10 @@ export function pickRenderScale(rawScene) {
  *          cameraSequence the wiring reads); sdf is ground-unioned + ready.
  */
 export function expandAndCompile(sceneData, { rng = null, tokenHash } = {}) {
-  const variantScene = rng ? expandVariants(sceneData, rng) : sceneData;
+  // Wave A: inflate scene.materials string references first — everything
+  // downstream (stage, labels, compile) keeps seeing inline material objects.
+  const resolvedScene = resolveMaterialRefs(sceneData);
+  const variantScene = rng ? expandVariants(resolvedScene, rng) : resolvedScene;
   const stagedScene = expandStage(variantScene);
   const labeledScene = expandChartLabels(stagedScene);
   const compiled = compileSceneData(labeledScene, { tokenHash });

--- a/sdf-js/src/scene/assemble-deck.js
+++ b/sdf-js/src/scene/assemble-deck.js
@@ -650,10 +650,63 @@ export function assembleDeck(deck, opts = {}) {
       }
     : null;
 
+  // ---- Wave A (Blender borrow): collections + material registry ---------------
+  // Collections make the slicing semantics DATA: every subject carries a
+  // collection tag, the registry says how each collection behaves in a window
+  // (kind / cull policy / dressing budget). The id prefixes stay as pure
+  // identity; sliceDeckWindow prefers collections and keeps the regex path
+  // only as a fallback for pre-Wave-A scenes.
+  const allSubjects = [...subjects, ...massingSubjects, ...worldSubjects];
+  const collections = {};
+  deck.slides.forEach((_, k) => {
+    collections[`station-${k}`] = { kind: 'station', station: k };
+    if (k < deck.slides.length - 1) collections[`path-${k}`] = { kind: 'transit-path', from: k };
+  });
+  collections.massing = { kind: 'dressing', cull: 'never' };
+  collections.horizon = {
+    kind: 'dressing',
+    cull: 'nearest',
+    budget: { hero: HILLS_HERO, content: HILLS_CONTENT },
+    yieldTo: 'massing', // dressing budget conservation (spec §4)
+  };
+  collections.env = { kind: 'dressing', cull: 'never' };
+  for (const s of allSubjects) {
+    if (s.collection) continue; // renderer-assigned wins (none today)
+    const st = /^s(\d+)-/.exec(s.id || '');
+    const path = /^path-(\d+)-/.exec(s.id || '');
+    s.collection = st
+      ? `station-${st[1]}`
+      : path
+        ? `path-${path[1]}`
+        : (s.id || '').startsWith('massing-')
+          ? 'massing'
+          : (s.id || '').startsWith('horizon-')
+            ? 'horizon'
+            : 'env';
+  }
+  // Material registry: auto-dedup the inline materials (36 kinds × ~300 uses on
+  // the reference deck). Names are deterministic by first appearance; subjects
+  // hold string refs, resolveMaterialRefs() inflates them before compile.
+  const materials = {};
+  const matName = new Map();
+  for (const s of allSubjects) {
+    if (!s.material || typeof s.material !== 'object') continue;
+    const key = JSON.stringify(s.material);
+    let name = matName.get(key);
+    if (!name) {
+      name = `mat-${matName.size}`;
+      matName.set(key, name);
+      materials[name] = s.material;
+    }
+    s.material = name;
+  }
+
   return {
     v: 1,
     name: `(deck) ${deck.title || `${deck.slides.length} stations`}${opts.env ? ` · ${opts.env}` : ''}`,
-    subjects: [...subjects, ...massingSubjects, ...worldSubjects],
+    collections,
+    materials,
+    subjects: allSubjects,
     overlay,
     // flow: steadicam smoothing (total-continuity lock) — deck playback is one
     // breathing take; the runtime erases shot-boundary velocity kinks.
@@ -686,46 +739,71 @@ const HILLS_CONTENT = 3;
 export function sliceDeckWindow(scene, win) {
   if (!win || win.kind === 'finale') return scene;
   const wanted = new Set(win.stations);
-  const keep = (s) => {
+  const cols = scene.collections || null;
+
+  // Wave A: collection-driven slicing — the routing rules live in DATA
+  // (scene.collections), ids are pure identity. The regex path below stays as
+  // a fallback for pre-Wave-A scenes and is deleted once no producer emits
+  // collection-less decks.
+  const keepByCollection = (s) => {
+    const c = cols[s.collection];
+    if (!c) return true; // untagged → shared dressing
+    if (c.kind === 'station') return wanted.has(c.station);
+    if (c.kind === 'transit-path') {
+      // Station windows keep only the OUTGOING segment (the world never pops
+      // in ahead of the lens — total-continuity lock); transit windows carry
+      // both segments they touch.
+      if (win.kind === 'station') return wanted.has(c.from);
+      return wanted.has(c.from) || wanted.has(c.from + 1);
+    }
+    return true; // dressing/decor: kept (nearest-cull handled below)
+  };
+  const keepLegacy = (s) => {
     const id = typeof s.id === 'string' ? s.id : '';
     const st = /^s(\d+)-/.exec(id);
     if (st) return wanted.has(Number(st[1]));
     const path = /^path-(\d+)-/.exec(id);
     if (path) {
       const i = Number(path[1]);
-      // Breadcrumbs earn their keep during TRANSIT flyovers. Station windows
-      // keep only the OUTGOING segment (path-k, leading to the next arena):
-      // when the transit starts, its path is ALREADY there — the world never
-      // pops in ahead of the lens (total-continuity lock). The incoming
-      // segment (path-(k-1)) still drops, but that pop happens BEHIND the
-      // camera at arrival, where nobody is looking. +5 leaves per station.
       if (win.kind === 'station') return wanted.has(i);
       return wanted.has(i) || wanted.has(i + 1);
     }
     return true;
   };
-  let subjects = scene.subjects.filter(keep);
+  let subjects = scene.subjects.filter(cols ? keepByCollection : keepLegacy);
+
   if (Array.isArray(win.origin)) {
-    // Dressing budget CONSERVATION (spec §4): chapter massing (`massing-`
-    // prefix) is kept in every window and is NEVER distance-culled — the far
-    // side is exactly what foreshadowing needs, and the nearest-first trim
-    // below would throw it away first. The horizon-slab quota shrinks in
-    // exchange, so the per-window dressing total stays in the same band.
-    const massingCount = subjects.filter(
-      (s) => typeof s.id === 'string' && s.id.startsWith('massing-'),
-    ).length;
-    const hillBudget = Math.max(
-      0,
-      (win.tier === 'hero' ? HILLS_HERO : HILLS_CONTENT) - massingCount,
-    );
-    const hills = subjects.filter((s) => typeof s.id === 'string' && s.id.startsWith('horizon-'));
-    if (hills.length > hillBudget) {
+    // Dressing budget CONSERVATION (spec §4): 'never'-culled dressing (chapter
+    // massing) stays in every window — the far side is exactly what
+    // foreshadowing needs; the nearest-culled collection's quota shrinks in
+    // exchange (yieldTo), so the per-window dressing total stays in one band.
+    const tierKey = win.tier === 'hero' ? 'hero' : 'content';
+    const cullNearest = (memberOf, budget) => {
+      const members = subjects.filter(memberOf);
+      if (members.length <= budget) return;
       const distSq = (s) => {
         const t = (s.transform && s.transform.translate) || [0, 0, 0];
         return (t[0] - win.origin[0]) ** 2 + (t[2] - win.origin[2]) ** 2;
       };
-      const near = new Set([...hills].sort((a, b) => distSq(a) - distSq(b)).slice(0, hillBudget));
-      subjects = subjects.filter((s) => !s.id || !s.id.startsWith('horizon-') || near.has(s));
+      const near = new Set(members.sort((a, b) => distSq(a) - distSq(b)).slice(0, budget));
+      subjects = subjects.filter((s) => !memberOf(s) || near.has(s));
+    };
+    if (cols) {
+      for (const [name, c] of Object.entries(cols)) {
+        if (c.kind !== 'dressing' || c.cull !== 'nearest') continue;
+        const yieldCount = c.yieldTo
+          ? subjects.filter((s) => s.collection === c.yieldTo).length
+          : 0;
+        const base =
+          (c.budget && c.budget[tierKey]) ?? (tierKey === 'hero' ? HILLS_HERO : HILLS_CONTENT);
+        cullNearest((s) => s.collection === name, Math.max(0, base - yieldCount));
+      }
+    } else {
+      const massingCount = subjects.filter(
+        (s) => typeof s.id === 'string' && s.id.startsWith('massing-'),
+      ).length;
+      const budget = Math.max(0, (tierKey === 'hero' ? HILLS_HERO : HILLS_CONTENT) - massingCount);
+      cullNearest((s) => typeof s.id === 'string' && s.id.startsWith('horizon-'), budget);
     }
   }
   return { ...scene, subjects };

--- a/sdf-js/src/scene/spec.js
+++ b/sdf-js/src/scene/spec.js
@@ -797,22 +797,91 @@ export function validate(data) {
     data.subjects.forEach((s, i) => collectIds(s, `subjects[${i}]`));
   }
 
+  // Scene-level material registry (Blender-borrow Wave A: datablock reuse).
+  // Entries are validated like inline materials; subjects reference by name.
+  if (data.materials != null) {
+    if (typeof data.materials !== 'object' || Array.isArray(data.materials)) {
+      errors.push('materials: must be an object map { name: material }');
+    } else {
+      for (const [name, m] of Object.entries(data.materials)) {
+        if (m == null || typeof m !== 'object' || Array.isArray(m)) {
+          errors.push(`materials["${name}"]: must be a material object`);
+          continue;
+        }
+        for (const k of ['hue', 'sat', 'value', 'metal', 'glow']) {
+          if (m[k] != null && typeof m[k] !== 'number')
+            errors.push(`materials["${name}"].${k}: must be a number if present`);
+        }
+      }
+    }
+  }
+
+  // Scene-level collections registry (Wave A: slicing semantics as DATA — the
+  // id-prefix regex contracts retire once consumers read this instead).
+  if (data.collections != null) {
+    if (typeof data.collections !== 'object' || Array.isArray(data.collections)) {
+      errors.push('collections: must be an object map { name: meta }');
+    } else {
+      for (const [name, c] of Object.entries(data.collections)) {
+        if (c == null || typeof c !== 'object') {
+          errors.push(`collections["${name}"]: must be an object`);
+          continue;
+        }
+        if (c.kind != null && !['station', 'transit-path', 'dressing', 'decor'].includes(c.kind))
+          errors.push(`collections["${name}"].kind: unknown "${c.kind}"`);
+        if (c.cull != null && !['never', 'nearest'].includes(c.cull))
+          errors.push(`collections["${name}"].cull: must be 'never' or 'nearest'`);
+      }
+    }
+  }
+
   // Subject-level validation
   if (Array.isArray(data.subjects)) {
-    data.subjects.forEach((s, i) => validateSubject(s, `subjects[${i}]`, errors, warnings));
+    const ctx = { materials: data.materials || null, collections: data.collections || null };
+    data.subjects.forEach((s, i) => validateSubject(s, `subjects[${i}]`, errors, warnings, ctx));
   }
 
   return { ok: errors.length === 0, errors, warnings };
+}
+
+/**
+ * resolveMaterialRefs(scene) → scene
+ * Replace subject.material strings that name a scene.materials entry with the
+ * registry object (shallow scene copy; registry wins over MATERIAL_PRESETS).
+ * Runs before compile; scenes without a registry pass through untouched.
+ */
+export function resolveMaterialRefs(scene) {
+  if (!scene || !scene.materials) return scene;
+  const reg = scene.materials;
+  let changed = false;
+  const subjects = (scene.subjects || []).map((s) => {
+    if (s && typeof s.material === 'string' && reg[s.material]) {
+      changed = true;
+      return { ...s, material: { ...reg[s.material] } };
+    }
+    return s;
+  });
+  return changed ? { ...scene, subjects } : scene;
 }
 
 // =============================================================================
 // Subject validation (recursive)
 // =============================================================================
 
-function validateSubject(subj, path, errors, warnings) {
+function validateSubject(subj, path, errors, warnings, ctx = null) {
   if (subj == null || typeof subj !== 'object' || Array.isArray(subj)) {
     errors.push(`${path}: must be an object`);
     return;
+  }
+  // collection tag: with a registry present, a dangling reference is an ERROR
+  // (collections carry slicing/routing semantics — a typo would silently
+  // change what geometry exists in a window)
+  if (subj.collection != null) {
+    if (typeof subj.collection !== 'string') {
+      errors.push(`${path}.collection: must be a string`);
+    } else if (ctx && ctx.collections && !ctx.collections[subj.collection]) {
+      errors.push(`${path}.collection: "${subj.collection}" not in scene.collections`);
+    }
   }
 
   if (typeof subj.type !== 'string') {
@@ -854,7 +923,7 @@ function validateSubject(subj, path, errors, warnings) {
       warnings.push(`${path}: BooleanGroup "${subj.type}" with single child will be unwrapped`);
     } else {
       subj.children.forEach((c, i) =>
-        validateSubject(c, `${path}/children[${i}]`, errors, warnings),
+        validateSubject(c, `${path}/children[${i}]`, errors, warnings, ctx),
       );
     }
     // hg_sdf variants need args.r; missing is recoverable (default applied)
@@ -912,7 +981,7 @@ function validateSubject(subj, path, errors, warnings) {
     if (subj.source == null || typeof subj.source !== 'object') {
       errors.push(`${path}: DomainGroup "${subj.type}" requires a "source" Subject`);
     } else {
-      validateSubject(subj.source, `${path}/source`, errors, warnings);
+      validateSubject(subj.source, `${path}/source`, errors, warnings, ctx);
     }
     validateDomainArgs(subj.type, subj.args, `${path}.args`, errors, warnings);
   }
@@ -925,7 +994,7 @@ function validateSubject(subj, path, errors, warnings) {
     if (subj.source == null) {
       errors.push(`${path}: "${subj.type}" requires a "source" 2D primitive`);
     } else {
-      validateSubject(subj.source, `${path}/source`, errors, warnings);
+      validateSubject(subj.source, `${path}/source`, errors, warnings, ctx);
     }
   }
 
@@ -965,10 +1034,21 @@ function validateSubject(subj, path, errors, warnings) {
   // preset packs can ship preset names that older builds don't know yet.
   if (subj.material != null) {
     if (typeof subj.material === 'string') {
-      if (!MATERIAL_PRESETS[subj.material]) {
-        warnings.push(
-          `${path}.material: unknown preset "${subj.material}" — will fall back to default palette. Known: ${Object.keys(MATERIAL_PRESETS).join(', ')}`,
-        );
+      const inRegistry = !!(ctx && ctx.materials && ctx.materials[subj.material]);
+      if (!inRegistry && !MATERIAL_PRESETS[subj.material]) {
+        // With a scene registry present, a dangling name is an ERROR — the
+        // material is visual identity, silent palette fallback would produce
+        // a "looks right"-wrong. Without a registry, keep the forward-compat
+        // preset warning behavior.
+        if (ctx && ctx.materials) {
+          errors.push(
+            `${path}.material: "${subj.material}" not in scene.materials and not a preset`,
+          );
+        } else {
+          warnings.push(
+            `${path}.material: unknown preset "${subj.material}" — will fall back to default palette. Known: ${Object.keys(MATERIAL_PRESETS).join(', ')}`,
+          );
+        }
       }
     } else if (typeof subj.material === 'object' && !Array.isArray(subj.material)) {
       const m = subj.material;


### PR DESCRIPTION
## Wave A(spec §2/§3)

**collections:切片语义从 id 正则变成数据。**
- `scene.collections` 注册表携带路由语义(kind / station / from / cull / budget / **yieldTo** 预算守恒),每个 subject 带 `collection` 标签;id 前缀降级为纯身份
- `sliceDeckWindow` v2 按 collection 元数据过滤;legacy 正则保留为 pre-Wave-A 场景回退(全部生产者迁移后删除)
- **语义等价钉死**:radial + courtyard 的每一个窗口,collection 切片与 legacy 正则切片的 id 集合逐一相等(13 断言里的核心两条)

**材质注册表:datablock 复用。**
- assembleDeck 自动 dedup:字节 deck 319 个内联材质 → **36 条注册 + 319 个字符串引用**;`resolveMaterialRefs` 进管线首位,下游全部照旧看到内联对象
- 与 MATERIAL_PRESETS 共存(registry 优先);**悬空引用 = ERROR**(材质是视觉身份,collection 是路由语义——静默回退会产生"看起来对了"的错);无注册表时 preset warning 前向兼容不变

真机 smoke 过(金柱/配色零回归),suite 150/150,goldens 重烤。

Merge 后进 **Wave B:modifiers v1(expansion)**——面包屑/石板/guard/decor 全部改声明式,字节 deck 319→约 80 subjects。

🤖 Generated with [Claude Code](https://claude.com/claude-code)