### PR TITLE
feat(wave-b): Blender 借法第二波 — 放置修饰符 v1(expansion)

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -164,6 +164,7 @@ const TESTS = [
   { category: 'scene', file: 'sdf-js/scripts/test-tempo-tokens.mjs' },
   { category: 'scene', file: 'sdf-js/scripts/test-courtyard.mjs' },
   { category: 'scene', file: 'sdf-js/scripts/test-scene-collections.mjs' },
+  { category: 'scene', file: 'sdf-js/scripts/test-modifiers.mjs' },
   { category: 'scene', file: 'sdf-js/scripts/audit-2d-fidelity.mjs' },
   { category: 'scene', file: 'sdf-js/scripts/test-camera-shake.mjs' },
   { category: 'scene', file: 'sdf-js/scripts/test-text-to-ir.mjs' },

--- a/sdf-js/fixtures/golden/assemble-deck-courtyard.json
+++ b/sdf-js/fixtures/golden/assemble-deck-courtyard.json
@@ -848,91 +848,20 @@
       "collection": "station-0"
     },
     {
-      "id": "path-0-1",
+      "id": "path-0-runway",
       "type": "box",
       "args": {
         "dims": [1.7, 0.05, 0.32]
       },
+      "modifiers": [
+        {
+          "type": "array",
+          "count": 7,
+          "offset": [0.8950805849013479, 0, 4.884296673803914]
+        }
+      ],
       "transform": {
         "translate": [0.8950805849013479, 0.03, 4.884296673803914],
-        "rotate": [0, -1.3895505967801007, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-0"
-    },
-    {
-      "id": "path-0-2",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [1.7901611698026958, 0.03, 9.768593347607828],
-        "rotate": [0, -1.3895505967801007, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-0"
-    },
-    {
-      "id": "path-0-3",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [2.6852417547040437, 0.03, 14.652890021411743],
-        "rotate": [0, -1.3895505967801007, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-0"
-    },
-    {
-      "id": "path-0-4",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [3.5803223396053916, 0.03, 19.537186695215656],
-        "rotate": [0, -1.3895505967801007, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-0"
-    },
-    {
-      "id": "path-0-5",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [4.4754029245067395, 0.03, 24.42148336901957],
-        "rotate": [0, -1.3895505967801007, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-0"
-    },
-    {
-      "id": "path-0-6",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [5.370483509408087, 0.03, 29.305780042823486],
-        "rotate": [0, -1.3895505967801007, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-0"
-    },
-    {
-      "id": "path-0-7",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [6.265564094309435, 0.03, 34.190076716627395],
         "rotate": [0, -1.3895505967801007, 0]
       },
       "material": "mat-1",
@@ -1137,91 +1066,20 @@
       "collection": "station-1"
     },
     {
-      "id": "path-1-1",
+      "id": "path-1-runway",
       "type": "box",
       "args": {
         "dims": [1.7, 0.05, 0.32]
       },
+      "modifiers": [
+        {
+          "type": "array",
+          "count": 7,
+          "offset": [3.1339249792093407, 0, -1.981774078618058]
+        }
+      ],
       "transform": {
         "translate": [10.294569658420123, 0.03, 37.09259931181325],
-        "rotate": [0, 0.5638756044904756, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-1"
-    },
-    {
-      "id": "path-1-2",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [13.428494637629464, 0.03, 35.11082523319519],
-        "rotate": [0, 0.5638756044904756, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-1"
-    },
-    {
-      "id": "path-1-3",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [16.562419616838806, 0.03, 33.12905115457714],
-        "rotate": [0, 0.5638756044904756, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-1"
-    },
-    {
-      "id": "path-1-4",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [19.696344596048146, 0.03, 31.14727707595908],
-        "rotate": [0, 0.5638756044904756, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-1"
-    },
-    {
-      "id": "path-1-5",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [22.830269575257486, 0.03, 29.165502997341022],
-        "rotate": [0, 0.5638756044904756, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-1"
-    },
-    {
-      "id": "path-1-6",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [25.96419455446683, 0.03, 27.183728918722963],
-        "rotate": [0, 0.5638756044904756, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-1"
-    },
-    {
-      "id": "path-1-7",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [29.09811953367617, 0.03, 25.201954840104904],
         "rotate": [0, 0.5638756044904756, 0]
       },
       "material": "mat-1",
@@ -1419,24 +1277,18 @@
       "collection": "station-2"
     },
     {
-      "id": "s2-guard-l-0",
+      "id": "s2-guard-0",
       "type": "box",
       "args": {
         "dims": [0.9, 2.2, 0.5]
       },
-      "transform": {
-        "translate": [24.09704451288551, 1.1, 24.420180761486847],
-        "rotate": [0, -0.3, 0]
-      },
-      "material": "mat-13",
-      "collection": "station-2"
-    },
-    {
-      "id": "s2-guard-r-0",
-      "type": "box",
-      "args": {
-        "dims": [0.9, 2.2, 0.5]
-      },
+      "modifiers": [
+        {
+          "type": "mirror",
+          "axis": "x",
+          "origin": [32.23204451288551, 23.220180761486848]
+        }
+      ],
       "transform": {
         "translate": [40.367044512885506, 1.1, 24.420180761486847],
         "rotate": [0, 0.3, 0]
@@ -1445,24 +1297,18 @@
       "collection": "station-2"
     },
     {
-      "id": "s2-guard-l-1",
+      "id": "s2-guard-1",
       "type": "box",
       "args": {
         "dims": [0.9, 3.5, 0.5]
       },
-      "transform": {
-        "translate": [24.69704451288551, 1.75, 18.62018076148685],
-        "rotate": [0, -0.3, 0]
-      },
-      "material": "mat-13",
-      "collection": "station-2"
-    },
-    {
-      "id": "s2-guard-r-1",
-      "type": "box",
-      "args": {
-        "dims": [0.9, 3.5, 0.5]
-      },
+      "modifiers": [
+        {
+          "type": "mirror",
+          "axis": "x",
+          "origin": [32.23204451288551, 23.220180761486848]
+        }
+      ],
       "transform": {
         "translate": [39.767044512885505, 1.75, 18.62018076148685],
         "rotate": [0, 0.3, 0]
@@ -1471,24 +1317,18 @@
       "collection": "station-2"
     },
     {
-      "id": "s2-guard-l-2",
+      "id": "s2-guard-2",
       "type": "box",
       "args": {
         "dims": [0.9, 4.800000000000001, 0.5]
       },
-      "transform": {
-        "translate": [23.297044512885506, 2.4000000000000004, 16.420180761486847],
-        "rotate": [0, -0.3, 0]
-      },
-      "material": "mat-13",
-      "collection": "station-2"
-    },
-    {
-      "id": "s2-guard-r-2",
-      "type": "box",
-      "args": {
-        "dims": [0.9, 4.800000000000001, 0.5]
-      },
+      "modifiers": [
+        {
+          "type": "mirror",
+          "axis": "x",
+          "origin": [32.23204451288551, 23.220180761486848]
+        }
+      ],
       "transform": {
         "translate": [41.16704451288551, 2.4000000000000004, 16.420180761486847],
         "rotate": [0, 0.3, 0]
@@ -1497,91 +1337,20 @@
       "collection": "station-2"
     },
     {
-      "id": "path-2-1",
+      "id": "path-2-runway",
       "type": "box",
       "args": {
         "dims": [1.7, 0.05, 0.32]
       },
+      "modifiers": [
+        {
+          "type": "array",
+          "count": 7,
+          "offset": [0.8152886749354362, 0, -1.811497124931452]
+        }
+      ],
       "transform": {
         "translate": [33.047333187820946, 0.03, 21.408683636555395],
-        "rotate": [0, 1.1478896234270402, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-2"
-    },
-    {
-      "id": "path-2-2",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [33.862621862756384, 0.03, 19.597186511623946],
-        "rotate": [0, 1.1478896234270402, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-2"
-    },
-    {
-      "id": "path-2-3",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [34.677910537691815, 0.03, 17.785689386692493],
-        "rotate": [0, 1.1478896234270402, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-2"
-    },
-    {
-      "id": "path-2-4",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [35.49319921262725, 0.03, 15.97419226176104],
-        "rotate": [0, 1.1478896234270402, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-2"
-    },
-    {
-      "id": "path-2-5",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [36.30848788756269, 0.03, 14.162695136829587],
-        "rotate": [0, 1.1478896234270402, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-2"
-    },
-    {
-      "id": "path-2-6",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [37.12377656249812, 0.03, 12.351198011898136],
-        "rotate": [0, 1.1478896234270402, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-2"
-    },
-    {
-      "id": "path-2-7",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [37.93906523743356, 0.03, 10.539700886966685],
         "rotate": [0, 1.1478896234270402, 0]
       },
       "material": "mat-1",
@@ -1779,24 +1548,18 @@
       "collection": "station-3"
     },
     {
-      "id": "s3-guard-l-0",
+      "id": "s3-guard-0",
       "type": "box",
       "args": {
         "dims": [0.9, 2.2, 0.5]
       },
-      "transform": {
-        "translate": [30.619353912369, 1.1, 9.928203762035231],
-        "rotate": [0, -0.3, 0]
-      },
-      "material": "mat-13",
-      "collection": "station-3"
-    },
-    {
-      "id": "s3-guard-r-0",
-      "type": "box",
-      "args": {
-        "dims": [0.9, 2.2, 0.5]
-      },
+      "modifiers": [
+        {
+          "type": "mirror",
+          "axis": "x",
+          "origin": [38.754353912369, 8.728203762035232]
+        }
+      ],
       "transform": {
         "translate": [46.889353912368996, 1.1, 9.928203762035231],
         "rotate": [0, 0.3, 0]
@@ -1805,24 +1568,18 @@
       "collection": "station-3"
     },
     {
-      "id": "s3-guard-l-1",
+      "id": "s3-guard-1",
       "type": "box",
       "args": {
         "dims": [0.9, 3.5, 0.5]
       },
-      "transform": {
-        "translate": [31.219353912368998, 1.75, 4.128203762035232],
-        "rotate": [0, -0.3, 0]
-      },
-      "material": "mat-13",
-      "collection": "station-3"
-    },
-    {
-      "id": "s3-guard-r-1",
-      "type": "box",
-      "args": {
-        "dims": [0.9, 3.5, 0.5]
-      },
+      "modifiers": [
+        {
+          "type": "mirror",
+          "axis": "x",
+          "origin": [38.754353912369, 8.728203762035232]
+        }
+      ],
       "transform": {
         "translate": [46.289353912368995, 1.75, 4.128203762035232],
         "rotate": [0, 0.3, 0]
@@ -1831,24 +1588,18 @@
       "collection": "station-3"
     },
     {
-      "id": "s3-guard-l-2",
+      "id": "s3-guard-2",
       "type": "box",
       "args": {
         "dims": [0.9, 4.800000000000001, 0.5]
       },
-      "transform": {
-        "translate": [29.819353912368996, 2.4000000000000004, 1.9282037620352313],
-        "rotate": [0, -0.3, 0]
-      },
-      "material": "mat-13",
-      "collection": "station-3"
-    },
-    {
-      "id": "s3-guard-r-2",
-      "type": "box",
-      "args": {
-        "dims": [0.9, 4.800000000000001, 0.5]
-      },
+      "modifiers": [
+        {
+          "type": "mirror",
+          "axis": "x",
+          "origin": [38.754353912369, 8.728203762035232]
+        }
+      ],
       "transform": {
         "translate": [47.689353912369, 2.4000000000000004, 1.9282037620352313],
         "rotate": [0, 0.3, 0]
@@ -1857,91 +1608,20 @@
       "collection": "station-3"
     },
     {
-      "id": "path-3-1",
+      "id": "path-3-runway",
       "type": "box",
       "args": {
         "dims": [1.7, 0.05, 0.32]
       },
+      "modifiers": [
+        {
+          "type": "array",
+          "count": 7,
+          "offset": [0.040002434757789196, 0, -1.986106055155752]
+        }
+      ],
       "transform": {
         "translate": [38.79435634712679, 0.03, 6.7420977068794805],
-        "rotate": [0, 1.5506579123488082, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-3"
-    },
-    {
-      "id": "path-3-2",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [38.834358781884575, 0.03, 4.755991651723728],
-        "rotate": [0, 1.5506579123488082, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-3"
-    },
-    {
-      "id": "path-3-3",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [38.87436121664236, 0.03, 2.769885596567976],
-        "rotate": [0, 1.5506579123488082, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-3"
-    },
-    {
-      "id": "path-3-4",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [38.91436365140015, 0.03, 0.7837795414122244],
-        "rotate": [0, 1.5506579123488082, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-3"
-    },
-    {
-      "id": "path-3-5",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [38.95436608615795, 0.03, -1.202326513743527],
-        "rotate": [0, 1.5506579123488082, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-3"
-    },
-    {
-      "id": "path-3-6",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [38.994368520915735, 0.03, -3.1884325688992803],
-        "rotate": [0, 1.5506579123488082, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-3"
-    },
-    {
-      "id": "path-3-7",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [39.03437095567352, 0.03, -5.174538624055032],
         "rotate": [0, 1.5506579123488082, 0]
       },
       "material": "mat-1",
@@ -2139,24 +1819,18 @@
       "collection": "station-4"
     },
     {
-      "id": "s4-guard-l-0",
+      "id": "s4-guard-0",
       "type": "box",
       "args": {
         "dims": [0.9, 2.2, 0.5]
       },
-      "transform": {
-        "translate": [30.939373390431314, 1.1, -5.960644679210782],
-        "rotate": [0, -0.3, 0]
-      },
-      "material": "mat-13",
-      "collection": "station-4"
-    },
-    {
-      "id": "s4-guard-r-0",
-      "type": "box",
-      "args": {
-        "dims": [0.9, 2.2, 0.5]
-      },
+      "modifiers": [
+        {
+          "type": "mirror",
+          "axis": "x",
+          "origin": [39.07437339043131, -7.160644679210782]
+        }
+      ],
       "transform": {
         "translate": [47.20937339043131, 1.1, -5.960644679210782],
         "rotate": [0, 0.3, 0]
@@ -2165,24 +1839,18 @@
       "collection": "station-4"
     },
     {
-      "id": "s4-guard-l-1",
+      "id": "s4-guard-1",
       "type": "box",
       "args": {
         "dims": [0.9, 3.5, 0.5]
       },
-      "transform": {
-        "translate": [31.53937339043131, 1.75, -11.760644679210781],
-        "rotate": [0, -0.3, 0]
-      },
-      "material": "mat-13",
-      "collection": "station-4"
-    },
-    {
-      "id": "s4-guard-r-1",
-      "type": "box",
-      "args": {
-        "dims": [0.9, 3.5, 0.5]
-      },
+      "modifiers": [
+        {
+          "type": "mirror",
+          "axis": "x",
+          "origin": [39.07437339043131, -7.160644679210782]
+        }
+      ],
       "transform": {
         "translate": [46.609373390431315, 1.75, -11.760644679210781],
         "rotate": [0, 0.3, 0]
@@ -2191,24 +1859,18 @@
       "collection": "station-4"
     },
     {
-      "id": "s4-guard-l-2",
+      "id": "s4-guard-2",
       "type": "box",
       "args": {
         "dims": [0.9, 4.800000000000001, 0.5]
       },
-      "transform": {
-        "translate": [30.13937339043131, 2.4000000000000004, -13.960644679210784],
-        "rotate": [0, -0.3, 0]
-      },
-      "material": "mat-13",
-      "collection": "station-4"
-    },
-    {
-      "id": "s4-guard-r-2",
-      "type": "box",
-      "args": {
-        "dims": [0.9, 4.800000000000001, 0.5]
-      },
+      "modifiers": [
+        {
+          "type": "mirror",
+          "axis": "x",
+          "origin": [39.07437339043131, -7.160644679210782]
+        }
+      ],
       "transform": {
         "translate": [48.009373390431314, 2.4000000000000004, -13.960644679210784],
         "rotate": [0, 0.3, 0]
@@ -2217,91 +1879,20 @@
       "collection": "station-4"
     },
     {
-      "id": "path-4-1",
+      "id": "path-4-runway",
       "type": "box",
       "args": {
         "dims": [1.7, 0.05, 0.32]
       },
+      "modifiers": [
+        {
+          "type": "array",
+          "count": 7,
+          "offset": [-0.7416858395884978, 0, -1.8428563624077698]
+        }
+      ],
       "transform": {
         "translate": [38.33268755084281, 0.03, -9.003501041618552],
-        "rotate": [0, 1.9534262012705768, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-4"
-    },
-    {
-      "id": "path-4-2",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [37.591001711254314, 0.03, -10.846357404026321],
-        "rotate": [0, 1.9534262012705768, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-4"
-    },
-    {
-      "id": "path-4-3",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [36.849315871665816, 0.03, -12.689213766434092],
-        "rotate": [0, 1.9534262012705768, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-4"
-    },
-    {
-      "id": "path-4-4",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [36.107630032077324, 0.03, -14.532070128841863],
-        "rotate": [0, 1.9534262012705768, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-4"
-    },
-    {
-      "id": "path-4-5",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [35.365944192488826, 0.03, -16.37492649124963],
-        "rotate": [0, 1.9534262012705768, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-4"
-    },
-    {
-      "id": "path-4-6",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [34.62425835290033, 0.03, -18.2177828536574],
-        "rotate": [0, 1.9534262012705768, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-4"
-    },
-    {
-      "id": "path-4-7",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [33.88257251331183, 0.03, -20.060639216065173],
         "rotate": [0, 1.9534262012705768, 0]
       },
       "material": "mat-1",
@@ -2499,24 +2090,18 @@
       "collection": "station-5"
     },
     {
-      "id": "s5-guard-l-0",
+      "id": "s5-guard-0",
       "type": "box",
       "args": {
         "dims": [0.9, 2.2, 0.5]
       },
-      "transform": {
-        "translate": [25.00588667372333, 1.1, -20.703495578472943],
-        "rotate": [0, -0.3, 0]
-      },
-      "material": "mat-13",
-      "collection": "station-5"
-    },
-    {
-      "id": "s5-guard-r-0",
-      "type": "box",
-      "args": {
-        "dims": [0.9, 2.2, 0.5]
-      },
+      "modifiers": [
+        {
+          "type": "mirror",
+          "axis": "x",
+          "origin": [33.14088667372333, -21.903495578472942]
+        }
+      ],
       "transform": {
         "translate": [41.27588667372333, 1.1, -20.703495578472943],
         "rotate": [0, 0.3, 0]
@@ -2525,24 +2110,18 @@
       "collection": "station-5"
     },
     {
-      "id": "s5-guard-l-1",
+      "id": "s5-guard-1",
       "type": "box",
       "args": {
         "dims": [0.9, 3.5, 0.5]
       },
-      "transform": {
-        "translate": [25.60588667372333, 1.75, -26.503495578472943],
-        "rotate": [0, -0.3, 0]
-      },
-      "material": "mat-13",
-      "collection": "station-5"
-    },
-    {
-      "id": "s5-guard-r-1",
-      "type": "box",
-      "args": {
-        "dims": [0.9, 3.5, 0.5]
-      },
+      "modifiers": [
+        {
+          "type": "mirror",
+          "axis": "x",
+          "origin": [33.14088667372333, -21.903495578472942]
+        }
+      ],
       "transform": {
         "translate": [40.675886673723326, 1.75, -26.503495578472943],
         "rotate": [0, 0.3, 0]
@@ -2551,24 +2130,18 @@
       "collection": "station-5"
     },
     {
-      "id": "s5-guard-l-2",
+      "id": "s5-guard-2",
       "type": "box",
       "args": {
         "dims": [0.9, 4.800000000000001, 0.5]
       },
-      "transform": {
-        "translate": [24.205886673723327, 2.4000000000000004, -28.703495578472943],
-        "rotate": [0, -0.3, 0]
-      },
-      "material": "mat-13",
-      "collection": "station-5"
-    },
-    {
-      "id": "s5-guard-r-2",
-      "type": "box",
-      "args": {
-        "dims": [0.9, 4.800000000000001, 0.5]
-      },
+      "modifiers": [
+        {
+          "type": "mirror",
+          "axis": "x",
+          "origin": [33.14088667372333, -21.903495578472942]
+        }
+      ],
       "transform": {
         "translate": [42.07588667372333, 2.4000000000000004, -28.703495578472943],
         "rotate": [0, 0.3, 0]
@@ -2577,91 +2150,20 @@
       "collection": "station-5"
     },
     {
-      "id": "path-5-1",
+      "id": "path-5-runway",
       "type": "box",
       "args": {
         "dims": [1.7, 0.05, 0.32]
       },
+      "modifiers": [
+        {
+          "type": "array",
+          "count": 7,
+          "offset": [-1.4046738869062971, 0, -1.4046738869062985]
+        }
+      ],
       "transform": {
         "translate": [31.73621278681703, 0.03, -23.30816946537924],
-        "rotate": [0, 2.3561944901923444, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-5"
-    },
-    {
-      "id": "path-5-2",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [30.331538899910736, 0.03, -24.71284335228554],
-        "rotate": [0, 2.3561944901923444, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-5"
-    },
-    {
-      "id": "path-5-3",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [28.926865013004438, 0.03, -26.117517239191837],
-        "rotate": [0, 2.3561944901923444, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-5"
-    },
-    {
-      "id": "path-5-4",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [27.522191126098143, 0.03, -27.522191126098136],
-        "rotate": [0, 2.3561944901923444, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-5"
-    },
-    {
-      "id": "path-5-5",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [26.117517239191844, 0.03, -28.926865013004434],
-        "rotate": [0, 2.3561944901923444, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-5"
-    },
-    {
-      "id": "path-5-6",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [24.712843352285546, 0.03, -30.331538899910733],
-        "rotate": [0, 2.3561944901923444, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-5"
-    },
-    {
-      "id": "path-5-7",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [23.30816946537925, 0.03, -31.73621278681703],
         "rotate": [0, 2.3561944901923444, 0]
       },
       "material": "mat-1",
@@ -2878,91 +2380,20 @@
       "collection": "station-6"
     },
     {
-      "id": "path-6-1",
+      "id": "path-6-runway",
       "type": "box",
       "args": {
         "dims": [1.7, 0.05, 0.32]
       },
+      "modifiers": [
+        {
+          "type": "array",
+          "count": 7,
+          "offset": [-3.6330175322104665, 0, -0.7416858395884978]
+        }
+      ],
       "transform": {
         "translate": [18.270478046262486, 0.03, -33.88257251331183],
-        "rotate": [0, 2.940208509128909, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-6"
-    },
-    {
-      "id": "path-6-2",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [14.63746051405202, 0.03, -34.62425835290033],
-        "rotate": [0, 2.940208509128909, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-6"
-    },
-    {
-      "id": "path-6-3",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [11.004442981841553, 0.03, -35.365944192488826],
-        "rotate": [0, 2.940208509128909, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-6"
-    },
-    {
-      "id": "path-6-4",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [7.3714254496310865, 0.03, -36.107630032077324],
-        "rotate": [0, 2.940208509128909, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-6"
-    },
-    {
-      "id": "path-6-5",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [3.73840791742062, 0.03, -36.849315871665816],
-        "rotate": [0, 2.940208509128909, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-6"
-    },
-    {
-      "id": "path-6-6",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [0.10539038521015343, 0.03, -37.591001711254314],
-        "rotate": [0, 2.940208509128909, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-6"
-    },
-    {
-      "id": "path-6-7",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [-3.527627147000313, 0.03, -38.33268755084281],
         "rotate": [0, 2.940208509128909, 0]
       },
       "material": "mat-1",
@@ -3749,91 +3180,20 @@
       "collection": "station-7"
     },
     {
-      "id": "path-7-1",
+      "id": "path-7-runway",
       "type": "box",
       "args": {
         "dims": [1.7, 0.05, 0.32]
       },
+      "modifiers": [
+        {
+          "type": "array",
+          "count": 7,
+          "offset": [-1.842856362407772, 0, 0.7416858395884987]
+        }
+      ],
       "transform": {
         "translate": [-9.003501041618552, 0.03, -38.33268755084281],
-        "rotate": [0, -2.758962779114113, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-7"
-    },
-    {
-      "id": "path-7-2",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [-10.846357404026325, 0.03, -37.591001711254314],
-        "rotate": [0, -2.758962779114113, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-7"
-    },
-    {
-      "id": "path-7-3",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [-12.689213766434095, 0.03, -36.849315871665816],
-        "rotate": [0, -2.758962779114113, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-7"
-    },
-    {
-      "id": "path-7-4",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [-14.532070128841868, 0.03, -36.10763003207732],
-        "rotate": [0, -2.758962779114113, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-7"
-    },
-    {
-      "id": "path-7-5",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [-16.37492649124964, 0.03, -35.36594419248882],
-        "rotate": [0, -2.758962779114113, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-7"
-    },
-    {
-      "id": "path-7-6",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [-18.21778285365741, 0.03, -34.62425835290032],
-        "rotate": [0, -2.758962779114113, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-7"
-    },
-    {
-      "id": "path-7-7",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [-20.060639216065184, 0.03, -33.88257251331182],
         "rotate": [0, -2.758962779114113, 0]
       },
       "material": "mat-1",
@@ -3924,91 +3284,20 @@
       "collection": "station-8"
     },
     {
-      "id": "path-8-1",
+      "id": "path-8-runway",
       "type": "box",
       "args": {
         "dims": [1.7, 0.05, 0.32]
       },
+      "modifiers": [
+        {
+          "type": "array",
+          "count": 7,
+          "offset": [-1.4046738869062958, 0, 1.4046738869062962]
+        }
+      ],
       "transform": {
         "translate": [-23.30816946537925, 0.03, -31.736212786817028],
-        "rotate": [0, -2.356194490192345, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-8"
-    },
-    {
-      "id": "path-8-2",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [-24.712843352285546, 0.03, -30.33153889991073],
-        "rotate": [0, -2.356194490192345, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-8"
-    },
-    {
-      "id": "path-8-3",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [-26.117517239191844, 0.03, -28.926865013004434],
-        "rotate": [0, -2.356194490192345, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-8"
-    },
-    {
-      "id": "path-8-4",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [-27.52219112609814, 0.03, -27.522191126098136],
-        "rotate": [0, -2.356194490192345, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-8"
-    },
-    {
-      "id": "path-8-5",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [-28.926865013004434, 0.03, -26.11751723919184],
-        "rotate": [0, -2.356194490192345, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-8"
-    },
-    {
-      "id": "path-8-6",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [-30.331538899910733, 0.03, -24.712843352285546],
-        "rotate": [0, -2.356194490192345, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-8"
-    },
-    {
-      "id": "path-8-7",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [-31.736212786817028, 0.03, -23.30816946537925],
         "rotate": [0, -2.356194490192345, 0]
       },
       "material": "mat-1",
@@ -4238,24 +3527,18 @@
       "collection": "station-9"
     },
     {
-      "id": "s9-guard-l-0",
+      "id": "s9-guard-0",
       "type": "box",
       "args": {
         "dims": [0.9, 2.2, 0.5]
       },
-      "transform": {
-        "translate": [-41.910886673723326, 1.1, -20.703495578472953],
-        "rotate": [0, -0.3, 0]
-      },
-      "material": "mat-13",
-      "collection": "station-9"
-    },
-    {
-      "id": "s9-guard-r-0",
-      "type": "box",
-      "args": {
-        "dims": [0.9, 2.2, 0.5]
-      },
+      "modifiers": [
+        {
+          "type": "mirror",
+          "axis": "x",
+          "origin": [-33.14088667372332, -21.903495578472953]
+        }
+      ],
       "transform": {
         "translate": [-24.370886673723323, 1.1, -20.703495578472953],
         "rotate": [0, 0.3, 0]
@@ -4264,24 +3547,18 @@
       "collection": "station-9"
     },
     {
-      "id": "s9-guard-l-1",
+      "id": "s9-guard-1",
       "type": "box",
       "args": {
         "dims": [0.9, 3.5, 0.5]
       },
-      "transform": {
-        "translate": [-41.310886673723324, 1.75, -26.50349557847295],
-        "rotate": [0, -0.3, 0]
-      },
-      "material": "mat-13",
-      "collection": "station-9"
-    },
-    {
-      "id": "s9-guard-r-1",
-      "type": "box",
-      "args": {
-        "dims": [0.9, 3.5, 0.5]
-      },
+      "modifiers": [
+        {
+          "type": "mirror",
+          "axis": "x",
+          "origin": [-33.14088667372332, -21.903495578472953]
+        }
+      ],
       "transform": {
         "translate": [-24.97088667372332, 1.75, -26.50349557847295],
         "rotate": [0, 0.3, 0]
@@ -4290,24 +3567,18 @@
       "collection": "station-9"
     },
     {
-      "id": "s9-guard-l-2",
+      "id": "s9-guard-2",
       "type": "box",
       "args": {
         "dims": [0.9, 4.800000000000001, 0.5]
       },
-      "transform": {
-        "translate": [-42.71088667372332, 2.4000000000000004, -28.703495578472953],
-        "rotate": [0, -0.3, 0]
-      },
-      "material": "mat-13",
-      "collection": "station-9"
-    },
-    {
-      "id": "s9-guard-r-2",
-      "type": "box",
-      "args": {
-        "dims": [0.9, 4.800000000000001, 0.5]
-      },
+      "modifiers": [
+        {
+          "type": "mirror",
+          "axis": "x",
+          "origin": [-33.14088667372332, -21.903495578472953]
+        }
+      ],
       "transform": {
         "translate": [-23.570886673723322, 2.4000000000000004, -28.703495578472953],
         "rotate": [0, 0.3, 0]
@@ -4316,91 +3587,20 @@
       "collection": "station-9"
     },
     {
-      "id": "path-9-1",
+      "id": "path-9-runway",
       "type": "box",
       "args": {
         "dims": [1.7, 0.05, 0.32]
       },
+      "modifiers": [
+        {
+          "type": "array",
+          "count": 7,
+          "offset": [-0.7416858395884987, 0, 3.6330175322104665]
+        }
+      ],
       "transform": {
         "translate": [-33.88257251331182, 0.03, -18.270478046262486],
-        "rotate": [0, -1.772180471255781, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-9"
-    },
-    {
-      "id": "path-9-2",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [-34.62425835290032, 0.03, -14.63746051405202],
-        "rotate": [0, -1.772180471255781, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-9"
-    },
-    {
-      "id": "path-9-3",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [-35.36594419248882, 0.03, -11.004442981841553],
-        "rotate": [0, -1.772180471255781, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-9"
-    },
-    {
-      "id": "path-9-4",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [-36.10763003207732, 0.03, -7.3714254496310865],
-        "rotate": [0, -1.772180471255781, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-9"
-    },
-    {
-      "id": "path-9-5",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [-36.849315871665816, 0.03, -3.73840791742062],
-        "rotate": [0, -1.772180471255781, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-9"
-    },
-    {
-      "id": "path-9-6",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [-37.591001711254314, 0.03, -0.10539038521015343],
-        "rotate": [0, -1.772180471255781, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-9"
-    },
-    {
-      "id": "path-9-7",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [-38.33268755084281, 0.03, 3.527627147000313],
         "rotate": [0, -1.772180471255781, 0]
       },
       "material": "mat-1",
@@ -4590,91 +3790,20 @@
       "collection": "station-10"
     },
     {
-      "id": "path-10-1",
+      "id": "path-10-runway",
       "type": "box",
       "args": {
         "dims": [1.7, 0.05, 0.32]
       },
+      "modifiers": [
+        {
+          "type": "array",
+          "count": 7,
+          "offset": [0.7416858395884995, 0, 1.842856362407774]
+        }
+      ],
       "transform": {
         "translate": [-38.33268755084281, 0.03, 9.003501041618552],
-        "rotate": [0, -1.1881664523192166, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-10"
-    },
-    {
-      "id": "path-10-2",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [-37.591001711254314, 0.03, 10.846357404026326],
-        "rotate": [0, -1.1881664523192166, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-10"
-    },
-    {
-      "id": "path-10-3",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [-36.849315871665816, 0.03, 12.6892137664341],
-        "rotate": [0, -1.1881664523192166, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-10"
-    },
-    {
-      "id": "path-10-4",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [-36.10763003207731, 0.03, 14.532070128841873],
-        "rotate": [0, -1.1881664523192166, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-10"
-    },
-    {
-      "id": "path-10-5",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [-35.36594419248881, 0.03, 16.374926491249646],
-        "rotate": [0, -1.1881664523192166, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-10"
-    },
-    {
-      "id": "path-10-6",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [-34.62425835290031, 0.03, 18.217782853657422],
-        "rotate": [0, -1.1881664523192166, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-10"
-    },
-    {
-      "id": "path-10-7",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [-33.882572513311814, 0.03, 20.060639216065198],
         "rotate": [0, -1.1881664523192166, 0]
       },
       "material": "mat-1",
@@ -4898,91 +4027,20 @@
       "collection": "station-11"
     },
     {
-      "id": "path-11-1",
+      "id": "path-11-runway",
       "type": "box",
       "args": {
         "dims": [1.7, 0.05, 0.32]
       },
+      "modifiers": [
+        {
+          "type": "array",
+          "count": 7,
+          "offset": [1.404673886906299, 0, 1.4046738869062967]
+        }
+      ],
       "transform": {
         "translate": [-31.736212786817017, 0.03, 23.308169465379265],
-        "rotate": [0, -0.7853981633974475, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-11"
-    },
-    {
-      "id": "path-11-2",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [-30.33153889991072, 0.03, 24.712843352285564],
-        "rotate": [0, -0.7853981633974475, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-11"
-    },
-    {
-      "id": "path-11-3",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [-28.926865013004416, 0.03, 26.117517239191862],
-        "rotate": [0, -0.7853981633974475, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-11"
-    },
-    {
-      "id": "path-11-4",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [-27.52219112609812, 0.03, 27.522191126098157],
-        "rotate": [0, -0.7853981633974475, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-11"
-    },
-    {
-      "id": "path-11-5",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [-26.11751723919182, 0.03, 28.926865013004452],
-        "rotate": [0, -0.7853981633974475, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-11"
-    },
-    {
-      "id": "path-11-6",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [-24.71284335228552, 0.03, 30.33153889991075],
-        "rotate": [0, -0.7853981633974475, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-11"
-    },
-    {
-      "id": "path-11-7",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [-23.308169465379223, 0.03, 31.73621278681705],
         "rotate": [0, -0.7853981633974475, 0]
       },
       "material": "mat-1",
@@ -5084,24 +4142,18 @@
       "collection": "station-12"
     },
     {
-      "id": "s12-guard-l-0",
+      "id": "s12-guard-0",
       "type": "box",
       "args": {
         "dims": [0.9, 2.2, 0.5]
       },
-      "transform": {
-        "translate": [-28.133495578472925, 1.1, 34.34088667372335],
-        "rotate": [0, -0.3, 0]
-      },
-      "material": "mat-13",
-      "collection": "station-12"
-    },
-    {
-      "id": "s12-guard-r-0",
-      "type": "box",
-      "args": {
-        "dims": [0.9, 2.2, 0.5]
-      },
+      "modifiers": [
+        {
+          "type": "mirror",
+          "axis": "x",
+          "origin": [-21.903495578472924, 33.140886673723344]
+        }
+      ],
       "transform": {
         "translate": [-15.673495578472924, 1.1, 34.34088667372335],
         "rotate": [0, 0.3, 0]
@@ -5110,24 +4162,18 @@
       "collection": "station-12"
     },
     {
-      "id": "s12-guard-l-1",
+      "id": "s12-guard-1",
       "type": "box",
       "args": {
         "dims": [0.9, 3.5, 0.5]
       },
-      "transform": {
-        "translate": [-27.533495578472923, 1.75, 28.540886673723342],
-        "rotate": [0, -0.3, 0]
-      },
-      "material": "mat-13",
-      "collection": "station-12"
-    },
-    {
-      "id": "s12-guard-r-1",
-      "type": "box",
-      "args": {
-        "dims": [0.9, 3.5, 0.5]
-      },
+      "modifiers": [
+        {
+          "type": "mirror",
+          "axis": "x",
+          "origin": [-21.903495578472924, 33.140886673723344]
+        }
+      ],
       "transform": {
         "translate": [-16.273495578472925, 1.75, 28.540886673723342],
         "rotate": [0, 0.3, 0]
@@ -5136,24 +4182,18 @@
       "collection": "station-12"
     },
     {
-      "id": "s12-guard-l-2",
+      "id": "s12-guard-2",
       "type": "box",
       "args": {
         "dims": [0.9, 4.800000000000001, 0.5]
       },
-      "transform": {
-        "translate": [-28.933495578472925, 2.4000000000000004, 26.340886673723343],
-        "rotate": [0, -0.3, 0]
-      },
-      "material": "mat-13",
-      "collection": "station-12"
-    },
-    {
-      "id": "s12-guard-r-2",
-      "type": "box",
-      "args": {
-        "dims": [0.9, 4.800000000000001, 0.5]
-      },
+      "modifiers": [
+        {
+          "type": "mirror",
+          "axis": "x",
+          "origin": [-21.903495578472924, 33.140886673723344]
+        }
+      ],
       "transform": {
         "translate": [-14.873495578472923, 2.4000000000000004, 26.340886673723343],
         "rotate": [0, 0.3, 0]

--- a/sdf-js/fixtures/golden/assemble-deck-grid.json
+++ b/sdf-js/fixtures/golden/assemble-deck-grid.json
@@ -839,91 +839,20 @@
       "collection": "station-0"
     },
     {
-      "id": "path-0-1",
+      "id": "path-0-runway",
       "type": "box",
       "args": {
         "dims": [1.7, 0.05, 0.32]
       },
+      "modifiers": [
+        {
+          "type": "array",
+          "count": 7,
+          "offset": [2, 0, 0]
+        }
+      ],
       "transform": {
         "translate": [2, 0.03, 0],
-        "rotate": [0, 0, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-0"
-    },
-    {
-      "id": "path-0-2",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [4, 0.03, 0],
-        "rotate": [0, 0, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-0"
-    },
-    {
-      "id": "path-0-3",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [6, 0.03, 0],
-        "rotate": [0, 0, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-0"
-    },
-    {
-      "id": "path-0-4",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [8, 0.03, 0],
-        "rotate": [0, 0, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-0"
-    },
-    {
-      "id": "path-0-5",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [10, 0.03, 0],
-        "rotate": [0, 0, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-0"
-    },
-    {
-      "id": "path-0-6",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [12, 0.03, 0],
-        "rotate": [0, 0, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-0"
-    },
-    {
-      "id": "path-0-7",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [14, 0.03, 0],
         "rotate": [0, 0, 0]
       },
       "material": "mat-1",
@@ -1128,91 +1057,20 @@
       "collection": "station-1"
     },
     {
-      "id": "path-1-1",
+      "id": "path-1-runway",
       "type": "box",
       "args": {
         "dims": [1.7, 0.05, 0.32]
       },
+      "modifiers": [
+        {
+          "type": "array",
+          "count": 7,
+          "offset": [2, 0, 0]
+        }
+      ],
       "transform": {
         "translate": [18, 0.03, 0],
-        "rotate": [0, 0, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-1"
-    },
-    {
-      "id": "path-1-2",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [20, 0.03, 0],
-        "rotate": [0, 0, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-1"
-    },
-    {
-      "id": "path-1-3",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [22, 0.03, 0],
-        "rotate": [0, 0, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-1"
-    },
-    {
-      "id": "path-1-4",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [24, 0.03, 0],
-        "rotate": [0, 0, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-1"
-    },
-    {
-      "id": "path-1-5",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [26, 0.03, 0],
-        "rotate": [0, 0, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-1"
-    },
-    {
-      "id": "path-1-6",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [28, 0.03, 0],
-        "rotate": [0, 0, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-1"
-    },
-    {
-      "id": "path-1-7",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [30, 0.03, 0],
         "rotate": [0, 0, 0]
       },
       "material": "mat-1",
@@ -1410,24 +1268,18 @@
       "collection": "station-2"
     },
     {
-      "id": "s2-guard-l-0",
+      "id": "s2-guard-0",
       "type": "box",
       "args": {
         "dims": [0.9, 2.2, 0.5]
       },
-      "transform": {
-        "translate": [23.865000000000002, 1.1, 1.2],
-        "rotate": [0, -0.3, 0]
-      },
-      "material": "mat-13",
-      "collection": "station-2"
-    },
-    {
-      "id": "s2-guard-r-0",
-      "type": "box",
-      "args": {
-        "dims": [0.9, 2.2, 0.5]
-      },
+      "modifiers": [
+        {
+          "type": "mirror",
+          "axis": "x",
+          "origin": [32, 0]
+        }
+      ],
       "transform": {
         "translate": [40.135, 1.1, 1.2],
         "rotate": [0, 0.3, 0]
@@ -1436,24 +1288,18 @@
       "collection": "station-2"
     },
     {
-      "id": "s2-guard-l-1",
+      "id": "s2-guard-1",
       "type": "box",
       "args": {
         "dims": [0.9, 3.5, 0.5]
       },
-      "transform": {
-        "translate": [24.465, 1.75, -4.6],
-        "rotate": [0, -0.3, 0]
-      },
-      "material": "mat-13",
-      "collection": "station-2"
-    },
-    {
-      "id": "s2-guard-r-1",
-      "type": "box",
-      "args": {
-        "dims": [0.9, 3.5, 0.5]
-      },
+      "modifiers": [
+        {
+          "type": "mirror",
+          "axis": "x",
+          "origin": [32, 0]
+        }
+      ],
       "transform": {
         "translate": [39.535, 1.75, -4.6],
         "rotate": [0, 0.3, 0]
@@ -1462,24 +1308,18 @@
       "collection": "station-2"
     },
     {
-      "id": "s2-guard-l-2",
+      "id": "s2-guard-2",
       "type": "box",
       "args": {
         "dims": [0.9, 4.800000000000001, 0.5]
       },
-      "transform": {
-        "translate": [23.064999999999998, 2.4000000000000004, -6.800000000000001],
-        "rotate": [0, -0.3, 0]
-      },
-      "material": "mat-13",
-      "collection": "station-2"
-    },
-    {
-      "id": "s2-guard-r-2",
-      "type": "box",
-      "args": {
-        "dims": [0.9, 4.800000000000001, 0.5]
-      },
+      "modifiers": [
+        {
+          "type": "mirror",
+          "axis": "x",
+          "origin": [32, 0]
+        }
+      ],
       "transform": {
         "translate": [40.935, 2.4000000000000004, -6.800000000000001],
         "rotate": [0, 0.3, 0]
@@ -1488,91 +1328,20 @@
       "collection": "station-2"
     },
     {
-      "id": "path-2-1",
+      "id": "path-2-runway",
       "type": "box",
       "args": {
         "dims": [1.7, 0.05, 0.32]
       },
+      "modifiers": [
+        {
+          "type": "array",
+          "count": 7,
+          "offset": [2, 0, 0]
+        }
+      ],
       "transform": {
         "translate": [34, 0.03, 0],
-        "rotate": [0, 0, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-2"
-    },
-    {
-      "id": "path-2-2",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [36, 0.03, 0],
-        "rotate": [0, 0, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-2"
-    },
-    {
-      "id": "path-2-3",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [38, 0.03, 0],
-        "rotate": [0, 0, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-2"
-    },
-    {
-      "id": "path-2-4",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [40, 0.03, 0],
-        "rotate": [0, 0, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-2"
-    },
-    {
-      "id": "path-2-5",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [42, 0.03, 0],
-        "rotate": [0, 0, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-2"
-    },
-    {
-      "id": "path-2-6",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [44, 0.03, 0],
-        "rotate": [0, 0, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-2"
-    },
-    {
-      "id": "path-2-7",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [46, 0.03, 0],
         "rotate": [0, 0, 0]
       },
       "material": "mat-1",
@@ -1770,24 +1539,18 @@
       "collection": "station-3"
     },
     {
-      "id": "s3-guard-l-0",
+      "id": "s3-guard-0",
       "type": "box",
       "args": {
         "dims": [0.9, 2.2, 0.5]
       },
-      "transform": {
-        "translate": [39.865, 1.1, 1.2],
-        "rotate": [0, -0.3, 0]
-      },
-      "material": "mat-13",
-      "collection": "station-3"
-    },
-    {
-      "id": "s3-guard-r-0",
-      "type": "box",
-      "args": {
-        "dims": [0.9, 2.2, 0.5]
-      },
+      "modifiers": [
+        {
+          "type": "mirror",
+          "axis": "x",
+          "origin": [48, 0]
+        }
+      ],
       "transform": {
         "translate": [56.135, 1.1, 1.2],
         "rotate": [0, 0.3, 0]
@@ -1796,24 +1559,18 @@
       "collection": "station-3"
     },
     {
-      "id": "s3-guard-l-1",
+      "id": "s3-guard-1",
       "type": "box",
       "args": {
         "dims": [0.9, 3.5, 0.5]
       },
-      "transform": {
-        "translate": [40.465, 1.75, -4.6],
-        "rotate": [0, -0.3, 0]
-      },
-      "material": "mat-13",
-      "collection": "station-3"
-    },
-    {
-      "id": "s3-guard-r-1",
-      "type": "box",
-      "args": {
-        "dims": [0.9, 3.5, 0.5]
-      },
+      "modifiers": [
+        {
+          "type": "mirror",
+          "axis": "x",
+          "origin": [48, 0]
+        }
+      ],
       "transform": {
         "translate": [55.535, 1.75, -4.6],
         "rotate": [0, 0.3, 0]
@@ -1822,24 +1579,18 @@
       "collection": "station-3"
     },
     {
-      "id": "s3-guard-l-2",
+      "id": "s3-guard-2",
       "type": "box",
       "args": {
         "dims": [0.9, 4.800000000000001, 0.5]
       },
-      "transform": {
-        "translate": [39.065, 2.4000000000000004, -6.800000000000001],
-        "rotate": [0, -0.3, 0]
-      },
-      "material": "mat-13",
-      "collection": "station-3"
-    },
-    {
-      "id": "s3-guard-r-2",
-      "type": "box",
-      "args": {
-        "dims": [0.9, 4.800000000000001, 0.5]
-      },
+      "modifiers": [
+        {
+          "type": "mirror",
+          "axis": "x",
+          "origin": [48, 0]
+        }
+      ],
       "transform": {
         "translate": [56.935, 2.4000000000000004, -6.800000000000001],
         "rotate": [0, 0.3, 0]
@@ -1848,91 +1599,20 @@
       "collection": "station-3"
     },
     {
-      "id": "path-3-1",
+      "id": "path-3-runway",
       "type": "box",
       "args": {
         "dims": [1.7, 0.05, 0.32]
       },
+      "modifiers": [
+        {
+          "type": "array",
+          "count": 7,
+          "offset": [-6, 0, -2]
+        }
+      ],
       "transform": {
         "translate": [42, 0.03, -2],
-        "rotate": [0, 2.819842099193151, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-3"
-    },
-    {
-      "id": "path-3-2",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [36, 0.03, -4],
-        "rotate": [0, 2.819842099193151, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-3"
-    },
-    {
-      "id": "path-3-3",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [30, 0.03, -6],
-        "rotate": [0, 2.819842099193151, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-3"
-    },
-    {
-      "id": "path-3-4",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [24, 0.03, -8],
-        "rotate": [0, 2.819842099193151, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-3"
-    },
-    {
-      "id": "path-3-5",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [18, 0.03, -10],
-        "rotate": [0, 2.819842099193151, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-3"
-    },
-    {
-      "id": "path-3-6",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [12, 0.03, -12],
-        "rotate": [0, 2.819842099193151, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-3"
-    },
-    {
-      "id": "path-3-7",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [6, 0.03, -14],
         "rotate": [0, 2.819842099193151, 0]
       },
       "material": "mat-1",
@@ -2130,24 +1810,18 @@
       "collection": "station-4"
     },
     {
-      "id": "s4-guard-l-0",
+      "id": "s4-guard-0",
       "type": "box",
       "args": {
         "dims": [0.9, 2.2, 0.5]
       },
-      "transform": {
-        "translate": [-8.135, 1.1, -14.8],
-        "rotate": [0, -0.3, 0]
-      },
-      "material": "mat-13",
-      "collection": "station-4"
-    },
-    {
-      "id": "s4-guard-r-0",
-      "type": "box",
-      "args": {
-        "dims": [0.9, 2.2, 0.5]
-      },
+      "modifiers": [
+        {
+          "type": "mirror",
+          "axis": "x",
+          "origin": [0, -16]
+        }
+      ],
       "transform": {
         "translate": [8.135, 1.1, -14.8],
         "rotate": [0, 0.3, 0]
@@ -2156,24 +1830,18 @@
       "collection": "station-4"
     },
     {
-      "id": "s4-guard-l-1",
+      "id": "s4-guard-1",
       "type": "box",
       "args": {
         "dims": [0.9, 3.5, 0.5]
       },
-      "transform": {
-        "translate": [-7.535, 1.75, -20.6],
-        "rotate": [0, -0.3, 0]
-      },
-      "material": "mat-13",
-      "collection": "station-4"
-    },
-    {
-      "id": "s4-guard-r-1",
-      "type": "box",
-      "args": {
-        "dims": [0.9, 3.5, 0.5]
-      },
+      "modifiers": [
+        {
+          "type": "mirror",
+          "axis": "x",
+          "origin": [0, -16]
+        }
+      ],
       "transform": {
         "translate": [7.535, 1.75, -20.6],
         "rotate": [0, 0.3, 0]
@@ -2182,24 +1850,18 @@
       "collection": "station-4"
     },
     {
-      "id": "s4-guard-l-2",
+      "id": "s4-guard-2",
       "type": "box",
       "args": {
         "dims": [0.9, 4.800000000000001, 0.5]
       },
-      "transform": {
-        "translate": [-8.935, 2.4000000000000004, -22.8],
-        "rotate": [0, -0.3, 0]
-      },
-      "material": "mat-13",
-      "collection": "station-4"
-    },
-    {
-      "id": "s4-guard-r-2",
-      "type": "box",
-      "args": {
-        "dims": [0.9, 4.800000000000001, 0.5]
-      },
+      "modifiers": [
+        {
+          "type": "mirror",
+          "axis": "x",
+          "origin": [0, -16]
+        }
+      ],
       "transform": {
         "translate": [8.935, 2.4000000000000004, -22.8],
         "rotate": [0, 0.3, 0]
@@ -2208,91 +1870,20 @@
       "collection": "station-4"
     },
     {
-      "id": "path-4-1",
+      "id": "path-4-runway",
       "type": "box",
       "args": {
         "dims": [1.7, 0.05, 0.32]
       },
+      "modifiers": [
+        {
+          "type": "array",
+          "count": 7,
+          "offset": [2, 0, 0]
+        }
+      ],
       "transform": {
         "translate": [2, 0.03, -16],
-        "rotate": [0, 0, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-4"
-    },
-    {
-      "id": "path-4-2",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [4, 0.03, -16],
-        "rotate": [0, 0, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-4"
-    },
-    {
-      "id": "path-4-3",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [6, 0.03, -16],
-        "rotate": [0, 0, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-4"
-    },
-    {
-      "id": "path-4-4",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [8, 0.03, -16],
-        "rotate": [0, 0, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-4"
-    },
-    {
-      "id": "path-4-5",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [10, 0.03, -16],
-        "rotate": [0, 0, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-4"
-    },
-    {
-      "id": "path-4-6",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [12, 0.03, -16],
-        "rotate": [0, 0, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-4"
-    },
-    {
-      "id": "path-4-7",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [14, 0.03, -16],
         "rotate": [0, 0, 0]
       },
       "material": "mat-1",
@@ -2490,24 +2081,18 @@
       "collection": "station-5"
     },
     {
-      "id": "s5-guard-l-0",
+      "id": "s5-guard-0",
       "type": "box",
       "args": {
         "dims": [0.9, 2.2, 0.5]
       },
-      "transform": {
-        "translate": [7.865, 1.1, -14.8],
-        "rotate": [0, -0.3, 0]
-      },
-      "material": "mat-13",
-      "collection": "station-5"
-    },
-    {
-      "id": "s5-guard-r-0",
-      "type": "box",
-      "args": {
-        "dims": [0.9, 2.2, 0.5]
-      },
+      "modifiers": [
+        {
+          "type": "mirror",
+          "axis": "x",
+          "origin": [16, -16]
+        }
+      ],
       "transform": {
         "translate": [24.134999999999998, 1.1, -14.8],
         "rotate": [0, 0.3, 0]
@@ -2516,24 +2101,18 @@
       "collection": "station-5"
     },
     {
-      "id": "s5-guard-l-1",
+      "id": "s5-guard-1",
       "type": "box",
       "args": {
         "dims": [0.9, 3.5, 0.5]
       },
-      "transform": {
-        "translate": [8.465, 1.75, -20.6],
-        "rotate": [0, -0.3, 0]
-      },
-      "material": "mat-13",
-      "collection": "station-5"
-    },
-    {
-      "id": "s5-guard-r-1",
-      "type": "box",
-      "args": {
-        "dims": [0.9, 3.5, 0.5]
-      },
+      "modifiers": [
+        {
+          "type": "mirror",
+          "axis": "x",
+          "origin": [16, -16]
+        }
+      ],
       "transform": {
         "translate": [23.535, 1.75, -20.6],
         "rotate": [0, 0.3, 0]
@@ -2542,24 +2121,18 @@
       "collection": "station-5"
     },
     {
-      "id": "s5-guard-l-2",
+      "id": "s5-guard-2",
       "type": "box",
       "args": {
         "dims": [0.9, 4.800000000000001, 0.5]
       },
-      "transform": {
-        "translate": [7.0649999999999995, 2.4000000000000004, -22.8],
-        "rotate": [0, -0.3, 0]
-      },
-      "material": "mat-13",
-      "collection": "station-5"
-    },
-    {
-      "id": "s5-guard-r-2",
-      "type": "box",
-      "args": {
-        "dims": [0.9, 4.800000000000001, 0.5]
-      },
+      "modifiers": [
+        {
+          "type": "mirror",
+          "axis": "x",
+          "origin": [16, -16]
+        }
+      ],
       "transform": {
         "translate": [24.935000000000002, 2.4000000000000004, -22.8],
         "rotate": [0, 0.3, 0]
@@ -2568,91 +2141,20 @@
       "collection": "station-5"
     },
     {
-      "id": "path-5-1",
+      "id": "path-5-runway",
       "type": "box",
       "args": {
         "dims": [1.7, 0.05, 0.32]
       },
+      "modifiers": [
+        {
+          "type": "array",
+          "count": 7,
+          "offset": [2, 0, 0]
+        }
+      ],
       "transform": {
         "translate": [18, 0.03, -16],
-        "rotate": [0, 0, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-5"
-    },
-    {
-      "id": "path-5-2",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [20, 0.03, -16],
-        "rotate": [0, 0, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-5"
-    },
-    {
-      "id": "path-5-3",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [22, 0.03, -16],
-        "rotate": [0, 0, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-5"
-    },
-    {
-      "id": "path-5-4",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [24, 0.03, -16],
-        "rotate": [0, 0, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-5"
-    },
-    {
-      "id": "path-5-5",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [26, 0.03, -16],
-        "rotate": [0, 0, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-5"
-    },
-    {
-      "id": "path-5-6",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [28, 0.03, -16],
-        "rotate": [0, 0, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-5"
-    },
-    {
-      "id": "path-5-7",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [30, 0.03, -16],
         "rotate": [0, 0, 0]
       },
       "material": "mat-1",
@@ -2869,91 +2371,20 @@
       "collection": "station-6"
     },
     {
-      "id": "path-6-1",
+      "id": "path-6-runway",
       "type": "box",
       "args": {
         "dims": [1.7, 0.05, 0.32]
       },
+      "modifiers": [
+        {
+          "type": "array",
+          "count": 7,
+          "offset": [2, 0, 0]
+        }
+      ],
       "transform": {
         "translate": [34, 0.03, -16],
-        "rotate": [0, 0, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-6"
-    },
-    {
-      "id": "path-6-2",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [36, 0.03, -16],
-        "rotate": [0, 0, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-6"
-    },
-    {
-      "id": "path-6-3",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [38, 0.03, -16],
-        "rotate": [0, 0, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-6"
-    },
-    {
-      "id": "path-6-4",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [40, 0.03, -16],
-        "rotate": [0, 0, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-6"
-    },
-    {
-      "id": "path-6-5",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [42, 0.03, -16],
-        "rotate": [0, 0, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-6"
-    },
-    {
-      "id": "path-6-6",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [44, 0.03, -16],
-        "rotate": [0, 0, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-6"
-    },
-    {
-      "id": "path-6-7",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [46, 0.03, -16],
         "rotate": [0, 0, 0]
       },
       "material": "mat-1",
@@ -3740,91 +3171,20 @@
       "collection": "station-7"
     },
     {
-      "id": "path-7-1",
+      "id": "path-7-runway",
       "type": "box",
       "args": {
         "dims": [1.7, 0.05, 0.32]
       },
+      "modifiers": [
+        {
+          "type": "array",
+          "count": 7,
+          "offset": [-6, 0, -2]
+        }
+      ],
       "transform": {
         "translate": [42, 0.03, -18],
-        "rotate": [0, 2.819842099193151, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-7"
-    },
-    {
-      "id": "path-7-2",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [36, 0.03, -20],
-        "rotate": [0, 2.819842099193151, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-7"
-    },
-    {
-      "id": "path-7-3",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [30, 0.03, -22],
-        "rotate": [0, 2.819842099193151, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-7"
-    },
-    {
-      "id": "path-7-4",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [24, 0.03, -24],
-        "rotate": [0, 2.819842099193151, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-7"
-    },
-    {
-      "id": "path-7-5",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [18, 0.03, -26],
-        "rotate": [0, 2.819842099193151, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-7"
-    },
-    {
-      "id": "path-7-6",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [12, 0.03, -28],
-        "rotate": [0, 2.819842099193151, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-7"
-    },
-    {
-      "id": "path-7-7",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [6, 0.03, -30],
         "rotate": [0, 2.819842099193151, 0]
       },
       "material": "mat-1",
@@ -3915,91 +3275,20 @@
       "collection": "station-8"
     },
     {
-      "id": "path-8-1",
+      "id": "path-8-runway",
       "type": "box",
       "args": {
         "dims": [1.7, 0.05, 0.32]
       },
+      "modifiers": [
+        {
+          "type": "array",
+          "count": 7,
+          "offset": [2, 0, 0]
+        }
+      ],
       "transform": {
         "translate": [2, 0.03, -32],
-        "rotate": [0, 0, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-8"
-    },
-    {
-      "id": "path-8-2",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [4, 0.03, -32],
-        "rotate": [0, 0, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-8"
-    },
-    {
-      "id": "path-8-3",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [6, 0.03, -32],
-        "rotate": [0, 0, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-8"
-    },
-    {
-      "id": "path-8-4",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [8, 0.03, -32],
-        "rotate": [0, 0, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-8"
-    },
-    {
-      "id": "path-8-5",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [10, 0.03, -32],
-        "rotate": [0, 0, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-8"
-    },
-    {
-      "id": "path-8-6",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [12, 0.03, -32],
-        "rotate": [0, 0, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-8"
-    },
-    {
-      "id": "path-8-7",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [14, 0.03, -32],
         "rotate": [0, 0, 0]
       },
       "material": "mat-1",
@@ -4229,24 +3518,18 @@
       "collection": "station-9"
     },
     {
-      "id": "s9-guard-l-0",
+      "id": "s9-guard-0",
       "type": "box",
       "args": {
         "dims": [0.9, 2.2, 0.5]
       },
-      "transform": {
-        "translate": [7.23, 1.1, -30.8],
-        "rotate": [0, -0.3, 0]
-      },
-      "material": "mat-13",
-      "collection": "station-9"
-    },
-    {
-      "id": "s9-guard-r-0",
-      "type": "box",
-      "args": {
-        "dims": [0.9, 2.2, 0.5]
-      },
+      "modifiers": [
+        {
+          "type": "mirror",
+          "axis": "x",
+          "origin": [16, -32]
+        }
+      ],
       "transform": {
         "translate": [24.77, 1.1, -30.8],
         "rotate": [0, 0.3, 0]
@@ -4255,24 +3538,18 @@
       "collection": "station-9"
     },
     {
-      "id": "s9-guard-l-1",
+      "id": "s9-guard-1",
       "type": "box",
       "args": {
         "dims": [0.9, 3.5, 0.5]
       },
-      "transform": {
-        "translate": [7.83, 1.75, -36.6],
-        "rotate": [0, -0.3, 0]
-      },
-      "material": "mat-13",
-      "collection": "station-9"
-    },
-    {
-      "id": "s9-guard-r-1",
-      "type": "box",
-      "args": {
-        "dims": [0.9, 3.5, 0.5]
-      },
+      "modifiers": [
+        {
+          "type": "mirror",
+          "axis": "x",
+          "origin": [16, -32]
+        }
+      ],
       "transform": {
         "translate": [24.17, 1.75, -36.6],
         "rotate": [0, 0.3, 0]
@@ -4281,24 +3558,18 @@
       "collection": "station-9"
     },
     {
-      "id": "s9-guard-l-2",
+      "id": "s9-guard-2",
       "type": "box",
       "args": {
         "dims": [0.9, 4.800000000000001, 0.5]
       },
-      "transform": {
-        "translate": [6.43, 2.4000000000000004, -38.8],
-        "rotate": [0, -0.3, 0]
-      },
-      "material": "mat-13",
-      "collection": "station-9"
-    },
-    {
-      "id": "s9-guard-r-2",
-      "type": "box",
-      "args": {
-        "dims": [0.9, 4.800000000000001, 0.5]
-      },
+      "modifiers": [
+        {
+          "type": "mirror",
+          "axis": "x",
+          "origin": [16, -32]
+        }
+      ],
       "transform": {
         "translate": [25.57, 2.4000000000000004, -38.8],
         "rotate": [0, 0.3, 0]
@@ -4307,91 +3578,20 @@
       "collection": "station-9"
     },
     {
-      "id": "path-9-1",
+      "id": "path-9-runway",
       "type": "box",
       "args": {
         "dims": [1.7, 0.05, 0.32]
       },
+      "modifiers": [
+        {
+          "type": "array",
+          "count": 7,
+          "offset": [2, 0, 0]
+        }
+      ],
       "transform": {
         "translate": [18, 0.03, -32],
-        "rotate": [0, 0, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-9"
-    },
-    {
-      "id": "path-9-2",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [20, 0.03, -32],
-        "rotate": [0, 0, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-9"
-    },
-    {
-      "id": "path-9-3",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [22, 0.03, -32],
-        "rotate": [0, 0, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-9"
-    },
-    {
-      "id": "path-9-4",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [24, 0.03, -32],
-        "rotate": [0, 0, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-9"
-    },
-    {
-      "id": "path-9-5",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [26, 0.03, -32],
-        "rotate": [0, 0, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-9"
-    },
-    {
-      "id": "path-9-6",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [28, 0.03, -32],
-        "rotate": [0, 0, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-9"
-    },
-    {
-      "id": "path-9-7",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [30, 0.03, -32],
         "rotate": [0, 0, 0]
       },
       "material": "mat-1",
@@ -4581,91 +3781,20 @@
       "collection": "station-10"
     },
     {
-      "id": "path-10-1",
+      "id": "path-10-runway",
       "type": "box",
       "args": {
         "dims": [1.7, 0.05, 0.32]
       },
+      "modifiers": [
+        {
+          "type": "array",
+          "count": 7,
+          "offset": [2, 0, 0]
+        }
+      ],
       "transform": {
         "translate": [34, 0.03, -32],
-        "rotate": [0, 0, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-10"
-    },
-    {
-      "id": "path-10-2",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [36, 0.03, -32],
-        "rotate": [0, 0, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-10"
-    },
-    {
-      "id": "path-10-3",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [38, 0.03, -32],
-        "rotate": [0, 0, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-10"
-    },
-    {
-      "id": "path-10-4",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [40, 0.03, -32],
-        "rotate": [0, 0, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-10"
-    },
-    {
-      "id": "path-10-5",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [42, 0.03, -32],
-        "rotate": [0, 0, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-10"
-    },
-    {
-      "id": "path-10-6",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [44, 0.03, -32],
-        "rotate": [0, 0, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-10"
-    },
-    {
-      "id": "path-10-7",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [46, 0.03, -32],
         "rotate": [0, 0, 0]
       },
       "material": "mat-1",
@@ -4889,91 +4018,20 @@
       "collection": "station-11"
     },
     {
-      "id": "path-11-1",
+      "id": "path-11-runway",
       "type": "box",
       "args": {
         "dims": [1.7, 0.05, 0.32]
       },
+      "modifiers": [
+        {
+          "type": "array",
+          "count": 7,
+          "offset": [-6, 0, -2]
+        }
+      ],
       "transform": {
         "translate": [42, 0.03, -34],
-        "rotate": [0, 2.819842099193151, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-11"
-    },
-    {
-      "id": "path-11-2",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [36, 0.03, -36],
-        "rotate": [0, 2.819842099193151, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-11"
-    },
-    {
-      "id": "path-11-3",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [30, 0.03, -38],
-        "rotate": [0, 2.819842099193151, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-11"
-    },
-    {
-      "id": "path-11-4",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [24, 0.03, -40],
-        "rotate": [0, 2.819842099193151, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-11"
-    },
-    {
-      "id": "path-11-5",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [18, 0.03, -42],
-        "rotate": [0, 2.819842099193151, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-11"
-    },
-    {
-      "id": "path-11-6",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [12, 0.03, -44],
-        "rotate": [0, 2.819842099193151, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-11"
-    },
-    {
-      "id": "path-11-7",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [6, 0.03, -46],
         "rotate": [0, 2.819842099193151, 0]
       },
       "material": "mat-1",
@@ -5075,24 +4133,18 @@
       "collection": "station-12"
     },
     {
-      "id": "s12-guard-l-0",
+      "id": "s12-guard-0",
       "type": "box",
       "args": {
         "dims": [0.9, 2.2, 0.5]
       },
-      "transform": {
-        "translate": [-6.2299999999999995, 1.1, -46.8],
-        "rotate": [0, -0.3, 0]
-      },
-      "material": "mat-13",
-      "collection": "station-12"
-    },
-    {
-      "id": "s12-guard-r-0",
-      "type": "box",
-      "args": {
-        "dims": [0.9, 2.2, 0.5]
-      },
+      "modifiers": [
+        {
+          "type": "mirror",
+          "axis": "x",
+          "origin": [0, -48]
+        }
+      ],
       "transform": {
         "translate": [6.2299999999999995, 1.1, -46.8],
         "rotate": [0, 0.3, 0]
@@ -5101,24 +4153,18 @@
       "collection": "station-12"
     },
     {
-      "id": "s12-guard-l-1",
+      "id": "s12-guard-1",
       "type": "box",
       "args": {
         "dims": [0.9, 3.5, 0.5]
       },
-      "transform": {
-        "translate": [-5.63, 1.75, -52.6],
-        "rotate": [0, -0.3, 0]
-      },
-      "material": "mat-13",
-      "collection": "station-12"
-    },
-    {
-      "id": "s12-guard-r-1",
-      "type": "box",
-      "args": {
-        "dims": [0.9, 3.5, 0.5]
-      },
+      "modifiers": [
+        {
+          "type": "mirror",
+          "axis": "x",
+          "origin": [0, -48]
+        }
+      ],
       "transform": {
         "translate": [5.63, 1.75, -52.6],
         "rotate": [0, 0.3, 0]
@@ -5127,24 +4173,18 @@
       "collection": "station-12"
     },
     {
-      "id": "s12-guard-l-2",
+      "id": "s12-guard-2",
       "type": "box",
       "args": {
         "dims": [0.9, 4.800000000000001, 0.5]
       },
-      "transform": {
-        "translate": [-7.03, 2.4000000000000004, -54.8],
-        "rotate": [0, -0.3, 0]
-      },
-      "material": "mat-13",
-      "collection": "station-12"
-    },
-    {
-      "id": "s12-guard-r-2",
-      "type": "box",
-      "args": {
-        "dims": [0.9, 4.800000000000001, 0.5]
-      },
+      "modifiers": [
+        {
+          "type": "mirror",
+          "axis": "x",
+          "origin": [0, -48]
+        }
+      ],
       "transform": {
         "translate": [7.03, 2.4000000000000004, -54.8],
         "rotate": [0, 0.3, 0]

--- a/sdf-js/fixtures/golden/assemble-deck-line.json
+++ b/sdf-js/fixtures/golden/assemble-deck-line.json
@@ -839,91 +839,20 @@
       "collection": "station-0"
     },
     {
-      "id": "path-0-1",
+      "id": "path-0-runway",
       "type": "box",
       "args": {
         "dims": [1.7, 0.05, 0.32]
       },
+      "modifiers": [
+        {
+          "type": "array",
+          "count": 7,
+          "offset": [2, 0, 0]
+        }
+      ],
       "transform": {
         "translate": [2, 0.03, 0],
-        "rotate": [0, 0, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-0"
-    },
-    {
-      "id": "path-0-2",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [4, 0.03, 0],
-        "rotate": [0, 0, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-0"
-    },
-    {
-      "id": "path-0-3",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [6, 0.03, 0],
-        "rotate": [0, 0, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-0"
-    },
-    {
-      "id": "path-0-4",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [8, 0.03, 0],
-        "rotate": [0, 0, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-0"
-    },
-    {
-      "id": "path-0-5",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [10, 0.03, 0],
-        "rotate": [0, 0, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-0"
-    },
-    {
-      "id": "path-0-6",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [12, 0.03, 0],
-        "rotate": [0, 0, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-0"
-    },
-    {
-      "id": "path-0-7",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [14, 0.03, 0],
         "rotate": [0, 0, 0]
       },
       "material": "mat-1",
@@ -1128,91 +1057,20 @@
       "collection": "station-1"
     },
     {
-      "id": "path-1-1",
+      "id": "path-1-runway",
       "type": "box",
       "args": {
         "dims": [1.7, 0.05, 0.32]
       },
+      "modifiers": [
+        {
+          "type": "array",
+          "count": 7,
+          "offset": [2, 0, 0]
+        }
+      ],
       "transform": {
         "translate": [18, 0.03, 0],
-        "rotate": [0, 0, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-1"
-    },
-    {
-      "id": "path-1-2",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [20, 0.03, 0],
-        "rotate": [0, 0, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-1"
-    },
-    {
-      "id": "path-1-3",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [22, 0.03, 0],
-        "rotate": [0, 0, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-1"
-    },
-    {
-      "id": "path-1-4",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [24, 0.03, 0],
-        "rotate": [0, 0, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-1"
-    },
-    {
-      "id": "path-1-5",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [26, 0.03, 0],
-        "rotate": [0, 0, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-1"
-    },
-    {
-      "id": "path-1-6",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [28, 0.03, 0],
-        "rotate": [0, 0, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-1"
-    },
-    {
-      "id": "path-1-7",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [30, 0.03, 0],
         "rotate": [0, 0, 0]
       },
       "material": "mat-1",
@@ -1410,24 +1268,18 @@
       "collection": "station-2"
     },
     {
-      "id": "s2-guard-l-0",
+      "id": "s2-guard-0",
       "type": "box",
       "args": {
         "dims": [0.9, 2.2, 0.5]
       },
-      "transform": {
-        "translate": [23.865000000000002, 1.1, 1.2],
-        "rotate": [0, -0.3, 0]
-      },
-      "material": "mat-13",
-      "collection": "station-2"
-    },
-    {
-      "id": "s2-guard-r-0",
-      "type": "box",
-      "args": {
-        "dims": [0.9, 2.2, 0.5]
-      },
+      "modifiers": [
+        {
+          "type": "mirror",
+          "axis": "x",
+          "origin": [32, 0]
+        }
+      ],
       "transform": {
         "translate": [40.135, 1.1, 1.2],
         "rotate": [0, 0.3, 0]
@@ -1436,24 +1288,18 @@
       "collection": "station-2"
     },
     {
-      "id": "s2-guard-l-1",
+      "id": "s2-guard-1",
       "type": "box",
       "args": {
         "dims": [0.9, 3.5, 0.5]
       },
-      "transform": {
-        "translate": [24.465, 1.75, -4.6],
-        "rotate": [0, -0.3, 0]
-      },
-      "material": "mat-13",
-      "collection": "station-2"
-    },
-    {
-      "id": "s2-guard-r-1",
-      "type": "box",
-      "args": {
-        "dims": [0.9, 3.5, 0.5]
-      },
+      "modifiers": [
+        {
+          "type": "mirror",
+          "axis": "x",
+          "origin": [32, 0]
+        }
+      ],
       "transform": {
         "translate": [39.535, 1.75, -4.6],
         "rotate": [0, 0.3, 0]
@@ -1462,24 +1308,18 @@
       "collection": "station-2"
     },
     {
-      "id": "s2-guard-l-2",
+      "id": "s2-guard-2",
       "type": "box",
       "args": {
         "dims": [0.9, 4.800000000000001, 0.5]
       },
-      "transform": {
-        "translate": [23.064999999999998, 2.4000000000000004, -6.800000000000001],
-        "rotate": [0, -0.3, 0]
-      },
-      "material": "mat-13",
-      "collection": "station-2"
-    },
-    {
-      "id": "s2-guard-r-2",
-      "type": "box",
-      "args": {
-        "dims": [0.9, 4.800000000000001, 0.5]
-      },
+      "modifiers": [
+        {
+          "type": "mirror",
+          "axis": "x",
+          "origin": [32, 0]
+        }
+      ],
       "transform": {
         "translate": [40.935, 2.4000000000000004, -6.800000000000001],
         "rotate": [0, 0.3, 0]
@@ -1488,91 +1328,20 @@
       "collection": "station-2"
     },
     {
-      "id": "path-2-1",
+      "id": "path-2-runway",
       "type": "box",
       "args": {
         "dims": [1.7, 0.05, 0.32]
       },
+      "modifiers": [
+        {
+          "type": "array",
+          "count": 7,
+          "offset": [2, 0, 0]
+        }
+      ],
       "transform": {
         "translate": [34, 0.03, 0],
-        "rotate": [0, 0, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-2"
-    },
-    {
-      "id": "path-2-2",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [36, 0.03, 0],
-        "rotate": [0, 0, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-2"
-    },
-    {
-      "id": "path-2-3",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [38, 0.03, 0],
-        "rotate": [0, 0, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-2"
-    },
-    {
-      "id": "path-2-4",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [40, 0.03, 0],
-        "rotate": [0, 0, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-2"
-    },
-    {
-      "id": "path-2-5",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [42, 0.03, 0],
-        "rotate": [0, 0, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-2"
-    },
-    {
-      "id": "path-2-6",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [44, 0.03, 0],
-        "rotate": [0, 0, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-2"
-    },
-    {
-      "id": "path-2-7",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [46, 0.03, 0],
         "rotate": [0, 0, 0]
       },
       "material": "mat-1",
@@ -1770,24 +1539,18 @@
       "collection": "station-3"
     },
     {
-      "id": "s3-guard-l-0",
+      "id": "s3-guard-0",
       "type": "box",
       "args": {
         "dims": [0.9, 2.2, 0.5]
       },
-      "transform": {
-        "translate": [39.865, 1.1, 1.2],
-        "rotate": [0, -0.3, 0]
-      },
-      "material": "mat-13",
-      "collection": "station-3"
-    },
-    {
-      "id": "s3-guard-r-0",
-      "type": "box",
-      "args": {
-        "dims": [0.9, 2.2, 0.5]
-      },
+      "modifiers": [
+        {
+          "type": "mirror",
+          "axis": "x",
+          "origin": [48, 0]
+        }
+      ],
       "transform": {
         "translate": [56.135, 1.1, 1.2],
         "rotate": [0, 0.3, 0]
@@ -1796,24 +1559,18 @@
       "collection": "station-3"
     },
     {
-      "id": "s3-guard-l-1",
+      "id": "s3-guard-1",
       "type": "box",
       "args": {
         "dims": [0.9, 3.5, 0.5]
       },
-      "transform": {
-        "translate": [40.465, 1.75, -4.6],
-        "rotate": [0, -0.3, 0]
-      },
-      "material": "mat-13",
-      "collection": "station-3"
-    },
-    {
-      "id": "s3-guard-r-1",
-      "type": "box",
-      "args": {
-        "dims": [0.9, 3.5, 0.5]
-      },
+      "modifiers": [
+        {
+          "type": "mirror",
+          "axis": "x",
+          "origin": [48, 0]
+        }
+      ],
       "transform": {
         "translate": [55.535, 1.75, -4.6],
         "rotate": [0, 0.3, 0]
@@ -1822,24 +1579,18 @@
       "collection": "station-3"
     },
     {
-      "id": "s3-guard-l-2",
+      "id": "s3-guard-2",
       "type": "box",
       "args": {
         "dims": [0.9, 4.800000000000001, 0.5]
       },
-      "transform": {
-        "translate": [39.065, 2.4000000000000004, -6.800000000000001],
-        "rotate": [0, -0.3, 0]
-      },
-      "material": "mat-13",
-      "collection": "station-3"
-    },
-    {
-      "id": "s3-guard-r-2",
-      "type": "box",
-      "args": {
-        "dims": [0.9, 4.800000000000001, 0.5]
-      },
+      "modifiers": [
+        {
+          "type": "mirror",
+          "axis": "x",
+          "origin": [48, 0]
+        }
+      ],
       "transform": {
         "translate": [56.935, 2.4000000000000004, -6.800000000000001],
         "rotate": [0, 0.3, 0]
@@ -1848,91 +1599,20 @@
       "collection": "station-3"
     },
     {
-      "id": "path-3-1",
+      "id": "path-3-runway",
       "type": "box",
       "args": {
         "dims": [1.7, 0.05, 0.32]
       },
+      "modifiers": [
+        {
+          "type": "array",
+          "count": 7,
+          "offset": [2, 0, 0]
+        }
+      ],
       "transform": {
         "translate": [50, 0.03, 0],
-        "rotate": [0, 0, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-3"
-    },
-    {
-      "id": "path-3-2",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [52, 0.03, 0],
-        "rotate": [0, 0, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-3"
-    },
-    {
-      "id": "path-3-3",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [54, 0.03, 0],
-        "rotate": [0, 0, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-3"
-    },
-    {
-      "id": "path-3-4",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [56, 0.03, 0],
-        "rotate": [0, 0, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-3"
-    },
-    {
-      "id": "path-3-5",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [58, 0.03, 0],
-        "rotate": [0, 0, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-3"
-    },
-    {
-      "id": "path-3-6",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [60, 0.03, 0],
-        "rotate": [0, 0, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-3"
-    },
-    {
-      "id": "path-3-7",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [62, 0.03, 0],
         "rotate": [0, 0, 0]
       },
       "material": "mat-1",
@@ -2130,24 +1810,18 @@
       "collection": "station-4"
     },
     {
-      "id": "s4-guard-l-0",
+      "id": "s4-guard-0",
       "type": "box",
       "args": {
         "dims": [0.9, 2.2, 0.5]
       },
-      "transform": {
-        "translate": [55.865, 1.1, 1.2],
-        "rotate": [0, -0.3, 0]
-      },
-      "material": "mat-13",
-      "collection": "station-4"
-    },
-    {
-      "id": "s4-guard-r-0",
-      "type": "box",
-      "args": {
-        "dims": [0.9, 2.2, 0.5]
-      },
+      "modifiers": [
+        {
+          "type": "mirror",
+          "axis": "x",
+          "origin": [64, 0]
+        }
+      ],
       "transform": {
         "translate": [72.135, 1.1, 1.2],
         "rotate": [0, 0.3, 0]
@@ -2156,24 +1830,18 @@
       "collection": "station-4"
     },
     {
-      "id": "s4-guard-l-1",
+      "id": "s4-guard-1",
       "type": "box",
       "args": {
         "dims": [0.9, 3.5, 0.5]
       },
-      "transform": {
-        "translate": [56.465, 1.75, -4.6],
-        "rotate": [0, -0.3, 0]
-      },
-      "material": "mat-13",
-      "collection": "station-4"
-    },
-    {
-      "id": "s4-guard-r-1",
-      "type": "box",
-      "args": {
-        "dims": [0.9, 3.5, 0.5]
-      },
+      "modifiers": [
+        {
+          "type": "mirror",
+          "axis": "x",
+          "origin": [64, 0]
+        }
+      ],
       "transform": {
         "translate": [71.535, 1.75, -4.6],
         "rotate": [0, 0.3, 0]
@@ -2182,24 +1850,18 @@
       "collection": "station-4"
     },
     {
-      "id": "s4-guard-l-2",
+      "id": "s4-guard-2",
       "type": "box",
       "args": {
         "dims": [0.9, 4.800000000000001, 0.5]
       },
-      "transform": {
-        "translate": [55.065, 2.4000000000000004, -6.800000000000001],
-        "rotate": [0, -0.3, 0]
-      },
-      "material": "mat-13",
-      "collection": "station-4"
-    },
-    {
-      "id": "s4-guard-r-2",
-      "type": "box",
-      "args": {
-        "dims": [0.9, 4.800000000000001, 0.5]
-      },
+      "modifiers": [
+        {
+          "type": "mirror",
+          "axis": "x",
+          "origin": [64, 0]
+        }
+      ],
       "transform": {
         "translate": [72.935, 2.4000000000000004, -6.800000000000001],
         "rotate": [0, 0.3, 0]
@@ -2208,91 +1870,20 @@
       "collection": "station-4"
     },
     {
-      "id": "path-4-1",
+      "id": "path-4-runway",
       "type": "box",
       "args": {
         "dims": [1.7, 0.05, 0.32]
       },
+      "modifiers": [
+        {
+          "type": "array",
+          "count": 7,
+          "offset": [2, 0, 0]
+        }
+      ],
       "transform": {
         "translate": [66, 0.03, 0],
-        "rotate": [0, 0, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-4"
-    },
-    {
-      "id": "path-4-2",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [68, 0.03, 0],
-        "rotate": [0, 0, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-4"
-    },
-    {
-      "id": "path-4-3",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [70, 0.03, 0],
-        "rotate": [0, 0, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-4"
-    },
-    {
-      "id": "path-4-4",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [72, 0.03, 0],
-        "rotate": [0, 0, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-4"
-    },
-    {
-      "id": "path-4-5",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [74, 0.03, 0],
-        "rotate": [0, 0, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-4"
-    },
-    {
-      "id": "path-4-6",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [76, 0.03, 0],
-        "rotate": [0, 0, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-4"
-    },
-    {
-      "id": "path-4-7",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [78, 0.03, 0],
         "rotate": [0, 0, 0]
       },
       "material": "mat-1",
@@ -2490,24 +2081,18 @@
       "collection": "station-5"
     },
     {
-      "id": "s5-guard-l-0",
+      "id": "s5-guard-0",
       "type": "box",
       "args": {
         "dims": [0.9, 2.2, 0.5]
       },
-      "transform": {
-        "translate": [71.865, 1.1, 1.2],
-        "rotate": [0, -0.3, 0]
-      },
-      "material": "mat-13",
-      "collection": "station-5"
-    },
-    {
-      "id": "s5-guard-r-0",
-      "type": "box",
-      "args": {
-        "dims": [0.9, 2.2, 0.5]
-      },
+      "modifiers": [
+        {
+          "type": "mirror",
+          "axis": "x",
+          "origin": [80, 0]
+        }
+      ],
       "transform": {
         "translate": [88.135, 1.1, 1.2],
         "rotate": [0, 0.3, 0]
@@ -2516,24 +2101,18 @@
       "collection": "station-5"
     },
     {
-      "id": "s5-guard-l-1",
+      "id": "s5-guard-1",
       "type": "box",
       "args": {
         "dims": [0.9, 3.5, 0.5]
       },
-      "transform": {
-        "translate": [72.465, 1.75, -4.6],
-        "rotate": [0, -0.3, 0]
-      },
-      "material": "mat-13",
-      "collection": "station-5"
-    },
-    {
-      "id": "s5-guard-r-1",
-      "type": "box",
-      "args": {
-        "dims": [0.9, 3.5, 0.5]
-      },
+      "modifiers": [
+        {
+          "type": "mirror",
+          "axis": "x",
+          "origin": [80, 0]
+        }
+      ],
       "transform": {
         "translate": [87.535, 1.75, -4.6],
         "rotate": [0, 0.3, 0]
@@ -2542,24 +2121,18 @@
       "collection": "station-5"
     },
     {
-      "id": "s5-guard-l-2",
+      "id": "s5-guard-2",
       "type": "box",
       "args": {
         "dims": [0.9, 4.800000000000001, 0.5]
       },
-      "transform": {
-        "translate": [71.065, 2.4000000000000004, -6.800000000000001],
-        "rotate": [0, -0.3, 0]
-      },
-      "material": "mat-13",
-      "collection": "station-5"
-    },
-    {
-      "id": "s5-guard-r-2",
-      "type": "box",
-      "args": {
-        "dims": [0.9, 4.800000000000001, 0.5]
-      },
+      "modifiers": [
+        {
+          "type": "mirror",
+          "axis": "x",
+          "origin": [80, 0]
+        }
+      ],
       "transform": {
         "translate": [88.935, 2.4000000000000004, -6.800000000000001],
         "rotate": [0, 0.3, 0]
@@ -2568,91 +2141,20 @@
       "collection": "station-5"
     },
     {
-      "id": "path-5-1",
+      "id": "path-5-runway",
       "type": "box",
       "args": {
         "dims": [1.7, 0.05, 0.32]
       },
+      "modifiers": [
+        {
+          "type": "array",
+          "count": 7,
+          "offset": [2, 0, 0]
+        }
+      ],
       "transform": {
         "translate": [82, 0.03, 0],
-        "rotate": [0, 0, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-5"
-    },
-    {
-      "id": "path-5-2",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [84, 0.03, 0],
-        "rotate": [0, 0, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-5"
-    },
-    {
-      "id": "path-5-3",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [86, 0.03, 0],
-        "rotate": [0, 0, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-5"
-    },
-    {
-      "id": "path-5-4",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [88, 0.03, 0],
-        "rotate": [0, 0, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-5"
-    },
-    {
-      "id": "path-5-5",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [90, 0.03, 0],
-        "rotate": [0, 0, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-5"
-    },
-    {
-      "id": "path-5-6",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [92, 0.03, 0],
-        "rotate": [0, 0, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-5"
-    },
-    {
-      "id": "path-5-7",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [94, 0.03, 0],
         "rotate": [0, 0, 0]
       },
       "material": "mat-1",
@@ -2869,91 +2371,20 @@
       "collection": "station-6"
     },
     {
-      "id": "path-6-1",
+      "id": "path-6-runway",
       "type": "box",
       "args": {
         "dims": [1.7, 0.05, 0.32]
       },
+      "modifiers": [
+        {
+          "type": "array",
+          "count": 7,
+          "offset": [2, 0, 0]
+        }
+      ],
       "transform": {
         "translate": [98, 0.03, 0],
-        "rotate": [0, 0, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-6"
-    },
-    {
-      "id": "path-6-2",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [100, 0.03, 0],
-        "rotate": [0, 0, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-6"
-    },
-    {
-      "id": "path-6-3",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [102, 0.03, 0],
-        "rotate": [0, 0, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-6"
-    },
-    {
-      "id": "path-6-4",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [104, 0.03, 0],
-        "rotate": [0, 0, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-6"
-    },
-    {
-      "id": "path-6-5",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [106, 0.03, 0],
-        "rotate": [0, 0, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-6"
-    },
-    {
-      "id": "path-6-6",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [108, 0.03, 0],
-        "rotate": [0, 0, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-6"
-    },
-    {
-      "id": "path-6-7",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [110, 0.03, 0],
         "rotate": [0, 0, 0]
       },
       "material": "mat-1",
@@ -3740,91 +3171,20 @@
       "collection": "station-7"
     },
     {
-      "id": "path-7-1",
+      "id": "path-7-runway",
       "type": "box",
       "args": {
         "dims": [1.7, 0.05, 0.32]
       },
+      "modifiers": [
+        {
+          "type": "array",
+          "count": 7,
+          "offset": [2, 0, 0]
+        }
+      ],
       "transform": {
         "translate": [114, 0.03, 0],
-        "rotate": [0, 0, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-7"
-    },
-    {
-      "id": "path-7-2",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [116, 0.03, 0],
-        "rotate": [0, 0, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-7"
-    },
-    {
-      "id": "path-7-3",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [118, 0.03, 0],
-        "rotate": [0, 0, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-7"
-    },
-    {
-      "id": "path-7-4",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [120, 0.03, 0],
-        "rotate": [0, 0, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-7"
-    },
-    {
-      "id": "path-7-5",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [122, 0.03, 0],
-        "rotate": [0, 0, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-7"
-    },
-    {
-      "id": "path-7-6",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [124, 0.03, 0],
-        "rotate": [0, 0, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-7"
-    },
-    {
-      "id": "path-7-7",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [126, 0.03, 0],
         "rotate": [0, 0, 0]
       },
       "material": "mat-1",
@@ -3915,91 +3275,20 @@
       "collection": "station-8"
     },
     {
-      "id": "path-8-1",
+      "id": "path-8-runway",
       "type": "box",
       "args": {
         "dims": [1.7, 0.05, 0.32]
       },
+      "modifiers": [
+        {
+          "type": "array",
+          "count": 7,
+          "offset": [2, 0, 0]
+        }
+      ],
       "transform": {
         "translate": [130, 0.03, 0],
-        "rotate": [0, 0, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-8"
-    },
-    {
-      "id": "path-8-2",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [132, 0.03, 0],
-        "rotate": [0, 0, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-8"
-    },
-    {
-      "id": "path-8-3",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [134, 0.03, 0],
-        "rotate": [0, 0, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-8"
-    },
-    {
-      "id": "path-8-4",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [136, 0.03, 0],
-        "rotate": [0, 0, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-8"
-    },
-    {
-      "id": "path-8-5",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [138, 0.03, 0],
-        "rotate": [0, 0, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-8"
-    },
-    {
-      "id": "path-8-6",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [140, 0.03, 0],
-        "rotate": [0, 0, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-8"
-    },
-    {
-      "id": "path-8-7",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [142, 0.03, 0],
         "rotate": [0, 0, 0]
       },
       "material": "mat-1",
@@ -4229,24 +3518,18 @@
       "collection": "station-9"
     },
     {
-      "id": "s9-guard-l-0",
+      "id": "s9-guard-0",
       "type": "box",
       "args": {
         "dims": [0.9, 2.2, 0.5]
       },
-      "transform": {
-        "translate": [135.23, 1.1, 1.2],
-        "rotate": [0, -0.3, 0]
-      },
-      "material": "mat-13",
-      "collection": "station-9"
-    },
-    {
-      "id": "s9-guard-r-0",
-      "type": "box",
-      "args": {
-        "dims": [0.9, 2.2, 0.5]
-      },
+      "modifiers": [
+        {
+          "type": "mirror",
+          "axis": "x",
+          "origin": [144, 0]
+        }
+      ],
       "transform": {
         "translate": [152.77, 1.1, 1.2],
         "rotate": [0, 0.3, 0]
@@ -4255,24 +3538,18 @@
       "collection": "station-9"
     },
     {
-      "id": "s9-guard-l-1",
+      "id": "s9-guard-1",
       "type": "box",
       "args": {
         "dims": [0.9, 3.5, 0.5]
       },
-      "transform": {
-        "translate": [135.83, 1.75, -4.6],
-        "rotate": [0, -0.3, 0]
-      },
-      "material": "mat-13",
-      "collection": "station-9"
-    },
-    {
-      "id": "s9-guard-r-1",
-      "type": "box",
-      "args": {
-        "dims": [0.9, 3.5, 0.5]
-      },
+      "modifiers": [
+        {
+          "type": "mirror",
+          "axis": "x",
+          "origin": [144, 0]
+        }
+      ],
       "transform": {
         "translate": [152.17, 1.75, -4.6],
         "rotate": [0, 0.3, 0]
@@ -4281,24 +3558,18 @@
       "collection": "station-9"
     },
     {
-      "id": "s9-guard-l-2",
+      "id": "s9-guard-2",
       "type": "box",
       "args": {
         "dims": [0.9, 4.800000000000001, 0.5]
       },
-      "transform": {
-        "translate": [134.43, 2.4000000000000004, -6.800000000000001],
-        "rotate": [0, -0.3, 0]
-      },
-      "material": "mat-13",
-      "collection": "station-9"
-    },
-    {
-      "id": "s9-guard-r-2",
-      "type": "box",
-      "args": {
-        "dims": [0.9, 4.800000000000001, 0.5]
-      },
+      "modifiers": [
+        {
+          "type": "mirror",
+          "axis": "x",
+          "origin": [144, 0]
+        }
+      ],
       "transform": {
         "translate": [153.57, 2.4000000000000004, -6.800000000000001],
         "rotate": [0, 0.3, 0]
@@ -4307,91 +3578,20 @@
       "collection": "station-9"
     },
     {
-      "id": "path-9-1",
+      "id": "path-9-runway",
       "type": "box",
       "args": {
         "dims": [1.7, 0.05, 0.32]
       },
+      "modifiers": [
+        {
+          "type": "array",
+          "count": 7,
+          "offset": [2, 0, 0]
+        }
+      ],
       "transform": {
         "translate": [146, 0.03, 0],
-        "rotate": [0, 0, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-9"
-    },
-    {
-      "id": "path-9-2",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [148, 0.03, 0],
-        "rotate": [0, 0, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-9"
-    },
-    {
-      "id": "path-9-3",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [150, 0.03, 0],
-        "rotate": [0, 0, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-9"
-    },
-    {
-      "id": "path-9-4",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [152, 0.03, 0],
-        "rotate": [0, 0, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-9"
-    },
-    {
-      "id": "path-9-5",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [154, 0.03, 0],
-        "rotate": [0, 0, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-9"
-    },
-    {
-      "id": "path-9-6",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [156, 0.03, 0],
-        "rotate": [0, 0, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-9"
-    },
-    {
-      "id": "path-9-7",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [158, 0.03, 0],
         "rotate": [0, 0, 0]
       },
       "material": "mat-1",
@@ -4581,91 +3781,20 @@
       "collection": "station-10"
     },
     {
-      "id": "path-10-1",
+      "id": "path-10-runway",
       "type": "box",
       "args": {
         "dims": [1.7, 0.05, 0.32]
       },
+      "modifiers": [
+        {
+          "type": "array",
+          "count": 7,
+          "offset": [2, 0, 0]
+        }
+      ],
       "transform": {
         "translate": [162, 0.03, 0],
-        "rotate": [0, 0, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-10"
-    },
-    {
-      "id": "path-10-2",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [164, 0.03, 0],
-        "rotate": [0, 0, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-10"
-    },
-    {
-      "id": "path-10-3",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [166, 0.03, 0],
-        "rotate": [0, 0, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-10"
-    },
-    {
-      "id": "path-10-4",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [168, 0.03, 0],
-        "rotate": [0, 0, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-10"
-    },
-    {
-      "id": "path-10-5",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [170, 0.03, 0],
-        "rotate": [0, 0, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-10"
-    },
-    {
-      "id": "path-10-6",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [172, 0.03, 0],
-        "rotate": [0, 0, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-10"
-    },
-    {
-      "id": "path-10-7",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [174, 0.03, 0],
         "rotate": [0, 0, 0]
       },
       "material": "mat-1",
@@ -4889,91 +4018,20 @@
       "collection": "station-11"
     },
     {
-      "id": "path-11-1",
+      "id": "path-11-runway",
       "type": "box",
       "args": {
         "dims": [1.7, 0.05, 0.32]
       },
+      "modifiers": [
+        {
+          "type": "array",
+          "count": 7,
+          "offset": [2, 0, 0]
+        }
+      ],
       "transform": {
         "translate": [178, 0.03, 0],
-        "rotate": [0, 0, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-11"
-    },
-    {
-      "id": "path-11-2",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [180, 0.03, 0],
-        "rotate": [0, 0, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-11"
-    },
-    {
-      "id": "path-11-3",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [182, 0.03, 0],
-        "rotate": [0, 0, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-11"
-    },
-    {
-      "id": "path-11-4",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [184, 0.03, 0],
-        "rotate": [0, 0, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-11"
-    },
-    {
-      "id": "path-11-5",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [186, 0.03, 0],
-        "rotate": [0, 0, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-11"
-    },
-    {
-      "id": "path-11-6",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [188, 0.03, 0],
-        "rotate": [0, 0, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-11"
-    },
-    {
-      "id": "path-11-7",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [190, 0.03, 0],
         "rotate": [0, 0, 0]
       },
       "material": "mat-1",
@@ -5075,24 +4133,18 @@
       "collection": "station-12"
     },
     {
-      "id": "s12-guard-l-0",
+      "id": "s12-guard-0",
       "type": "box",
       "args": {
         "dims": [0.9, 2.2, 0.5]
       },
-      "transform": {
-        "translate": [185.77, 1.1, 1.2],
-        "rotate": [0, -0.3, 0]
-      },
-      "material": "mat-13",
-      "collection": "station-12"
-    },
-    {
-      "id": "s12-guard-r-0",
-      "type": "box",
-      "args": {
-        "dims": [0.9, 2.2, 0.5]
-      },
+      "modifiers": [
+        {
+          "type": "mirror",
+          "axis": "x",
+          "origin": [192, 0]
+        }
+      ],
       "transform": {
         "translate": [198.23, 1.1, 1.2],
         "rotate": [0, 0.3, 0]
@@ -5101,24 +4153,18 @@
       "collection": "station-12"
     },
     {
-      "id": "s12-guard-l-1",
+      "id": "s12-guard-1",
       "type": "box",
       "args": {
         "dims": [0.9, 3.5, 0.5]
       },
-      "transform": {
-        "translate": [186.37, 1.75, -4.6],
-        "rotate": [0, -0.3, 0]
-      },
-      "material": "mat-13",
-      "collection": "station-12"
-    },
-    {
-      "id": "s12-guard-r-1",
-      "type": "box",
-      "args": {
-        "dims": [0.9, 3.5, 0.5]
-      },
+      "modifiers": [
+        {
+          "type": "mirror",
+          "axis": "x",
+          "origin": [192, 0]
+        }
+      ],
       "transform": {
         "translate": [197.63, 1.75, -4.6],
         "rotate": [0, 0.3, 0]
@@ -5127,24 +4173,18 @@
       "collection": "station-12"
     },
     {
-      "id": "s12-guard-l-2",
+      "id": "s12-guard-2",
       "type": "box",
       "args": {
         "dims": [0.9, 4.800000000000001, 0.5]
       },
-      "transform": {
-        "translate": [184.97, 2.4000000000000004, -6.800000000000001],
-        "rotate": [0, -0.3, 0]
-      },
-      "material": "mat-13",
-      "collection": "station-12"
-    },
-    {
-      "id": "s12-guard-r-2",
-      "type": "box",
-      "args": {
-        "dims": [0.9, 4.800000000000001, 0.5]
-      },
+      "modifiers": [
+        {
+          "type": "mirror",
+          "axis": "x",
+          "origin": [192, 0]
+        }
+      ],
       "transform": {
         "translate": [199.03, 2.4000000000000004, -6.800000000000001],
         "rotate": [0, 0.3, 0]

--- a/sdf-js/fixtures/golden/assemble-deck-radial.json
+++ b/sdf-js/fixtures/golden/assemble-deck-radial.json
@@ -839,91 +839,20 @@
       "collection": "station-0"
     },
     {
-      "id": "path-0-1",
+      "id": "path-0-runway",
       "type": "box",
       "args": {
         "dims": [1.7, 0.05, 0.32]
       },
+      "modifiers": [
+        {
+          "type": "array",
+          "count": 7,
+          "offset": [1.9230377400028875, 0, -0.4739862326857551]
+        }
+      ],
       "transform": {
         "translate": [1.9230377400028875, 0.03, 32.630241930428475],
-        "rotate": [0, 0.24166097335306091, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-0"
-    },
-    {
-      "id": "path-0-2",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [3.846075480005775, 0.03, 32.15625569774272],
-        "rotate": [0, 0.24166097335306091, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-0"
-    },
-    {
-      "id": "path-0-3",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [5.769113220008663, 0.03, 31.68226946505696],
-        "rotate": [0, 0.24166097335306091, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-0"
-    },
-    {
-      "id": "path-0-4",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [7.69215096001155, 0.03, 31.20828323237121],
-        "rotate": [0, 0.24166097335306091, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-0"
-    },
-    {
-      "id": "path-0-5",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [9.615188700014437, 0.03, 30.734296999685455],
-        "rotate": [0, 0.24166097335306091, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-0"
-    },
-    {
-      "id": "path-0-6",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [11.538226440017326, 0.03, 30.260310766999698],
-        "rotate": [0, 0.24166097335306091, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-0"
-    },
-    {
-      "id": "path-0-7",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [13.461264180020212, 0.03, 29.78632453431394],
         "rotate": [0, 0.24166097335306091, 0]
       },
       "material": "mat-1",
@@ -1128,91 +1057,20 @@
       "collection": "station-1"
     },
     {
-      "id": "path-1-1",
+      "id": "path-1-runway",
       "type": "box",
       "args": {
         "dims": [1.7, 0.05, 0.32]
       },
+      "modifiers": [
+        {
+          "type": "array",
+          "count": 7,
+          "offset": [1.482492968885288, 0, -1.3133741643022883]
+        }
+      ],
       "transform": {
         "translate": [16.866794888908387, 0.03, 27.9989641373259],
-        "rotate": [0, 0.724982920059183, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-1"
-    },
-    {
-      "id": "path-1-2",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [18.349287857793676, 0.03, 26.68558997302361],
-        "rotate": [0, 0.724982920059183, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-1"
-    },
-    {
-      "id": "path-1-3",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [19.831780826678965, 0.03, 25.37221580872132],
-        "rotate": [0, 0.724982920059183, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-1"
-    },
-    {
-      "id": "path-1-4",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [21.31427379556425, 0.03, 24.058841644419033],
-        "rotate": [0, 0.724982920059183, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-1"
-    },
-    {
-      "id": "path-1-5",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [22.79676676444954, 0.03, 22.745467480116744],
-        "rotate": [0, 0.724982920059183, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-1"
-    },
-    {
-      "id": "path-1-6",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [24.279259733334825, 0.03, 21.43209331581446],
-        "rotate": [0, 0.724982920059183, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-1"
-    },
-    {
-      "id": "path-1-7",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [25.761752702220114, 0.03, 20.11871915151217],
         "rotate": [0, 0.724982920059183, 0]
       },
       "material": "mat-1",
@@ -1410,24 +1268,18 @@
       "collection": "station-2"
     },
     {
-      "id": "s2-guard-l-0",
+      "id": "s2-guard-0",
       "type": "box",
       "args": {
         "dims": [0.9, 2.2, 0.5]
       },
-      "transform": {
-        "translate": [19.109245671105406, 1.1, 20.00534498720988],
-        "rotate": [0, -0.3, 0]
-      },
-      "material": "mat-13",
-      "collection": "station-2"
-    },
-    {
-      "id": "s2-guard-r-0",
-      "type": "box",
-      "args": {
-        "dims": [0.9, 2.2, 0.5]
-      },
+      "modifiers": [
+        {
+          "type": "mirror",
+          "axis": "x",
+          "origin": [27.244245671105404, 18.80534498720988]
+        }
+      ],
       "transform": {
         "translate": [35.3792456711054, 1.1, 20.00534498720988],
         "rotate": [0, 0.3, 0]
@@ -1436,24 +1288,18 @@
       "collection": "station-2"
     },
     {
-      "id": "s2-guard-l-1",
+      "id": "s2-guard-1",
       "type": "box",
       "args": {
         "dims": [0.9, 3.5, 0.5]
       },
-      "transform": {
-        "translate": [19.709245671105403, 1.75, 14.205344987209882],
-        "rotate": [0, -0.3, 0]
-      },
-      "material": "mat-13",
-      "collection": "station-2"
-    },
-    {
-      "id": "s2-guard-r-1",
-      "type": "box",
-      "args": {
-        "dims": [0.9, 3.5, 0.5]
-      },
+      "modifiers": [
+        {
+          "type": "mirror",
+          "axis": "x",
+          "origin": [27.244245671105404, 18.80534498720988]
+        }
+      ],
       "transform": {
         "translate": [34.7792456711054, 1.75, 14.205344987209882],
         "rotate": [0, 0.3, 0]
@@ -1462,24 +1308,18 @@
       "collection": "station-2"
     },
     {
-      "id": "s2-guard-l-2",
+      "id": "s2-guard-2",
       "type": "box",
       "args": {
         "dims": [0.9, 4.800000000000001, 0.5]
       },
-      "transform": {
-        "translate": [18.3092456711054, 2.4000000000000004, 12.005344987209881],
-        "rotate": [0, -0.3, 0]
-      },
-      "material": "mat-13",
-      "collection": "station-2"
-    },
-    {
-      "id": "s2-guard-r-2",
-      "type": "box",
-      "args": {
-        "dims": [0.9, 4.800000000000001, 0.5]
-      },
+      "modifiers": [
+        {
+          "type": "mirror",
+          "axis": "x",
+          "origin": [27.244245671105404, 18.80534498720988]
+        }
+      ],
       "transform": {
         "translate": [36.179245671105406, 2.4000000000000004, 12.005344987209881],
         "rotate": [0, 0.3, 0]
@@ -1488,91 +1328,20 @@
       "collection": "station-2"
     },
     {
-      "id": "path-2-1",
+      "id": "path-2-runway",
       "type": "box",
       "args": {
         "dims": [1.7, 0.05, 0.32]
       },
+      "modifiers": [
+        {
+          "type": "array",
+          "count": 7,
+          "offset": [0.7023269245731019, 0, -1.8518839027516654]
+        }
+      ],
       "transform": {
         "translate": [27.946572595678504, 0.03, 16.953461084458215],
-        "rotate": [0, 1.208304866765305, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-2"
-    },
-    {
-      "id": "path-2-2",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [28.648899520251607, 0.03, 15.101577181706551],
-        "rotate": [0, 1.208304866765305, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-2"
-    },
-    {
-      "id": "path-2-3",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [29.35122644482471, 0.03, 13.249693278954886],
-        "rotate": [0, 1.208304866765305, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-2"
-    },
-    {
-      "id": "path-2-4",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [30.05355336939781, 0.03, 11.39780937620322],
-        "rotate": [0, 1.208304866765305, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-2"
-    },
-    {
-      "id": "path-2-5",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [30.75588029397091, 0.03, 9.545925473451554],
-        "rotate": [0, 1.208304866765305, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-2"
-    },
-    {
-      "id": "path-2-6",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [31.458207218544015, 0.03, 7.6940415706998895],
-        "rotate": [0, 1.208304866765305, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-2"
-    },
-    {
-      "id": "path-2-7",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [32.16053414311712, 0.03, 5.842157667948225],
         "rotate": [0, 1.208304866765305, 0]
       },
       "material": "mat-1",
@@ -1770,24 +1539,18 @@
       "collection": "station-3"
     },
     {
-      "id": "s3-guard-l-0",
+      "id": "s3-guard-0",
       "type": "box",
       "args": {
         "dims": [0.9, 2.2, 0.5]
       },
-      "transform": {
-        "translate": [24.72786106769022, 1.1, 5.190273765196559],
-        "rotate": [0, -0.3, 0]
-      },
-      "material": "mat-13",
-      "collection": "station-3"
-    },
-    {
-      "id": "s3-guard-r-0",
-      "type": "box",
-      "args": {
-        "dims": [0.9, 2.2, 0.5]
-      },
+      "modifiers": [
+        {
+          "type": "mirror",
+          "axis": "x",
+          "origin": [32.86286106769022, 3.9902737651965587]
+        }
+      ],
       "transform": {
         "translate": [40.997861067690216, 1.1, 5.190273765196559],
         "rotate": [0, 0.3, 0]
@@ -1796,24 +1559,18 @@
       "collection": "station-3"
     },
     {
-      "id": "s3-guard-l-1",
+      "id": "s3-guard-1",
       "type": "box",
       "args": {
         "dims": [0.9, 3.5, 0.5]
       },
-      "transform": {
-        "translate": [25.32786106769022, 1.75, -0.6097262348034409],
-        "rotate": [0, -0.3, 0]
-      },
-      "material": "mat-13",
-      "collection": "station-3"
-    },
-    {
-      "id": "s3-guard-r-1",
-      "type": "box",
-      "args": {
-        "dims": [0.9, 3.5, 0.5]
-      },
+      "modifiers": [
+        {
+          "type": "mirror",
+          "axis": "x",
+          "origin": [32.86286106769022, 3.9902737651965587]
+        }
+      ],
       "transform": {
         "translate": [40.397861067690215, 1.75, -0.6097262348034409],
         "rotate": [0, 0.3, 0]
@@ -1822,24 +1579,18 @@
       "collection": "station-3"
     },
     {
-      "id": "s3-guard-l-2",
+      "id": "s3-guard-2",
       "type": "box",
       "args": {
         "dims": [0.9, 4.800000000000001, 0.5]
       },
-      "transform": {
-        "translate": [23.927861067690216, 2.4000000000000004, -2.809726234803442],
-        "rotate": [0, -0.3, 0]
-      },
-      "material": "mat-13",
-      "collection": "station-3"
-    },
-    {
-      "id": "s3-guard-r-2",
-      "type": "box",
-      "args": {
-        "dims": [0.9, 4.800000000000001, 0.5]
-      },
+      "modifiers": [
+        {
+          "type": "mirror",
+          "axis": "x",
+          "origin": [32.86286106769022, 3.9902737651965587]
+        }
+      ],
       "transform": {
         "translate": [41.79786106769022, 2.4000000000000004, -2.809726234803442],
         "rotate": [0, 0.3, 0]
@@ -1848,91 +1599,20 @@
       "collection": "station-3"
     },
     {
-      "id": "path-3-1",
+      "id": "path-3-runway",
       "type": "box",
       "args": {
         "dims": [1.7, 0.05, 0.32]
       },
+      "modifiers": [
+        {
+          "type": "array",
+          "count": 7,
+          "offset": [-0.23873375420180754, 0, -1.966149356701]
+        }
+      ],
       "transform": {
         "translate": [32.62412731348841, 0.03, 2.0241244084955587],
-        "rotate": [0, 1.6916268134714274, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-3"
-    },
-    {
-      "id": "path-3-2",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [32.385393559286605, 0.03, 0.05797505179455875],
-        "rotate": [0, 1.6916268134714274, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-3"
-    },
-    {
-      "id": "path-3-3",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [32.146659805084795, 0.03, -1.9081743049064412],
-        "rotate": [0, 1.6916268134714274, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-3"
-    },
-    {
-      "id": "path-3-4",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [31.90792605088299, 0.03, -3.8743236616074412],
-        "rotate": [0, 1.6916268134714274, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-3"
-    },
-    {
-      "id": "path-3-5",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [31.66919229668118, 0.03, -5.84047301830844],
-        "rotate": [0, 1.6916268134714274, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-3"
-    },
-    {
-      "id": "path-3-6",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [31.43045854247937, 0.03, -7.806622375009441],
-        "rotate": [0, 1.6916268134714274, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-3"
-    },
-    {
-      "id": "path-3-7",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [31.191724788277565, 0.03, -9.772771731710442],
         "rotate": [0, 1.6916268134714274, 0]
       },
       "material": "mat-1",
@@ -2130,24 +1810,18 @@
       "collection": "station-4"
     },
     {
-      "id": "s4-guard-l-0",
+      "id": "s4-guard-0",
       "type": "box",
       "args": {
         "dims": [0.9, 2.2, 0.5]
       },
-      "transform": {
-        "translate": [22.81799103407576, 1.1, -10.538921088411442],
-        "rotate": [0, -0.3, 0]
-      },
-      "material": "mat-13",
-      "collection": "station-4"
-    },
-    {
-      "id": "s4-guard-r-0",
-      "type": "box",
-      "args": {
-        "dims": [0.9, 2.2, 0.5]
-      },
+      "modifiers": [
+        {
+          "type": "mirror",
+          "axis": "x",
+          "origin": [30.952991034075758, -11.738921088411441]
+        }
+      ],
       "transform": {
         "translate": [39.087991034075756, 1.1, -10.538921088411442],
         "rotate": [0, 0.3, 0]
@@ -2156,24 +1830,18 @@
       "collection": "station-4"
     },
     {
-      "id": "s4-guard-l-1",
+      "id": "s4-guard-1",
       "type": "box",
       "args": {
         "dims": [0.9, 3.5, 0.5]
       },
-      "transform": {
-        "translate": [23.417991034075758, 1.75, -16.33892108841144],
-        "rotate": [0, -0.3, 0]
-      },
-      "material": "mat-13",
-      "collection": "station-4"
-    },
-    {
-      "id": "s4-guard-r-1",
-      "type": "box",
-      "args": {
-        "dims": [0.9, 3.5, 0.5]
-      },
+      "modifiers": [
+        {
+          "type": "mirror",
+          "axis": "x",
+          "origin": [30.952991034075758, -11.738921088411441]
+        }
+      ],
       "transform": {
         "translate": [38.48799103407576, 1.75, -16.33892108841144],
         "rotate": [0, 0.3, 0]
@@ -2182,24 +1850,18 @@
       "collection": "station-4"
     },
     {
-      "id": "s4-guard-l-2",
+      "id": "s4-guard-2",
       "type": "box",
       "args": {
         "dims": [0.9, 4.800000000000001, 0.5]
       },
-      "transform": {
-        "translate": [22.017991034075756, 2.4000000000000004, -18.538921088411442],
-        "rotate": [0, -0.3, 0]
-      },
-      "material": "mat-13",
-      "collection": "station-4"
-    },
-    {
-      "id": "s4-guard-r-2",
-      "type": "box",
-      "args": {
-        "dims": [0.9, 4.800000000000001, 0.5]
-      },
+      "modifiers": [
+        {
+          "type": "mirror",
+          "axis": "x",
+          "origin": [30.952991034075758, -11.738921088411441]
+        }
+      ],
       "transform": {
         "translate": [39.88799103407576, 2.4000000000000004, -18.538921088411442],
         "rotate": [0, 0.3, 0]
@@ -2208,91 +1870,20 @@
       "collection": "station-4"
     },
     {
-      "id": "path-4-1",
+      "id": "path-4-runway",
       "type": "box",
       "args": {
         "dims": [1.7, 0.05, 0.32]
       },
+      "modifiers": [
+        {
+          "type": "array",
+          "count": 7,
+          "offset": [-1.1251034069427068, 0, -1.6299936876985037]
+        }
+      ],
       "transform": {
         "translate": [29.82788762713305, 0.03, -13.368914776109944],
-        "rotate": [0, 2.174948760177549, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-4"
-    },
-    {
-      "id": "path-4-2",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [28.702784220190345, 0.03, -14.998908463808448],
-        "rotate": [0, 2.174948760177549, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-4"
-    },
-    {
-      "id": "path-4-3",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [27.57768081324764, 0.03, -16.628902151506953],
-        "rotate": [0, 2.174948760177549, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-4"
-    },
-    {
-      "id": "path-4-4",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [26.452577406304933, 0.03, -18.258895839205458],
-        "rotate": [0, 2.174948760177549, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-4"
-    },
-    {
-      "id": "path-4-5",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [25.327473999362226, 0.03, -19.88888952690396],
-        "rotate": [0, 2.174948760177549, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-4"
-    },
-    {
-      "id": "path-4-6",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [24.202370592419516, 0.03, -21.518883214602464],
-        "rotate": [0, 2.174948760177549, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-4"
-    },
-    {
-      "id": "path-4-7",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [23.07726718547681, 0.03, -23.14887690230097],
         "rotate": [0, 2.174948760177549, 0]
       },
       "material": "mat-1",
@@ -2490,24 +2081,18 @@
       "collection": "station-5"
     },
     {
-      "id": "s5-guard-l-0",
+      "id": "s5-guard-0",
       "type": "box",
       "args": {
         "dims": [0.9, 2.2, 0.5]
       },
-      "transform": {
-        "translate": [13.817163778534104, 1.1, -23.57887058999947],
-        "rotate": [0, -0.3, 0]
-      },
-      "material": "mat-13",
-      "collection": "station-5"
-    },
-    {
-      "id": "s5-guard-r-0",
-      "type": "box",
-      "args": {
-        "dims": [0.9, 2.2, 0.5]
-      },
+      "modifiers": [
+        {
+          "type": "mirror",
+          "axis": "x",
+          "origin": [21.952163778534103, -24.77887058999947]
+        }
+      ],
       "transform": {
         "translate": [30.087163778534105, 1.1, -23.57887058999947],
         "rotate": [0, 0.3, 0]
@@ -2516,24 +2101,18 @@
       "collection": "station-5"
     },
     {
-      "id": "s5-guard-l-1",
+      "id": "s5-guard-1",
       "type": "box",
       "args": {
         "dims": [0.9, 3.5, 0.5]
       },
-      "transform": {
-        "translate": [14.417163778534103, 1.75, -29.378870589999472],
-        "rotate": [0, -0.3, 0]
-      },
-      "material": "mat-13",
-      "collection": "station-5"
-    },
-    {
-      "id": "s5-guard-r-1",
-      "type": "box",
-      "args": {
-        "dims": [0.9, 3.5, 0.5]
-      },
+      "modifiers": [
+        {
+          "type": "mirror",
+          "axis": "x",
+          "origin": [21.952163778534103, -24.77887058999947]
+        }
+      ],
       "transform": {
         "translate": [29.487163778534104, 1.75, -29.378870589999472],
         "rotate": [0, 0.3, 0]
@@ -2542,24 +2121,18 @@
       "collection": "station-5"
     },
     {
-      "id": "s5-guard-l-2",
+      "id": "s5-guard-2",
       "type": "box",
       "args": {
         "dims": [0.9, 4.800000000000001, 0.5]
       },
-      "transform": {
-        "translate": [13.017163778534103, 2.4000000000000004, -31.57887058999947],
-        "rotate": [0, -0.3, 0]
-      },
-      "material": "mat-13",
-      "collection": "station-5"
-    },
-    {
-      "id": "s5-guard-r-2",
-      "type": "box",
-      "args": {
-        "dims": [0.9, 4.800000000000001, 0.5]
-      },
+      "modifiers": [
+        {
+          "type": "mirror",
+          "axis": "x",
+          "origin": [21.952163778534103, -24.77887058999947]
+        }
+      ],
       "transform": {
         "translate": [30.887163778534102, 2.4000000000000004, -31.57887058999947],
         "rotate": [0, 0.3, 0]
@@ -2568,91 +2141,20 @@
       "collection": "station-5"
     },
     {
-      "id": "path-5-1",
+      "id": "path-5-runway",
       "type": "box",
       "args": {
         "dims": [1.7, 0.05, 0.32]
       },
+      "modifiers": [
+        {
+          "type": "array",
+          "count": 7,
+          "offset": [-1.7537254281189432, 0, -0.9204261083976695]
+        }
+      ],
       "transform": {
         "translate": [20.19843835041516, 0.03, -25.69929669839714],
-        "rotate": [0, 2.6582707068836715, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-5"
-    },
-    {
-      "id": "path-5-2",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [18.44471292229622, 0.03, -26.61972280679481],
-        "rotate": [0, 2.6582707068836715, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-5"
-    },
-    {
-      "id": "path-5-3",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [16.690987494177275, 0.03, -27.54014891519248],
-        "rotate": [0, 2.6582707068836715, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-5"
-    },
-    {
-      "id": "path-5-4",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [14.93726206605833, 0.03, -28.46057502359015],
-        "rotate": [0, 2.6582707068836715, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-5"
-    },
-    {
-      "id": "path-5-5",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [13.183536637939387, 0.03, -29.38100113198782],
-        "rotate": [0, 2.6582707068836715, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-5"
-    },
-    {
-      "id": "path-5-6",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [11.429811209820445, 0.03, -30.301427240385486],
-        "rotate": [0, 2.6582707068836715, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-5"
-    },
-    {
-      "id": "path-5-7",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [9.676085781701502, 0.03, -31.221853348783156],
         "rotate": [0, 2.6582707068836715, 0]
       },
       "material": "mat-1",
@@ -2869,91 +2371,20 @@
       "collection": "station-6"
     },
     {
-      "id": "path-6-1",
+      "id": "path-6-runway",
       "type": "box",
       "args": {
         "dims": [1.7, 0.05, 0.32]
       },
+      "modifiers": [
+        {
+          "type": "array",
+          "count": 7,
+          "offset": [-1.9805900883956382, 0, 0]
+        }
+      ],
       "transform": {
         "translate": [5.9417702651869195, 0.03, -32.14227945718083],
-        "rotate": [0, -3.141592653589793, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-6"
-    },
-    {
-      "id": "path-6-2",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [3.961180176791281, 0.03, -32.14227945718083],
-        "rotate": [0, -3.141592653589793, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-6"
-    },
-    {
-      "id": "path-6-3",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [1.980590088395643, 0.03, -32.14227945718083],
-        "rotate": [0, -3.141592653589793, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-6"
-    },
-    {
-      "id": "path-6-4",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [4.440892098500626e-15, 0.03, -32.14227945718083],
-        "rotate": [0, -3.141592653589793, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-6"
-    },
-    {
-      "id": "path-6-5",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [-1.9805900883956342, 0.03, -32.14227945718083],
-        "rotate": [0, -3.141592653589793, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-6"
-    },
-    {
-      "id": "path-6-6",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [-3.961180176791271, 0.03, -32.14227945718083],
-        "rotate": [0, -3.141592653589793, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-6"
-    },
-    {
-      "id": "path-6-7",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [-5.94177026518691, 0.03, -32.14227945718083],
         "rotate": [0, -3.141592653589793, 0]
       },
       "material": "mat-1",
@@ -3740,91 +3171,20 @@
       "collection": "station-7"
     },
     {
-      "id": "path-7-1",
+      "id": "path-7-runway",
       "type": "box",
       "args": {
         "dims": [1.7, 0.05, 0.32]
       },
+      "modifiers": [
+        {
+          "type": "array",
+          "count": 7,
+          "offset": [-1.7537254281189436, 0, 0.920426108397669]
+        }
+      ],
       "transform": {
         "translate": [-9.676085781701492, 0.03, -31.221853348783156],
-        "rotate": [0, -2.6582707068836715, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-7"
-    },
-    {
-      "id": "path-7-2",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [-11.429811209820436, 0.03, -30.30142724038549],
-        "rotate": [0, -2.6582707068836715, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-7"
-    },
-    {
-      "id": "path-7-3",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [-13.18353663793938, 0.03, -29.38100113198782],
-        "rotate": [0, -2.6582707068836715, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-7"
-    },
-    {
-      "id": "path-7-4",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [-14.937262066058324, 0.03, -28.460575023590152],
-        "rotate": [0, -2.6582707068836715, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-7"
-    },
-    {
-      "id": "path-7-5",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [-16.690987494177268, 0.03, -27.540148915192482],
-        "rotate": [0, -2.6582707068836715, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-7"
-    },
-    {
-      "id": "path-7-6",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [-18.44471292229621, 0.03, -26.61972280679481],
-        "rotate": [0, -2.6582707068836715, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-7"
-    },
-    {
-      "id": "path-7-7",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [-20.198438350415152, 0.03, -25.69929669839714],
         "rotate": [0, -2.6582707068836715, 0]
       },
       "material": "mat-1",
@@ -3915,91 +3275,20 @@
       "collection": "station-8"
     },
     {
-      "id": "path-8-1",
+      "id": "path-8-runway",
       "type": "box",
       "args": {
         "dims": [1.7, 0.05, 0.32]
       },
+      "modifiers": [
+        {
+          "type": "array",
+          "count": 7,
+          "offset": [-1.1251034069427073, 0, 1.6299936876985022]
+        }
+      ],
       "transform": {
         "translate": [-23.077267185476803, 0.03, -23.148876902300973],
-        "rotate": [0, -2.1749487601775495, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-8"
-    },
-    {
-      "id": "path-8-2",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [-24.202370592419513, 0.03, -21.51888321460247],
-        "rotate": [0, -2.1749487601775495, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-8"
-    },
-    {
-      "id": "path-8-3",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [-25.32747399936222, 0.03, -19.888889526903966],
-        "rotate": [0, -2.1749487601775495, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-8"
-    },
-    {
-      "id": "path-8-4",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [-26.452577406304925, 0.03, -18.258895839205465],
-        "rotate": [0, -2.1749487601775495, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-8"
-    },
-    {
-      "id": "path-8-5",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [-27.577680813247632, 0.03, -16.628902151506963],
-        "rotate": [0, -2.1749487601775495, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-8"
-    },
-    {
-      "id": "path-8-6",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [-28.70278422019034, 0.03, -14.998908463808462],
-        "rotate": [0, -2.1749487601775495, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-8"
-    },
-    {
-      "id": "path-8-7",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [-29.827887627133048, 0.03, -13.368914776109959],
         "rotate": [0, -2.1749487601775495, 0]
       },
       "material": "mat-1",
@@ -4229,24 +3518,18 @@
       "collection": "station-9"
     },
     {
-      "id": "s9-guard-l-0",
+      "id": "s9-guard-0",
       "type": "box",
       "args": {
         "dims": [0.9, 2.2, 0.5]
       },
-      "transform": {
-        "translate": [-39.722991034075754, 1.1, -10.538921088411458],
-        "rotate": [0, -0.3, 0]
-      },
-      "material": "mat-13",
-      "collection": "station-9"
-    },
-    {
-      "id": "s9-guard-r-0",
-      "type": "box",
-      "args": {
-        "dims": [0.9, 2.2, 0.5]
-      },
+      "modifiers": [
+        {
+          "type": "mirror",
+          "axis": "x",
+          "origin": [-30.952991034075755, -11.738921088411457]
+        }
+      ],
       "transform": {
         "translate": [-22.182991034075755, 1.1, -10.538921088411458],
         "rotate": [0, 0.3, 0]
@@ -4255,24 +3538,18 @@
       "collection": "station-9"
     },
     {
-      "id": "s9-guard-l-1",
+      "id": "s9-guard-1",
       "type": "box",
       "args": {
         "dims": [0.9, 3.5, 0.5]
       },
-      "transform": {
-        "translate": [-39.12299103407575, 1.75, -16.338921088411457],
-        "rotate": [0, -0.3, 0]
-      },
-      "material": "mat-13",
-      "collection": "station-9"
-    },
-    {
-      "id": "s9-guard-r-1",
-      "type": "box",
-      "args": {
-        "dims": [0.9, 3.5, 0.5]
-      },
+      "modifiers": [
+        {
+          "type": "mirror",
+          "axis": "x",
+          "origin": [-30.952991034075755, -11.738921088411457]
+        }
+      ],
       "transform": {
         "translate": [-22.782991034075756, 1.75, -16.338921088411457],
         "rotate": [0, 0.3, 0]
@@ -4281,24 +3558,18 @@
       "collection": "station-9"
     },
     {
-      "id": "s9-guard-l-2",
+      "id": "s9-guard-2",
       "type": "box",
       "args": {
         "dims": [0.9, 4.800000000000001, 0.5]
       },
-      "transform": {
-        "translate": [-40.52299103407576, 2.4000000000000004, -18.538921088411456],
-        "rotate": [0, -0.3, 0]
-      },
-      "material": "mat-13",
-      "collection": "station-9"
-    },
-    {
-      "id": "s9-guard-r-2",
-      "type": "box",
-      "args": {
-        "dims": [0.9, 4.800000000000001, 0.5]
-      },
+      "modifiers": [
+        {
+          "type": "mirror",
+          "axis": "x",
+          "origin": [-30.952991034075755, -11.738921088411457]
+        }
+      ],
       "transform": {
         "translate": [-21.382991034075754, 2.4000000000000004, -18.538921088411456],
         "rotate": [0, 0.3, 0]
@@ -4307,91 +3578,20 @@
       "collection": "station-9"
     },
     {
-      "id": "path-9-1",
+      "id": "path-9-runway",
       "type": "box",
       "args": {
         "dims": [1.7, 0.05, 0.32]
       },
+      "modifiers": [
+        {
+          "type": "array",
+          "count": 7,
+          "offset": [-0.23873375420180798, 0, 1.9661493567010027]
+        }
+      ],
       "transform": {
         "translate": [-31.19172478827756, 0.03, -9.772771731710455],
-        "rotate": [0, -1.6916268134714274, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-9"
-    },
-    {
-      "id": "path-9-2",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [-31.43045854247937, 0.03, -7.806622375009452],
-        "rotate": [0, -1.6916268134714274, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-9"
-    },
-    {
-      "id": "path-9-3",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [-31.669192296681178, 0.03, -5.840473018308449],
-        "rotate": [0, -1.6916268134714274, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-9"
-    },
-    {
-      "id": "path-9-4",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [-31.907926050882985, 0.03, -3.8743236616074466],
-        "rotate": [0, -1.6916268134714274, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-9"
-    },
-    {
-      "id": "path-9-5",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [-32.146659805084795, 0.03, -1.908174304906444],
-        "rotate": [0, -1.6916268134714274, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-9"
-    },
-    {
-      "id": "path-9-6",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [-32.385393559286605, 0.03, 0.05797505179455875],
-        "rotate": [0, -1.6916268134714274, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-9"
-    },
-    {
-      "id": "path-9-7",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [-32.62412731348841, 0.03, 2.0241244084955614],
         "rotate": [0, -1.6916268134714274, 0]
       },
       "material": "mat-1",
@@ -4581,91 +3781,20 @@
       "collection": "station-10"
     },
     {
-      "id": "path-10-1",
+      "id": "path-10-runway",
       "type": "box",
       "args": {
         "dims": [1.7, 0.05, 0.32]
       },
+      "modifiers": [
+        {
+          "type": "array",
+          "count": 7,
+          "offset": [0.7023269245730992, 0, 1.85188390275166]
+        }
+      ],
       "transform": {
         "translate": [-32.16053414311712, 0.03, 5.842157667948225],
-        "rotate": [0, -1.2083048667653054, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-10"
-    },
-    {
-      "id": "path-10-2",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [-31.45820721854402, 0.03, 7.694041570699885],
-        "rotate": [0, -1.2083048667653054, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-10"
-    },
-    {
-      "id": "path-10-3",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [-30.75588029397092, 0.03, 9.545925473451545],
-        "rotate": [0, -1.2083048667653054, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-10"
-    },
-    {
-      "id": "path-10-4",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [-30.05355336939782, 0.03, 11.397809376203206],
-        "rotate": [0, -1.2083048667653054, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-10"
-    },
-    {
-      "id": "path-10-5",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [-29.35122644482472, 0.03, 13.249693278954865],
-        "rotate": [0, -1.2083048667653054, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-10"
-    },
-    {
-      "id": "path-10-6",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [-28.648899520251625, 0.03, 15.101577181706524],
-        "rotate": [0, -1.2083048667653054, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-10"
-    },
-    {
-      "id": "path-10-7",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [-27.946572595678525, 0.03, 16.953461084458187],
         "rotate": [0, -1.2083048667653054, 0]
       },
       "material": "mat-1",
@@ -4889,91 +4018,20 @@
       "collection": "station-11"
     },
     {
-      "id": "path-11-1",
+      "id": "path-11-runway",
       "type": "box",
       "args": {
         "dims": [1.7, 0.05, 0.32]
       },
+      "modifiers": [
+        {
+          "type": "array",
+          "count": 7,
+          "offset": [1.482492968885291, 0, 1.3133741643022931]
+        }
+      ],
       "transform": {
         "translate": [-25.761752702220132, 0.03, 20.11871915151214],
-        "rotate": [0, -0.7249829200591837, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-11"
-    },
-    {
-      "id": "path-11-2",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [-24.279259733334843, 0.03, 21.432093315814434],
-        "rotate": [0, -0.7249829200591837, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-11"
-    },
-    {
-      "id": "path-11-3",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [-22.79676676444955, 0.03, 22.745467480116726],
-        "rotate": [0, -0.7249829200591837, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-11"
-    },
-    {
-      "id": "path-11-4",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [-21.31427379556426, 0.03, 24.05884164441902],
-        "rotate": [0, -0.7249829200591837, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-11"
-    },
-    {
-      "id": "path-11-5",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [-19.83178082667897, 0.03, 25.37221580872131],
-        "rotate": [0, -0.7249829200591837, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-11"
-    },
-    {
-      "id": "path-11-6",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [-18.349287857793676, 0.03, 26.685589973023603],
-        "rotate": [0, -0.7249829200591837, 0]
-      },
-      "material": "mat-1",
-      "collection": "path-11"
-    },
-    {
-      "id": "path-11-7",
-      "type": "box",
-      "args": {
-        "dims": [1.7, 0.05, 0.32]
-      },
-      "transform": {
-        "translate": [-16.866794888908387, 0.03, 27.9989641373259],
         "rotate": [0, -0.7249829200591837, 0]
       },
       "material": "mat-1",
@@ -5075,24 +4133,18 @@
       "collection": "station-12"
     },
     {
-      "id": "s12-guard-l-0",
+      "id": "s12-guard-0",
       "type": "box",
       "args": {
         "dims": [0.9, 2.2, 0.5]
       },
-      "transform": {
-        "translate": [-21.614301920023095, 1.1, 30.51233830162819],
-        "rotate": [0, -0.3, 0]
-      },
-      "material": "mat-13",
-      "collection": "station-12"
-    },
-    {
-      "id": "s12-guard-r-0",
-      "type": "box",
-      "args": {
-        "dims": [0.9, 2.2, 0.5]
-      },
+      "modifiers": [
+        {
+          "type": "mirror",
+          "axis": "x",
+          "origin": [-15.384301920023097, 29.31233830162819]
+        }
+      ],
       "transform": {
         "translate": [-9.154301920023098, 1.1, 30.51233830162819],
         "rotate": [0, 0.3, 0]
@@ -5101,24 +4153,18 @@
       "collection": "station-12"
     },
     {
-      "id": "s12-guard-l-1",
+      "id": "s12-guard-1",
       "type": "box",
       "args": {
         "dims": [0.9, 3.5, 0.5]
       },
-      "transform": {
-        "translate": [-21.014301920023097, 1.75, 24.712338301628193],
-        "rotate": [0, -0.3, 0]
-      },
-      "material": "mat-13",
-      "collection": "station-12"
-    },
-    {
-      "id": "s12-guard-r-1",
-      "type": "box",
-      "args": {
-        "dims": [0.9, 3.5, 0.5]
-      },
+      "modifiers": [
+        {
+          "type": "mirror",
+          "axis": "x",
+          "origin": [-15.384301920023097, 29.31233830162819]
+        }
+      ],
       "transform": {
         "translate": [-9.754301920023096, 1.75, 24.712338301628193],
         "rotate": [0, 0.3, 0]
@@ -5127,24 +4173,18 @@
       "collection": "station-12"
     },
     {
-      "id": "s12-guard-l-2",
+      "id": "s12-guard-2",
       "type": "box",
       "args": {
         "dims": [0.9, 4.800000000000001, 0.5]
       },
-      "transform": {
-        "translate": [-22.414301920023096, 2.4000000000000004, 22.51233830162819],
-        "rotate": [0, -0.3, 0]
-      },
-      "material": "mat-13",
-      "collection": "station-12"
-    },
-    {
-      "id": "s12-guard-r-2",
-      "type": "box",
-      "args": {
-        "dims": [0.9, 4.800000000000001, 0.5]
-      },
+      "modifiers": [
+        {
+          "type": "mirror",
+          "axis": "x",
+          "origin": [-15.384301920023097, 29.31233830162819]
+        }
+      ],
       "transform": {
         "translate": [-8.354301920023097, 2.4000000000000004, 22.51233830162819],
         "rotate": [0, 0.3, 0]

--- a/sdf-js/scripts/test-assemble-deck.mjs
+++ b/sdf-js/scripts/test-assemble-deck.mjs
@@ -53,9 +53,14 @@ const deck = JSON.parse(
   const stationSubjects = scene.subjects.filter((s) => /^s\d+-/.test(s.id));
   const pathMarkers = scene.subjects.filter((s) => /^path-/.test(s.id));
   ok(stationSubjects.length === expected, `all station subjects present (${expected})`);
+  // Wave B: each gap is ONE runway subject carrying an array modifier (the
+  // seven strips are expansion-time instances, not authored subjects)
   ok(
-    pathMarkers.length === (deck.slides.length - 1) * 7,
-    'breadcrumb path markers span each gap (7 per segment since R4)',
+    pathMarkers.length === deck.slides.length - 1 &&
+      pathMarkers.every(
+        (s) => s.modifiers && s.modifiers[0].type === 'array' && s.modifiers[0].count === 7,
+      ),
+    'breadcrumb runway = 1 subject × array(7) per gap (Wave B)',
   );
   ok(
     scene.subjects.filter((s) => s.id.startsWith('horizon-')).length === 14,

--- a/sdf-js/scripts/test-modifiers.mjs
+++ b/sdf-js/scripts/test-modifiers.mjs
@@ -1,0 +1,206 @@
+// sdf-js/scripts/test-modifiers.mjs — Blender-borrow Wave B: placement
+// modifiers. Claims pinned here: (1) expansion math per type; (2) SEMANTIC
+// EQUIVALENCE — the assembled deck's runway/guard instances land exactly
+// where the hand-unrolled subjects used to; (3) scatter determinism;
+// (4) validator errors on malformed stacks.
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+import { expandModifiers } from '../src/scene/modifiers.js';
+import { assembleDeck } from '../src/scene/assemble-deck.js';
+import { validate } from '../src/scene/spec.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const DECK = JSON.parse(readFileSync(resolve(__dirname, '../scenes/ir/bytedance-bp.json'), 'utf8'));
+
+let pass = 0,
+  fail = 0;
+const ok = (c, n) => (c ? (pass++, console.log(`  ✓ ${n}`)) : (fail++, console.log(`  ✗ ${n}`)));
+const near = (a, b) => Math.abs(a - b) < 1e-9;
+console.log('=== placement modifiers (Wave B) ===\n');
+
+const D = {
+  camera: { yaw: 0, pitch: -0.1, distance: 8, focal: 1.2, targetX: 0, targetY: 1, targetZ: 0 },
+  light: { azimuth: 0.5, altitude: 0.7, distance: 30, intensity: 1 },
+};
+const box = (extra) => ({ id: 'b', type: 'box', args: { dims: [1, 1, 1] }, ...extra });
+
+// ---- array ---------------------------------------------------------------------
+{
+  const s = expandModifiers({
+    v: 1,
+    subjects: [
+      box({
+        modifiers: [{ type: 'array', count: 3, offset: [2, 0, 0] }],
+        transform: { translate: [1, 0.5, 0] },
+      }),
+    ],
+  });
+  ok(s.subjects.length === 3, 'array(3) → 3 instances');
+  ok(
+    near(s.subjects[0].transform.translate[0], 1) &&
+      near(s.subjects[1].transform.translate[0], 3) &&
+      near(s.subjects[2].transform.translate[0], 5),
+    'array instances step by offset from the base',
+  );
+  ok(
+    s.subjects.every((x, i) => x.id === `b#${i}` && !x.modifiers),
+    'instance ids #i, modifiers consumed',
+  );
+}
+
+// ---- mirror --------------------------------------------------------------------
+{
+  const s = expandModifiers({
+    v: 1,
+    subjects: [
+      box({
+        modifiers: [{ type: 'mirror', axis: 'x' }],
+        transform: { translate: [4, 1, 2], rotate: [0, 0.3, 0] },
+      }),
+    ],
+  });
+  ok(s.subjects.length === 2, 'mirror → 2 instances');
+  const [a, b2] = s.subjects.map((x) => x.transform);
+  ok(
+    near(a.translate[0], 4) && near(b2.translate[0], -4) && near(b2.translate[2], 2),
+    'mirror flips x, keeps z',
+  );
+  ok(near(a.rotate[1], 0.3) && near(b2.rotate[1], -0.3), 'mirror negates yaw (true reflection)');
+}
+
+// ---- radial + composition -------------------------------------------------------
+{
+  const s = expandModifiers({
+    v: 1,
+    subjects: [
+      box({
+        modifiers: [
+          { type: 'radial', count: 4, radius: 10, faceCenter: true },
+          { type: 'mirror', axis: 'z' },
+        ],
+        transform: { translate: [0, 2, 0] },
+      }),
+    ],
+  });
+  ok(s.subjects.length === 8, 'stack composes in order (radial×4 then mirror×2 = 8)');
+  const r0 = s.subjects[0].transform.translate;
+  ok(near(Math.hypot(r0[0], r0[2]), 10) && near(r0[1], 2), 'radial ring radius + y preserved');
+}
+
+// ---- scatter determinism ---------------------------------------------------------
+{
+  const mk = () =>
+    expandModifiers({
+      v: 1,
+      subjects: [
+        box({
+          modifiers: [
+            {
+              type: 'scatter',
+              count: 6,
+              seed: 'atlas',
+              region: { kind: 'annulus', rMin: 5, rMax: 8 },
+            },
+          ],
+          transform: { translate: [0, 0.4, 0] },
+        }),
+      ],
+    });
+  const a = JSON.stringify(mk());
+  ok(a === JSON.stringify(mk()), 'scatter is deterministic (same seed → same field)');
+  const radii = mk().subjects.map((x) =>
+    Math.hypot(x.transform.translate[0], x.transform.translate[2]),
+  );
+  ok(
+    radii.every((r) => r >= 5 - 1e-9 && r <= 8 + 1e-9),
+    'scatter stays inside the annulus region',
+  );
+}
+
+// ---- semantic equivalence on the real deck ---------------------------------------
+{
+  const scene = assembleDeck(DECK, { layout: 'radial' });
+  const runways = scene.subjects.filter((s) => /-runway$/.test(s.id));
+  ok(
+    runways.length === DECK.slides.length - 1,
+    `runway subjects authored once per gap (${runways.length})`,
+  );
+  const expanded = expandModifiers(scene);
+  const strips = expanded.subjects.filter((s) => /-runway#\d+$/.test(s.id));
+  ok(
+    strips.length === (DECK.slides.length - 1) * 7,
+    `expansion restores 7 strips per gap (${strips.length})`,
+  );
+  // the strips must land exactly on the legacy hand-unrolled positions:
+  // origin + step·d for d = 1..7 along each segment
+  const win = scene.deckWindows.filter((w) => w.kind === 'station');
+  const originOf = (k) => win.find((w) => w.stations[0] === k).origin;
+  let exact = true;
+  for (let k = 0; k < DECK.slides.length - 1 && exact; k++) {
+    const [ax, , az] = originOf(k);
+    const [bx, , bz] = originOf(k + 1);
+    for (let d = 1; d <= 7; d++) {
+      const inst = expanded.subjects.find((s) => s.id === `path-${k}-runway#${d - 1}`);
+      const ex = ax + ((bx - ax) * d) / 8;
+      const ez = az + ((bz - az) * d) / 8;
+      if (
+        !inst ||
+        !near(inst.transform.translate[0], ex) ||
+        !near(inst.transform.translate[2], ez)
+      ) {
+        exact = false;
+        break;
+      }
+    }
+  }
+  ok(exact, 'runway instances land exactly on the legacy hand-unrolled positions');
+  // guards: one subject per tier, mirror expands to the legacy ± pair
+  const guards = expanded.subjects.filter((s) => /^s\d+-guard-\d+#\d+$/.test(s.id));
+  ok(
+    guards.length > 0 && guards.length % 2 === 0,
+    `guard mirrors expand to pairs (${guards.length})`,
+  );
+  const pair = guards.filter((s) => s.id.startsWith('s2-guard-0'));
+  ok(
+    pair.length === 2 &&
+      near(pair[0].transform.translate[0] + pair[1].transform.translate[0], 2 * originOf(2)[0]) &&
+      near(pair[0].transform.rotate[1], 0.3) &&
+      near(pair[1].transform.rotate[1], -0.3),
+    'guard pair mirrors across the station axis with negated yaw',
+  );
+  // collections ride onto instances (routing unaffected)
+  ok(
+    strips.every((s) => s.collection && s.collection.startsWith('path-')),
+    'instances inherit the collection tag',
+  );
+}
+
+// ---- validator -------------------------------------------------------------------
+{
+  const bad = validate({
+    v: 1,
+    defaults: D,
+    subjects: [box({ modifiers: [{ type: 'spiral', count: 3 }] })],
+  });
+  ok(
+    !bad.ok && bad.errors.some((e) => e.includes('unknown "spiral"')),
+    'unknown modifier type = ERROR',
+  );
+  const noSeed = validate({
+    v: 1,
+    defaults: D,
+    subjects: [
+      box({
+        modifiers: [{ type: 'scatter', count: 3, region: { kind: 'annulus', rMin: 1, rMax: 2 } }],
+      }),
+    ],
+  });
+  ok(
+    !noSeed.ok && noSeed.errors.some((e) => e.includes('seed')),
+    'scatter without seed = ERROR (determinism covenant)',
+  );
+}
+
+console.log(`\n${pass}/${pass + fail} passed`);
+process.exit(fail ? 1 : 0);

--- a/sdf-js/src/runtime/apply-studio-scene.js
+++ b/sdf-js/src/runtime/apply-studio-scene.js
@@ -27,6 +27,7 @@ import { expandVariants } from '../scene/generator-s.js';
 import { expandChartLabels } from '../scene/chart-labels.js';
 import { expandStage } from '../scene/stage.js';
 import { resolveMaterialRefs } from '../scene/spec.js';
+import { expandModifiers } from '../scene/modifiers.js';
 import { union as sdfUnion } from '../sdf/dn.js';
 
 // Does the scene change pixels on its own (no input)? Drives studio's idle-stop:
@@ -79,7 +80,7 @@ export function pickRenderScale(rawScene) {
 export function expandAndCompile(sceneData, { rng = null, tokenHash } = {}) {
   // Wave A: inflate scene.materials string references first — everything
   // downstream (stage, labels, compile) keeps seeing inline material objects.
-  const resolvedScene = resolveMaterialRefs(sceneData);
+  const resolvedScene = expandModifiers(resolveMaterialRefs(sceneData));
   const variantScene = rng ? expandVariants(resolvedScene, rng) : resolvedScene;
   const stagedScene = expandStage(variantScene);
   const labeledScene = expandChartLabels(stagedScene);

--- a/sdf-js/src/scene/assemble-deck.js
+++ b/sdf-js/src/scene/assemble-deck.js
@@ -16,6 +16,7 @@
 import { renderIR } from './render-ir.js';
 import { getEnvironment, horizonSilhouettes } from './environments.js';
 import { makeDeckDecor } from './deck-decor.js';
+import { shiftModifier } from './modifiers.js';
 import { TEMPO } from './tempo-tokens.js';
 
 // Every structure renderer emits build-ins of exactly this shape:
@@ -410,6 +411,12 @@ export function assembleDeck(deck, opts = {}) {
           ),
         }));
       }
+      // Wave B: modifier spatial anchors (mirror planes, radial centers,
+      // scatter regions) ride the transplant like build-in exprs do — this
+      // module owns placement, patterns stay renderer-local.
+      if (Array.isArray(moved.modifiers)) {
+        moved.modifiers = moved.modifiers.map((m) => shiftModifier(m, origin));
+      }
       subjects.push(moved);
     }
 
@@ -535,30 +542,31 @@ export function assembleDeck(deck, opts = {}) {
       const dz = next[2] - origin[2];
       const yaw = Math.atan2(dz, dx); // marker long axis along the segment
       const dots = 7; // R3: five chips read as debris; seven make a line
-      for (let d = 1; d <= dots; d++) {
-        const f = d / (dots + 1);
-        subjects.push({
-          id: `path-${k}-${d}`,
-          type: 'box',
-          // R1 critique: 0.9×0.06 chips were invisible in the transit frame —
-          // the flight had no guide line. Long low glowing strips read as a
-          // runway; the ground between stations stops being a black gap.
-          args: { dims: [1.7, 0.05, 0.32] },
-          transform: {
-            translate: [origin[0] + dx * f, 0.03, origin[2] + dz * f],
-            rotate: [0, -yaw, 0],
-          },
-          material: {
-            hue: 0.58,
-            sat: 0.25,
-            value: 0.85,
-            glow: 0.45, // R3: 0.12 was invisible in the dark field — the runway must READ
-            kind: 'normal',
-            roughness: 0.5,
-            clearcoat: 0.2,
-          },
-        });
-      }
+      const step = [dx / (dots + 1), 0, dz / (dots + 1)];
+      // Wave B: ONE runway subject with an array modifier — the seven strips
+      // used to be hand-unrolled; the placement pattern is now data.
+      subjects.push({
+        id: `path-${k}-runway`,
+        type: 'box',
+        // R1 critique: 0.9×0.06 chips were invisible in the transit frame —
+        // the flight had no guide line. Long low glowing strips read as a
+        // runway; the ground between stations stops being a black gap.
+        args: { dims: [1.7, 0.05, 0.32] },
+        modifiers: [{ type: 'array', count: dots, offset: step }],
+        transform: {
+          translate: [origin[0] + step[0], 0.03, origin[2] + step[2]],
+          rotate: [0, -yaw, 0],
+        },
+        material: {
+          hue: 0.58,
+          sat: 0.25,
+          value: 0.85,
+          glow: 0.45, // R3: 0.12 was invisible in the dark field — the runway must READ
+          kind: 'normal',
+          roughness: 0.5,
+          clearcoat: 0.2,
+        },
+      });
       // Layer C: inlay flanking the breadcrumbs (path-${k}-decor- prefix →
       // lives only in this transit's windows, dropped inside stations).
       if (decor) subjects.push(...decor.segment(k, origin, next));

--- a/sdf-js/src/scene/modifiers.js
+++ b/sdf-js/src/scene/modifiers.js
@@ -1,0 +1,158 @@
+// sdf-js/src/scene/modifiers.js — Blender-borrow Wave B: PLACEMENT modifiers.
+//
+// `subject.modifiers` is an ordered, non-destructive stack that multiplies a
+// subject's PLACEMENT (translate + yaw), applied at expansion time. This is a
+// deliberate simplification of Blender's modifier stack: Blender's Array/
+// Mirror operate in geometry space; ours operate on where copies STAND. Every
+// repetition in the corpus (breadcrumb runways, guard pairs, rings, scatter
+// fields) is a placement pattern, and placement-space keeps the semantics
+// trivially explainable to the lift LLM ("this subject, standing N times").
+//
+// v1 = EXPANSION ONLY (spec §1.2): compile-time unrolling into N instances —
+// the semantic win (small JSON, no hand-unrolled arrays, no id contracts).
+// The leaf-count perf win is Wave C's domain-rep lowering; scatter is
+// expansion forever (irregular placements can't domain-repeat).
+//
+// Determinism: scatter uses the repo's named-lane PRNG (makeHashRand) keyed
+// by `${seed}:${subject.id}` — same seed, same field, forever (mint-hash
+// covenant). No Math.random anywhere.
+//
+// Limitation (documented, validator-warned): animation exprs produce the FULL
+// y for a channel, so instances of a y-offsetting array share the same y
+// motion — an array with offset[1] ≠ 0 plus a translate.y animation is
+// unsupported in v1.
+import { makeHashRand } from '../present/decor/rand.js';
+
+export const MODIFIER_TYPES = ['array', 'radial', 'mirror', 'scatter'];
+const MAX_COUNT = 64;
+
+// One instance = { t: [dx,dy,dz] ABSOLUTE translate, yaw, yawFlip }.
+const applyOne = {
+  array(instances, m) {
+    const out = [];
+    const [ox, oy, oz] = m.offset;
+    for (const inst of instances)
+      for (let i = 0; i < m.count; i++)
+        out.push({ ...inst, t: [inst.t[0] + ox * i, inst.t[1] + oy * i, inst.t[2] + oz * i] });
+    return out;
+  },
+  radial(instances, m) {
+    const out = [];
+    const [cx, cz] = m.center || [0, 0];
+    const start = m.startAngle || 0;
+    for (const inst of instances)
+      for (let i = 0; i < m.count; i++) {
+        const th = start + (i * 2 * Math.PI) / m.count;
+        out.push({
+          ...inst,
+          t: [cx + Math.sin(th) * m.radius, inst.t[1], cz + Math.cos(th) * m.radius],
+          yaw: m.faceCenter ? inst.yaw + th : inst.yaw,
+        });
+      }
+    return out;
+  },
+  mirror(instances, m) {
+    const out = [];
+    const [ox, oz] = m.origin || [0, 0]; // mirror PLANE position (world x=ox / z=oz)
+    for (const inst of instances) {
+      out.push(inst);
+      // true geometric mirror for yaw-only subjects (the analytic renderer's
+      // rotation constraint anyway): position reflects across the plane,
+      // yaw negates
+      out.push(
+        m.axis === 'x'
+          ? { ...inst, t: [2 * ox - inst.t[0], inst.t[1], inst.t[2]], yaw: -inst.yaw }
+          : { ...inst, t: [inst.t[0], inst.t[1], 2 * oz - inst.t[2]], yaw: -inst.yaw },
+      );
+    }
+    return out;
+  },
+  scatter(instances, m, subjectId) {
+    const R = makeHashRand(`${m.seed}:${subjectId}`);
+    const out = [];
+    for (const inst of instances)
+      for (let i = 0; i < m.count; i++) {
+        let x, z;
+        if (m.region.kind === 'annulus') {
+          const [cx, cz] = m.region.center || [0, 0];
+          const th = R.range(`a${i}`, 0, 2 * Math.PI);
+          const r = R.range(`r${i}`, m.region.rMin, m.region.rMax);
+          x = cx + Math.sin(th) * r;
+          z = cz + Math.cos(th) * r;
+        } else {
+          x = R.range(`x${i}`, m.region.min[0], m.region.max[0]);
+          z = R.range(`z${i}`, m.region.min[1], m.region.max[1]);
+        }
+        out.push({ ...inst, t: [x, inst.t[1], z], yaw: inst.yaw + R.range(`y${i}`, 0, Math.PI) });
+      }
+    return out;
+  },
+};
+
+/**
+ * shiftModifier(m, [dx, dy, dz]) → modifier
+ * Rewrite a modifier's SPATIAL anchors when its subject is transplanted to a
+ * new origin (assembleDeck's job — the same contract as its build-in-expr
+ * rewriting: placement shifts, patterns don't). array offsets are relative
+ * (unchanged); mirror planes, radial centers and scatter regions are
+ * positions and must ride along.
+ */
+export function shiftModifier(m, [dx, , dz]) {
+  if (m.type === 'mirror') {
+    const [ox, oz] = m.origin || [0, 0];
+    return { ...m, origin: [ox + dx, oz + dz] };
+  }
+  if (m.type === 'radial') {
+    const [cx, cz] = m.center || [0, 0];
+    return { ...m, center: [cx + dx, cz + dz] };
+  }
+  if (m.type === 'scatter') {
+    const r = m.region;
+    if (r.kind === 'annulus') {
+      const [cx, cz] = r.center || [0, 0];
+      return { ...m, region: { ...r, center: [cx + dx, cz + dz] } };
+    }
+    return {
+      ...m,
+      region: { ...r, min: [r.min[0] + dx, r.min[1] + dz], max: [r.max[0] + dx, r.max[1] + dz] },
+    };
+  }
+  return m; // array: offset is relative
+}
+
+/**
+ * expandModifiers(scene) → scene
+ * Unroll every modifier stack into plain instances. Instance ids are
+ * `{id}#{i}` (identity only — routing rides the copied collection tag). A
+ * scene without modifiers passes through untouched (referential no-op).
+ */
+export function expandModifiers(scene) {
+  if (!scene || !Array.isArray(scene.subjects)) return scene;
+  if (!scene.subjects.some((s) => s && Array.isArray(s.modifiers) && s.modifiers.length))
+    return scene;
+  const subjects = [];
+  for (const s of scene.subjects) {
+    if (!s || !Array.isArray(s.modifiers) || !s.modifiers.length) {
+      subjects.push(s);
+      continue;
+    }
+    const base = (s.transform && s.transform.translate) || [0, 0, 0];
+    const rot = (s.transform && s.transform.rotate) || [0, 0, 0];
+    let instances = [{ t: [...base], yaw: rot[1] }];
+    for (const m of s.modifiers) instances = applyOne[m.type](instances, m, s.id);
+    instances.forEach((inst, i) => {
+      const clone = { ...s, id: `${s.id}#${i}` };
+      delete clone.modifiers;
+      clone.transform = {
+        ...(s.transform || {}),
+        translate: inst.t,
+        // pitch/roll ride through untouched; yaw comes from the instance
+        ...(rot[0] || rot[2] || inst.yaw || (s.transform && s.transform.rotate)
+          ? { rotate: [rot[0], inst.yaw, rot[2]] }
+          : {}),
+      };
+      subjects.push(clone);
+    });
+  }
+  return { ...scene, subjects };
+}

--- a/sdf-js/src/scene/render-magnitude.js
+++ b/sdf-js/src/scene/render-magnitude.js
@@ -141,34 +141,35 @@ export function renderMagnitude(ir, opts = {}) {
   const rowSpanG = rowSpanOf(N);
   for (let g = 0; g < 3; g++) {
     const gh = 2.2 + g * 1.3;
-    for (const side of [-1, 1]) {
-      // R2 (第三层深度): the nearest guard pair moves CAMERA-SIDE (z +1.7,
-      // between lens and subject) — during the tracking walk it sweeps the
-      // frame edge out of focus, buying parallax and physical presence; the
-      // deeper pairs stay behind as the perspective guides.
-      const fg = g === 0;
-      subjects.push({
-        id: `guard-${side < 0 ? 'l' : 'r'}-${g}`,
-        type: 'box',
-        args: { dims: [0.9, gh, 0.5] },
-        transform: {
-          translate: [
-            side * (rowSpanG / 2 + (fg ? 4.6 : 2.6 + g * 1.4)), // R3: 3.4/z1.7 smeared bokeh blobs onto the columns at payoff
-            gh / 2,
-            fg ? 1.2 : -2.4 - g * 2.2,
-          ],
-          rotate: [0, side * 0.3, 0],
-        },
-        material: {
-          hue: 0.62,
-          sat: 0.25,
-          value: 0.14,
-          kind: 'normal',
-          roughness: 0.5,
-          clearcoat: 0.35,
-        },
-      });
-    }
+    // R2 (第三层深度): the nearest guard pair sits CAMERA-SIDE (z +1.2,
+    // between lens and subject) — during the tracking walk it sweeps the
+    // frame edge out of focus, buying parallax and physical presence; the
+    // deeper pairs stay behind as the perspective guides.
+    // Wave B: each PAIR is one subject with a mirror modifier (the symmetric
+    // placement is data, not two hand-placed boxes).
+    const fg = g === 0;
+    subjects.push({
+      id: `guard-${g}`,
+      type: 'box',
+      args: { dims: [0.9, gh, 0.5] },
+      modifiers: [{ type: 'mirror', axis: 'x' }],
+      transform: {
+        translate: [
+          rowSpanG / 2 + (fg ? 4.6 : 2.6 + g * 1.4), // R3: 3.4/z1.7 smeared bokeh blobs onto the columns at payoff
+          gh / 2,
+          fg ? 1.2 : -2.4 - g * 2.2,
+        ],
+        rotate: [0, 0.3, 0],
+      },
+      material: {
+        hue: 0.62,
+        sat: 0.25,
+        value: 0.14,
+        kind: 'normal',
+        roughness: 0.5,
+        clearcoat: 0.35,
+      },
+    });
   }
 
   // ---- camera: five beats, magnitude variation --------------------------------

--- a/sdf-js/src/scene/spec.js
+++ b/sdf-js/src/scene/spec.js
@@ -884,6 +884,64 @@ function validateSubject(subj, path, errors, warnings, ctx = null) {
     }
   }
 
+  // Placement modifiers (Blender-borrow Wave B). Unknown type = ERROR — a
+  // typo'd modifier silently dropping N instances would be a "looks right"
+  // wrong. Validator/expander sync law: expandModifiers consumes exactly this.
+  if (subj.modifiers != null) {
+    if (!Array.isArray(subj.modifiers)) {
+      errors.push(`${path}.modifiers: must be an array`);
+    } else {
+      subj.modifiers.forEach((m, mi) => {
+        const mp = `${path}.modifiers[${mi}]`;
+        if (!m || typeof m !== 'object') {
+          errors.push(`${mp}: must be an object`);
+          return;
+        }
+        if (!['array', 'radial', 'mirror', 'scatter'].includes(m.type)) {
+          errors.push(`${mp}.type: unknown "${m.type}"`);
+          return;
+        }
+        const needCount = (lo) => {
+          if (!Number.isInteger(m.count) || m.count < lo || m.count > 64)
+            errors.push(`${mp}.count: integer ${lo}..64 required`);
+        };
+        if (m.type === 'array') {
+          needCount(2);
+          if (!Array.isArray(m.offset) || m.offset.length !== 3) {
+            errors.push(`${mp}.offset: [x,y,z] required`);
+          } else if (
+            m.offset[1] !== 0 &&
+            Array.isArray(subj.animation) &&
+            subj.animation.some((a) => a && a.channel === 'transform.translate.y')
+          ) {
+            warnings.push(
+              `${mp}: y-offset array + translate.y animation — instances share ONE y motion (v1 limit)`,
+            );
+          }
+        }
+        if (m.type === 'radial') {
+          needCount(2);
+          if (typeof m.radius !== 'number' || m.radius <= 0)
+            errors.push(`${mp}.radius: positive number required`);
+        }
+        if (m.type === 'mirror' && m.axis !== 'x' && m.axis !== 'z')
+          errors.push(`${mp}.axis: 'x' or 'z' required`);
+        if (m.type === 'scatter') {
+          needCount(1);
+          if (m.seed == null) errors.push(`${mp}.seed: required (determinism covenant)`);
+          const r = m.region;
+          const annOk =
+            r && r.kind === 'annulus' && typeof r.rMin === 'number' && typeof r.rMax === 'number';
+          const boxOk = r && r.kind === 'box' && Array.isArray(r.min) && Array.isArray(r.max);
+          if (!annOk && !boxOk)
+            errors.push(
+              `${mp}.region: {kind:'annulus', rMin, rMax} or {kind:'box', min, max} required`,
+            );
+        }
+      });
+    }
+  }
+
   if (typeof subj.type !== 'string') {
     errors.push(`${path}: missing or non-string "type"`);
     return;


### PR DESCRIPTION
## Wave B(spec §1)

**四个放置修饰符**:`array` / `radial` / `mirror` / `scatter`,按序组合,编译期展开。语义定为 **placement**(作用于摆放而非 Blender 的几何空间)——语料里所有重复都是摆放模式,对 lift LLM 的可解释性也最好("这个 subject,站 N 次")。

- scatter 复用 `makeHashRand` 命名 lane,**无 seed = ERROR**(确定性契约);未知 type = ERROR
- **测试抓到一个真语义 bug**:站内 mirror 被 transplant 后绕世界原点翻转——修法是 `shiftModifier`:mirror 平面/radial 圆心/scatter 区域随 origin 平移,与 build-in expr 重写同一契约("装配器拥有摆放,渲染器拥有模式")
- 生产者改写:面包屑 84→12(array×7)、guard 每站 6→3(mirror 对);**authored subjects 319→229(-28%)**
- 语义等价钉死:runway 实例逐点落在旧手工展开的位置、guard 对镜像 + yaw 取负(18 断言)
- v1 = expansion only,leaf 数不变——**性能修复按 spec 分界在 Wave C(domain-rep lowering)**,不拿本波宣称性能

suite 151/151,goldens 重烤,真机 smoke 零视觉回归。

Merge 后 Wave C(domain-rep lowering,stone/rich 渲染档的 leaf 超线性修复)——那波我会先做 GLSL 侧的 spike 验证再全量,风险高于 A/B。

🤖 Generated with [Claude Code](https://claude.com/claude-code)