### PR TITLE
Wave A2: collections born at creation sites — id-regex routing deleted

### DIFF
--- a/sdf-js/fixtures/golden/assemble-deck-courtyard.json
+++ b/sdf-js/fixtures/golden/assemble-deck-courtyard.json
@@ -849,6 +849,7 @@
     },
     {
       "id": "path-0-runway",
+      "collection": "path-0",
       "type": "box",
       "args": {
         "dims": [1.7, 0.05, 0.32]
@@ -864,8 +865,7 @@
         "translate": [0.8950805849013479, 0.03, 4.884296673803914],
         "rotate": [0, -1.3895505967801007, 0]
       },
-      "material": "mat-1",
-      "collection": "path-0"
+      "material": "mat-1"
     },
     {
       "id": "s1-dome",
@@ -1067,6 +1067,7 @@
     },
     {
       "id": "path-1-runway",
+      "collection": "path-1",
       "type": "box",
       "args": {
         "dims": [1.7, 0.05, 0.32]
@@ -1082,8 +1083,7 @@
         "translate": [10.294569658420123, 0.03, 37.09259931181325],
         "rotate": [0, 0.5638756044904756, 0]
       },
-      "material": "mat-1",
-      "collection": "path-1"
+      "material": "mat-1"
     },
     {
       "id": "s2-plinth-0",
@@ -1338,6 +1338,7 @@
     },
     {
       "id": "path-2-runway",
+      "collection": "path-2",
       "type": "box",
       "args": {
         "dims": [1.7, 0.05, 0.32]
@@ -1353,8 +1354,7 @@
         "translate": [33.047333187820946, 0.03, 21.408683636555395],
         "rotate": [0, 1.1478896234270402, 0]
       },
-      "material": "mat-1",
-      "collection": "path-2"
+      "material": "mat-1"
     },
     {
       "id": "s3-plinth-0",
@@ -1609,6 +1609,7 @@
     },
     {
       "id": "path-3-runway",
+      "collection": "path-3",
       "type": "box",
       "args": {
         "dims": [1.7, 0.05, 0.32]
@@ -1624,8 +1625,7 @@
         "translate": [38.79435634712679, 0.03, 6.7420977068794805],
         "rotate": [0, 1.5506579123488082, 0]
       },
-      "material": "mat-1",
-      "collection": "path-3"
+      "material": "mat-1"
     },
     {
       "id": "s4-plinth-0",
@@ -1880,6 +1880,7 @@
     },
     {
       "id": "path-4-runway",
+      "collection": "path-4",
       "type": "box",
       "args": {
         "dims": [1.7, 0.05, 0.32]
@@ -1895,8 +1896,7 @@
         "translate": [38.33268755084281, 0.03, -9.003501041618552],
         "rotate": [0, 1.9534262012705768, 0]
       },
-      "material": "mat-1",
-      "collection": "path-4"
+      "material": "mat-1"
     },
     {
       "id": "s5-plinth-0",
@@ -2151,6 +2151,7 @@
     },
     {
       "id": "path-5-runway",
+      "collection": "path-5",
       "type": "box",
       "args": {
         "dims": [1.7, 0.05, 0.32]
@@ -2166,8 +2167,7 @@
         "translate": [31.73621278681703, 0.03, -23.30816946537924],
         "rotate": [0, 2.3561944901923444, 0]
       },
-      "material": "mat-1",
-      "collection": "path-5"
+      "material": "mat-1"
     },
     {
       "id": "s6-past-0",
@@ -2381,6 +2381,7 @@
     },
     {
       "id": "path-6-runway",
+      "collection": "path-6",
       "type": "box",
       "args": {
         "dims": [1.7, 0.05, 0.32]
@@ -2396,8 +2397,7 @@
         "translate": [18.270478046262486, 0.03, -33.88257251331183],
         "rotate": [0, 2.940208509128909, 0]
       },
-      "material": "mat-1",
-      "collection": "path-6"
+      "material": "mat-1"
     },
     {
       "id": "s7-net-node-0",
@@ -3181,6 +3181,7 @@
     },
     {
       "id": "path-7-runway",
+      "collection": "path-7",
       "type": "box",
       "args": {
         "dims": [1.7, 0.05, 0.32]
@@ -3196,8 +3197,7 @@
         "translate": [-9.003501041618552, 0.03, -38.33268755084281],
         "rotate": [0, -2.758962779114113, 0]
       },
-      "material": "mat-1",
-      "collection": "path-7"
+      "material": "mat-1"
     },
     {
       "id": "s8-stage-0",
@@ -3285,6 +3285,7 @@
     },
     {
       "id": "path-8-runway",
+      "collection": "path-8",
       "type": "box",
       "args": {
         "dims": [1.7, 0.05, 0.32]
@@ -3300,8 +3301,7 @@
         "translate": [-23.30816946537925, 0.03, -31.736212786817028],
         "rotate": [0, -2.356194490192345, 0]
       },
-      "material": "mat-1",
-      "collection": "path-8"
+      "material": "mat-1"
     },
     {
       "id": "s9-plinth-0",
@@ -3588,6 +3588,7 @@
     },
     {
       "id": "path-9-runway",
+      "collection": "path-9",
       "type": "box",
       "args": {
         "dims": [1.7, 0.05, 0.32]
@@ -3603,8 +3604,7 @@
         "translate": [-33.88257251331182, 0.03, -18.270478046262486],
         "rotate": [0, -1.772180471255781, 0]
       },
-      "material": "mat-1",
-      "collection": "path-9"
+      "material": "mat-1"
     },
     {
       "id": "s10-node-0",
@@ -3791,6 +3791,7 @@
     },
     {
       "id": "path-10-runway",
+      "collection": "path-10",
       "type": "box",
       "args": {
         "dims": [1.7, 0.05, 0.32]
@@ -3806,8 +3807,7 @@
         "translate": [-38.33268755084281, 0.03, 9.003501041618552],
         "rotate": [0, -1.1881664523192166, 0]
       },
-      "material": "mat-1",
-      "collection": "path-10"
+      "material": "mat-1"
     },
     {
       "id": "s11-backboard",
@@ -4028,6 +4028,7 @@
     },
     {
       "id": "path-11-runway",
+      "collection": "path-11",
       "type": "box",
       "args": {
         "dims": [1.7, 0.05, 0.32]
@@ -4043,8 +4044,7 @@
         "translate": [-31.736212786817017, 0.03, 23.308169465379265],
         "rotate": [0, -0.7853981633974475, 0]
       },
-      "material": "mat-1",
-      "collection": "path-11"
+      "material": "mat-1"
     },
     {
       "id": "s12-plinth-0",

--- a/sdf-js/fixtures/golden/assemble-deck-grid.json
+++ b/sdf-js/fixtures/golden/assemble-deck-grid.json
@@ -840,6 +840,7 @@
     },
     {
       "id": "path-0-runway",
+      "collection": "path-0",
       "type": "box",
       "args": {
         "dims": [1.7, 0.05, 0.32]
@@ -855,8 +856,7 @@
         "translate": [2, 0.03, 0],
         "rotate": [0, 0, 0]
       },
-      "material": "mat-1",
-      "collection": "path-0"
+      "material": "mat-1"
     },
     {
       "id": "s1-dome",
@@ -1058,6 +1058,7 @@
     },
     {
       "id": "path-1-runway",
+      "collection": "path-1",
       "type": "box",
       "args": {
         "dims": [1.7, 0.05, 0.32]
@@ -1073,8 +1074,7 @@
         "translate": [18, 0.03, 0],
         "rotate": [0, 0, 0]
       },
-      "material": "mat-1",
-      "collection": "path-1"
+      "material": "mat-1"
     },
     {
       "id": "s2-plinth-0",
@@ -1329,6 +1329,7 @@
     },
     {
       "id": "path-2-runway",
+      "collection": "path-2",
       "type": "box",
       "args": {
         "dims": [1.7, 0.05, 0.32]
@@ -1344,8 +1345,7 @@
         "translate": [34, 0.03, 0],
         "rotate": [0, 0, 0]
       },
-      "material": "mat-1",
-      "collection": "path-2"
+      "material": "mat-1"
     },
     {
       "id": "s3-plinth-0",
@@ -1600,6 +1600,7 @@
     },
     {
       "id": "path-3-runway",
+      "collection": "path-3",
       "type": "box",
       "args": {
         "dims": [1.7, 0.05, 0.32]
@@ -1615,8 +1616,7 @@
         "translate": [42, 0.03, -2],
         "rotate": [0, 2.819842099193151, 0]
       },
-      "material": "mat-1",
-      "collection": "path-3"
+      "material": "mat-1"
     },
     {
       "id": "s4-plinth-0",
@@ -1871,6 +1871,7 @@
     },
     {
       "id": "path-4-runway",
+      "collection": "path-4",
       "type": "box",
       "args": {
         "dims": [1.7, 0.05, 0.32]
@@ -1886,8 +1887,7 @@
         "translate": [2, 0.03, -16],
         "rotate": [0, 0, 0]
       },
-      "material": "mat-1",
-      "collection": "path-4"
+      "material": "mat-1"
     },
     {
       "id": "s5-plinth-0",
@@ -2142,6 +2142,7 @@
     },
     {
       "id": "path-5-runway",
+      "collection": "path-5",
       "type": "box",
       "args": {
         "dims": [1.7, 0.05, 0.32]
@@ -2157,8 +2158,7 @@
         "translate": [18, 0.03, -16],
         "rotate": [0, 0, 0]
       },
-      "material": "mat-1",
-      "collection": "path-5"
+      "material": "mat-1"
     },
     {
       "id": "s6-past-0",
@@ -2372,6 +2372,7 @@
     },
     {
       "id": "path-6-runway",
+      "collection": "path-6",
       "type": "box",
       "args": {
         "dims": [1.7, 0.05, 0.32]
@@ -2387,8 +2388,7 @@
         "translate": [34, 0.03, -16],
         "rotate": [0, 0, 0]
       },
-      "material": "mat-1",
-      "collection": "path-6"
+      "material": "mat-1"
     },
     {
       "id": "s7-net-node-0",
@@ -3172,6 +3172,7 @@
     },
     {
       "id": "path-7-runway",
+      "collection": "path-7",
       "type": "box",
       "args": {
         "dims": [1.7, 0.05, 0.32]
@@ -3187,8 +3188,7 @@
         "translate": [42, 0.03, -18],
         "rotate": [0, 2.819842099193151, 0]
       },
-      "material": "mat-1",
-      "collection": "path-7"
+      "material": "mat-1"
     },
     {
       "id": "s8-stage-0",
@@ -3276,6 +3276,7 @@
     },
     {
       "id": "path-8-runway",
+      "collection": "path-8",
       "type": "box",
       "args": {
         "dims": [1.7, 0.05, 0.32]
@@ -3291,8 +3292,7 @@
         "translate": [2, 0.03, -32],
         "rotate": [0, 0, 0]
       },
-      "material": "mat-1",
-      "collection": "path-8"
+      "material": "mat-1"
     },
     {
       "id": "s9-plinth-0",
@@ -3579,6 +3579,7 @@
     },
     {
       "id": "path-9-runway",
+      "collection": "path-9",
       "type": "box",
       "args": {
         "dims": [1.7, 0.05, 0.32]
@@ -3594,8 +3595,7 @@
         "translate": [18, 0.03, -32],
         "rotate": [0, 0, 0]
       },
-      "material": "mat-1",
-      "collection": "path-9"
+      "material": "mat-1"
     },
     {
       "id": "s10-node-0",
@@ -3782,6 +3782,7 @@
     },
     {
       "id": "path-10-runway",
+      "collection": "path-10",
       "type": "box",
       "args": {
         "dims": [1.7, 0.05, 0.32]
@@ -3797,8 +3798,7 @@
         "translate": [34, 0.03, -32],
         "rotate": [0, 0, 0]
       },
-      "material": "mat-1",
-      "collection": "path-10"
+      "material": "mat-1"
     },
     {
       "id": "s11-backboard",
@@ -4019,6 +4019,7 @@
     },
     {
       "id": "path-11-runway",
+      "collection": "path-11",
       "type": "box",
       "args": {
         "dims": [1.7, 0.05, 0.32]
@@ -4034,8 +4035,7 @@
         "translate": [42, 0.03, -34],
         "rotate": [0, 2.819842099193151, 0]
       },
-      "material": "mat-1",
-      "collection": "path-11"
+      "material": "mat-1"
     },
     {
       "id": "s12-plinth-0",

--- a/sdf-js/fixtures/golden/assemble-deck-line.json
+++ b/sdf-js/fixtures/golden/assemble-deck-line.json
@@ -840,6 +840,7 @@
     },
     {
       "id": "path-0-runway",
+      "collection": "path-0",
       "type": "box",
       "args": {
         "dims": [1.7, 0.05, 0.32]
@@ -855,8 +856,7 @@
         "translate": [2, 0.03, 0],
         "rotate": [0, 0, 0]
       },
-      "material": "mat-1",
-      "collection": "path-0"
+      "material": "mat-1"
     },
     {
       "id": "s1-dome",
@@ -1058,6 +1058,7 @@
     },
     {
       "id": "path-1-runway",
+      "collection": "path-1",
       "type": "box",
       "args": {
         "dims": [1.7, 0.05, 0.32]
@@ -1073,8 +1074,7 @@
         "translate": [18, 0.03, 0],
         "rotate": [0, 0, 0]
       },
-      "material": "mat-1",
-      "collection": "path-1"
+      "material": "mat-1"
     },
     {
       "id": "s2-plinth-0",
@@ -1329,6 +1329,7 @@
     },
     {
       "id": "path-2-runway",
+      "collection": "path-2",
       "type": "box",
       "args": {
         "dims": [1.7, 0.05, 0.32]
@@ -1344,8 +1345,7 @@
         "translate": [34, 0.03, 0],
         "rotate": [0, 0, 0]
       },
-      "material": "mat-1",
-      "collection": "path-2"
+      "material": "mat-1"
     },
     {
       "id": "s3-plinth-0",
@@ -1600,6 +1600,7 @@
     },
     {
       "id": "path-3-runway",
+      "collection": "path-3",
       "type": "box",
       "args": {
         "dims": [1.7, 0.05, 0.32]
@@ -1615,8 +1616,7 @@
         "translate": [50, 0.03, 0],
         "rotate": [0, 0, 0]
       },
-      "material": "mat-1",
-      "collection": "path-3"
+      "material": "mat-1"
     },
     {
       "id": "s4-plinth-0",
@@ -1871,6 +1871,7 @@
     },
     {
       "id": "path-4-runway",
+      "collection": "path-4",
       "type": "box",
       "args": {
         "dims": [1.7, 0.05, 0.32]
@@ -1886,8 +1887,7 @@
         "translate": [66, 0.03, 0],
         "rotate": [0, 0, 0]
       },
-      "material": "mat-1",
-      "collection": "path-4"
+      "material": "mat-1"
     },
     {
       "id": "s5-plinth-0",
@@ -2142,6 +2142,7 @@
     },
     {
       "id": "path-5-runway",
+      "collection": "path-5",
       "type": "box",
       "args": {
         "dims": [1.7, 0.05, 0.32]
@@ -2157,8 +2158,7 @@
         "translate": [82, 0.03, 0],
         "rotate": [0, 0, 0]
       },
-      "material": "mat-1",
-      "collection": "path-5"
+      "material": "mat-1"
     },
     {
       "id": "s6-past-0",
@@ -2372,6 +2372,7 @@
     },
     {
       "id": "path-6-runway",
+      "collection": "path-6",
       "type": "box",
       "args": {
         "dims": [1.7, 0.05, 0.32]
@@ -2387,8 +2388,7 @@
         "translate": [98, 0.03, 0],
         "rotate": [0, 0, 0]
       },
-      "material": "mat-1",
-      "collection": "path-6"
+      "material": "mat-1"
     },
     {
       "id": "s7-net-node-0",
@@ -3172,6 +3172,7 @@
     },
     {
       "id": "path-7-runway",
+      "collection": "path-7",
       "type": "box",
       "args": {
         "dims": [1.7, 0.05, 0.32]
@@ -3187,8 +3188,7 @@
         "translate": [114, 0.03, 0],
         "rotate": [0, 0, 0]
       },
-      "material": "mat-1",
-      "collection": "path-7"
+      "material": "mat-1"
     },
     {
       "id": "s8-stage-0",
@@ -3276,6 +3276,7 @@
     },
     {
       "id": "path-8-runway",
+      "collection": "path-8",
       "type": "box",
       "args": {
         "dims": [1.7, 0.05, 0.32]
@@ -3291,8 +3292,7 @@
         "translate": [130, 0.03, 0],
         "rotate": [0, 0, 0]
       },
-      "material": "mat-1",
-      "collection": "path-8"
+      "material": "mat-1"
     },
     {
       "id": "s9-plinth-0",
@@ -3579,6 +3579,7 @@
     },
     {
       "id": "path-9-runway",
+      "collection": "path-9",
       "type": "box",
       "args": {
         "dims": [1.7, 0.05, 0.32]
@@ -3594,8 +3595,7 @@
         "translate": [146, 0.03, 0],
         "rotate": [0, 0, 0]
       },
-      "material": "mat-1",
-      "collection": "path-9"
+      "material": "mat-1"
     },
     {
       "id": "s10-node-0",
@@ -3782,6 +3782,7 @@
     },
     {
       "id": "path-10-runway",
+      "collection": "path-10",
       "type": "box",
       "args": {
         "dims": [1.7, 0.05, 0.32]
@@ -3797,8 +3798,7 @@
         "translate": [162, 0.03, 0],
         "rotate": [0, 0, 0]
       },
-      "material": "mat-1",
-      "collection": "path-10"
+      "material": "mat-1"
     },
     {
       "id": "s11-backboard",
@@ -4019,6 +4019,7 @@
     },
     {
       "id": "path-11-runway",
+      "collection": "path-11",
       "type": "box",
       "args": {
         "dims": [1.7, 0.05, 0.32]
@@ -4034,8 +4035,7 @@
         "translate": [178, 0.03, 0],
         "rotate": [0, 0, 0]
       },
-      "material": "mat-1",
-      "collection": "path-11"
+      "material": "mat-1"
     },
     {
       "id": "s12-plinth-0",

--- a/sdf-js/fixtures/golden/assemble-deck-radial.json
+++ b/sdf-js/fixtures/golden/assemble-deck-radial.json
@@ -840,6 +840,7 @@
     },
     {
       "id": "path-0-runway",
+      "collection": "path-0",
       "type": "box",
       "args": {
         "dims": [1.7, 0.05, 0.32]
@@ -855,8 +856,7 @@
         "translate": [1.9230377400028875, 0.03, 32.630241930428475],
         "rotate": [0, 0.24166097335306091, 0]
       },
-      "material": "mat-1",
-      "collection": "path-0"
+      "material": "mat-1"
     },
     {
       "id": "s1-dome",
@@ -1058,6 +1058,7 @@
     },
     {
       "id": "path-1-runway",
+      "collection": "path-1",
       "type": "box",
       "args": {
         "dims": [1.7, 0.05, 0.32]
@@ -1073,8 +1074,7 @@
         "translate": [16.866794888908387, 0.03, 27.9989641373259],
         "rotate": [0, 0.724982920059183, 0]
       },
-      "material": "mat-1",
-      "collection": "path-1"
+      "material": "mat-1"
     },
     {
       "id": "s2-plinth-0",
@@ -1329,6 +1329,7 @@
     },
     {
       "id": "path-2-runway",
+      "collection": "path-2",
       "type": "box",
       "args": {
         "dims": [1.7, 0.05, 0.32]
@@ -1344,8 +1345,7 @@
         "translate": [27.946572595678504, 0.03, 16.953461084458215],
         "rotate": [0, 1.208304866765305, 0]
       },
-      "material": "mat-1",
-      "collection": "path-2"
+      "material": "mat-1"
     },
     {
       "id": "s3-plinth-0",
@@ -1600,6 +1600,7 @@
     },
     {
       "id": "path-3-runway",
+      "collection": "path-3",
       "type": "box",
       "args": {
         "dims": [1.7, 0.05, 0.32]
@@ -1615,8 +1616,7 @@
         "translate": [32.62412731348841, 0.03, 2.0241244084955587],
         "rotate": [0, 1.6916268134714274, 0]
       },
-      "material": "mat-1",
-      "collection": "path-3"
+      "material": "mat-1"
     },
     {
       "id": "s4-plinth-0",
@@ -1871,6 +1871,7 @@
     },
     {
       "id": "path-4-runway",
+      "collection": "path-4",
       "type": "box",
       "args": {
         "dims": [1.7, 0.05, 0.32]
@@ -1886,8 +1887,7 @@
         "translate": [29.82788762713305, 0.03, -13.368914776109944],
         "rotate": [0, 2.174948760177549, 0]
       },
-      "material": "mat-1",
-      "collection": "path-4"
+      "material": "mat-1"
     },
     {
       "id": "s5-plinth-0",
@@ -2142,6 +2142,7 @@
     },
     {
       "id": "path-5-runway",
+      "collection": "path-5",
       "type": "box",
       "args": {
         "dims": [1.7, 0.05, 0.32]
@@ -2157,8 +2158,7 @@
         "translate": [20.19843835041516, 0.03, -25.69929669839714],
         "rotate": [0, 2.6582707068836715, 0]
       },
-      "material": "mat-1",
-      "collection": "path-5"
+      "material": "mat-1"
     },
     {
       "id": "s6-past-0",
@@ -2372,6 +2372,7 @@
     },
     {
       "id": "path-6-runway",
+      "collection": "path-6",
       "type": "box",
       "args": {
         "dims": [1.7, 0.05, 0.32]
@@ -2387,8 +2388,7 @@
         "translate": [5.9417702651869195, 0.03, -32.14227945718083],
         "rotate": [0, -3.141592653589793, 0]
       },
-      "material": "mat-1",
-      "collection": "path-6"
+      "material": "mat-1"
     },
     {
       "id": "s7-net-node-0",
@@ -3172,6 +3172,7 @@
     },
     {
       "id": "path-7-runway",
+      "collection": "path-7",
       "type": "box",
       "args": {
         "dims": [1.7, 0.05, 0.32]
@@ -3187,8 +3188,7 @@
         "translate": [-9.676085781701492, 0.03, -31.221853348783156],
         "rotate": [0, -2.6582707068836715, 0]
       },
-      "material": "mat-1",
-      "collection": "path-7"
+      "material": "mat-1"
     },
     {
       "id": "s8-stage-0",
@@ -3276,6 +3276,7 @@
     },
     {
       "id": "path-8-runway",
+      "collection": "path-8",
       "type": "box",
       "args": {
         "dims": [1.7, 0.05, 0.32]
@@ -3291,8 +3292,7 @@
         "translate": [-23.077267185476803, 0.03, -23.148876902300973],
         "rotate": [0, -2.1749487601775495, 0]
       },
-      "material": "mat-1",
-      "collection": "path-8"
+      "material": "mat-1"
     },
     {
       "id": "s9-plinth-0",
@@ -3579,6 +3579,7 @@
     },
     {
       "id": "path-9-runway",
+      "collection": "path-9",
       "type": "box",
       "args": {
         "dims": [1.7, 0.05, 0.32]
@@ -3594,8 +3595,7 @@
         "translate": [-31.19172478827756, 0.03, -9.772771731710455],
         "rotate": [0, -1.6916268134714274, 0]
       },
-      "material": "mat-1",
-      "collection": "path-9"
+      "material": "mat-1"
     },
     {
       "id": "s10-node-0",
@@ -3782,6 +3782,7 @@
     },
     {
       "id": "path-10-runway",
+      "collection": "path-10",
       "type": "box",
       "args": {
         "dims": [1.7, 0.05, 0.32]
@@ -3797,8 +3798,7 @@
         "translate": [-32.16053414311712, 0.03, 5.842157667948225],
         "rotate": [0, -1.2083048667653054, 0]
       },
-      "material": "mat-1",
-      "collection": "path-10"
+      "material": "mat-1"
     },
     {
       "id": "s11-backboard",
@@ -4019,6 +4019,7 @@
     },
     {
       "id": "path-11-runway",
+      "collection": "path-11",
       "type": "box",
       "args": {
         "dims": [1.7, 0.05, 0.32]
@@ -4034,8 +4035,7 @@
         "translate": [-25.761752702220132, 0.03, 20.11871915151214],
         "rotate": [0, -0.7249829200591837, 0]
       },
-      "material": "mat-1",
-      "collection": "path-11"
+      "material": "mat-1"
     },
     {
       "id": "s12-plinth-0",

--- a/sdf-js/scripts/test-assemble-deck.mjs
+++ b/sdf-js/scripts/test-assemble-deck.mjs
@@ -50,8 +50,9 @@ const deck = JSON.parse(
 
   // subjects: sum of stations (prefixed) + breadcrumb path markers between them
   const expected = stations.reduce((s, st) => s + st.subjects.length, 0);
-  const stationSubjects = scene.subjects.filter((s) => /^s\d+-/.test(s.id));
-  const pathMarkers = scene.subjects.filter((s) => /^path-/.test(s.id));
+  const col = (s) => s.collection || '';
+  const stationSubjects = scene.subjects.filter((s) => col(s).startsWith('station-'));
+  const pathMarkers = scene.subjects.filter((s) => col(s).startsWith('path-'));
   ok(stationSubjects.length === expected, `all station subjects present (${expected})`);
   // Wave B: each gap is ONE runway subject carrying an array modifier (the
   // seven strips are expansion-time instances, not authored subjects)
@@ -63,25 +64,20 @@ const deck = JSON.parse(
     'breadcrumb runway = 1 subject × array(7) per gap (Wave B)',
   );
   ok(
-    scene.subjects.filter((s) => s.id.startsWith('horizon-')).length === 14,
+    scene.subjects.filter((s) => col(s) === 'horizon').length === 14,
     'default world gets the horizon silhouette ring',
   );
   ok(
-    scene.subjects.every(
-      (s) => /^s\d+-/.test(s.id) || /^path-/.test(s.id) || /^horizon-/.test(s.id),
-    ),
-    'ids prefixed per station (no collisions)',
+    scene.subjects.every((s) => col(s) && scene.collections[col(s)]),
+    'every subject carries a registered collection (Wave A2: routing is data)',
   );
-  const xOf = (pfx) => {
+  const xOf = (k) => {
     const xs = scene.subjects
-      .filter((s) => s.id.startsWith(pfx))
+      .filter((s) => col(s) === `station-${k}`)
       .map((s) => s.transform.translate[0]);
     return xs.reduce((a, b) => a + b, 0) / xs.length;
   };
-  ok(
-    xOf('s1-') - xOf('s0-') > 10 && xOf('s2-') - xOf('s1-') > 10,
-    'stations spaced along the deck axis',
-  );
+  ok(xOf(1) - xOf(0) > 10 && xOf(2) - xOf(1) > 10, 'stations spaced along the deck axis');
 
   // camera: all station shots + one transit between each pair + the deck finale
   const shotCount =
@@ -147,7 +143,7 @@ const deck = JSON.parse(
   const grid = assembleDeck(JSON.parse(JSON.stringify(deck)), { layout: 'grid' });
   const zs = new Set(
     grid.subjects
-      .filter((s) => /^s\d+-/.test(s.id))
+      .filter((s) => (s.collection || '').startsWith('station-'))
       .map((s) => Math.round(s.transform.translate[2] / 8)),
   );
   ok(zs.size >= 2, 'grid: stations occupy multiple rows');
@@ -156,7 +152,9 @@ const deck = JSON.parse(
   // deck.layout field is honored; opts.layout overrides
   const viaField = assembleDeck({ ...JSON.parse(JSON.stringify(deck)), layout: 'radial' });
   ok(
-    viaField.subjects.some((s) => /^s\d+-/.test(s.id) && Math.abs(s.transform.translate[2]) > 5),
+    viaField.subjects.some(
+      (s) => (s.collection || '').startsWith('station-') && Math.abs(s.transform.translate[2]) > 5,
+    ),
     'deck.layout field honored',
   );
 }

--- a/sdf-js/scripts/test-courtyard.mjs
+++ b/sdf-js/scripts/test-courtyard.mjs
@@ -80,7 +80,7 @@ const stations = new Map(
 
 // ---- massing: budget conservation + never distance-culled -----------------------
 {
-  const massing = scene.subjects.filter((s) => s.id.startsWith('massing-'));
+  const massing = scene.subjects.filter((s) => s.collection === 'massing');
   ok(
     massing.length === DECK.zones.length * 2 + 3,
     `1 hull + 1 tower per chapter + 3 world-heart proxies (${massing.length})`,
@@ -105,9 +105,9 @@ const stations = new Map(
   );
   const stWin = scene.deckWindows.find((w) => w.kind === 'station' && w.stations[0] === 3);
   const sliced = sliceDeckWindow(scene, stWin);
-  const keptMassing = sliced.subjects.filter((s) => s.id.startsWith('massing-'));
+  const keptMassing = sliced.subjects.filter((s) => s.collection === 'massing');
   ok(keptMassing.length === massing.length, 'station window keeps ALL massing (never culled)');
-  const hills = sliced.subjects.filter((s) => s.id.startsWith('horizon-'));
+  const hills = sliced.subjects.filter((s) => s.collection === 'horizon');
   ok(hills.length === 0, `slab quota yields to massing (slabs=${hills.length}, conservation)`);
   ok(
     massing

--- a/sdf-js/scripts/test-deck-decor.mjs
+++ b/sdf-js/scripts/test-deck-decor.mjs
@@ -69,9 +69,9 @@ const ANALYTIC_TYPES = new Set(['box', 'sphere', 'capsule', 'ellipsoid', 'cylind
   const origins = new Map(
     scene.deckWindows.filter((w) => w.kind === 'station').map((w) => [w.stations[0], w.origin]),
   );
-  const stelae = decor.filter((s) => /^s\d+-decor-stela-/.test(s.id));
+  const stelae = decor.filter((s) => /-decor-stela-/.test(s.id));
   const inBand = stelae.every((s) => {
-    const k = Number(/^s(\d+)-/.exec(s.id)[1]);
+    const k = Number(/^station-(\d+)$/.exec(s.collection)[1]);
     const o = origins.get(k);
     const t = s.transform.translate;
     const r = Math.hypot(t[0] - o[0], t[2] - o[2]);
@@ -87,7 +87,7 @@ const ANALYTIC_TYPES = new Set(['box', 'sphere', 'capsule', 'ellipsoid', 'cylind
   const sliced = sliceDeckWindow(scene, stWin);
   const decorIn = sliced.subjects.filter((x) => /-decor-/.test(x.id));
   ok(
-    decorIn.every((x) => x.id.startsWith('s3-decor-') || x.id.startsWith('path-3-decor-')),
+    decorIn.every((x) => x.collection === 'station-3' || x.collection === 'path-3'),
     'station window carries only its own decor + the OUTGOING inlay (continuity: the world ahead never pops in)',
   );
   ok(
@@ -96,14 +96,18 @@ const ANALYTIC_TYPES = new Set(['box', 'sphere', 'capsule', 'ellipsoid', 'cylind
   );
   const trWin = scene.deckWindows.find((w) => w.kind === 'transit');
   const trSliced = sliceDeckWindow(scene, trWin);
-  const trDecor = trSliced.subjects.filter((x) => /^path-\d+-decor-/.test(x.id));
+  const trDecor = trSliced.subjects.filter(
+    (x) => /-decor-/.test(x.id) && (x.collection || '').startsWith('path-'),
+  );
   ok(
     trDecor.length > 0 && trDecor.length <= SEGMENT_DECOR_MAX,
     `transit window carries its inlay, ≤ cap (${trDecor.length}/${SEGMENT_DECOR_MAX})`,
   );
-  const trStelae = trSliced.subjects.filter((x) => /^s\d+-decor-/.test(x.id));
+  const trStelae = trSliced.subjects.filter(
+    (x) => /-decor-stela-/.test(x.id) && (x.collection || '').startsWith('station-'),
+  );
   ok(
-    trStelae.every((x) => /^s(0|1)-/.test(x.id)),
+    trStelae.every((x) => x.collection === 'station-0' || x.collection === 'station-1'),
     'transit window stelae limited to its two endpoint stations',
   );
 }

--- a/sdf-js/scripts/test-deck-windows.mjs
+++ b/sdf-js/scripts/test-deck-windows.mjs
@@ -42,7 +42,7 @@ ok(wins[5].stations.join(',') === '0,1,2', 'finale window carries all stations')
 
 // ---- slicing ------------------------------------------------------------------
 const sliceOf = (i) => sliceDeckWindow(scene, wins[i]);
-const stationIds = (s, k) => s.subjects.filter((x) => x.id && x.id.startsWith(`s${k}-`)).length;
+const stationIds = (s, k) => s.subjects.filter((x) => x.collection === `station-${k}`).length;
 {
   const s1 = sliceOf(2); // station window of slide 1
   ok(stationIds(s1, 1) > 0, 'station slice keeps its own subjects');
@@ -56,7 +56,7 @@ const stationIds = (s, k) => s.subjects.filter((x) => x.id && x.id.startsWith(`s
   ok(stationIds(tr, 0) > 0 && stationIds(tr, 1) > 0, 'transit slice keeps both endpoint stations');
   ok(stationIds(tr, 2) === 0, 'transit slice drops the far station');
   ok(
-    tr.subjects.some((x) => x.id && x.id.startsWith('path-0-')),
+    tr.subjects.some((x) => x.collection === 'path-0'),
     'transit slice keeps the breadcrumb path it flies over',
   );
 }
@@ -64,8 +64,7 @@ ok(sliceOf(5).subjects.length === scene.subjects.length, 'finale slice is the fu
 
 // ---- horizon-hill trimming (super-linear shader cost: every leaf counts) ------
 {
-  const hills = (s) =>
-    s.subjects.filter((x) => typeof x.id === 'string' && x.id.startsWith('horizon-'));
+  const hills = (s) => s.subjects.filter((x) => x.collection === 'horizon');
   const fullHills = hills(scene).length;
   ok(fullHills > 7, `full deck rings ${fullHills} monoliths (needs trimming to matter)`);
   // ambience tiers: data stations trim the skyline hard (focus on the data),
@@ -142,7 +141,8 @@ for (let i = 0; i < wins.length; i++) {
   ok(chips.length > 0, 'value chips carry the station accent color');
   const stationHues = new Set();
   for (const sub of sc.subjects) {
-    const m = /^s(\d+)-mono-1$/.exec(sub.id || '');
+    if (!/-mono-1$/.test(sub.id || '')) continue; // id = identity...
+    const m = /^station-(\d+)$/.exec(sub.collection || ''); // ...collection = whose
     if (m) stationHues.add(`${m[1]}:${matOf(sc, sub).hue.toFixed(3)}`);
   }
   const hues = [...stationHues].map((x) => x.split(':')[1]);

--- a/sdf-js/scripts/test-scene-collections.mjs
+++ b/sdf-js/scripts/test-scene-collections.mjs
@@ -17,7 +17,7 @@ let pass = 0,
 const ok = (c, n) => (c ? (pass++, console.log(`  ✓ ${n}`)) : (fail++, console.log(`  ✗ ${n}`)));
 console.log('=== scene collections + material registry (Wave A) ===\n');
 
-// ---- semantic equivalence: collections vs legacy regex --------------------------
+// ---- collections are the ONLY routing channel (Wave A2: legacy regex gone) ------
 for (const layout of ['radial', 'courtyard']) {
   const scene = assembleDeck(DECK, { layout });
   ok(!!scene.collections && !!scene.materials, `${layout}: collections + materials emitted`);
@@ -27,27 +27,29 @@ for (const layout of ['radial', 'courtyard']) {
     ),
     `${layout}: every subject carries a registered collection`,
   );
-  // strip collections/tags → the slicer falls back to the legacy regex path
-  const legacy = {
+  // a scene without a collections registry has no routing data — sliceDeckWindow
+  // passes it through whole rather than guessing from id strings (Wave A2
+  // contract: ids are pure identity, never routing)
+  const bare = { ...scene, collections: undefined };
+  const win = scene.deckWindows.find((w) => w.kind === 'station');
+  ok(
+    sliceDeckWindow(bare, win).subjects.length === scene.subjects.length,
+    `${layout}: no registry → whole world passes through (ids never route)`,
+  );
+  // routing really flows from the TAG, not the id: retag one station subject
+  // to a far station and it must leave its home window
+  const sliced = sliceDeckWindow(scene, win).subjects.map((s) => s.id);
+  const victim = scene.subjects.find((s) => s.collection === `station-${win.stations[0]}`);
+  const lastStation = `station-${DECK.slides.length - 1}`;
+  const retagged = {
     ...scene,
-    collections: undefined,
-    subjects: scene.subjects.map((s) => ({ ...s, collection: undefined })),
+    subjects: scene.subjects.map((s) => (s === victim ? { ...s, collection: lastStation } : s)),
   };
-  let identical = true;
-  for (const win of scene.deckWindows) {
-    const a = sliceDeckWindow(scene, win)
-      .subjects.map((s) => s.id)
-      .join('|');
-    const b = sliceDeckWindow(legacy, win)
-      .subjects.map((s) => s.id)
-      .join('|');
-    if (a !== b) {
-      identical = false;
-      console.log(`    ✗ window ${win.kind}[${win.stations}] diverges`);
-      break;
-    }
-  }
-  ok(identical, `${layout}: collection slicing ≡ legacy regex slicing (every window)`);
+  const slicedRetag = sliceDeckWindow(retagged, win).subjects.map((s) => s.id);
+  ok(
+    sliced.includes(victim.id) && !slicedRetag.includes(victim.id),
+    `${layout}: retagging a subject moves it between windows (tag routes, id doesn't)`,
+  );
 }
 
 // ---- material registry round-trip ------------------------------------------------

--- a/sdf-js/src/scene/assemble-deck.js
+++ b/sdf-js/src/scene/assemble-deck.js
@@ -399,6 +399,9 @@ export function assembleDeck(deck, opts = {}) {
     for (const s of st.subjects) {
       const moved = JSON.parse(JSON.stringify(s));
       moved.id = `s${k}-${s.id}`;
+      // Wave A2: collection assigned AT BIRTH (renderer-assigned wins) — ids
+      // are pure identity, routing rides the tag from the moment it exists.
+      moved.collection = moved.collection || `station-${k}`;
       moved.transform = moved.transform || {};
       moved.transform.translate = addV(moved.transform.translate || [0, 0, 0], origin);
       if (Array.isArray(moved.animation)) {
@@ -476,7 +479,8 @@ export function assembleDeck(deck, opts = {}) {
     // Layer C: stelae ring in the station's annulus (outside the fitted
     // platform, inside the transit corridor). The `s${k}-decor-` prefix means
     // sliceDeckWindow scopes these to this station's windows automatically.
-    if (decor) subjects.push(...decor.station(k, origin));
+    if (decor)
+      subjects.push(...decor.station(k, origin).map((d) => ({ ...d, collection: `station-${k}` })));
 
     const stationDur = seqDuration(st.cameraSequence.shots);
     windows.push({
@@ -547,6 +551,7 @@ export function assembleDeck(deck, opts = {}) {
       // used to be hand-unrolled; the placement pattern is now data.
       subjects.push({
         id: `path-${k}-runway`,
+        collection: `path-${k}`,
         type: 'box',
         // R1 critique: 0.9×0.06 chips were invisible in the transit frame —
         // the flight had no guide line. Long low glowing strips read as a
@@ -569,7 +574,10 @@ export function assembleDeck(deck, opts = {}) {
       });
       // Layer C: inlay flanking the breadcrumbs (path-${k}-decor- prefix →
       // lives only in this transit's windows, dropped inside stations).
-      if (decor) subjects.push(...decor.segment(k, origin, next));
+      if (decor)
+        subjects.push(
+          ...decor.segment(k, origin, next).map((d) => ({ ...d, collection: `path-${k}` })),
+        );
     }
   });
 
@@ -660,11 +668,14 @@ export function assembleDeck(deck, opts = {}) {
 
   // ---- Wave A (Blender borrow): collections + material registry ---------------
   // Collections make the slicing semantics DATA: every subject carries a
-  // collection tag, the registry says how each collection behaves in a window
-  // (kind / cull policy / dressing budget). The id prefixes stay as pure
-  // identity; sliceDeckWindow prefers collections and keeps the regex path
-  // only as a fallback for pre-Wave-A scenes.
-  const allSubjects = [...subjects, ...massingSubjects, ...worldSubjects];
+  // collection tag from its creation site (Wave A2 — no id-regex tagging
+  // anywhere), the registry says how each collection behaves in a window
+  // (kind / cull policy / dressing budget). The id prefixes are pure identity.
+  const allSubjects = [
+    ...subjects,
+    ...massingSubjects.map((s) => ({ ...s, collection: 'massing' })),
+    ...worldSubjects.map((s) => ({ ...s, collection: env ? 'env' : 'horizon' })),
+  ];
   const collections = {};
   deck.slides.forEach((_, k) => {
     collections[`station-${k}`] = { kind: 'station', station: k };
@@ -678,19 +689,12 @@ export function assembleDeck(deck, opts = {}) {
     yieldTo: 'massing', // dressing budget conservation (spec §4)
   };
   collections.env = { kind: 'dressing', cull: 'never' };
+  // Wave A2: no regex tagging — every creation site above attaches its own
+  // collection. A subject slipping through untagged would be kept in EVERY
+  // window (silent leaf bloat), so it's a hard error here, not a fallback.
   for (const s of allSubjects) {
-    if (s.collection) continue; // renderer-assigned wins (none today)
-    const st = /^s(\d+)-/.exec(s.id || '');
-    const path = /^path-(\d+)-/.exec(s.id || '');
-    s.collection = st
-      ? `station-${st[1]}`
-      : path
-        ? `path-${path[1]}`
-        : (s.id || '').startsWith('massing-')
-          ? 'massing'
-          : (s.id || '').startsWith('horizon-')
-            ? 'horizon'
-            : 'env';
+    if (!s.collection)
+      throw new Error(`assembleDeck: subject '${s.id}' has no collection (untagged producer)`);
   }
   // Material registry: auto-dedup the inline materials (36 kinds × ~300 uses on
   // the reference deck). Names are deterministic by first appearance; subjects
@@ -731,10 +735,10 @@ export function assembleDeck(deck, opts = {}) {
 // filtered — camera timeline, overlay and defaults are shared by reference so
 // the presentation clock, teleprompter and postFx are byte-identical across
 // window swaps (the swap changes WHICH GEOMETRY EXISTS, never when/how it is
-// filmed). Relies on assembleDeck's own naming: station subjects are prefixed
-// `s${k}-`, breadcrumb paths `path-${k}-` (connecting k → k+1); anything else
-// is shared world dressing (horizon hills, env terrain) and stays in every
-// window so the backdrop never pops.
+// filmed). Routing is entirely `subject.collection` + the scene.collections
+// registry (Wave A2 — ids are pure identity): station-k / path-k membership
+// decides window inclusion; dressing collections (massing/horizon/env) stay
+// in every window so the backdrop never pops.
 // Shader cost is SUPER-linear in leaf count on Apple GPUs, so even the cheap
 // horizon-hill silhouettes (14 leaves ringing the deck centroid) dominate a
 // 5-subject station window. Keep only the nearest few per window — they are
@@ -746,13 +750,13 @@ const HILLS_HERO = 7;
 const HILLS_CONTENT = 3;
 export function sliceDeckWindow(scene, win) {
   if (!win || win.kind === 'finale') return scene;
+  const cols = scene.collections;
+  if (!cols) return scene; // no routing data → nothing to slice (whole world)
   const wanted = new Set(win.stations);
-  const cols = scene.collections || null;
 
-  // Wave A: collection-driven slicing — the routing rules live in DATA
-  // (scene.collections), ids are pure identity. The regex path below stays as
-  // a fallback for pre-Wave-A scenes and is deleted once no producer emits
-  // collection-less decks.
+  // Wave A2: collection-driven slicing ONLY — the routing rules live in DATA
+  // (scene.collections), ids are pure identity. The pre-Wave-A id-regex
+  // fallback is gone; assembleDeck hard-errors on untagged subjects instead.
   const keepByCollection = (s) => {
     const c = cols[s.collection];
     if (!c) return true; // untagged → shared dressing
@@ -766,19 +770,7 @@ export function sliceDeckWindow(scene, win) {
     }
     return true; // dressing/decor: kept (nearest-cull handled below)
   };
-  const keepLegacy = (s) => {
-    const id = typeof s.id === 'string' ? s.id : '';
-    const st = /^s(\d+)-/.exec(id);
-    if (st) return wanted.has(Number(st[1]));
-    const path = /^path-(\d+)-/.exec(id);
-    if (path) {
-      const i = Number(path[1]);
-      if (win.kind === 'station') return wanted.has(i);
-      return wanted.has(i) || wanted.has(i + 1);
-    }
-    return true;
-  };
-  let subjects = scene.subjects.filter(cols ? keepByCollection : keepLegacy);
+  let subjects = scene.subjects.filter(keepByCollection);
 
   if (Array.isArray(win.origin)) {
     // Dressing budget CONSERVATION (spec §4): 'never'-culled dressing (chapter
@@ -796,22 +788,12 @@ export function sliceDeckWindow(scene, win) {
       const near = new Set(members.sort((a, b) => distSq(a) - distSq(b)).slice(0, budget));
       subjects = subjects.filter((s) => !memberOf(s) || near.has(s));
     };
-    if (cols) {
-      for (const [name, c] of Object.entries(cols)) {
-        if (c.kind !== 'dressing' || c.cull !== 'nearest') continue;
-        const yieldCount = c.yieldTo
-          ? subjects.filter((s) => s.collection === c.yieldTo).length
-          : 0;
-        const base =
-          (c.budget && c.budget[tierKey]) ?? (tierKey === 'hero' ? HILLS_HERO : HILLS_CONTENT);
-        cullNearest((s) => s.collection === name, Math.max(0, base - yieldCount));
-      }
-    } else {
-      const massingCount = subjects.filter(
-        (s) => typeof s.id === 'string' && s.id.startsWith('massing-'),
-      ).length;
-      const budget = Math.max(0, (tierKey === 'hero' ? HILLS_HERO : HILLS_CONTENT) - massingCount);
-      cullNearest((s) => typeof s.id === 'string' && s.id.startsWith('horizon-'), budget);
+    for (const [name, c] of Object.entries(cols)) {
+      if (c.kind !== 'dressing' || c.cull !== 'nearest') continue;
+      const yieldCount = c.yieldTo ? subjects.filter((s) => s.collection === c.yieldTo).length : 0;
+      const base =
+        (c.budget && c.budget[tierKey]) ?? (tierKey === 'hero' ? HILLS_HERO : HILLS_CONTENT);
+      cullNearest((s) => s.collection === name, Math.max(0, base - yieldCount));
     }
   }
   return { ...scene, subjects };


### PR DESCRIPTION
## What

Blender-borrow **Wave A2** (the deferred half of Wave A, per plan §A-4): finish the migration off id-prefix routing and delete the legacy fallback.

- Every subject gets its `collection` tag **at its creation site** (station transplant loop, decor station/segment, breadcrumb runway, massing, horizon/env) — the post-hoc id-regex tagger loop is gone.
- An untagged subject is now a **hard `assembleDeck` error** (it would silently ride every window = leaf bloat), not a fallback.
- `sliceDeckWindow`: `keepLegacy` regex fallback and the collection-less dressing-budget branch **deleted**. A scene without a collections registry passes through whole — ids never route.
- **Milestone met**: `grep` finds zero `/^s(\d+)-/` consumers outside the archived `spike-w0.mjs`.

## Tests

- Routing-semantics assertions migrated to collection filters; id regexes kept only where they assert *naming* (e.g. `-mono-1$` identity + `station-(\d+)` collection for "whose").
- `test-scene-collections`: the migration-period "collection ≡ legacy regex" equivalence block is replaced by the new contract — no registry → whole world passes through; **retagging a subject moves it between windows** (tag routes, id doesn't).
- Suite **152/152**.

## Zero-drift proof

- Goldens re-baked: key-sort-normalized compare vs HEAD is **IDENTICAL** for all 4 layouts (pure key-order diff — `collection` now serializes at birth position).
- Assembled bytedance scene under browser opts (`stage` + `decorSeed`) is **hash-identical to main** after key-sort.
- Browser: analytic deck boots and plays, slicing routes correctly, only pre-existing warnings.

## Wave D evidence (noted, not acted on)

The full-world finale window costs **~85s of the 112s analytic warmup** on this machine (392 subjects; the analytic tier has no window cap by design since the finale/free-cam money shot needs the whole world). Pre-existing — quantified here as the立项 input for finale leaf economics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)