### PR TITLE
Finale-LOD: silhouette proxies for far stations in the money shot

### DIFF
--- a/sdf-js/fixtures/golden/assemble-deck-courtyard.json
+++ b/sdf-js/fixtures/golden/assemble-deck-courtyard.json
@@ -4,103 +4,319 @@
   "collections": {
     "station-0": {
       "kind": "station",
-      "station": 0
+      "station": 0,
+      "tier": "hero"
+    },
+    "station-0-decor": {
+      "kind": "station",
+      "station": 0,
+      "tier": "hero",
+      "finaleDrop": true
+    },
+    "proxy-0": {
+      "kind": "proxy",
+      "station": 0,
+      "tier": "hero"
     },
     "path-0": {
       "kind": "transit-path",
       "from": 0
     },
+    "path-0-decor": {
+      "kind": "transit-path",
+      "from": 0,
+      "finaleDrop": true
+    },
     "station-1": {
       "kind": "station",
-      "station": 1
+      "station": 1,
+      "tier": "hero"
+    },
+    "station-1-decor": {
+      "kind": "station",
+      "station": 1,
+      "tier": "hero",
+      "finaleDrop": true
+    },
+    "proxy-1": {
+      "kind": "proxy",
+      "station": 1,
+      "tier": "hero"
     },
     "path-1": {
       "kind": "transit-path",
       "from": 1
     },
+    "path-1-decor": {
+      "kind": "transit-path",
+      "from": 1,
+      "finaleDrop": true
+    },
     "station-2": {
       "kind": "station",
-      "station": 2
+      "station": 2,
+      "tier": "content"
+    },
+    "station-2-decor": {
+      "kind": "station",
+      "station": 2,
+      "tier": "content",
+      "finaleDrop": true
+    },
+    "proxy-2": {
+      "kind": "proxy",
+      "station": 2,
+      "tier": "content"
     },
     "path-2": {
       "kind": "transit-path",
       "from": 2
     },
+    "path-2-decor": {
+      "kind": "transit-path",
+      "from": 2,
+      "finaleDrop": true
+    },
     "station-3": {
       "kind": "station",
-      "station": 3
+      "station": 3,
+      "tier": "content"
+    },
+    "station-3-decor": {
+      "kind": "station",
+      "station": 3,
+      "tier": "content",
+      "finaleDrop": true
+    },
+    "proxy-3": {
+      "kind": "proxy",
+      "station": 3,
+      "tier": "content"
     },
     "path-3": {
       "kind": "transit-path",
       "from": 3
     },
+    "path-3-decor": {
+      "kind": "transit-path",
+      "from": 3,
+      "finaleDrop": true
+    },
     "station-4": {
       "kind": "station",
-      "station": 4
+      "station": 4,
+      "tier": "content"
+    },
+    "station-4-decor": {
+      "kind": "station",
+      "station": 4,
+      "tier": "content",
+      "finaleDrop": true
+    },
+    "proxy-4": {
+      "kind": "proxy",
+      "station": 4,
+      "tier": "content"
     },
     "path-4": {
       "kind": "transit-path",
       "from": 4
     },
+    "path-4-decor": {
+      "kind": "transit-path",
+      "from": 4,
+      "finaleDrop": true
+    },
     "station-5": {
       "kind": "station",
-      "station": 5
+      "station": 5,
+      "tier": "content"
+    },
+    "station-5-decor": {
+      "kind": "station",
+      "station": 5,
+      "tier": "content",
+      "finaleDrop": true
+    },
+    "proxy-5": {
+      "kind": "proxy",
+      "station": 5,
+      "tier": "content"
     },
     "path-5": {
       "kind": "transit-path",
       "from": 5
     },
+    "path-5-decor": {
+      "kind": "transit-path",
+      "from": 5,
+      "finaleDrop": true
+    },
     "station-6": {
       "kind": "station",
-      "station": 6
+      "station": 6,
+      "tier": "content"
+    },
+    "station-6-decor": {
+      "kind": "station",
+      "station": 6,
+      "tier": "content",
+      "finaleDrop": true
+    },
+    "proxy-6": {
+      "kind": "proxy",
+      "station": 6,
+      "tier": "content"
     },
     "path-6": {
       "kind": "transit-path",
       "from": 6
     },
+    "path-6-decor": {
+      "kind": "transit-path",
+      "from": 6,
+      "finaleDrop": true
+    },
     "station-7": {
       "kind": "station",
-      "station": 7
+      "station": 7,
+      "tier": "content"
+    },
+    "station-7-decor": {
+      "kind": "station",
+      "station": 7,
+      "tier": "content",
+      "finaleDrop": true
+    },
+    "proxy-7": {
+      "kind": "proxy",
+      "station": 7,
+      "tier": "content"
     },
     "path-7": {
       "kind": "transit-path",
       "from": 7
     },
+    "path-7-decor": {
+      "kind": "transit-path",
+      "from": 7,
+      "finaleDrop": true
+    },
     "station-8": {
       "kind": "station",
-      "station": 8
+      "station": 8,
+      "tier": "content"
+    },
+    "station-8-decor": {
+      "kind": "station",
+      "station": 8,
+      "tier": "content",
+      "finaleDrop": true
+    },
+    "proxy-8": {
+      "kind": "proxy",
+      "station": 8,
+      "tier": "content"
     },
     "path-8": {
       "kind": "transit-path",
       "from": 8
     },
+    "path-8-decor": {
+      "kind": "transit-path",
+      "from": 8,
+      "finaleDrop": true
+    },
     "station-9": {
       "kind": "station",
-      "station": 9
+      "station": 9,
+      "tier": "content"
+    },
+    "station-9-decor": {
+      "kind": "station",
+      "station": 9,
+      "tier": "content",
+      "finaleDrop": true
+    },
+    "proxy-9": {
+      "kind": "proxy",
+      "station": 9,
+      "tier": "content"
     },
     "path-9": {
       "kind": "transit-path",
       "from": 9
     },
+    "path-9-decor": {
+      "kind": "transit-path",
+      "from": 9,
+      "finaleDrop": true
+    },
     "station-10": {
       "kind": "station",
-      "station": 10
+      "station": 10,
+      "tier": "content"
+    },
+    "station-10-decor": {
+      "kind": "station",
+      "station": 10,
+      "tier": "content",
+      "finaleDrop": true
+    },
+    "proxy-10": {
+      "kind": "proxy",
+      "station": 10,
+      "tier": "content"
     },
     "path-10": {
       "kind": "transit-path",
       "from": 10
     },
+    "path-10-decor": {
+      "kind": "transit-path",
+      "from": 10,
+      "finaleDrop": true
+    },
     "station-11": {
       "kind": "station",
-      "station": 11
+      "station": 11,
+      "tier": "content"
+    },
+    "station-11-decor": {
+      "kind": "station",
+      "station": 11,
+      "tier": "content",
+      "finaleDrop": true
+    },
+    "proxy-11": {
+      "kind": "proxy",
+      "station": 11,
+      "tier": "content"
     },
     "path-11": {
       "kind": "transit-path",
       "from": 11
     },
+    "path-11-decor": {
+      "kind": "transit-path",
+      "from": 11,
+      "finaleDrop": true
+    },
     "station-12": {
       "kind": "station",
-      "station": 12
+      "station": 12,
+      "tier": "content"
+    },
+    "station-12-decor": {
+      "kind": "station",
+      "station": 12,
+      "tier": "content",
+      "finaleDrop": true
+    },
+    "proxy-12": {
+      "kind": "proxy",
+      "station": 12,
+      "tier": "content"
     },
     "massing": {
       "kind": "dressing",
@@ -411,6 +627,15 @@
     },
     "mat-35": {
       "hue": 0.62,
+      "sat": 0.22,
+      "value": 0.2,
+      "metal": 0,
+      "glow": 0,
+      "kind": "normal",
+      "roughness": 0.6
+    },
+    "mat-36": {
+      "hue": 0.62,
       "sat": 0.28,
       "value": 0.32,
       "metal": 0,
@@ -418,7 +643,7 @@
       "kind": "normal",
       "roughness": 0.85
     },
-    "mat-36": {
+    "mat-37": {
       "hue": 0.62,
       "sat": 0.25,
       "value": 0.14,
@@ -4202,6 +4427,162 @@
       "collection": "station-12"
     },
     {
+      "id": "proxy-0",
+      "collection": "proxy-0",
+      "type": "box",
+      "args": {
+        "dims": [22.475, 19.3, 26.95]
+      },
+      "transform": {
+        "translate": [0.21249999999999947, 9.65, -14.575000000000001]
+      },
+      "material": "mat-35"
+    },
+    {
+      "id": "proxy-1",
+      "collection": "proxy-1",
+      "type": "box",
+      "args": {
+        "dims": [7.815803487450424, 2.62, 5.200000000000003]
+      },
+      "transform": {
+        "translate": [7.160644679210783, 1.31, 37.87437339043131]
+      },
+      "material": "mat-35"
+    },
+    {
+      "id": "proxy-2",
+      "collection": "proxy-2",
+      "type": "box",
+      "args": {
+        "dims": [13.090000000000007, 4.800000000000001, 8.5]
+      },
+      "transform": {
+        "translate": [35.07204451288551, 2.4000000000000004, 20.420180761486847]
+      },
+      "material": "mat-35"
+    },
+    {
+      "id": "proxy-3",
+      "collection": "proxy-3",
+      "type": "box",
+      "args": {
+        "dims": [13.090000000000003, 4.800000000000001, 8.5]
+      },
+      "transform": {
+        "translate": [41.594353912369, 2.4000000000000004, 5.928203762035231]
+      },
+      "material": "mat-35"
+    },
+    {
+      "id": "proxy-4",
+      "collection": "proxy-4",
+      "type": "box",
+      "args": {
+        "dims": [13.090000000000003, 4.800000000000001, 8.500000000000002]
+      },
+      "transform": {
+        "translate": [41.914373390431315, 2.4000000000000004, -9.960644679210784]
+      },
+      "material": "mat-35"
+    },
+    {
+      "id": "proxy-5",
+      "collection": "proxy-5",
+      "type": "box",
+      "args": {
+        "dims": [13.090000000000007, 4.800000000000001, 8.5]
+      },
+      "transform": {
+        "translate": [35.98088667372333, 2.4000000000000004, -24.703495578472943]
+      },
+      "material": "mat-35"
+    },
+    {
+      "id": "proxy-6",
+      "collection": "proxy-6",
+      "type": "box",
+      "args": {
+        "dims": [9.099999999999994, 4.55, 2]
+      },
+      "transform": {
+        "translate": [21.903495578472953, 2.275, -33.14088667372333]
+      },
+      "material": "mat-35"
+    },
+    {
+      "id": "proxy-7",
+      "collection": "proxy-7",
+      "type": "box",
+      "args": {
+        "dims": [10.660325427650136, 6.480307652106461, 8.620701580479576]
+      },
+      "transform": {
+        "translate": [-7.5923854298419595, 3.2401538260532305, -39.2478865762433]
+      },
+      "material": "mat-35"
+    },
+    {
+      "id": "proxy-8",
+      "collection": "proxy-8",
+      "type": "box",
+      "args": {
+        "dims": [2, 3.6000000000000005, 2]
+      },
+      "transform": {
+        "translate": [-21.903495578472956, 1.8000000000000003, -33.14088667372332]
+      },
+      "material": "mat-35"
+    },
+    {
+      "id": "proxy-9",
+      "collection": "proxy-9",
+      "type": "box",
+      "args": {
+        "dims": [14.360000000000003, 4.800000000000001, 8.5]
+      },
+      "transform": {
+        "translate": [-30.300886673723326, 2.4000000000000004, -24.703495578472953]
+      },
+      "material": "mat-35"
+    },
+    {
+      "id": "proxy-10",
+      "collection": "proxy-10",
+      "type": "box",
+      "args": {
+        "dims": [4.8908965343808575, 3.95, 5.141709530190581]
+      },
+      "transform": {
+        "translate": [-39.07437339043131, 1.975, 7.031499444306068]
+      },
+      "material": "mat-35"
+    },
+    {
+      "id": "proxy-11",
+      "collection": "proxy-11",
+      "type": "box",
+      "args": {
+        "dims": [14.919999999999998, 5.41, 7.560000000000002]
+      },
+      "transform": {
+        "translate": [-32.94088667372331, 2.705, 18.63349557847297]
+      },
+      "material": "mat-35"
+    },
+    {
+      "id": "proxy-12",
+      "collection": "proxy-12",
+      "type": "box",
+      "args": {
+        "dims": [9.280000000000001, 4.800000000000001, 8.500000000000004]
+      },
+      "transform": {
+        "translate": [-19.063495578472924, 2.4000000000000004, 30.340886673723347]
+      },
+      "material": "mat-35"
+    },
+    {
       "id": "massing-center-0",
       "type": "box",
       "args": {
@@ -4210,7 +4591,7 @@
       "transform": {
         "translate": [0, 3.2, -6]
       },
-      "material": "mat-35",
+      "material": "mat-36",
       "collection": "massing"
     },
     {
@@ -4222,7 +4603,7 @@
       "transform": {
         "translate": [-2.6, 2.4, -11]
       },
-      "material": "mat-35",
+      "material": "mat-36",
       "collection": "massing"
     },
     {
@@ -4234,7 +4615,7 @@
       "transform": {
         "translate": [2.8, 2.9, -15]
       },
-      "material": "mat-35",
+      "material": "mat-36",
       "collection": "massing"
     },
     {
@@ -4246,7 +4627,7 @@
       "transform": {
         "translate": [13.28931596488358, -2.8800000000000003, 72.5174502266342]
       },
-      "material": "mat-35",
+      "material": "mat-36",
       "collection": "massing"
     },
     {
@@ -4258,7 +4639,7 @@
       "transform": {
         "translate": [16.03331596488358, 2.5600000000000005, 71.53745022663419]
       },
-      "material": "mat-35",
+      "material": "mat-36",
       "collection": "massing"
     },
     {
@@ -4270,7 +4651,7 @@
       "transform": {
         "translate": [72.51745022663418, -4.365, -13.289315964883572]
       },
-      "material": "mat-35",
+      "material": "mat-36",
       "collection": "massing"
     },
     {
@@ -4282,7 +4663,7 @@
       "transform": {
         "translate": [76.43745022663418, 3.88, -14.689315964883573]
       },
-      "material": "mat-35",
+      "material": "mat-36",
       "collection": "massing"
     },
     {
@@ -4294,7 +4675,7 @@
       "transform": {
         "translate": [-40.65031662901047, -3.375, -61.50559538894061]
       },
-      "material": "mat-35",
+      "material": "mat-36",
       "collection": "massing"
     },
     {
@@ -4306,7 +4687,7 @@
       "transform": {
         "translate": [-37.514316629010466, 3, -62.62559538894061]
       },
-      "material": "mat-35",
+      "material": "mat-36",
       "collection": "massing"
     },
     {
@@ -4318,7 +4699,7 @@
       "transform": {
         "translate": [-61.5055953889406, -3.375, 40.65031662901049]
       },
-      "material": "mat-35",
+      "material": "mat-36",
       "collection": "massing"
     },
     {
@@ -4330,7 +4711,7 @@
       "transform": {
         "translate": [-58.369595388940596, 3, 39.53031662901049]
       },
-      "material": "mat-35",
+      "material": "mat-36",
       "collection": "massing"
     },
     {
@@ -4343,7 +4724,7 @@
         "translate": [1.2263089363890987, 7.016592952333921, 146.67096777177466],
         "rotate": [0, 0, 0]
       },
-      "material": "mat-36",
+      "material": "mat-37",
       "collection": "horizon"
     },
     {
@@ -4356,7 +4737,7 @@
         "translate": [64.5329298516853, 7.62296579657653, 91.08047383992307],
         "rotate": [0, 0.34528374665954953, 0]
       },
-      "material": "mat-36",
+      "material": "mat-37",
       "collection": "horizon"
     },
     {
@@ -4369,7 +4750,7 @@
         "translate": [43.39754332424673, 4.819555072083943, 56.41238060860907],
         "rotate": [0, -0.3486303089654353, 0]
       },
-      "material": "mat-36",
+      "material": "mat-37",
       "collection": "horizon"
     },
     {
@@ -4382,7 +4763,7 @@
         "translate": [134.46622904649587, 4.842001421418689, -17.175477915113298],
         "rotate": [0, 0.006725560193740241, 0]
       },
-      "material": "mat-36",
+      "material": "mat-37",
       "collection": "horizon"
     },
     {
@@ -4395,7 +4776,7 @@
         "translate": [134.66618037907008, 7.640377316314558, 14.168395165144068],
         "rotate": [0, 0.3418395632353122, 0]
       },
-      "material": "mat-36",
+      "material": "mat-37",
       "collection": "horizon"
     },
     {
@@ -4408,7 +4789,7 @@
         "translate": [42.816902701975984, 6.990241111126378, -60.495683719332064],
         "rotate": [0, -0.35187830398866804, 0]
       },
-      "material": "mat-36",
+      "material": "mat-37",
       "collection": "horizon"
     },
     {
@@ -4421,7 +4802,7 @@
         "translate": [65.80315081682447, 4.3376940527581525, -93.36080373692268],
         "rotate": [0, 0.01344921888845539, 0]
       },
-      "material": "mat-36",
+      "material": "mat-37",
       "collection": "horizon"
     },
     {
@@ -4434,7 +4815,7 @@
         "translate": [-1.3953903972815036, 5.582809968766616, -150.31673056098157],
         "rotate": [0, 0.33829873245717335, 0]
       },
-      "material": "mat-36",
+      "material": "mat-37",
       "collection": "horizon"
     },
     {
@@ -4447,7 +4828,7 @@
         "translate": [-45.43582032906106, 7.956071234520032, -72.65186988494834],
         "rotate": [0, -0.35502681343260184, 0]
       },
-      "material": "mat-36",
+      "material": "mat-37",
       "collection": "horizon"
     },
     {
@@ -4460,7 +4841,7 @@
         "translate": [-52.155267541445745, 6.178620822448911, -73.67225718275498],
         "rotate": [0, 0.020169075122725907, 0]
       },
-      "material": "mat-36",
+      "material": "mat-37",
       "collection": "horizon"
     },
     {
@@ -4473,7 +4854,7 @@
         "translate": [-148.08101776841508, 4.204050667126552, 14.763947213869454],
         "rotate": [0, 0.33466225541442246, 0]
       },
-      "material": "mat-36",
+      "material": "mat-37",
       "collection": "horizon"
     },
     {
@@ -4486,7 +4867,7 @@
         "translate": [-104.28482505381457, 6.424407144257572, -14.704759955716549],
         "rotate": [0, -0.35807494712787274, 0]
       },
-      "material": "mat-36",
+      "material": "mat-37",
       "collection": "horizon"
     },
     {
@@ -4499,7 +4880,7 @@
         "translate": [-40.94467813570855, 7.900940120366205, 59.06064086865428],
         "rotate": [0, 0.02688322901019139, 0]
       },
-      "material": "mat-36",
+      "material": "mat-37",
       "collection": "horizon"
     },
     {
@@ -4512,7 +4893,7 @@
         "translate": [-80.49790324126236, 5.34938983448815, 110.4302823633431],
         "rotate": [0, 0.3309311602381515, 0]
       },
-      "material": "mat-36",
+      "material": "mat-37",
       "collection": "horizon"
     }
   ],
@@ -6878,6 +7259,7 @@
     {
       "kind": "finale",
       "stations": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12],
+      "anchor": 0,
       "start": 6.4,
       "end": 8.600000000000001
     },
@@ -7085,6 +7467,7 @@
     {
       "kind": "finale",
       "stations": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12],
+      "anchor": 12,
       "start": 153.8,
       "end": 156.8
     }

--- a/sdf-js/fixtures/golden/assemble-deck-grid.json
+++ b/sdf-js/fixtures/golden/assemble-deck-grid.json
@@ -4,103 +4,319 @@
   "collections": {
     "station-0": {
       "kind": "station",
-      "station": 0
+      "station": 0,
+      "tier": "hero"
+    },
+    "station-0-decor": {
+      "kind": "station",
+      "station": 0,
+      "tier": "hero",
+      "finaleDrop": true
+    },
+    "proxy-0": {
+      "kind": "proxy",
+      "station": 0,
+      "tier": "hero"
     },
     "path-0": {
       "kind": "transit-path",
       "from": 0
     },
+    "path-0-decor": {
+      "kind": "transit-path",
+      "from": 0,
+      "finaleDrop": true
+    },
     "station-1": {
       "kind": "station",
-      "station": 1
+      "station": 1,
+      "tier": "hero"
+    },
+    "station-1-decor": {
+      "kind": "station",
+      "station": 1,
+      "tier": "hero",
+      "finaleDrop": true
+    },
+    "proxy-1": {
+      "kind": "proxy",
+      "station": 1,
+      "tier": "hero"
     },
     "path-1": {
       "kind": "transit-path",
       "from": 1
     },
+    "path-1-decor": {
+      "kind": "transit-path",
+      "from": 1,
+      "finaleDrop": true
+    },
     "station-2": {
       "kind": "station",
-      "station": 2
+      "station": 2,
+      "tier": "content"
+    },
+    "station-2-decor": {
+      "kind": "station",
+      "station": 2,
+      "tier": "content",
+      "finaleDrop": true
+    },
+    "proxy-2": {
+      "kind": "proxy",
+      "station": 2,
+      "tier": "content"
     },
     "path-2": {
       "kind": "transit-path",
       "from": 2
     },
+    "path-2-decor": {
+      "kind": "transit-path",
+      "from": 2,
+      "finaleDrop": true
+    },
     "station-3": {
       "kind": "station",
-      "station": 3
+      "station": 3,
+      "tier": "content"
+    },
+    "station-3-decor": {
+      "kind": "station",
+      "station": 3,
+      "tier": "content",
+      "finaleDrop": true
+    },
+    "proxy-3": {
+      "kind": "proxy",
+      "station": 3,
+      "tier": "content"
     },
     "path-3": {
       "kind": "transit-path",
       "from": 3
     },
+    "path-3-decor": {
+      "kind": "transit-path",
+      "from": 3,
+      "finaleDrop": true
+    },
     "station-4": {
       "kind": "station",
-      "station": 4
+      "station": 4,
+      "tier": "content"
+    },
+    "station-4-decor": {
+      "kind": "station",
+      "station": 4,
+      "tier": "content",
+      "finaleDrop": true
+    },
+    "proxy-4": {
+      "kind": "proxy",
+      "station": 4,
+      "tier": "content"
     },
     "path-4": {
       "kind": "transit-path",
       "from": 4
     },
+    "path-4-decor": {
+      "kind": "transit-path",
+      "from": 4,
+      "finaleDrop": true
+    },
     "station-5": {
       "kind": "station",
-      "station": 5
+      "station": 5,
+      "tier": "content"
+    },
+    "station-5-decor": {
+      "kind": "station",
+      "station": 5,
+      "tier": "content",
+      "finaleDrop": true
+    },
+    "proxy-5": {
+      "kind": "proxy",
+      "station": 5,
+      "tier": "content"
     },
     "path-5": {
       "kind": "transit-path",
       "from": 5
     },
+    "path-5-decor": {
+      "kind": "transit-path",
+      "from": 5,
+      "finaleDrop": true
+    },
     "station-6": {
       "kind": "station",
-      "station": 6
+      "station": 6,
+      "tier": "content"
+    },
+    "station-6-decor": {
+      "kind": "station",
+      "station": 6,
+      "tier": "content",
+      "finaleDrop": true
+    },
+    "proxy-6": {
+      "kind": "proxy",
+      "station": 6,
+      "tier": "content"
     },
     "path-6": {
       "kind": "transit-path",
       "from": 6
     },
+    "path-6-decor": {
+      "kind": "transit-path",
+      "from": 6,
+      "finaleDrop": true
+    },
     "station-7": {
       "kind": "station",
-      "station": 7
+      "station": 7,
+      "tier": "content"
+    },
+    "station-7-decor": {
+      "kind": "station",
+      "station": 7,
+      "tier": "content",
+      "finaleDrop": true
+    },
+    "proxy-7": {
+      "kind": "proxy",
+      "station": 7,
+      "tier": "content"
     },
     "path-7": {
       "kind": "transit-path",
       "from": 7
     },
+    "path-7-decor": {
+      "kind": "transit-path",
+      "from": 7,
+      "finaleDrop": true
+    },
     "station-8": {
       "kind": "station",
-      "station": 8
+      "station": 8,
+      "tier": "content"
+    },
+    "station-8-decor": {
+      "kind": "station",
+      "station": 8,
+      "tier": "content",
+      "finaleDrop": true
+    },
+    "proxy-8": {
+      "kind": "proxy",
+      "station": 8,
+      "tier": "content"
     },
     "path-8": {
       "kind": "transit-path",
       "from": 8
     },
+    "path-8-decor": {
+      "kind": "transit-path",
+      "from": 8,
+      "finaleDrop": true
+    },
     "station-9": {
       "kind": "station",
-      "station": 9
+      "station": 9,
+      "tier": "content"
+    },
+    "station-9-decor": {
+      "kind": "station",
+      "station": 9,
+      "tier": "content",
+      "finaleDrop": true
+    },
+    "proxy-9": {
+      "kind": "proxy",
+      "station": 9,
+      "tier": "content"
     },
     "path-9": {
       "kind": "transit-path",
       "from": 9
     },
+    "path-9-decor": {
+      "kind": "transit-path",
+      "from": 9,
+      "finaleDrop": true
+    },
     "station-10": {
       "kind": "station",
-      "station": 10
+      "station": 10,
+      "tier": "content"
+    },
+    "station-10-decor": {
+      "kind": "station",
+      "station": 10,
+      "tier": "content",
+      "finaleDrop": true
+    },
+    "proxy-10": {
+      "kind": "proxy",
+      "station": 10,
+      "tier": "content"
     },
     "path-10": {
       "kind": "transit-path",
       "from": 10
     },
+    "path-10-decor": {
+      "kind": "transit-path",
+      "from": 10,
+      "finaleDrop": true
+    },
     "station-11": {
       "kind": "station",
-      "station": 11
+      "station": 11,
+      "tier": "content"
+    },
+    "station-11-decor": {
+      "kind": "station",
+      "station": 11,
+      "tier": "content",
+      "finaleDrop": true
+    },
+    "proxy-11": {
+      "kind": "proxy",
+      "station": 11,
+      "tier": "content"
     },
     "path-11": {
       "kind": "transit-path",
       "from": 11
     },
+    "path-11-decor": {
+      "kind": "transit-path",
+      "from": 11,
+      "finaleDrop": true
+    },
     "station-12": {
       "kind": "station",
-      "station": 12
+      "station": 12,
+      "tier": "content"
+    },
+    "station-12-decor": {
+      "kind": "station",
+      "station": 12,
+      "tier": "content",
+      "finaleDrop": true
+    },
+    "proxy-12": {
+      "kind": "proxy",
+      "station": 12,
+      "tier": "content"
     },
     "massing": {
       "kind": "dressing",
@@ -410,6 +626,15 @@
       "clearcoat": 0.45
     },
     "mat-35": {
+      "hue": 0.62,
+      "sat": 0.22,
+      "value": 0.2,
+      "metal": 0,
+      "glow": 0,
+      "kind": "normal",
+      "roughness": 0.6
+    },
+    "mat-36": {
       "hue": 0.62,
       "sat": 0.25,
       "value": 0.14,
@@ -4193,6 +4418,162 @@
       "collection": "station-12"
     },
     {
+      "id": "proxy-0",
+      "collection": "proxy-0",
+      "type": "box",
+      "args": {
+        "dims": [22.475, 19.3, 26.95]
+      },
+      "transform": {
+        "translate": [0.21249999999999947, 9.65, -14.575000000000001]
+      },
+      "material": "mat-35"
+    },
+    {
+      "id": "proxy-1",
+      "collection": "proxy-1",
+      "type": "box",
+      "args": {
+        "dims": [7.815803487450427, 2.62, 5.2]
+      },
+      "transform": {
+        "translate": [16, 1.31, -1.1999999999999997]
+      },
+      "material": "mat-35"
+    },
+    {
+      "id": "proxy-2",
+      "collection": "proxy-2",
+      "type": "box",
+      "args": {
+        "dims": [13.090000000000007, 4.800000000000001, 8.5]
+      },
+      "transform": {
+        "translate": [34.84, 2.4000000000000004, -2.8000000000000003]
+      },
+      "material": "mat-35"
+    },
+    {
+      "id": "proxy-3",
+      "collection": "proxy-3",
+      "type": "box",
+      "args": {
+        "dims": [13.090000000000003, 4.800000000000001, 8.5]
+      },
+      "transform": {
+        "translate": [50.84, 2.4000000000000004, -2.8000000000000003]
+      },
+      "material": "mat-35"
+    },
+    {
+      "id": "proxy-4",
+      "collection": "proxy-4",
+      "type": "box",
+      "args": {
+        "dims": [13.09, 4.800000000000001, 8.5]
+      },
+      "transform": {
+        "translate": [2.84, 2.4000000000000004, -18.8]
+      },
+      "material": "mat-35"
+    },
+    {
+      "id": "proxy-5",
+      "collection": "proxy-5",
+      "type": "box",
+      "args": {
+        "dims": [13.090000000000002, 4.800000000000001, 8.5]
+      },
+      "transform": {
+        "translate": [18.84, 2.4000000000000004, -18.8]
+      },
+      "material": "mat-35"
+    },
+    {
+      "id": "proxy-6",
+      "collection": "proxy-6",
+      "type": "box",
+      "args": {
+        "dims": [9.099999999999994, 4.55, 2]
+      },
+      "transform": {
+        "translate": [32, 2.275, -16]
+      },
+      "material": "mat-35"
+    },
+    {
+      "id": "proxy-7",
+      "collection": "proxy-7",
+      "type": "box",
+      "args": {
+        "dims": [10.660325427650129, 6.480307652106461, 8.620701580479576]
+      },
+      "transform": {
+        "translate": [47.56825924936882, 3.2401538260532305, -16.17351318581199]
+      },
+      "material": "mat-35"
+    },
+    {
+      "id": "proxy-8",
+      "collection": "proxy-8",
+      "type": "box",
+      "args": {
+        "dims": [2, 3.6000000000000005, 2]
+      },
+      "transform": {
+        "translate": [0, 1.8000000000000003, -32]
+      },
+      "material": "mat-35"
+    },
+    {
+      "id": "proxy-9",
+      "collection": "proxy-9",
+      "type": "box",
+      "args": {
+        "dims": [14.36, 4.800000000000001, 8.499999999999996]
+      },
+      "transform": {
+        "translate": [18.84, 2.4000000000000004, -34.8]
+      },
+      "material": "mat-35"
+    },
+    {
+      "id": "proxy-10",
+      "collection": "proxy-10",
+      "type": "box",
+      "args": {
+        "dims": [4.890896534380861, 3.95, 5.141709530190575]
+      },
+      "transform": {
+        "translate": [32, 1.975, -32.12914523490471]
+      },
+      "material": "mat-35"
+    },
+    {
+      "id": "proxy-11",
+      "collection": "proxy-11",
+      "type": "box",
+      "args": {
+        "dims": [14.920000000000002, 5.41, 7.559999999999999]
+      },
+      "transform": {
+        "translate": [48.2, 2.705, -35.269999999999996]
+      },
+      "material": "mat-35"
+    },
+    {
+      "id": "proxy-12",
+      "collection": "proxy-12",
+      "type": "box",
+      "args": {
+        "dims": [9.280000000000001, 4.800000000000001, 8.5]
+      },
+      "transform": {
+        "translate": [2.8400000000000003, 2.4000000000000004, -50.8]
+      },
+      "material": "mat-35"
+    },
+    {
       "id": "horizon-0",
       "type": "box",
       "args": {
@@ -4202,7 +4583,7 @@
         "translate": [22.153846153846153, 7.016592952333921, 129.98604452013421],
         "rotate": [0, 0, 0]
       },
-      "material": "mat-35",
+      "material": "mat-36",
       "collection": "horizon"
     },
     {
@@ -4215,7 +4596,7 @@
         "translate": [85.46046706914235, 7.62296579657653, 74.39555058828262],
         "rotate": [0, 0.34528374665954953, 0]
       },
-      "material": "mat-35",
+      "material": "mat-36",
       "collection": "horizon"
     },
     {
@@ -4228,7 +4609,7 @@
         "translate": [64.32508054170378, 4.819555072083943, 39.72745735696862],
         "rotate": [0, -0.3486303089654353, 0]
       },
-      "material": "mat-35",
+      "material": "mat-36",
       "collection": "horizon"
     },
     {
@@ -4241,7 +4622,7 @@
         "translate": [155.39376626395293, 4.842001421418689, -33.860401166753746],
         "rotate": [0, 0.006725560193740241, 0]
       },
-      "material": "mat-35",
+      "material": "mat-36",
       "collection": "horizon"
     },
     {
@@ -4254,7 +4635,7 @@
         "translate": [155.59371759652714, 7.640377316314558, -2.516528086496381],
         "rotate": [0, 0.3418395632353122, 0]
       },
-      "material": "mat-35",
+      "material": "mat-36",
       "collection": "horizon"
     },
     {
@@ -4267,7 +4648,7 @@
         "translate": [63.74443991943304, 6.990241111126378, -77.18060697097252],
         "rotate": [0, -0.35187830398866804, 0]
       },
-      "material": "mat-35",
+      "material": "mat-36",
       "collection": "horizon"
     },
     {
@@ -4280,7 +4661,7 @@
         "translate": [86.73068803428151, 4.3376940527581525, -110.04572698856313],
         "rotate": [0, 0.01344921888845539, 0]
       },
-      "material": "mat-35",
+      "material": "mat-36",
       "collection": "horizon"
     },
     {
@@ -4293,7 +4674,7 @@
         "translate": [19.53214682017555, 5.582809968766616, -167.001653812622],
         "rotate": [0, 0.33829873245717335, 0]
       },
-      "material": "mat-35",
+      "material": "mat-36",
       "collection": "horizon"
     },
     {
@@ -4306,7 +4687,7 @@
         "translate": [-24.508283111604, 7.956071234520032, -89.3367931365888],
         "rotate": [0, -0.35502681343260184, 0]
       },
-      "material": "mat-35",
+      "material": "mat-36",
       "collection": "horizon"
     },
     {
@@ -4319,7 +4700,7 @@
         "translate": [-31.227730323988688, 6.178620822448911, -90.35718043439542],
         "rotate": [0, 0.020169075122725907, 0]
       },
-      "material": "mat-35",
+      "material": "mat-36",
       "collection": "horizon"
     },
     {
@@ -4332,7 +4713,7 @@
         "translate": [-127.15348055095802, 4.204050667126552, -1.9209760377709948],
         "rotate": [0, 0.33466225541442246, 0]
       },
-      "material": "mat-35",
+      "material": "mat-36",
       "collection": "horizon"
     },
     {
@@ -4345,7 +4726,7 @@
         "translate": [-83.35728783635753, 6.424407144257572, -31.389683207356995],
         "rotate": [0, -0.35807494712787274, 0]
       },
-      "material": "mat-35",
+      "material": "mat-36",
       "collection": "horizon"
     },
     {
@@ -4358,7 +4739,7 @@
         "translate": [-20.017140918251492, 7.900940120366205, 42.375717617013834],
         "rotate": [0, 0.02688322901019139, 0]
       },
-      "material": "mat-35",
+      "material": "mat-36",
       "collection": "horizon"
     },
     {
@@ -4371,7 +4752,7 @@
         "translate": [-59.57036602380531, 5.34938983448815, 93.74535911170264],
         "rotate": [0, 0.3309311602381515, 0]
       },
-      "material": "mat-35",
+      "material": "mat-36",
       "collection": "horizon"
     }
   ],
@@ -6871,6 +7252,7 @@
     {
       "kind": "finale",
       "stations": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12],
+      "anchor": 12,
       "start": 148.30000000000004,
       "end": 151.30000000000004
     }

--- a/sdf-js/fixtures/golden/assemble-deck-line.json
+++ b/sdf-js/fixtures/golden/assemble-deck-line.json
@@ -4,103 +4,319 @@
   "collections": {
     "station-0": {
       "kind": "station",
-      "station": 0
+      "station": 0,
+      "tier": "hero"
+    },
+    "station-0-decor": {
+      "kind": "station",
+      "station": 0,
+      "tier": "hero",
+      "finaleDrop": true
+    },
+    "proxy-0": {
+      "kind": "proxy",
+      "station": 0,
+      "tier": "hero"
     },
     "path-0": {
       "kind": "transit-path",
       "from": 0
     },
+    "path-0-decor": {
+      "kind": "transit-path",
+      "from": 0,
+      "finaleDrop": true
+    },
     "station-1": {
       "kind": "station",
-      "station": 1
+      "station": 1,
+      "tier": "hero"
+    },
+    "station-1-decor": {
+      "kind": "station",
+      "station": 1,
+      "tier": "hero",
+      "finaleDrop": true
+    },
+    "proxy-1": {
+      "kind": "proxy",
+      "station": 1,
+      "tier": "hero"
     },
     "path-1": {
       "kind": "transit-path",
       "from": 1
     },
+    "path-1-decor": {
+      "kind": "transit-path",
+      "from": 1,
+      "finaleDrop": true
+    },
     "station-2": {
       "kind": "station",
-      "station": 2
+      "station": 2,
+      "tier": "content"
+    },
+    "station-2-decor": {
+      "kind": "station",
+      "station": 2,
+      "tier": "content",
+      "finaleDrop": true
+    },
+    "proxy-2": {
+      "kind": "proxy",
+      "station": 2,
+      "tier": "content"
     },
     "path-2": {
       "kind": "transit-path",
       "from": 2
     },
+    "path-2-decor": {
+      "kind": "transit-path",
+      "from": 2,
+      "finaleDrop": true
+    },
     "station-3": {
       "kind": "station",
-      "station": 3
+      "station": 3,
+      "tier": "content"
+    },
+    "station-3-decor": {
+      "kind": "station",
+      "station": 3,
+      "tier": "content",
+      "finaleDrop": true
+    },
+    "proxy-3": {
+      "kind": "proxy",
+      "station": 3,
+      "tier": "content"
     },
     "path-3": {
       "kind": "transit-path",
       "from": 3
     },
+    "path-3-decor": {
+      "kind": "transit-path",
+      "from": 3,
+      "finaleDrop": true
+    },
     "station-4": {
       "kind": "station",
-      "station": 4
+      "station": 4,
+      "tier": "content"
+    },
+    "station-4-decor": {
+      "kind": "station",
+      "station": 4,
+      "tier": "content",
+      "finaleDrop": true
+    },
+    "proxy-4": {
+      "kind": "proxy",
+      "station": 4,
+      "tier": "content"
     },
     "path-4": {
       "kind": "transit-path",
       "from": 4
     },
+    "path-4-decor": {
+      "kind": "transit-path",
+      "from": 4,
+      "finaleDrop": true
+    },
     "station-5": {
       "kind": "station",
-      "station": 5
+      "station": 5,
+      "tier": "content"
+    },
+    "station-5-decor": {
+      "kind": "station",
+      "station": 5,
+      "tier": "content",
+      "finaleDrop": true
+    },
+    "proxy-5": {
+      "kind": "proxy",
+      "station": 5,
+      "tier": "content"
     },
     "path-5": {
       "kind": "transit-path",
       "from": 5
     },
+    "path-5-decor": {
+      "kind": "transit-path",
+      "from": 5,
+      "finaleDrop": true
+    },
     "station-6": {
       "kind": "station",
-      "station": 6
+      "station": 6,
+      "tier": "content"
+    },
+    "station-6-decor": {
+      "kind": "station",
+      "station": 6,
+      "tier": "content",
+      "finaleDrop": true
+    },
+    "proxy-6": {
+      "kind": "proxy",
+      "station": 6,
+      "tier": "content"
     },
     "path-6": {
       "kind": "transit-path",
       "from": 6
     },
+    "path-6-decor": {
+      "kind": "transit-path",
+      "from": 6,
+      "finaleDrop": true
+    },
     "station-7": {
       "kind": "station",
-      "station": 7
+      "station": 7,
+      "tier": "content"
+    },
+    "station-7-decor": {
+      "kind": "station",
+      "station": 7,
+      "tier": "content",
+      "finaleDrop": true
+    },
+    "proxy-7": {
+      "kind": "proxy",
+      "station": 7,
+      "tier": "content"
     },
     "path-7": {
       "kind": "transit-path",
       "from": 7
     },
+    "path-7-decor": {
+      "kind": "transit-path",
+      "from": 7,
+      "finaleDrop": true
+    },
     "station-8": {
       "kind": "station",
-      "station": 8
+      "station": 8,
+      "tier": "content"
+    },
+    "station-8-decor": {
+      "kind": "station",
+      "station": 8,
+      "tier": "content",
+      "finaleDrop": true
+    },
+    "proxy-8": {
+      "kind": "proxy",
+      "station": 8,
+      "tier": "content"
     },
     "path-8": {
       "kind": "transit-path",
       "from": 8
     },
+    "path-8-decor": {
+      "kind": "transit-path",
+      "from": 8,
+      "finaleDrop": true
+    },
     "station-9": {
       "kind": "station",
-      "station": 9
+      "station": 9,
+      "tier": "content"
+    },
+    "station-9-decor": {
+      "kind": "station",
+      "station": 9,
+      "tier": "content",
+      "finaleDrop": true
+    },
+    "proxy-9": {
+      "kind": "proxy",
+      "station": 9,
+      "tier": "content"
     },
     "path-9": {
       "kind": "transit-path",
       "from": 9
     },
+    "path-9-decor": {
+      "kind": "transit-path",
+      "from": 9,
+      "finaleDrop": true
+    },
     "station-10": {
       "kind": "station",
-      "station": 10
+      "station": 10,
+      "tier": "content"
+    },
+    "station-10-decor": {
+      "kind": "station",
+      "station": 10,
+      "tier": "content",
+      "finaleDrop": true
+    },
+    "proxy-10": {
+      "kind": "proxy",
+      "station": 10,
+      "tier": "content"
     },
     "path-10": {
       "kind": "transit-path",
       "from": 10
     },
+    "path-10-decor": {
+      "kind": "transit-path",
+      "from": 10,
+      "finaleDrop": true
+    },
     "station-11": {
       "kind": "station",
-      "station": 11
+      "station": 11,
+      "tier": "content"
+    },
+    "station-11-decor": {
+      "kind": "station",
+      "station": 11,
+      "tier": "content",
+      "finaleDrop": true
+    },
+    "proxy-11": {
+      "kind": "proxy",
+      "station": 11,
+      "tier": "content"
     },
     "path-11": {
       "kind": "transit-path",
       "from": 11
     },
+    "path-11-decor": {
+      "kind": "transit-path",
+      "from": 11,
+      "finaleDrop": true
+    },
     "station-12": {
       "kind": "station",
-      "station": 12
+      "station": 12,
+      "tier": "content"
+    },
+    "station-12-decor": {
+      "kind": "station",
+      "station": 12,
+      "tier": "content",
+      "finaleDrop": true
+    },
+    "proxy-12": {
+      "kind": "proxy",
+      "station": 12,
+      "tier": "content"
     },
     "massing": {
       "kind": "dressing",
@@ -410,6 +626,15 @@
       "clearcoat": 0.45
     },
     "mat-35": {
+      "hue": 0.62,
+      "sat": 0.22,
+      "value": 0.2,
+      "metal": 0,
+      "glow": 0,
+      "kind": "normal",
+      "roughness": 0.6
+    },
+    "mat-36": {
       "hue": 0.62,
       "sat": 0.25,
       "value": 0.14,
@@ -4193,6 +4418,162 @@
       "collection": "station-12"
     },
     {
+      "id": "proxy-0",
+      "collection": "proxy-0",
+      "type": "box",
+      "args": {
+        "dims": [22.475, 19.3, 26.95]
+      },
+      "transform": {
+        "translate": [0.21249999999999947, 9.65, -14.575000000000001]
+      },
+      "material": "mat-35"
+    },
+    {
+      "id": "proxy-1",
+      "collection": "proxy-1",
+      "type": "box",
+      "args": {
+        "dims": [7.815803487450427, 2.62, 5.2]
+      },
+      "transform": {
+        "translate": [16, 1.31, -1.1999999999999997]
+      },
+      "material": "mat-35"
+    },
+    {
+      "id": "proxy-2",
+      "collection": "proxy-2",
+      "type": "box",
+      "args": {
+        "dims": [13.090000000000007, 4.800000000000001, 8.5]
+      },
+      "transform": {
+        "translate": [34.84, 2.4000000000000004, -2.8000000000000003]
+      },
+      "material": "mat-35"
+    },
+    {
+      "id": "proxy-3",
+      "collection": "proxy-3",
+      "type": "box",
+      "args": {
+        "dims": [13.090000000000003, 4.800000000000001, 8.5]
+      },
+      "transform": {
+        "translate": [50.84, 2.4000000000000004, -2.8000000000000003]
+      },
+      "material": "mat-35"
+    },
+    {
+      "id": "proxy-4",
+      "collection": "proxy-4",
+      "type": "box",
+      "args": {
+        "dims": [13.090000000000003, 4.800000000000001, 8.5]
+      },
+      "transform": {
+        "translate": [66.84, 2.4000000000000004, -2.8000000000000003]
+      },
+      "material": "mat-35"
+    },
+    {
+      "id": "proxy-5",
+      "collection": "proxy-5",
+      "type": "box",
+      "args": {
+        "dims": [13.090000000000003, 4.800000000000001, 8.5]
+      },
+      "transform": {
+        "translate": [82.84, 2.4000000000000004, -2.8000000000000003]
+      },
+      "material": "mat-35"
+    },
+    {
+      "id": "proxy-6",
+      "collection": "proxy-6",
+      "type": "box",
+      "args": {
+        "dims": [9.100000000000023, 4.55, 2]
+      },
+      "transform": {
+        "translate": [96, 2.275, 0]
+      },
+      "material": "mat-35"
+    },
+    {
+      "id": "proxy-7",
+      "collection": "proxy-7",
+      "type": "box",
+      "args": {
+        "dims": [10.66032542765015, 6.480307652106461, 8.620701580479576]
+      },
+      "transform": {
+        "translate": [111.56825924936882, 3.2401538260532305, -0.17351318581199138]
+      },
+      "material": "mat-35"
+    },
+    {
+      "id": "proxy-8",
+      "collection": "proxy-8",
+      "type": "box",
+      "args": {
+        "dims": [2, 3.6000000000000005, 2]
+      },
+      "transform": {
+        "translate": [128, 1.8000000000000003, 0]
+      },
+      "material": "mat-35"
+    },
+    {
+      "id": "proxy-9",
+      "collection": "proxy-9",
+      "type": "box",
+      "args": {
+        "dims": [14.359999999999985, 4.800000000000001, 8.5]
+      },
+      "transform": {
+        "translate": [146.83999999999997, 2.4000000000000004, -2.8000000000000003]
+      },
+      "material": "mat-35"
+    },
+    {
+      "id": "proxy-10",
+      "collection": "proxy-10",
+      "type": "box",
+      "args": {
+        "dims": [4.890896534380886, 3.95, 5.14170953019058]
+      },
+      "transform": {
+        "translate": [160, 1.975, -0.1291452349047102]
+      },
+      "material": "mat-35"
+    },
+    {
+      "id": "proxy-11",
+      "collection": "proxy-11",
+      "type": "box",
+      "args": {
+        "dims": [14.920000000000016, 5.41, 7.56]
+      },
+      "transform": {
+        "translate": [176.2, 2.705, -3.27]
+      },
+      "material": "mat-35"
+    },
+    {
+      "id": "proxy-12",
+      "collection": "proxy-12",
+      "type": "box",
+      "args": {
+        "dims": [9.280000000000001, 4.800000000000001, 8.5]
+      },
+      "transform": {
+        "translate": [194.83999999999997, 2.4000000000000004, -2.8000000000000003]
+      },
+      "material": "mat-35"
+    },
+    {
       "id": "horizon-0",
       "type": "box",
       "args": {
@@ -4202,7 +4583,7 @@
         "translate": [96, 7.016592952333921, 148.44758298167267],
         "rotate": [0, 0, 0]
       },
-      "material": "mat-35",
+      "material": "mat-36",
       "collection": "horizon"
     },
     {
@@ -4215,7 +4596,7 @@
         "translate": [159.3066209152962, 7.62296579657653, 92.85708904982108],
         "rotate": [0, 0.34528374665954953, 0]
       },
-      "material": "mat-35",
+      "material": "mat-36",
       "collection": "horizon"
     },
     {
@@ -4228,7 +4609,7 @@
         "translate": [138.17123438785762, 4.819555072083943, 58.18899581850708],
         "rotate": [0, -0.3486303089654353, 0]
       },
-      "material": "mat-35",
+      "material": "mat-36",
       "collection": "horizon"
     },
     {
@@ -4241,7 +4622,7 @@
         "translate": [229.23992011010677, 4.842001421418689, -15.398862705215285],
         "rotate": [0, 0.006725560193740241, 0]
       },
-      "material": "mat-35",
+      "material": "mat-36",
       "collection": "horizon"
     },
     {
@@ -4254,7 +4635,7 @@
         "translate": [229.43987144268098, 7.640377316314558, 15.945010375042079],
         "rotate": [0, 0.3418395632353122, 0]
       },
-      "material": "mat-35",
+      "material": "mat-36",
       "collection": "horizon"
     },
     {
@@ -4267,7 +4648,7 @@
         "translate": [137.5905937655869, 6.990241111126378, -58.71906850943405],
         "rotate": [0, -0.35187830398866804, 0]
       },
-      "material": "mat-35",
+      "material": "mat-36",
       "collection": "horizon"
     },
     {
@@ -4280,7 +4661,7 @@
         "translate": [160.57684188043538, 4.3376940527581525, -91.58418852702466],
         "rotate": [0, 0.01344921888845539, 0]
       },
-      "material": "mat-35",
+      "material": "mat-36",
       "collection": "horizon"
     },
     {
@@ -4293,7 +4674,7 @@
         "translate": [93.3783006663294, 5.582809968766616, -148.54011535108356],
         "rotate": [0, 0.33829873245717335, 0]
       },
-      "material": "mat-35",
+      "material": "mat-36",
       "collection": "horizon"
     },
     {
@@ -4306,7 +4687,7 @@
         "translate": [49.337870734549846, 7.956071234520032, -70.87525467505033],
         "rotate": [0, -0.35502681343260184, 0]
       },
-      "material": "mat-35",
+      "material": "mat-36",
       "collection": "horizon"
     },
     {
@@ -4319,7 +4700,7 @@
         "translate": [42.61842352216516, 6.178620822448911, -71.89564197285696],
         "rotate": [0, 0.020169075122725907, 0]
       },
-      "material": "mat-35",
+      "material": "mat-36",
       "collection": "horizon"
     },
     {
@@ -4332,7 +4713,7 @@
         "translate": [-53.30732670480418, 4.204050667126552, 16.540562423767465],
         "rotate": [0, 0.33466225541442246, 0]
       },
-      "material": "mat-35",
+      "material": "mat-36",
       "collection": "horizon"
     },
     {
@@ -4345,7 +4726,7 @@
         "translate": [-9.511133990203675, 6.424407144257572, -12.928144745818537],
         "rotate": [0, -0.35807494712787274, 0]
       },
-      "material": "mat-35",
+      "material": "mat-36",
       "collection": "horizon"
     },
     {
@@ -4358,7 +4739,7 @@
         "translate": [53.829012927902355, 7.900940120366205, 60.837256078552294],
         "rotate": [0, 0.02688322901019139, 0]
       },
-      "material": "mat-35",
+      "material": "mat-36",
       "collection": "horizon"
     },
     {
@@ -4371,7 +4752,7 @@
         "translate": [14.275787822348533, 5.34938983448815, 112.20689757324111],
         "rotate": [0, 0.3309311602381515, 0]
       },
-      "material": "mat-35",
+      "material": "mat-36",
       "collection": "horizon"
     }
   ],
@@ -6871,6 +7252,7 @@
     {
       "kind": "finale",
       "stations": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12],
+      "anchor": 12,
       "start": 148.30000000000004,
       "end": 151.30000000000004
     }

--- a/sdf-js/fixtures/golden/assemble-deck-radial.json
+++ b/sdf-js/fixtures/golden/assemble-deck-radial.json
@@ -4,103 +4,319 @@
   "collections": {
     "station-0": {
       "kind": "station",
-      "station": 0
+      "station": 0,
+      "tier": "hero"
+    },
+    "station-0-decor": {
+      "kind": "station",
+      "station": 0,
+      "tier": "hero",
+      "finaleDrop": true
+    },
+    "proxy-0": {
+      "kind": "proxy",
+      "station": 0,
+      "tier": "hero"
     },
     "path-0": {
       "kind": "transit-path",
       "from": 0
     },
+    "path-0-decor": {
+      "kind": "transit-path",
+      "from": 0,
+      "finaleDrop": true
+    },
     "station-1": {
       "kind": "station",
-      "station": 1
+      "station": 1,
+      "tier": "hero"
+    },
+    "station-1-decor": {
+      "kind": "station",
+      "station": 1,
+      "tier": "hero",
+      "finaleDrop": true
+    },
+    "proxy-1": {
+      "kind": "proxy",
+      "station": 1,
+      "tier": "hero"
     },
     "path-1": {
       "kind": "transit-path",
       "from": 1
     },
+    "path-1-decor": {
+      "kind": "transit-path",
+      "from": 1,
+      "finaleDrop": true
+    },
     "station-2": {
       "kind": "station",
-      "station": 2
+      "station": 2,
+      "tier": "content"
+    },
+    "station-2-decor": {
+      "kind": "station",
+      "station": 2,
+      "tier": "content",
+      "finaleDrop": true
+    },
+    "proxy-2": {
+      "kind": "proxy",
+      "station": 2,
+      "tier": "content"
     },
     "path-2": {
       "kind": "transit-path",
       "from": 2
     },
+    "path-2-decor": {
+      "kind": "transit-path",
+      "from": 2,
+      "finaleDrop": true
+    },
     "station-3": {
       "kind": "station",
-      "station": 3
+      "station": 3,
+      "tier": "content"
+    },
+    "station-3-decor": {
+      "kind": "station",
+      "station": 3,
+      "tier": "content",
+      "finaleDrop": true
+    },
+    "proxy-3": {
+      "kind": "proxy",
+      "station": 3,
+      "tier": "content"
     },
     "path-3": {
       "kind": "transit-path",
       "from": 3
     },
+    "path-3-decor": {
+      "kind": "transit-path",
+      "from": 3,
+      "finaleDrop": true
+    },
     "station-4": {
       "kind": "station",
-      "station": 4
+      "station": 4,
+      "tier": "content"
+    },
+    "station-4-decor": {
+      "kind": "station",
+      "station": 4,
+      "tier": "content",
+      "finaleDrop": true
+    },
+    "proxy-4": {
+      "kind": "proxy",
+      "station": 4,
+      "tier": "content"
     },
     "path-4": {
       "kind": "transit-path",
       "from": 4
     },
+    "path-4-decor": {
+      "kind": "transit-path",
+      "from": 4,
+      "finaleDrop": true
+    },
     "station-5": {
       "kind": "station",
-      "station": 5
+      "station": 5,
+      "tier": "content"
+    },
+    "station-5-decor": {
+      "kind": "station",
+      "station": 5,
+      "tier": "content",
+      "finaleDrop": true
+    },
+    "proxy-5": {
+      "kind": "proxy",
+      "station": 5,
+      "tier": "content"
     },
     "path-5": {
       "kind": "transit-path",
       "from": 5
     },
+    "path-5-decor": {
+      "kind": "transit-path",
+      "from": 5,
+      "finaleDrop": true
+    },
     "station-6": {
       "kind": "station",
-      "station": 6
+      "station": 6,
+      "tier": "content"
+    },
+    "station-6-decor": {
+      "kind": "station",
+      "station": 6,
+      "tier": "content",
+      "finaleDrop": true
+    },
+    "proxy-6": {
+      "kind": "proxy",
+      "station": 6,
+      "tier": "content"
     },
     "path-6": {
       "kind": "transit-path",
       "from": 6
     },
+    "path-6-decor": {
+      "kind": "transit-path",
+      "from": 6,
+      "finaleDrop": true
+    },
     "station-7": {
       "kind": "station",
-      "station": 7
+      "station": 7,
+      "tier": "content"
+    },
+    "station-7-decor": {
+      "kind": "station",
+      "station": 7,
+      "tier": "content",
+      "finaleDrop": true
+    },
+    "proxy-7": {
+      "kind": "proxy",
+      "station": 7,
+      "tier": "content"
     },
     "path-7": {
       "kind": "transit-path",
       "from": 7
     },
+    "path-7-decor": {
+      "kind": "transit-path",
+      "from": 7,
+      "finaleDrop": true
+    },
     "station-8": {
       "kind": "station",
-      "station": 8
+      "station": 8,
+      "tier": "content"
+    },
+    "station-8-decor": {
+      "kind": "station",
+      "station": 8,
+      "tier": "content",
+      "finaleDrop": true
+    },
+    "proxy-8": {
+      "kind": "proxy",
+      "station": 8,
+      "tier": "content"
     },
     "path-8": {
       "kind": "transit-path",
       "from": 8
     },
+    "path-8-decor": {
+      "kind": "transit-path",
+      "from": 8,
+      "finaleDrop": true
+    },
     "station-9": {
       "kind": "station",
-      "station": 9
+      "station": 9,
+      "tier": "content"
+    },
+    "station-9-decor": {
+      "kind": "station",
+      "station": 9,
+      "tier": "content",
+      "finaleDrop": true
+    },
+    "proxy-9": {
+      "kind": "proxy",
+      "station": 9,
+      "tier": "content"
     },
     "path-9": {
       "kind": "transit-path",
       "from": 9
     },
+    "path-9-decor": {
+      "kind": "transit-path",
+      "from": 9,
+      "finaleDrop": true
+    },
     "station-10": {
       "kind": "station",
-      "station": 10
+      "station": 10,
+      "tier": "content"
+    },
+    "station-10-decor": {
+      "kind": "station",
+      "station": 10,
+      "tier": "content",
+      "finaleDrop": true
+    },
+    "proxy-10": {
+      "kind": "proxy",
+      "station": 10,
+      "tier": "content"
     },
     "path-10": {
       "kind": "transit-path",
       "from": 10
     },
+    "path-10-decor": {
+      "kind": "transit-path",
+      "from": 10,
+      "finaleDrop": true
+    },
     "station-11": {
       "kind": "station",
-      "station": 11
+      "station": 11,
+      "tier": "content"
+    },
+    "station-11-decor": {
+      "kind": "station",
+      "station": 11,
+      "tier": "content",
+      "finaleDrop": true
+    },
+    "proxy-11": {
+      "kind": "proxy",
+      "station": 11,
+      "tier": "content"
     },
     "path-11": {
       "kind": "transit-path",
       "from": 11
     },
+    "path-11-decor": {
+      "kind": "transit-path",
+      "from": 11,
+      "finaleDrop": true
+    },
     "station-12": {
       "kind": "station",
-      "station": 12
+      "station": 12,
+      "tier": "content"
+    },
+    "station-12-decor": {
+      "kind": "station",
+      "station": 12,
+      "tier": "content",
+      "finaleDrop": true
+    },
+    "proxy-12": {
+      "kind": "proxy",
+      "station": 12,
+      "tier": "content"
     },
     "massing": {
       "kind": "dressing",
@@ -410,6 +626,15 @@
       "clearcoat": 0.45
     },
     "mat-35": {
+      "hue": 0.62,
+      "sat": 0.22,
+      "value": 0.2,
+      "metal": 0,
+      "glow": 0,
+      "kind": "normal",
+      "roughness": 0.6
+    },
+    "mat-36": {
       "hue": 0.62,
       "sat": 0.25,
       "value": 0.14,
@@ -4193,6 +4418,162 @@
       "collection": "station-12"
     },
     {
+      "id": "proxy-0",
+      "collection": "proxy-0",
+      "type": "box",
+      "args": {
+        "dims": [22.475, 19.3, 26.949999999999996]
+      },
+      "transform": {
+        "translate": [0.21249999999999947, 9.65, 18.52922816311423]
+      },
+      "material": "mat-35"
+    },
+    {
+      "id": "proxy-1",
+      "collection": "proxy-1",
+      "type": "box",
+      "args": {
+        "dims": [7.815803487450426, 2.62, 5.200000000000003]
+      },
+      "transform": {
+        "translate": [15.384301920023102, 1.31, 28.11233830162819]
+      },
+      "material": "mat-35"
+    },
+    {
+      "id": "proxy-2",
+      "collection": "proxy-2",
+      "type": "box",
+      "args": {
+        "dims": [13.090000000000007, 4.800000000000001, 8.5]
+      },
+      "transform": {
+        "translate": [30.084245671105407, 2.4000000000000004, 16.00534498720988]
+      },
+      "material": "mat-35"
+    },
+    {
+      "id": "proxy-3",
+      "collection": "proxy-3",
+      "type": "box",
+      "args": {
+        "dims": [13.090000000000007, 4.800000000000001, 8.5]
+      },
+      "transform": {
+        "translate": [35.70286106769022, 2.4000000000000004, 1.1902737651965585]
+      },
+      "material": "mat-35"
+    },
+    {
+      "id": "proxy-4",
+      "collection": "proxy-4",
+      "type": "box",
+      "args": {
+        "dims": [13.090000000000007, 4.800000000000001, 8.5]
+      },
+      "transform": {
+        "translate": [33.79299103407576, 2.4000000000000004, -14.538921088411442]
+      },
+      "material": "mat-35"
+    },
+    {
+      "id": "proxy-5",
+      "collection": "proxy-5",
+      "type": "box",
+      "args": {
+        "dims": [13.09, 4.800000000000001, 8.5]
+      },
+      "transform": {
+        "translate": [24.792163778534103, 2.4000000000000004, -27.57887058999947]
+      },
+      "material": "mat-35"
+    },
+    {
+      "id": "proxy-6",
+      "collection": "proxy-6",
+      "type": "box",
+      "args": {
+        "dims": [9.1, 4.55, 2]
+      },
+      "transform": {
+        "translate": [7.922360353582557, 2.275, -32.14227945718083]
+      },
+      "material": "mat-35"
+    },
+    {
+      "id": "proxy-7",
+      "collection": "proxy-7",
+      "type": "box",
+      "args": {
+        "dims": [10.660325427650134, 6.480307652106461, 8.620701580479576]
+      },
+      "transform": {
+        "translate": [-8.354101104213727, 3.2401538260532305, -32.31579264299282]
+      },
+      "material": "mat-35"
+    },
+    {
+      "id": "proxy-8",
+      "collection": "proxy-8",
+      "type": "box",
+      "args": {
+        "dims": [2, 3.6000000000000005, 2]
+      },
+      "transform": {
+        "translate": [-21.952163778534096, 1.8000000000000003, -24.778870589999475]
+      },
+      "material": "mat-35"
+    },
+    {
+      "id": "proxy-9",
+      "collection": "proxy-9",
+      "type": "box",
+      "args": {
+        "dims": [14.36, 4.800000000000001, 8.499999999999998]
+      },
+      "transform": {
+        "translate": [-28.112991034075755, 2.4000000000000004, -14.538921088411456]
+      },
+      "material": "mat-35"
+    },
+    {
+      "id": "proxy-10",
+      "collection": "proxy-10",
+      "type": "box",
+      "args": {
+        "dims": [4.890896534380865, 3.95, 5.141709530190579]
+      },
+      "transform": {
+        "translate": [-32.86286106769022, 1.975, 3.8611285302918543]
+      },
+      "material": "mat-35"
+    },
+    {
+      "id": "proxy-11",
+      "collection": "proxy-11",
+      "type": "box",
+      "args": {
+        "dims": [14.919999999999998, 5.41, 7.560000000000002]
+      },
+      "transform": {
+        "translate": [-27.044245671105422, 2.705, 15.535344987209847]
+      },
+      "material": "mat-35"
+    },
+    {
+      "id": "proxy-12",
+      "collection": "proxy-12",
+      "type": "box",
+      "args": {
+        "dims": [9.280000000000001, 4.800000000000001, 8.5]
+      },
+      "transform": {
+        "translate": [-12.544301920023099, 2.4000000000000004, 26.51233830162819]
+      },
+      "material": "mat-35"
+    },
+    {
       "id": "horizon-0",
       "type": "box",
       "args": {
@@ -4202,7 +4583,7 @@
         "translate": [-9.564998366001348e-16, 7.016592952333921, 148.44758298167267],
         "rotate": [0, 0, 0]
       },
-      "material": "mat-35",
+      "material": "mat-36",
       "collection": "horizon"
     },
     {
@@ -4215,7 +4596,7 @@
         "translate": [63.3066209152962, 7.62296579657653, 92.85708904982108],
         "rotate": [0, 0.34528374665954953, 0]
       },
-      "material": "mat-35",
+      "material": "mat-36",
       "collection": "horizon"
     },
     {
@@ -4228,7 +4609,7 @@
         "translate": [42.17123438785764, 4.819555072083943, 58.18899581850708],
         "rotate": [0, -0.3486303089654353, 0]
       },
-      "material": "mat-35",
+      "material": "mat-36",
       "collection": "horizon"
     },
     {
@@ -4241,7 +4622,7 @@
         "translate": [133.23992011010677, 4.842001421418689, -15.398862705215288],
         "rotate": [0, 0.006725560193740241, 0]
       },
-      "material": "mat-35",
+      "material": "mat-36",
       "collection": "horizon"
     },
     {
@@ -4254,7 +4635,7 @@
         "translate": [133.43987144268098, 7.640377316314558, 15.945010375042076],
         "rotate": [0, 0.3418395632353122, 0]
       },
-      "material": "mat-35",
+      "material": "mat-36",
       "collection": "horizon"
     },
     {
@@ -4267,7 +4648,7 @@
         "translate": [41.59059376558689, 6.990241111126378, -58.71906850943405],
         "rotate": [0, -0.35187830398866804, 0]
       },
-      "material": "mat-35",
+      "material": "mat-36",
       "collection": "horizon"
     },
     {
@@ -4280,7 +4661,7 @@
         "translate": [64.57684188043537, 4.3376940527581525, -91.58418852702466],
         "rotate": [0, 0.01344921888845539, 0]
       },
-      "material": "mat-35",
+      "material": "mat-36",
       "collection": "horizon"
     },
     {
@@ -4293,7 +4674,7 @@
         "translate": [-2.621699333670603, 5.582809968766616, -148.54011535108356],
         "rotate": [0, 0.33829873245717335, 0]
       },
-      "material": "mat-35",
+      "material": "mat-36",
       "collection": "horizon"
     },
     {
@@ -4306,7 +4687,7 @@
         "translate": [-46.662129265450154, 7.956071234520032, -70.87525467505033],
         "rotate": [0, -0.35502681343260184, 0]
       },
-      "material": "mat-35",
+      "material": "mat-36",
       "collection": "horizon"
     },
     {
@@ -4319,7 +4700,7 @@
         "translate": [-53.38157647783484, 6.178620822448911, -71.89564197285696],
         "rotate": [0, 0.020169075122725907, 0]
       },
-      "material": "mat-35",
+      "material": "mat-36",
       "collection": "horizon"
     },
     {
@@ -4332,7 +4713,7 @@
         "translate": [-149.30732670480418, 4.204050667126552, 16.54056242376746],
         "rotate": [0, 0.33466225541442246, 0]
       },
-      "material": "mat-35",
+      "material": "mat-36",
       "collection": "horizon"
     },
     {
@@ -4345,7 +4726,7 @@
         "translate": [-105.51113399020367, 6.424407144257572, -12.92814474581854],
         "rotate": [0, -0.35807494712787274, 0]
       },
-      "material": "mat-35",
+      "material": "mat-36",
       "collection": "horizon"
     },
     {
@@ -4358,7 +4739,7 @@
         "translate": [-42.170987072097645, 7.900940120366205, 60.837256078552294],
         "rotate": [0, 0.02688322901019139, 0]
       },
-      "material": "mat-35",
+      "material": "mat-36",
       "collection": "horizon"
     },
     {
@@ -4371,7 +4752,7 @@
         "translate": [-81.72421217765147, 5.34938983448815, 112.20689757324111],
         "rotate": [0, 0.3309311602381515, 0]
       },
-      "material": "mat-35",
+      "material": "mat-36",
       "collection": "horizon"
     }
   ],
@@ -6871,6 +7252,7 @@
     {
       "kind": "finale",
       "stations": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12],
+      "anchor": 12,
       "start": 148.30000000000004,
       "end": 151.30000000000004
     }

--- a/sdf-js/scripts/test-deck-decor.mjs
+++ b/sdf-js/scripts/test-deck-decor.mjs
@@ -71,7 +71,7 @@ const ANALYTIC_TYPES = new Set(['box', 'sphere', 'capsule', 'ellipsoid', 'cylind
   );
   const stelae = decor.filter((s) => /-decor-stela-/.test(s.id));
   const inBand = stelae.every((s) => {
-    const k = Number(/^station-(\d+)$/.exec(s.collection)[1]);
+    const k = Number(/^station-(\d+)-decor$/.exec(s.collection)[1]);
     const o = origins.get(k);
     const t = s.transform.translate;
     const r = Math.hypot(t[0] - o[0], t[2] - o[2]);
@@ -87,7 +87,7 @@ const ANALYTIC_TYPES = new Set(['box', 'sphere', 'capsule', 'ellipsoid', 'cylind
   const sliced = sliceDeckWindow(scene, stWin);
   const decorIn = sliced.subjects.filter((x) => /-decor-/.test(x.id));
   ok(
-    decorIn.every((x) => x.collection === 'station-3' || x.collection === 'path-3'),
+    decorIn.every((x) => x.collection === 'station-3-decor' || x.collection === 'path-3-decor'),
     'station window carries only its own decor + the OUTGOING inlay (continuity: the world ahead never pops in)',
   );
   ok(
@@ -107,7 +107,7 @@ const ANALYTIC_TYPES = new Set(['box', 'sphere', 'capsule', 'ellipsoid', 'cylind
     (x) => /-decor-stela-/.test(x.id) && (x.collection || '').startsWith('station-'),
   );
   ok(
-    trStelae.every((x) => x.collection === 'station-0' || x.collection === 'station-1'),
+    trStelae.every((x) => x.collection === 'station-0-decor' || x.collection === 'station-1-decor'),
     'transit window stelae limited to its two endpoint stations',
   );
 }

--- a/sdf-js/scripts/test-deck-windows.mjs
+++ b/sdf-js/scripts/test-deck-windows.mjs
@@ -60,7 +60,35 @@ const stationIds = (s, k) => s.subjects.filter((x) => x.collection === `station-
     'transit slice keeps the breadcrumb path it flies over',
   );
 }
-ok(sliceOf(5).subjects.length === scene.subjects.length, 'finale slice is the full world');
+{
+  // finale-LOD: the money shot keeps the ANCHOR station real (the camera
+  // rises from it — nothing swaps in front of the lens) and stands proxies
+  // in for every other station; runways + dressing stay, proxies never leak
+  // into normal windows.
+  const fin = sliceOf(5);
+  ok(fin.subjects.length < scene.subjects.length, 'finale slice is lighter than the full world');
+  ok(wins[5].anchor === 2, 'finale anchor = last station');
+  ok(stationIds(fin, 2) > 0, 'finale keeps the anchor station real');
+  ok(stationIds(fin, 0) === 0 && stationIds(fin, 1) === 0, 'far-station content leaves the finale');
+  const proxies = fin.subjects.filter((x) => (x.collection || '').startsWith('proxy-'));
+  ok(
+    proxies
+      .map((x) => x.collection)
+      .sort()
+      .join(',') === 'proxy-0,proxy-1',
+    'every non-anchor station stands as a silhouette proxy',
+  );
+  ok(
+    fin.subjects.some((x) => x.collection === 'path-0'),
+    'runways stay in the finale (the world lines)',
+  );
+  ok(
+    [0, 1, 2, 3, 4].every(
+      (i) => !sliceOf(i).subjects.some((x) => (x.collection || '').startsWith('proxy-')),
+    ),
+    'proxies never appear in normal windows',
+  );
+}
 
 // ---- horizon-hill trimming (super-linear shader cost: every leaf counts) ------
 {

--- a/sdf-js/src/runtime/deck-shader-windows.js
+++ b/sdf-js/src/runtime/deck-shader-windows.js
@@ -59,10 +59,14 @@ export function attachDeckWindows(
 
   // Window index → ground-unioned SDF. Compiled lazily (CPU-side, ~ms each);
   // the GPU program for each SDF lives in studio's programCache.
+  // Raymarch tiers take the LITE finale (heroes as proxies too — the hero-real
+  // finale sits on a D3D/ANGLE compile cliff, ~104s measured); analytic keeps
+  // heroes real for the money shot's composition.
+  const sliceOpts = { finaleLite: !!compileOpts.lowerRepeats };
   const sdfCache = new Map();
   const sdfFor = (i) => {
     if (!sdfCache.has(i)) {
-      const slice = sliceDeckWindow(scene, windows[i]);
+      const slice = sliceDeckWindow(scene, windows[i], sliceOpts);
       if (compileOpts.lowerRepeats && i > 0) {
         const n = expandModifiers(slice, { lower: true }).subjects.length;
         if (n > RAYMARCH_WINDOW_CAP) {

--- a/sdf-js/src/scene/assemble-deck.js
+++ b/sdf-js/src/scene/assemble-deck.js
@@ -134,6 +134,58 @@ function courtyardPlan(slides, zones, stride) {
   return { origins, center: [0, 0], ringR: R, zoneOf, centerIdx };
 }
 
+// ---- Finale-LOD proxies (Infinigen placeholder pattern) -----------------------
+// One grounded silhouette box per station, fit to the world-space bounds of its
+// CONTENT subjects. Stands in for far-station geometry in finale/overlook
+// windows, where the pull-back distance makes data detail sub-pixel but the
+// station's mass must keep holding the composition.
+function newBounds() {
+  return { minX: Infinity, maxX: -Infinity, maxY: 0, minZ: Infinity, maxZ: -Infinity };
+}
+
+// Rough per-type half-extents — silhouette fidelity, not collision precision.
+function halfExtents(s) {
+  const a = s.args || {};
+  if (Array.isArray(a.dims)) return [a.dims[0] / 2, a.dims[1] / 2, a.dims[2] / 2];
+  if (a.radius != null && a.height != null) return [a.radius, a.height / 2 + a.radius, a.radius]; // cylinder/capsule-ish
+  if (a.radius != null) return [a.radius, a.radius, a.radius];
+  return [0.8, 0.8, 0.8]; // exotic prims: a nudge, the AABB is dominated by placement
+}
+
+function accumulateBounds(b, s) {
+  const t = (s.transform && s.transform.translate) || [0, 0, 0];
+  const h = halfExtents(s);
+  b.minX = Math.min(b.minX, t[0] - h[0]);
+  b.maxX = Math.max(b.maxX, t[0] + h[0]);
+  b.maxY = Math.max(b.maxY, t[1] + h[1]);
+  b.minZ = Math.min(b.minZ, t[2] - h[2]);
+  b.maxZ = Math.max(b.maxZ, t[2] + h[2]);
+}
+
+function stationProxy(k, b) {
+  if (!b || !Number.isFinite(b.minX)) return null;
+  const w = Math.max(2, b.maxX - b.minX);
+  const d = Math.max(2, b.maxZ - b.minZ);
+  const h = Math.max(1.5, b.maxY);
+  return {
+    id: `proxy-${k}`,
+    collection: `proxy-${k}`,
+    type: 'box',
+    args: { dims: [w, h, d] },
+    transform: { translate: [(b.minX + b.maxX) / 2, h / 2, (b.minZ + b.maxZ) / 2] },
+    // massing-family silhouette discipline: dark, matte, zero glow
+    material: {
+      hue: 0.62,
+      sat: 0.22,
+      value: 0.2,
+      metal: 0,
+      glow: 0,
+      kind: 'normal',
+      roughness: 0.6,
+    },
+  };
+}
+
 // Zone massing (spec §4): 1 hull + 1 tower per chapter at a FIXED band outside
 // the ring (Wave-0 spike: a multiplicative push collapses on wide-arc zones
 // and lands inside the crane near-field). Independent `massing-` prefix —
@@ -280,6 +332,13 @@ export function assembleDeck(deck, opts = {}) {
   // the camera can actually see during each span. The runtime swaps in a
   // small per-window shader as playback crosses each boundary.
   const windows = [];
+  // Finale-LOD (Infinigen placeholder pattern): per-station world-space bounds
+  // accumulated during transplant → one grounded silhouette box per station.
+  // The finale/overlook windows swap far-station CONTENT for these proxies
+  // (at pull-back distance the data detail is sub-pixel; the full-world
+  // shader cost was ~85s of a 112s analytic warmup). Content subjects only —
+  // decor stelae ring at r≈8-12 and would balloon the silhouette.
+  const stationBounds = [];
 
   deck.slides.forEach((ir, k) => {
     // Render the station at the origin on its own clock, then transplant.
@@ -421,6 +480,7 @@ export function assembleDeck(deck, opts = {}) {
         moved.modifiers = moved.modifiers.map((m) => shiftModifier(m, origin));
       }
       subjects.push(moved);
+      accumulateBounds((stationBounds[k] = stationBounds[k] || newBounds()), moved);
     }
 
     // Overlay: shift anchors + reveal times; station titles reveal with their
@@ -479,8 +539,12 @@ export function assembleDeck(deck, opts = {}) {
     // Layer C: stelae ring in the station's annulus (outside the fitted
     // platform, inside the transit corridor). The `s${k}-decor-` prefix means
     // sliceDeckWindow scopes these to this station's windows automatically.
+    // own collection: routes with the station but drops at finale distance
+    // (stelae are sub-pixel from the money shot; they'd eat the leaf budget)
     if (decor)
-      subjects.push(...decor.station(k, origin).map((d) => ({ ...d, collection: `station-${k}` })));
+      subjects.push(
+        ...decor.station(k, origin).map((d) => ({ ...d, collection: `station-${k}-decor` })),
+      );
 
     const stationDur = seqDuration(st.cameraSequence.shots);
     windows.push({
@@ -529,6 +593,11 @@ export function assembleDeck(deck, opts = {}) {
       windows.push({
         kind: 'finale',
         stations: deck.slides.map((_, i) => i),
+        // finale-LOD anchor: the station the camera rises FROM keeps its real
+        // content (no swap in front of the lens); every other station shows
+        // its silhouette proxy — the overlook is a map beat, massing-level
+        // information is exactly what it communicates.
+        anchor: plan.centerIdx,
         start: clock,
         end: clock + dur,
       });
@@ -574,9 +643,11 @@ export function assembleDeck(deck, opts = {}) {
       });
       // Layer C: inlay flanking the breadcrumbs (path-${k}-decor- prefix →
       // lives only in this transit's windows, dropped inside stations).
+      // own collection: same window routing as the runway, but droppable at
+      // finale distance (inlay plates are sub-pixel from the money shot)
       if (decor)
         subjects.push(
-          ...decor.segment(k, origin, next).map((d) => ({ ...d, collection: `path-${k}` })),
+          ...decor.segment(k, origin, next).map((d) => ({ ...d, collection: `path-${k}-decor` })),
         );
     }
   });
@@ -618,6 +689,10 @@ export function assembleDeck(deck, opts = {}) {
     windows.push({
       kind: 'finale',
       stations: deck.slides.map((_, i) => i),
+      // finale-LOD anchor: the pull-back rises from the LAST station — it
+      // stays real (nothing swaps in front of the lens); the rest of the ring
+      // shows silhouette proxies, sub-pixel-different at this distance.
+      anchor: deck.slides.length - 1,
       start: clock,
       end: clock + TEMPO.finale,
     });
@@ -673,13 +748,25 @@ export function assembleDeck(deck, opts = {}) {
   // (kind / cull policy / dressing budget). The id prefixes are pure identity.
   const allSubjects = [
     ...subjects,
+    ...stationBounds.map((b, k) => stationProxy(k, b)).filter(Boolean),
     ...massingSubjects.map((s) => ({ ...s, collection: 'massing' })),
     ...worldSubjects.map((s) => ({ ...s, collection: env ? 'env' : 'horizon' })),
   ];
   const collections = {};
-  deck.slides.forEach((_, k) => {
-    collections[`station-${k}`] = { kind: 'station', station: k };
-    if (k < deck.slides.length - 1) collections[`path-${k}`] = { kind: 'transit-path', from: k };
+  deck.slides.forEach((ir, k) => {
+    // tier rides the registry: hold stations are HERO (narrative anchors) and
+    // keep their real geometry even in the finale — an AABB proxy turns the
+    // cover's monolith + satellite ring into a frame-dominating warehouse box
+    const tier = ir.structure === 'hold' ? 'hero' : 'content';
+    collections[`station-${k}`] = { kind: 'station', station: k, tier };
+    collections[`station-${k}-decor`] = { kind: 'station', station: k, tier, finaleDrop: true };
+    // finale-LOD: the proxy collection exists in NO normal window and stands
+    // in for far-station content in finale/overlook windows only
+    collections[`proxy-${k}`] = { kind: 'proxy', station: k, tier };
+    if (k < deck.slides.length - 1) {
+      collections[`path-${k}`] = { kind: 'transit-path', from: k };
+      collections[`path-${k}-decor`] = { kind: 'transit-path', from: k, finaleDrop: true };
+    }
   });
   collections.massing = { kind: 'dressing', cull: 'never' };
   collections.horizon = {
@@ -748,10 +835,38 @@ export function assembleDeck(deck, opts = {}) {
 // a hole in the world.
 const HILLS_HERO = 7;
 const HILLS_CONTENT = 3;
-export function sliceDeckWindow(scene, win) {
-  if (!win || win.kind === 'finale') return scene;
+export function sliceDeckWindow(scene, win, opts = {}) {
+  if (!win) return scene;
   const cols = scene.collections;
   if (!cols) return scene; // no routing data → nothing to slice (whole world)
+
+  // Finale-LOD: the full-world money shot swaps far-station CONTENT for the
+  // per-station silhouette proxies. The ANCHOR station (the one the camera
+  // rises from) keeps its real geometry — nothing may swap in front of the
+  // lens (total-continuity lock); at pull-back distance every other station's
+  // proxy is visually equivalent while the shader drops from ~390 leaves to
+  // well under the raymarch window cap. Runways stay (they draw the world's
+  // connective lines); transit inlay decor is sub-pixel and drops.
+  // opts.finaleLite (raymarch tiers): hero stations ALSO stand as proxies —
+  // their exotic prims + the leaf count push the D3D/ANGLE compiler off a
+  // cliff (~104s for the 87-leaf hero-real finale vs seconds at ~50 leaves).
+  // The analytic tier keeps heroes real: closed-form intersectors don't pay
+  // that cliff, and hero silhouettes are the money shot's composition.
+  if (win.kind === 'finale') {
+    if (win.anchor == null) return scene; // pre-LOD producer → whole world
+    // real geometry: the anchor (camera rises from it) + hero stations
+    // (narrative anchors whose silhouette IS their identity)
+    const real = (c) => c.station === win.anchor || (!opts.finaleLite && c.tier === 'hero');
+    const keep = (s) => {
+      const c = cols[s.collection];
+      if (!c) return true;
+      if (c.finaleDrop) return false; // decor: sub-pixel at pull-back distance
+      if (c.kind === 'proxy') return !real(c);
+      if (c.kind === 'station') return real(c);
+      return true; // dressing + runways
+    };
+    return { ...scene, subjects: scene.subjects.filter(keep) };
+  }
   const wanted = new Set(win.stations);
 
   // Wave A2: collection-driven slicing ONLY — the routing rules live in DATA
@@ -760,6 +875,7 @@ export function sliceDeckWindow(scene, win) {
   const keepByCollection = (s) => {
     const c = cols[s.collection];
     if (!c) return true; // untagged → shared dressing
+    if (c.kind === 'proxy') return false; // finale/overlook stand-ins only
     if (c.kind === 'station') return wanted.has(c.station);
     if (c.kind === 'transit-path') {
       // Station windows keep only the OUTGOING segment (the world never pops

--- a/sdf-js/src/scene/spec.js
+++ b/sdf-js/src/scene/spec.js
@@ -827,7 +827,12 @@ export function validate(data) {
           errors.push(`collections["${name}"]: must be an object`);
           continue;
         }
-        if (c.kind != null && !['station', 'transit-path', 'dressing', 'decor'].includes(c.kind))
+        // 'proxy' = finale-LOD silhouette stand-ins (in no normal window;
+        // finale/overlook swap far-station content for them)
+        if (
+          c.kind != null &&
+          !['station', 'transit-path', 'dressing', 'decor', 'proxy'].includes(c.kind)
+        )
           errors.push(`collections["${name}"].kind: unknown "${c.kind}"`);
         if (c.cull != null && !['never', 'nearest'].includes(c.cull))
           errors.push(`collections["${name}"].cull: must be 'never' or 'nearest'`);


### PR DESCRIPTION
## What

Direction ① approved 2026-07-13: cash in the Blender-borrow architecture as user-visible boot time, using the **Infinigen placeholder pattern** — per-station world-space bounds (accumulated at transplant) become one grounded silhouette box each (`collection: proxy-k`, present in NO normal window). Finale/overlook windows swap far-station content for these proxies.

**What stays real in the finale:**
- The **anchor station** (the camera rises from it — nothing may swap in front of the lens, total-continuity lock). Radial finale anchor = last station; courtyard overlook anchor = center.
- On the **analytic tier**: hero (hold) stations — their monolith/satellite silhouettes are the money shot composition; the AABB proxy turned the cover into a frame-dominating warehouse box (caught in browser, fixed via `tier` riding the registry).

**What drops at finale distance** (sub-pixel from the pull-back): station stelae and transit inlay, split into `*-decor` collections with `finaleDrop`.

**Raymarch tiers take the LITE finale** (heroes as proxies too): the hero-real 87-leaf stone finale sat on a D3D/ANGLE compile cliff — **~104s measured** vs seconds at ~50 leaves. Closed-form analytic intersectors do not pay that cliff. Threaded as `sliceDeckWindow(…, { finaleLite })` off `compileOpts.lowerRepeats`.

## Measured (bytedance-bp, 26 windows, this Windows machine)

| | before | after |
|---|---|---|
| analytic warmup | 112s | **31s** |
| analytic finale leaves | 392 | **162** |
| stone warmup | 4.7s but finale DEGRADED (cap fallback reused window 24) | **12s with a real whole-world proxied finale** (51 lowered leaves) |

Money shot verified in browser: hero stations real, content ring as dark silhouettes, runway lines intact, finale card centered, 120fps, 0 console errors.

## Contract changes

- collection kind `proxy` (validator whitelisted), `tier` on station/proxy entries, `finaleDrop` flag
- finale windows carry `anchor`; producers without it keep the old whole-world behavior
- station/transit decor moved to `station-k-decor` / `path-k-decor` collections (same window routing as before)
- goldens re-baked (new proxy subjects + registry entries — semantic diff reviewed); suite **152/152**

## Notes

- Free-cam (fly mode) uses the finale shader, so it now sees proxies for non-anchor stations — acceptable for a diagnostic mode; lazy full-world compile is a possible follow-up.
- Wave D original plan (analytic k-nearest repetition intersection) looks unnecessary now — the finale was the only over-budget window and this closes it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)