### PR TITLE
Wave C: domain-rep lowering — N modifier instances = 1 shader leaf on raymarch tiers

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -165,6 +165,7 @@ const TESTS = [
   { category: 'scene', file: 'sdf-js/scripts/test-courtyard.mjs' },
   { category: 'scene', file: 'sdf-js/scripts/test-scene-collections.mjs' },
   { category: 'scene', file: 'sdf-js/scripts/test-modifiers.mjs' },
+  { category: 'scene', file: 'sdf-js/scripts/test-domain-lowering.mjs' },
   { category: 'scene', file: 'sdf-js/scripts/audit-2d-fidelity.mjs' },
   { category: 'scene', file: 'sdf-js/scripts/test-camera-shake.mjs' },
   { category: 'scene', file: 'sdf-js/scripts/test-text-to-ir.mjs' },

--- a/sdf-js/apps/present/figure-core.js
+++ b/sdf-js/apps/present/figure-core.js
@@ -192,8 +192,13 @@ export function createFigure({
     lowStreak = 0;
     highStreak = 0;
     const loadingMsg = loading && loading.querySelector('.msg');
+    // Wave C: raymarch tiers lower qualifying modifiers to domain-rep (one
+    // leaf per pattern); the analytic tier keeps expansion (rep/mirror are
+    // outside its SUPPORTED set — lowering would drop whole frames to stone).
+    const compileOpts = { lowerRepeats: renderMode !== 'analytic' };
     const dw = attachDeckWindows(studio, scene, {
       holdDuringWarmup: !present,
+      compileOpts,
       // boundary swaps can stall the driver briefly — those samples are not a
       // render-cost signal, so the adaptive scaler sits out a grace window
       onSwap: () => {
@@ -216,7 +221,7 @@ export function createFigure({
         adaptAfter = performance.now() + ADAPT_GRACE_MS;
       });
     } else {
-      applyStudioScene(studio, scene);
+      applyStudioScene(studio, scene, compileOpts);
     }
   }
 

--- a/sdf-js/scripts/test-domain-lowering.mjs
+++ b/sdf-js/scripts/test-domain-lowering.mjs
@@ -1,0 +1,188 @@
+// sdf-js/scripts/test-domain-lowering.mjs — Wave C: domain-rep lowering.
+// The load-bearing claim is NUMERIC: for every qualifying modifier, the
+// lowered DomainGroup and the expanded instances are THE SAME SIGNED
+// DISTANCE FIELD. We sample the CPU SDF on a grid around the geometry and
+// pin |f_lowered − f_expanded| < 1e-6 — a wrong yaw convention, mirror
+// plane or center offset fails loudly here, no eyeballs needed.
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+import { expandModifiers } from '../src/scene/modifiers.js';
+import { assembleDeck, sliceDeckWindow } from '../src/scene/assemble-deck.js';
+import { expandAndCompile } from '../src/runtime/apply-studio-scene.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const DECK = JSON.parse(readFileSync(resolve(__dirname, '../scenes/ir/bytedance-bp.json'), 'utf8'));
+
+let pass = 0,
+  fail = 0;
+const ok = (c, n) => (c ? (pass++, console.log(`  ✓ ${n}`)) : (fail++, console.log(`  ✗ ${n}`)));
+console.log('=== domain-rep lowering (Wave C) ===\n');
+
+const D = {
+  camera: { yaw: 0, pitch: -0.1, distance: 8, focal: 1.2, targetX: 0, targetY: 1, targetZ: 0 },
+  light: { azimuth: 0.5, altitude: 0.7, distance: 30, intensity: 1 },
+};
+
+// max |f_a - f_b| over a sample grid
+function maxDiff(sdfA, sdfB, center, extent, steps = 7) {
+  let worst = 0;
+  for (let ix = 0; ix <= steps; ix++)
+    for (let iy = 0; iy <= 2; iy++)
+      for (let iz = 0; iz <= steps; iz++) {
+        const p = [
+          center[0] + ((ix / steps) * 2 - 1) * extent,
+          center[1] + iy * 0.8,
+          center[2] + ((iz / steps) * 2 - 1) * extent,
+        ];
+        worst = Math.max(worst, Math.abs(sdfA.f(p) - sdfB.f(p)));
+      }
+  return worst;
+}
+
+function bothForms(scene) {
+  const expanded = expandAndCompile(scene).sdf;
+  const lowered = expandAndCompile(scene, { lowerRepeats: true }).sdf;
+  return { expanded, lowered };
+}
+
+// ---- array run at an arbitrary angle ---------------------------------------------
+{
+  const scene = {
+    v: 1,
+    defaults: D,
+    subjects: [
+      {
+        id: 'run',
+        type: 'box',
+        args: { dims: [1.7, 0.05, 0.32] },
+        modifiers: [{ type: 'array', count: 7, offset: [1.9, 0, 1.1] }],
+        transform: { translate: [3, 0.5, -2], rotate: [0, -Math.atan2(1.1, 1.9), 0] },
+      },
+    ],
+  };
+  const { expanded, lowered } = bothForms(scene);
+  const d = maxDiff(expanded, lowered, [3 + 1.9 * 3, 0.5, -2 + 1.1 * 3], 12);
+  ok(d < 1e-6, `array(7) lowered ≡ expanded (max |Δf| = ${d.toExponential(2)})`);
+}
+
+// ---- misaligned child yaw refuses to lower (exactness guard) ---------------------
+// Domain rep evaluates the nearest tile only; a child not reflection-
+// symmetric about tile boundaries would overestimate near-boundary
+// distances. Correctness > leaves: it must fall back to expansion.
+{
+  const scene = {
+    v: 1,
+    subjects: [
+      {
+        id: 'run2',
+        type: 'box',
+        args: { dims: [1, 0.2, 0.4] },
+        modifiers: [{ type: 'array', count: 5, offset: [0, 0, 2.2] }],
+        transform: { translate: [-1, 0.3, 0], rotate: [0, 0.7, 0] },
+      },
+    ],
+  };
+  const low = expandModifiers(scene, { lower: true });
+  ok(
+    low.subjects.filter((s) => s.id.startsWith('run2#')).length === 5,
+    'misaligned child yaw falls back to expansion (exactness guard)',
+  );
+}
+
+// ---- mirror pair off-origin -------------------------------------------------------
+{
+  const scene = {
+    v: 1,
+    defaults: D,
+    subjects: [
+      {
+        id: 'pair',
+        type: 'box',
+        args: { dims: [0.9, 2.2, 0.5] },
+        modifiers: [{ type: 'mirror', axis: 'x', origin: [5, -3] }],
+        transform: { translate: [9.2, 1.1, -3], rotate: [0, 0.3, 0] },
+      },
+    ],
+  };
+  const { expanded, lowered } = bothForms(scene);
+  const d = maxDiff(expanded, lowered, [5, 1.1, -3], 8);
+  ok(d < 1e-6, `mirror pair lowered ≡ expanded (max |Δf| = ${d.toExponential(2)})`);
+}
+
+// ---- even counts / scatter refuse to lower (fallback to expansion) ---------------
+{
+  const scene = {
+    v: 1,
+    subjects: [
+      {
+        id: 'even',
+        type: 'box',
+        args: { dims: [1, 1, 1] },
+        modifiers: [{ type: 'array', count: 4, offset: [2, 0, 0] }],
+        transform: { translate: [0, 0.5, 0] },
+      },
+      {
+        id: 'dust',
+        type: 'sphere',
+        args: { radius: 0.2 },
+        modifiers: [
+          { type: 'scatter', count: 5, seed: 's', region: { kind: 'annulus', rMin: 3, rMax: 5 } },
+        ],
+        transform: { translate: [0, 0.2, 0] },
+      },
+    ],
+  };
+  const low = expandModifiers(scene, { lower: true });
+  ok(
+    low.subjects.filter((s) => s.id.startsWith('even#')).length === 4,
+    'even-count array falls back to expansion',
+  );
+  ok(
+    low.subjects.filter((s) => s.id.startsWith('dust#')).length === 5,
+    'scatter always expands (irregular placements)',
+  );
+}
+
+// ---- the real deck: transit slice, leaf economics + full-field equivalence -------
+{
+  const scene = assembleDeck(DECK, { layout: 'radial' });
+  // a magnitude→magnitude transit (stations 3-4): boxes/ellipsoids only, so
+  // the CPU point-eval covers every subject in the union (some exotic prims
+  // — hold stems etc. — have GPU-only eval paths and would poison sampling)
+  const win = scene.deckWindows.filter((w) => w.kind === 'transit')[3];
+  const rawSlice = sliceDeckWindow(scene, win);
+  const CPU_TYPES = new Set(['box', 'rounded_box', 'ellipsoid', 'sphere']);
+  const slice = {
+    ...rawSlice,
+    subjects: rawSlice.subjects.filter((s) => CPU_TYPES.has(s.type) || s.modifiers),
+  };
+  const low = expandModifiers(slice, { lower: true });
+  const reps = low.subjects.filter((s) => s.type === 'rep');
+  const mirrors = low.subjects.filter((s) => s.type === 'mirror');
+  ok(reps.length >= 2, `transit slice lowers its runways to rep nodes (${reps.length})`);
+  ok(mirrors.length >= 3, `station guards lower to mirror nodes (${mirrors.length})`);
+  const exp = expandModifiers(slice);
+  const saved = exp.subjects.length - low.subjects.length;
+  ok(
+    saved >= 12,
+    `leaf economics: ${exp.subjects.length} → ${low.subjects.length} subjects (−${saved})`,
+  );
+  // full-field equivalence on the real slice. Animations are stripped from
+  // BOTH forms identically — CPU point-eval has no clock, and the lowering
+  // path under test doesn't touch animation (it rides the wrapper verbatim).
+  const still = {
+    ...slice,
+    subjects: slice.subjects.map((s) => {
+      const c = { ...s };
+      delete c.animation;
+      return c;
+    }),
+  };
+  const { expanded, lowered } = bothForms(still);
+  const d = maxDiff(expanded, lowered, win.origin, 24, 9);
+  ok(d < 1e-6, `real transit slice: lowered ≡ expanded (max |Δf| = ${d.toExponential(2)})`);
+}
+
+console.log(`\n${pass}/${pass + fail} passed`);
+process.exit(fail ? 1 : 0);

--- a/sdf-js/src/render/analytic.js
+++ b/sdf-js/src/render/analytic.js
@@ -308,12 +308,15 @@ export function compileAnalyticFrag(subjects, opts = {}) {
       body += `    if (tk > 0.0 && tk < tHit) { tHit = tk; nHit = ${nBack}; alb = vec3(${flt(cr)}, ${flt(cg)}, ${flt(cb)}); glowK = ${flt(glow)}; hitId = ${flt(k)}; }\n`;
     } else if (s.type === 'ellipsoid') {
       const d = a.dims || [1, 1, 1];
-      proxyR = (d[0] + d[1] + d[2]) / 3 * 0.8;
+      proxyR = ((d[0] + d[1] + d[2]) / 3) * 0.8;
       body += `    float tk = iEllipsoid(q, dq, vec3(${flt(d[0])}, ${flt(d[1])}, ${flt(d[2])}));\n`;
       body += `    if (tk > 0.0 && tk < tHit) { tHit = tk; nHit = nEllipsoid(q + dq * tk, vec3(${flt(d[0])}, ${flt(d[1])}, ${flt(d[2])})); alb = vec3(${flt(cr)}, ${flt(cg)}, ${flt(cb)}); glowK = ${flt(glow)}; hitId = ${flt(k)}; }\n`;
     } else if (s.type === 'capsule') {
-      const pa = a.a || [0, 0, 0];
-      const pb = a.b || [0, 1, 0];
+      // {a,b} 端点形态优先；{radius,height} = 竖直、端点跨度 height、局部原点
+      // 居中 —— 跟 scene/compile.js 的 capsule 约定一致（此前 height 被静默丢弃）
+      const h = a.height;
+      const pa = a.a || (h != null ? [0, -h / 2, 0] : [0, 0, 0]);
+      const pb = a.b || (h != null ? [0, h / 2, 0] : [0, 1, 0]);
       const r = a.radius ?? 0.1;
       proxyR = r + Math.hypot(pb[0] - pa[0], pb[1] - pa[1], pb[2] - pa[2]) * 0.25;
       const paS = `vec3(${flt(pa[0])}, ${flt(pa[1])}, ${flt(pa[2])})`;

--- a/sdf-js/src/runtime/apply-studio-scene.js
+++ b/sdf-js/src/runtime/apply-studio-scene.js
@@ -77,10 +77,10 @@ export function pickRenderScale(rawScene) {
  *          scene to keep as the renderer's rawScene (carries lights/volumes/
  *          cameraSequence the wiring reads); sdf is ground-unioned + ready.
  */
-export function expandAndCompile(sceneData, { rng = null, tokenHash } = {}) {
+export function expandAndCompile(sceneData, { rng = null, tokenHash, lowerRepeats = false } = {}) {
   // Wave A: inflate scene.materials string references first — everything
   // downstream (stage, labels, compile) keeps seeing inline material objects.
-  const resolvedScene = expandModifiers(resolveMaterialRefs(sceneData));
+  const resolvedScene = expandModifiers(resolveMaterialRefs(sceneData), { lower: lowerRepeats });
   const variantScene = rng ? expandVariants(resolvedScene, rng) : resolvedScene;
   const stagedScene = expandStage(variantScene);
   const labeledScene = expandChartLabels(stagedScene);

--- a/sdf-js/src/runtime/deck-shader-windows.js
+++ b/sdf-js/src/runtime/deck-shader-windows.js
@@ -19,6 +19,16 @@
 // =============================================================================
 import { applyStudioScene, expandAndCompile } from './apply-studio-scene.js';
 import { sliceDeckWindow } from '../scene/assemble-deck.js';
+import { expandModifiers } from '../scene/modifiers.js';
+
+// Raymarch tiers only: a window whose slice still exceeds the sanity hard cap
+// after Wave-C lowering (the full-world finale: ~229 leaves → ~3100 uniform
+// slots → literal emission → multi-minute driver compile that hangs warmup)
+// reuses the PREVIOUS window's shader instead of compiling its own. This was
+// the de-facto behavior before (those windows crashed precompile and fell
+// through) — now it's deliberate, logged, and doesn't depend on a crash.
+// The analytic tier renders full-world windows fine and never takes this path.
+const RAYMARCH_WINDOW_CAP = 100;
 
 /** First window whose end is still ahead of t (clamped to the last window). */
 export function windowIndexAt(windows, t) {
@@ -42,7 +52,7 @@ export function windowIndexAt(windows, t) {
 export function attachDeckWindows(
   studio,
   scene,
-  { holdDuringWarmup = true, onSwap = null, onProgress = null } = {},
+  { holdDuringWarmup = true, onSwap = null, onProgress = null, compileOpts = {} } = {},
 ) {
   const windows = scene.deckWindows;
   if (!Array.isArray(windows) || windows.length < 2 || !studio.swapSDF) return null;
@@ -51,13 +61,26 @@ export function attachDeckWindows(
   // the GPU program for each SDF lives in studio's programCache.
   const sdfCache = new Map();
   const sdfFor = (i) => {
-    if (!sdfCache.has(i)) sdfCache.set(i, expandAndCompile(sliceDeckWindow(scene, windows[i])).sdf);
+    if (!sdfCache.has(i)) {
+      const slice = sliceDeckWindow(scene, windows[i]);
+      if (compileOpts.lowerRepeats && i > 0) {
+        const n = expandModifiers(slice, { lower: true }).subjects.length;
+        if (n > RAYMARCH_WINDOW_CAP) {
+          console.warn(
+            `[deck-windows] window ${i} (${windows[i].kind}): ${n} subjects after lowering > raymarch cap ${RAYMARCH_WINDOW_CAP} — reusing window ${i - 1}'s shader`,
+          );
+          sdfCache.set(i, sdfFor(i - 1));
+          return sdfCache.get(i);
+        }
+      }
+      sdfCache.set(i, expandAndCompile(slice, compileOpts).sdf);
+    }
     return sdfCache.get(i);
   };
 
   // Initial load renders window 0's slice (NOT the giant full-world shader —
   // the whole point is that the full shader only ever runs during the finale).
-  const first = applyStudioScene(studio, sliceDeckWindow(scene, windows[0]));
+  const first = applyStudioScene(studio, sliceDeckWindow(scene, windows[0]), compileOpts);
   sdfCache.set(0, first.sdf);
   let cur = 0;
   let stopped = false;

--- a/sdf-js/src/scene/compile.js
+++ b/sdf-js/src/scene/compile.js
@@ -246,6 +246,7 @@ import {
   engrave,
   groove,
   tongue,
+  mirrorAxis,
 } from '../sdf/dn.js';
 import { evalT } from '../sdf/time.js';
 import {
@@ -325,7 +326,14 @@ const PRIMITIVE_FACTORIES = {
   box: (a) => box(a.dims ?? a.size ?? 1, a.center),
   rounded_box: (a) => rounded_box(a.dims ?? a.size ?? 0.6, a.cornerR ?? a.radius ?? 0.05),
   torus: (a) => torus(a.majorR ?? a.radius ?? 0.4, a.minorR ?? a.thickness ?? 0.1),
-  capsule: (a) => capsule(a.a, a.b, a.radius ?? a.r ?? 0.1),
+  // {a,b} 端点形态优先；{radius,height} = 竖直、端点跨度 height、局部原点居中
+  // （height 形态此前被静默丢弃：a.a/a.b undefined → GPU 编译 vec3(undefined) 崩）
+  capsule: (a) => {
+    const r = a.radius ?? a.r ?? 0.1;
+    if (a.a || a.b) return capsule(a.a ?? [0, 0, 0], a.b ?? [0, 1, 0], r);
+    const h = a.height ?? 1;
+    return capsule([0, -h / 2, 0], [0, h / 2, 0], r);
+  },
   cylinder: (a) => cylinder(a.radius ?? 0.3, a.height ?? 1.0),
   capped_cylinder: (a) => capped_cylinder(a.a, a.b, a.radius ?? 0.1),
   cone: (a) => cone(a.height ?? 0.5, a.baseRadius ?? a.radius ?? 0.3),
@@ -1714,16 +1722,20 @@ function compileDomain(subj, defaultRegion, subjectInfos) {
   return { sdf, region };
 }
 
-// Mirror is not a chain op in sdf-js currently. v0: CPU-only wrapper.
-// TODO: M0 Day 4-5 — extend src/sdf/dn.js with `mirror()` chain op + GLSL emit.
+// 3D path goes through dn.js mirrorAxis (ast-carrying → GPU emits mirX3/Y3/Z3);
+// the old raw-lambda wrapper had no .ast and killed GPU compiles the moment a
+// mirror DomainGroup reached the raymarch tiers (Wave C lowering did exactly that).
+// 2D stays a CPU lambda — the 2D pipeline never GPU-compiles domain ops.
 function applyMirror(sourceSdf, axis) {
   const idx = axis === 'x' ? 0 : axis === 'y' ? 1 : 2;
   if (sourceSdf instanceof SDF3 || (sourceSdf && sourceSdf.f && sourceSdf.f.length === 1)) {
-    return new SDF3((p) => {
-      const q = [...p];
-      q[idx] = Math.abs(q[idx]);
-      return sourceSdf.f(q);
-    });
+    return sourceSdf instanceof SDF3
+      ? mirrorAxis(sourceSdf, idx)
+      : new SDF3((p) => {
+          const q = [...p];
+          q[idx] = Math.abs(q[idx]);
+          return sourceSdf.f(q);
+        });
   }
   return new SDF2((p) => {
     const q = [p[0], p[1]];

--- a/sdf-js/src/scene/modifiers.js
+++ b/sdf-js/src/scene/modifiers.js
@@ -120,13 +120,99 @@ export function shiftModifier(m, [dx, , dz]) {
   return m; // array: offset is relative
 }
 
+// ---- Wave C: domain-rep lowering -----------------------------------------------
+// For the stone/rich raymarch tiers, a qualifying modifier lowers to an
+// EXISTING DomainGroup (rep-with-count / mirror) instead of expanding: N
+// instances = ONE leaf in the shader — the super-linear leaf-cost fix.
+// The analytic tier never lowers (rep/mirror are outside its SUPPORTED set
+// and would drop the whole frame to stone); scatter never lowers (irregular
+// placements can't domain-repeat). Lowering is a pure OPTIMIZATION: the
+// semantics are defined by expansion, and the tests pin CPU-SDF distance
+// equality between the two forms.
+function tryLowerSubject(s) {
+  if (!Array.isArray(s.modifiers) || s.modifiers.length !== 1) return null;
+  const m = s.modifiers[0];
+  const base = (s.transform && s.transform.translate) || [0, 0, 0];
+  const rot = (s.transform && s.transform.rotate) || [0, 0, 0];
+  if (rot[0] || rot[2]) return null; // yaw-only frames
+  const inner = { ...s };
+  delete inner.modifiers;
+  delete inner.collection; // routing rides on the wrapper
+  delete inner.material; // per-leaf tagging happens on the wrapper
+  delete inner.animation; // wrapper owns motion (same semantics as expansion)
+  delete inner.pattern;
+
+  if (m.type === 'array') {
+    if (m.count % 2 === 0) return null; // rep tiles are 2c+1 → odd runs only
+    const [ox, oy, oz] = m.offset;
+    if (oy !== 0) return null; // XZ runs only
+    const L = Math.hypot(ox, oz);
+    if (L < 1e-9) return null;
+    const runYaw = Math.atan2(-oz, ox); // local +x → world run direction
+    // EXACTNESS GUARD: domain rep evaluates the nearest tile only. A child
+    // whose yaw differs from the run direction is not reflection-symmetric
+    // about tile boundaries — near-boundary distances overestimate (the
+    // classic no-neighbor-check rep artifact). Aligned children (the runway
+    // case, and any yaw offset that is a multiple of π for 180°-symmetric
+    // prims) are EXACT; everything else falls back to expansion. Never trade
+    // field correctness for a leaf.
+    const rel = ((rot[1] - runYaw) % Math.PI) + (rot[1] - runYaw < 0 ? Math.PI : 0);
+    const aligned = Math.min(rel % Math.PI, Math.PI - (rel % Math.PI)) < 1e-6;
+    if (!aligned) return null;
+    const c = (m.count - 1) / 2;
+    inner.id = `${s.id}-tile`;
+    inner.transform = { translate: [0, 0, 0], rotate: [0, rot[1] - runYaw, 0] };
+    return {
+      id: s.id,
+      type: 'rep',
+      args: { period: [L, 0, 0], count: [c, 0, 0] },
+      source: inner,
+      transform: {
+        translate: [base[0] + ox * c, base[1], base[2] + oz * c],
+        rotate: [0, runYaw, 0],
+      },
+      ...(s.material ? { material: s.material } : {}),
+      ...(s.pattern ? { pattern: s.pattern } : {}),
+      ...(s.collection ? { collection: s.collection } : {}),
+      ...(s.animation ? { animation: s.animation } : {}),
+    };
+  }
+
+  if (m.type === 'mirror') {
+    const [ox, oz] = m.origin || [0, 0];
+    const local = [base[0] - ox, base[1], base[2] - oz];
+    // the child must live strictly in the positive half of the fold — the
+    // abs() fold shows the +axis side on both halves
+    const coord = m.axis === 'x' ? local[0] : local[2];
+    if (coord <= 1e-6) return null;
+    inner.id = `${s.id}-half`;
+    inner.transform = { translate: local, rotate: [0, rot[1], 0] };
+    return {
+      id: s.id,
+      type: 'mirror',
+      args: { axis: m.axis },
+      source: inner,
+      transform: { translate: [ox, 0, oz] },
+      ...(s.material ? { material: s.material } : {}),
+      ...(s.pattern ? { pattern: s.pattern } : {}),
+      ...(s.collection ? { collection: s.collection } : {}),
+      ...(s.animation ? { animation: s.animation } : {}),
+    };
+  }
+
+  return null; // radial (no producer yet) / scatter (never — irregular)
+}
+
 /**
- * expandModifiers(scene) → scene
+ * expandModifiers(scene, opts?) → scene
  * Unroll every modifier stack into plain instances. Instance ids are
  * `{id}#{i}` (identity only — routing rides the copied collection tag). A
  * scene without modifiers passes through untouched (referential no-op).
+ * opts.lower — Wave C: qualifying single-modifier stacks lower to
+ * DomainGroups (one shader leaf) instead of expanding. Raymarch tiers only,
+ * never analytic.
  */
-export function expandModifiers(scene) {
+export function expandModifiers(scene, { lower = false } = {}) {
   if (!scene || !Array.isArray(scene.subjects)) return scene;
   if (!scene.subjects.some((s) => s && Array.isArray(s.modifiers) && s.modifiers.length))
     return scene;
@@ -135,6 +221,13 @@ export function expandModifiers(scene) {
     if (!s || !Array.isArray(s.modifiers) || !s.modifiers.length) {
       subjects.push(s);
       continue;
+    }
+    if (lower) {
+      const lowered = tryLowerSubject(s);
+      if (lowered) {
+        subjects.push(lowered);
+        continue;
+      }
     }
     const base = (s.transform && s.transform.translate) || [0, 0, 0];
     const rot = (s.transform && s.transform.rotate) || [0, 0, 0];

--- a/sdf-js/src/sdf/dn.js
+++ b/sdf-js/src/sdf/dn.js
@@ -294,6 +294,18 @@ export const erode = defineOpN('erode', (a, r) => (p) => a.f(p) + r);
 export const shell = defineOpN('shell', (a, thickness) => (p) => Math.abs(a.f(p)) - thickness / 2);
 
 /**
+ * 轴镜像(|axis| fold):两侧都显示 child 的 +axis 半边。child 必须活在
+ * 正半轴,否则两边都看不到它。Wave C 补齐:scene 层 'mirror' 域操作此前
+ * 只有 CPU lambda(无 .ast),GPU 编译直接炸 — 这个 op 让它上 GPU。
+ * @param axisIdx 0=x, 1=y, 2=z
+ */
+export const mirrorAxis = defineOpN('mirrorAxis', (a, axisIdx) => (p) => {
+  const q = [...p];
+  q[axisIdx] = Math.abs(q[axisIdx]);
+  return a.f(q);
+});
+
+/**
  * 域重复（domain repetition / pMod）：把每个轴 fold 到 [-P/2, +P/2] 后再 evaluate a。
  * 效果是空间的"平铺"—— 一个 circle 通过 rep 立刻变成网格化的圆点阵。
  *

--- a/sdf-js/src/sdf/sdf3.compile.js
+++ b/sdf-js/src/sdf/sdf3.compile.js
@@ -908,6 +908,15 @@ const OPS = {
     return walk(children[0], `repL3(${p}, ${vec3(period)}, ${vec3(count)})`);
   },
 
+  // ---- Axis mirror (|axis| fold) ------------------------------------------
+  // dn.js mirrorAxis 的 GPU 面：scalars[0] = axisIdx (0=x, 1=y, 2=z)。scene 层
+  // 'mirror' 域操作经 compile.js applyMirror 走到这里(Wave C lowering 产物)。
+  mirrorAxis: (sdf, p) => {
+    const axis = sdf.ast.scalars[0] ?? 0;
+    const fn = axis === 1 ? 'mirY3' : axis === 2 ? 'mirZ3' : 'mirX3';
+    return walk(sdf.ast.children[0], `${fn}(${p})`);
+  },
+
   // ---- 2D → 3D pseudo-primitive ops --------------------------------------
   // Wired 2026-05-23. Both take a single SDF2 child. revolve sweeps it around
   // the Y-axis (profile is in 2D XY plane; 2D-x maps to radial r = length(p.xz);

--- a/sdf-js/src/sdf/sdf3.glsl.js
+++ b/sdf-js/src/sdf/sdf3.glsl.js
@@ -1285,6 +1285,12 @@ vec3 repL3(vec3 p, vec3 period, vec3 count) {
   return p - q * id;
 }
 
+// ---- Axis mirror (|axis| fold) --------------------------------------------
+// 单轴 abs 折叠：两侧都显示 child 的 +axis 半边（dn.js mirrorAxis 的 GPU 面）
+vec3 mirX3(vec3 p) { return vec3(abs(p.x), p.y, p.z); }
+vec3 mirY3(vec3 p) { return vec3(p.x, abs(p.y), p.z); }
+vec3 mirZ3(vec3 p) { return vec3(p.x, p.y, abs(p.z)); }
+
 // ---- hg_sdf-style polar repetition + octant mirror -----------------------
 // pModPolar (hg_sdf): fold the two coords perpendicular to an axis into a
 // single pie sector of angle 2π/n. Source SDF evaluated in folded space


### PR DESCRIPTION
## What

Blender-borrow **Wave C** (per `docs/superpowers/2026-07-13-blender-borrow-spec.md`): qualifying placement modifiers **lower to domain ops** instead of expanding on the raymarch tiers — N instances become ONE shader leaf.

- `array` → `rep`-with-count DomainGroup (odd-count XZ runs; child yaw ≡ run yaw mod π)
- `mirror` → `mirror` DomainGroup (child strictly in the positive half of the fold)
- `scatter`/`radial` and anything failing the guards → expansion (unchanged semantics)
- Gating: `lowerRepeats: renderMode !== 'analytic'` threaded figure-core → `attachDeckWindows` → `expandAndCompile`. **Analytic (the default) never lowers** — rep/mirror are outside its support set.

Lowering is a pure optimization: semantics are defined by expansion, and `test-domain-lowering.mjs` pins CPU signed-distance equality between both forms at machine precision (max |Δf| ≤ 5.3e-15), including a real bytedance-bp transit slice (**60 → 36 subjects**).

## Exactness guards (correctness > leaves)

Domain rep evaluates the nearest tile only — a child not reflection-symmetric about tile boundaries would overestimate near-boundary distances (Δf up to 0.33 in micro-experiments). Misaligned yaws, even counts, y-offsets all **fall back to expansion**; the tests assert the fallbacks fire.

## Unlocked along the way (all found by the browser verify, all real bugs)

1. **`mirror` domain op was CPU-only** — `applyMirror` returned a raw lambda with no `.ast`, so any mirror DomainGroup killed GPU compiles (`missing .ast`). New ast-carrying `mirrorAxis` op in dn.js + `mirX3/Y3/Z3` GLSL + emitter case. The scene-layer TODO ("M0 Day 4-5") is now done.
2. **`capsule {radius,height}` was silently dropped everywhere** — GPU compile crashed on `vec3(undefined)`; analytic drew a default 0..1 unit capsule ignoring `height`. Now: vertical, endpoint span = `height`, centered at local origin — same convention in scene/compile.js and analytic.js. The hold-station glow stems finally render as authored.
3. **The capsule crash was masking a boot bomb**: with it fixed, the full-world finale window (~300 subjects → ~3100 uniform slots → literal emission) hung stone-mode warmup at 24/50 for 3+ minutes inside the driver. New raymarch-tier window cap: a window still over the sanity hard cap (100) after lowering **reuses the previous window's shader**, logged — the same fallback that crash used to produce, now deliberate. Finale-in-raymarch leaf economics is Wave D territory.

## Verification

- `test-domain-lowering.mjs` 9/9; full suite **152/152**
- Browser stone mode: `?ir=revenue-regions&mode=stone` — mirror guard pair renders symmetric, 240fps, 0 errors
- Browser stone deck: `?deck=bytedance-bp&mode=stone` — **26 windows warmed in 4.7s** (was: hung at 24/50), 0 console errors, rep-lowered runways render with even spacing, network station 240fps

🤖 Generated with [Claude Code](https://claude.com/claude-code)