### PR TITLE
Sprint 94: 中文排版 — 禁则断行 + 盘古之白 (优化路线图二)

### DIFF
--- a/sdf-js/scripts/test-cjk.mjs
+++ b/sdf-js/scripts/test-cjk.mjs
@@ -1,0 +1,88 @@
+// test-cjk.mjs — Sprint 94: 中文排版引擎单元测试.
+// 钉住三条规则: 盘古之白 / 禁则断行 (行首无收尾标点、latin 词不裂) / 尾行省略。
+import { pangu, wrapCJK, fitTextCJK } from '../src/present/atoms-2d/cjk-text.js';
+
+let passed = 0;
+let failed = 0;
+function ok(cond, msg, extra = '') {
+  if (cond) {
+    passed++;
+    console.log(`  ✓ ${msg}`);
+  } else {
+    failed++;
+    console.log(`  ✗ ${msg}${extra ? ` — ${extra}` : ''}`);
+  }
+}
+
+// 等宽 mock: 每字符 10px (thin space 也算 10 — 保守)
+const ctx = { measureText: (s) => ({ width: String(s).length * 10 }) };
+const SP = '\u2009';
+
+// ── 1. pangu 盘古之白 ──
+ok(pangu('质押1万ANT') === `质押${SP}1${SP}万${SP}ANT`, 'CJK↔数字/latin 边界补细空');
+ok(pangu('pure english text') === 'pure english text', '纯 latin 不动');
+ok(pangu('纯中文不动') === '纯中文不动', '纯 CJK 不动');
+ok(pangu('已有 空格 不再补') === '已有 空格 不再补', '已有空格不重复补');
+ok(pangu('（ANT）机制') === '（ANT）机制', '全角括号邻界不隔白');
+ok(pangu('费率0.5%封顶') === `费率${SP}0.5%${SP}封顶`, '小数与百分号随词');
+
+// ── 2. wrapCJK 禁则断行 ──
+{
+  // 8 字/行 (maxW=80): 「一二三四五六七，八九」 naive 切法第 8 字后断 → 第二行以「，」开头
+  const lines = wrapCJK(ctx, '一二三四五六七，八九', 80);
+  ok(
+    lines.every((l) => !'，。、；：！？'.includes(l[0])),
+    '行首无收尾标点 (禁则)',
+    JSON.stringify(lines),
+  );
+  ok(lines.join('') === '一二三四五六七，八九', '断行不丢字');
+}
+{
+  // 行尾禁: 起始标点「（」不能收行
+  const lines = wrapCJK(ctx, '一二三四五六七（八九）', 80);
+  ok(
+    lines.every((l) => !'（【「'.includes(l[l.length - 1])),
+    '行尾无起始标点 (禁则)',
+    JSON.stringify(lines),
+  );
+}
+{
+  // latin 词整体移行: maxW=100=10字, "中文中文中文 tokens" → tokens 不裂
+  const lines = wrapCJK(ctx, '中文中文中文说明 tokens', 100);
+  ok(
+    lines.some((l) => l.includes('tokens')),
+    'latin 词不裂 (整体移行)',
+    JSON.stringify(lines),
+  );
+  ok(
+    lines.every((l) => !/^\s/.test(l)),
+    '空白不领行',
+    JSON.stringify(lines),
+  );
+}
+{
+  // 超长 latin token (URL) 字符级兜底拆
+  const lines = wrapCJK(ctx, 'https-very-long-token-exceeding-width', 100);
+  ok(lines.length > 1 && lines.every((l) => l.length * 10 <= 100), '超宽 latin 长词字符级兜底');
+}
+{
+  // maxLines 截断 + 省略号
+  const lines = wrapCJK(ctx, '一二三四五六七八九十甲乙丙丁戊己庚辛', 80, 2);
+  ok(lines.length === 2 && lines[1].endsWith('…'), '超行数尾行加省略号', JSON.stringify(lines));
+  ok(ctx.measureText(lines[1]).width <= 80, '省略号行不超宽');
+}
+{
+  const lines = wrapCJK(ctx, '短文本', 200);
+  ok(lines.length === 1 && lines[0] === '短文本', '不需折行时原样单行');
+}
+
+// ── 3. fitTextCJK 单行 ──
+ok(fitTextCJK(ctx, '收入2亿', 200) === `收入${SP}2${SP}亿`, '宽度充裕: 单行带盘古之白');
+ok(fitTextCJK(ctx, '收入2亿元整', 60) === '收入2亿元整', '空间紧张: 先撤白救宽度');
+{
+  const s = fitTextCJK(ctx, '这是一段很长很长放不下的文字', 60);
+  ok(s.endsWith('…') && ctx.measureText(s).width <= 60, '实在放不下: 截断加省略号');
+}
+
+console.log(`\n${passed} passed, ${failed} failed`);
+if (failed) process.exit(1);

--- a/sdf-js/src/present/atoms-2d/charts/agenda/agenda-list.js
+++ b/sdf-js/src/present/atoms-2d/charts/agenda/agenda-list.js
@@ -14,6 +14,7 @@
 // =============================================================================
 
 import { rgbCss, rgbaCss, fitFontPx } from '../../renderer.js';
+import { pangu } from '../../cjk-text.js';
 import { resolveIcon } from '../../../../icons/index.js';
 
 export const spec = {
@@ -159,7 +160,7 @@ export function drawPseudo3D(ctx, args, opts = {}) {
       const weight = isHi ? '700' : '600';
       const lfs = fitFontPx(
         ctx,
-        it.label,
+        pangu(it.label),
         agendaMaxW,
         Math.round(rowH * 0.32),
         (fs) => `${weight} ${fs}px Inter, system-ui, sans-serif`,
@@ -168,7 +169,7 @@ export function drawPseudo3D(ctx, args, opts = {}) {
       ctx.textAlign = 'left';
       ctx.textBaseline = 'middle';
       const labelY = it.sublabel ? rowCY - rowH * 0.12 : rowCY;
-      ctx.fillText(String(it.label), textX, labelY);
+      ctx.fillText(pangu(it.label), textX, labelY);
     }
 
     // Sublabel
@@ -176,7 +177,7 @@ export function drawPseudo3D(ctx, args, opts = {}) {
       ctx.fillStyle = rgbaCss(fg, 0.6);
       const sfs = fitFontPx(
         ctx,
-        it.sublabel,
+        pangu(it.sublabel),
         agendaMaxW,
         Math.round(rowH * 0.22),
         (fs) => `500 ${fs}px Inter, system-ui, sans-serif`,
@@ -184,7 +185,7 @@ export function drawPseudo3D(ctx, args, opts = {}) {
       ctx.font = `500 ${sfs}px Inter, system-ui, sans-serif`;
       ctx.textAlign = 'left';
       ctx.textBaseline = 'middle';
-      ctx.fillText(String(it.sublabel), textX, rowCY + rowH * 0.18);
+      ctx.fillText(pangu(it.sublabel), textX, rowCY + rowH * 0.18);
     }
 
     // Faint separator (except after last)
@@ -297,7 +298,7 @@ function drawShowcase(
       ctx.fillStyle = isHi ? rgbCss(accent) : rgbCss(fg);
       const labelFs = fitFontSize(
         ctx,
-        String(it.label),
+        pangu(it.label),
         labelMaxW,
         Math.round(labelSize),
         10,
@@ -305,7 +306,7 @@ function drawShowcase(
       );
       ctx.font = `700 ${labelFs}px Inter, system-ui, sans-serif`;
       ctx.textBaseline = 'top';
-      ctx.fillText(String(it.label), labelX, cellY + Math.round(numSize * 0.18));
+      ctx.fillText(pangu(it.label), labelX, cellY + Math.round(numSize * 0.18));
     }
 
     // Sublabel below label
@@ -313,7 +314,7 @@ function drawShowcase(
       ctx.fillStyle = rgbaCss(fg, 0.55);
       const subLabelFs = fitFontSize(
         ctx,
-        String(it.sublabel),
+        pangu(it.sublabel),
         labelMaxW,
         Math.round(subSize),
         9,
@@ -322,7 +323,7 @@ function drawShowcase(
       ctx.font = `500 ${subLabelFs}px Inter, system-ui, sans-serif`;
       ctx.textBaseline = 'top';
       ctx.fillText(
-        String(it.sublabel),
+        pangu(it.sublabel),
         labelX,
         cellY + Math.round(numSize * 0.18) + Math.round(labelSize) + 4,
       );

--- a/sdf-js/src/present/atoms-2d/charts/data/kpi-card.js
+++ b/sdf-js/src/present/atoms-2d/charts/data/kpi-card.js
@@ -31,6 +31,7 @@
 // =============================================================================
 
 import { rgbCss, rgbaCss } from '../../renderer.js';
+import { pangu } from '../../cjk-text.js';
 import { resolveIcon } from '../../../../icons/index.js';
 
 export const spec = {
@@ -173,7 +174,7 @@ function _drawDark(ctx, args, opts = {}) {
   ctx.fillStyle = rgbaCss(bg, 0.85);
   let labelSize = Math.round(h * 0.11);
   const minLabelSize = Math.round(h * 0.07);
-  const labelText = String(args.label ?? '');
+  const labelText = pangu(args.label ?? ''); // Sprint 94: 盘古之白
   ctx.font = `700 ${labelSize}px Inter, system-ui, sans-serif`;
   while (ctx.measureText(labelText).width > availW && labelSize > minLabelSize) {
     labelSize -= 1;
@@ -287,7 +288,7 @@ function _drawLight(ctx, args, opts = {}) {
   ctx.fillStyle = rgbaCss(cardInk, 0.8);
   let labelSize = Math.round(h * 0.11);
   const minLabelSize = Math.round(h * 0.07);
-  const labelText = String(args.label ?? '');
+  const labelText = pangu(args.label ?? ''); // Sprint 94: 盘古之白
   ctx.font = `700 ${labelSize}px Inter, system-ui, sans-serif`;
   while (ctx.measureText(labelText).width > availW && labelSize > minLabelSize) {
     labelSize -= 1;
@@ -404,7 +405,7 @@ function _drawAccentBorder(ctx, args, opts = {}) {
   ctx.fillStyle = rgbaCss(cardInk, 0.8);
   let labelSize = Math.round(h * 0.11);
   const minLabelSize = Math.round(h * 0.07);
-  const labelText = String(args.label ?? '');
+  const labelText = pangu(args.label ?? ''); // Sprint 94: 盘古之白
   ctx.font = `700 ${labelSize}px Inter, system-ui, sans-serif`;
   while (ctx.measureText(labelText).width > availW && labelSize > minLabelSize) {
     labelSize -= 1;

--- a/sdf-js/src/present/atoms-2d/charts/lists/bullet-list.js
+++ b/sdf-js/src/present/atoms-2d/charts/lists/bullet-list.js
@@ -13,6 +13,7 @@
 // =============================================================================
 
 import { rgbCss, rgbaCss, fitFontPx } from '../../renderer.js';
+import { wrapCJK, pangu } from '../../cjk-text.js';
 import { resolveIcon } from '../../../../icons/index.js';
 
 export const spec = {
@@ -215,20 +216,9 @@ export function drawPseudo3D(ctx, args, opts = {}) {
       ctx.textBaseline = 'middle';
       const maxW = x + w - textX - PAD;
       const lineH = labelFontSize * 1.2;
-      const words = String(it.label).split(' ');
-      const lines = [];
-      let cur = '';
-      for (const word of words) {
-        const test = cur ? `${cur} ${word}` : word;
-        if (ctx.measureText(test).width > maxW && cur) {
-          lines.push(cur);
-          cur = word;
-        } else cur = test;
-      }
-      if (cur) lines.push(cur);
-      // Vertical center: cap lines so they fit in rowH
+      // Sprint 94: split(' ') 对无空格的 CJK 长句永不折行 → wrapCJK (禁则断行)
       const maxLines = Math.max(1, Math.floor((rowH - 8) / lineH));
-      const usedLines = lines.slice(0, maxLines);
+      const usedLines = wrapCJK(ctx, it.label, maxW, maxLines);
       const startY = rowCY - ((usedLines.length - 1) * lineH) / 2 - (it.sublabel ? rowH * 0.1 : 0);
       usedLines.forEach((line, li) => {
         ctx.fillText(line, textX, startY + li * lineH);
@@ -241,7 +231,7 @@ export function drawPseudo3D(ctx, args, opts = {}) {
       const subMaxW = x + w - textX - PAD;
       const subFs = fitFontPx(
         ctx,
-        it.sublabel,
+        pangu(it.sublabel),
         subMaxW,
         Math.round(rowH * 0.22),
         (fs) => `500 ${fs}px Inter, system-ui, sans-serif`,
@@ -249,7 +239,7 @@ export function drawPseudo3D(ctx, args, opts = {}) {
       ctx.font = `500 ${subFs}px Inter, system-ui, sans-serif`;
       ctx.textAlign = 'left';
       ctx.textBaseline = 'middle';
-      ctx.fillText(String(it.sublabel), textX, rowCY + rowH * 0.18);
+      ctx.fillText(pangu(it.sublabel), textX, rowCY + rowH * 0.18);
     }
   }
 }

--- a/sdf-js/src/present/atoms-2d/charts/lists/feature-card-grid.js
+++ b/sdf-js/src/present/atoms-2d/charts/lists/feature-card-grid.js
@@ -13,6 +13,7 @@
 
 import { rgbCss, rgbaCss } from '../../renderer.js';
 import { resolveIcon } from '../../../../icons/index.js';
+import { wrapCJK, pangu } from '../../cjk-text.js';
 
 export const spec = {
   type: 'feature-card-grid',
@@ -48,60 +49,8 @@ function lighten([r, g, b], amount = 0.85) {
   ];
 }
 
-// Word-wrap `text` to `maxW`, capped at `maxLines`. Tokenizes on whitespace
-// AND after hyphens (so "zero-knowledge" can break to "zero-" / "knowledge"
-// like a real typesetter, instead of only ever breaking on spaces). If the
-// full text needs more lines than that, the LAST visible line gets an
-// ellipsis appended — dropping whole trailing tokens first so we never cut a
-// word in half; only falls back to a char-level trim if a single token alone
-// is wider than maxW.
-function wrapText(ctx, text, maxW, maxLines = 4) {
-  const rawTokens = String(text).match(/\S+?-|\S+/g) || [];
-  // CJK has no spaces — a whole sentence arrives as ONE token and would
-  // never wrap (the pull-quote lesson, Sprint 37). Any token wider than the
-  // column breaks at char level first.
-  const tokens = [];
-  for (const tok of rawTokens) {
-    if (ctx.measureText(tok).width <= maxW) {
-      tokens.push(tok);
-      continue;
-    }
-    let chunk = '';
-    for (const ch of tok) {
-      if (chunk && ctx.measureText(chunk + ch).width > maxW) {
-        tokens.push(chunk);
-        chunk = ch;
-      } else {
-        chunk += ch;
-      }
-    }
-    if (chunk) tokens.push(chunk);
-  }
-  const allLines = [];
-  let line = '';
-  for (const tok of tokens) {
-    const needsSpace = line !== '' && !line.endsWith('-');
-    const test = needsSpace ? line + ' ' + tok : line + tok;
-    if (line && ctx.measureText(test).width > maxW) {
-      allLines.push(line);
-      line = tok;
-    } else {
-      line = test;
-    }
-  }
-  if (line) allLines.push(line);
-
-  if (allLines.length <= maxLines) return allLines;
-
-  const truncated = allLines.slice(0, maxLines);
-  let last = truncated[maxLines - 1];
-  while (last.length > 0 && ctx.measureText(last + '…').width > maxW) {
-    const idx = last.lastIndexOf(' ');
-    last = idx > 0 ? last.slice(0, idx) : last.slice(0, -1);
-  }
-  truncated[maxLines - 1] = last + '…';
-  return truncated;
-}
+// Sprint 94: 断行统一走 cjk-text.js wrapCJK — 禁则处理 (行首不见「，。」) +
+// latin 词完整 + 盘古之白, 替换掉此处的本地 wrapText (CJK 逐字硬切无禁则)。
 
 // Auto-shrink font size until `text` fits `maxW` (no truncation). Mirrors the
 // fitFontSize pattern in charts/lists/numbered-grid.js.
@@ -227,10 +176,11 @@ export function drawPseudo3D(ctx, args, opts = {}) {
     // Title — auto-shrink so long titles ("Performance", "Global Reach")
     // never overflow the card into its neighbor.
     if (f.title) {
+      const cardTitle = pangu(f.title);
       const titleTarget = Math.round(rowH * 0.13);
       const titleFs = fitFontSize(
         ctx,
-        f.title,
+        cardTitle,
         textMaxW,
         titleTarget,
         12,
@@ -240,7 +190,7 @@ export function drawPseudo3D(ctx, args, opts = {}) {
       ctx.fillStyle = rgbCss(fg);
       ctx.textAlign = 'center';
       ctx.textBaseline = 'top';
-      ctx.fillText(f.title, iconCX, curY);
+      ctx.fillText(cardTitle, iconCX, curY);
       curY += titleFs + 6;
     }
 
@@ -260,7 +210,7 @@ export function drawPseudo3D(ctx, args, opts = {}) {
     ctx.textAlign = 'center';
     ctx.textBaseline = 'top';
     if (f.body && maxLines > 0) {
-      const lines = wrapText(ctx, f.body, textMaxW, maxLines);
+      const lines = wrapCJK(ctx, f.body, textMaxW, maxLines);
       for (const line of lines) {
         ctx.fillText(line, iconCX, curY);
         curY += bodyFs + 2;

--- a/sdf-js/src/present/atoms-2d/charts/lists/numbered-grid.js
+++ b/sdf-js/src/present/atoms-2d/charts/lists/numbered-grid.js
@@ -12,6 +12,7 @@
 // =============================================================================
 
 import { rgbCss, rgbaCss } from '../../renderer.js';
+import { pangu } from '../../cjk-text.js';
 
 export const spec = {
   type: 'numbered-grid',
@@ -158,7 +159,7 @@ export function drawPseudo3D(ctx, args, opts = {}) {
       const labelTarget = Math.round(rowH * 0.14);
       const labelFs = fitFontSize(
         ctx,
-        item.label ?? '',
+        pangu(item.label ?? ''),
         textMaxW,
         labelTarget,
         10,
@@ -168,13 +169,13 @@ export function drawPseudo3D(ctx, args, opts = {}) {
       ctx.fillStyle = rgbCss(fg);
       ctx.textAlign = 'left';
       ctx.textBaseline = 'top';
-      ctx.fillText(item.label ?? '', textX, cellY + cellPad + Math.round(rowH * 0.12));
+      ctx.fillText(pangu(item.label ?? ''), textX, cellY + cellPad + Math.round(rowH * 0.12));
 
       if (item.sublabel) {
         const subTarget = Math.round(rowH * 0.1);
         const subFs = fitFontSize(
           ctx,
-          item.sublabel,
+          pangu(item.sublabel),
           textMaxW,
           subTarget,
           9,
@@ -182,7 +183,11 @@ export function drawPseudo3D(ctx, args, opts = {}) {
         );
         ctx.font = `500 ${subFs}px Inter, system-ui`;
         ctx.fillStyle = rgbaCss(fg, 0.5);
-        ctx.fillText(item.sublabel, textX, cellY + cellPad + Math.round(rowH * 0.12) + labelFs + 4);
+        ctx.fillText(
+          pangu(item.sublabel),
+          textX,
+          cellY + cellPad + Math.round(rowH * 0.12) + labelFs + 4,
+        );
       }
     } else if (numberStyle === 'circle') {
       const circleR = Math.min(rowH * 0.2, colW * 0.14, 28);
@@ -203,7 +208,7 @@ export function drawPseudo3D(ctx, args, opts = {}) {
       const labelTarget = Math.round(rowH * 0.14);
       const labelFs = fitFontSize(
         ctx,
-        item.label ?? '',
+        pangu(item.label ?? ''),
         textMaxW,
         labelTarget,
         10,
@@ -214,13 +219,13 @@ export function drawPseudo3D(ctx, args, opts = {}) {
       ctx.textAlign = 'center';
       ctx.textBaseline = 'top';
       const labelY = circleCY + circleR + 8;
-      ctx.fillText(item.label ?? '', cx, labelY);
+      ctx.fillText(pangu(item.label ?? ''), cx, labelY);
 
       if (item.sublabel) {
         const subTarget = Math.round(rowH * 0.1);
         const subFs = fitFontSize(
           ctx,
-          item.sublabel,
+          pangu(item.sublabel),
           textMaxW,
           subTarget,
           9,
@@ -228,7 +233,7 @@ export function drawPseudo3D(ctx, args, opts = {}) {
         );
         ctx.font = `500 ${subFs}px Inter, system-ui`;
         ctx.fillStyle = rgbaCss(fg, 0.5);
-        ctx.fillText(item.sublabel, cx, labelY + labelFs + 4);
+        ctx.fillText(pangu(item.sublabel), cx, labelY + labelFs + 4);
       }
     } else if (numberStyle === 'corner') {
       // Badge top-right
@@ -252,7 +257,7 @@ export function drawPseudo3D(ctx, args, opts = {}) {
       const labelTarget = Math.round(rowH * 0.14);
       const labelFs = fitFontSize(
         ctx,
-        item.label ?? '',
+        pangu(item.label ?? ''),
         textMaxW,
         labelTarget,
         10,
@@ -263,13 +268,13 @@ export function drawPseudo3D(ctx, args, opts = {}) {
       ctx.fillStyle = rgbCss(fg);
       ctx.textAlign = 'center';
       ctx.textBaseline = 'middle';
-      ctx.fillText(item.label ?? '', cx, item.sublabel ? centerY - labelFs * 0.4 : centerY);
+      ctx.fillText(pangu(item.label ?? ''), cx, item.sublabel ? centerY - labelFs * 0.4 : centerY);
 
       if (item.sublabel) {
         const subTarget = Math.round(rowH * 0.1);
         const subFs = fitFontSize(
           ctx,
-          item.sublabel,
+          pangu(item.sublabel),
           textMaxW,
           subTarget,
           9,
@@ -278,7 +283,7 @@ export function drawPseudo3D(ctx, args, opts = {}) {
         ctx.font = `500 ${subFs}px Inter, system-ui`;
         ctx.fillStyle = rgbaCss(fg, 0.5);
         ctx.textBaseline = 'top';
-        ctx.fillText(item.sublabel, cx, centerY + labelFs * 0.2);
+        ctx.fillText(pangu(item.sublabel), cx, centerY + labelFs * 0.2);
       }
     }
   }

--- a/sdf-js/src/present/atoms-2d/cjk-text.js
+++ b/sdf-js/src/present/atoms-2d/cjk-text.js
@@ -1,0 +1,142 @@
+// =============================================================================
+// cjk-text.js — Sprint 94: 中文排版引擎 (一次性投入, 全局受益).
+//
+// 裸 canvas fillText 的三宗罪, 逐条修:
+//   1. 断行: CJK 字符级硬切 → 行首出现「，。、」等收尾标点 (禁则处理缺失)
+//   2. 中西文混排: 「质押1万ANT」浑然一体 → 缺盘古之白 (CJK↔latin 细空)
+//   3. 尾行: 标点被硬折到下一行孤立成行
+//
+// API:
+//   pangu(text)                     — CJK↔latin/数字边界插 U+2009 THIN SPACE
+//   wrapCJK(ctx, text, maxW, maxLines) — 禁则断行 + 尾行省略号 (词不裂)
+//   fitTextCJK(ctx, text, maxW)     — 单行收缩: 先 pangu 再按需去白
+//
+// 禁则 (简化 JIS X 4051):
+//   行首禁: 收尾标点 ，。、；：！？）】」』％‰°℃…—·"'
+//   行尾禁: 起始标点 （【「『"'
+// =============================================================================
+
+const NO_LINE_START = '，。、；：！？）】」』》〉%％‰°℃…—·"\'’”';
+const NO_LINE_END = '（【「『《〈"\'‘“';
+// 全角/CJK 标点: pangu 边界上不隔白 (「（ANT）机制」的 ）↔机 不是混排边界)
+const CJK_PUNCT = '，。、；：！？（）【】「」『』《》〈〉…—·“”‘’％‰';
+const CJK_RE = /[\u2E80-\u9FFF\uF900-\uFAFF\u3000-\u303F\uFF00-\uFFEF]/;
+// '.' ',' 计入词内字符: 「0.5」「1,000」在断行时不裂开
+const LATIN_RE = /[A-Za-z0-9$%#@&+±=~<>*/\\.,'-]/;
+
+/** pangu(text) — 盘古之白: CJK 与 latin/数字之间补 THIN SPACE (U+2009)。 */
+export function pangu(text) {
+  const s = String(text);
+  let out = '';
+  for (let i = 0; i < s.length; i++) {
+    out += s[i];
+    const a = s[i];
+    const b = s[i + 1];
+    if (!b || a === ' ' || b === ' ') continue;
+    const ab = CJK_RE.test(a) && LATIN_RE.test(b);
+    const ba = LATIN_RE.test(a) && CJK_RE.test(b);
+    // 全角标点邻界不隔白 (「（ANT）机制」); 半角 %/. 随词, 照常隔
+    if ((ab || ba) && !CJK_PUNCT.includes(a) && !CJK_PUNCT.includes(b)) {
+      out += '\u2009';
+    }
+  }
+  return out;
+}
+
+// 切分为不可再分的排版单元: latin 词/数字串整体, CJK 逐字
+function tokens(text) {
+  const s = String(text);
+  const out = [];
+  let buf = '';
+  const flush = () => {
+    if (buf) out.push(buf);
+    buf = '';
+  };
+  for (const ch of s) {
+    if (LATIN_RE.test(ch)) {
+      buf += ch;
+    } else {
+      flush();
+      out.push(ch);
+    }
+  }
+  flush();
+  return out;
+}
+
+/**
+ * wrapCJK(ctx, text, maxW, maxLines) → string[] — 禁则断行。
+ * latin 词整体移行; 行首禁则标点回吸到上一行 (轻微超宽换孤立标点, 悬挂
+ * 式处理); 超过 maxLines 时尾行去整 token 加省略号。ctx.font 须已设置。
+ */
+export function wrapCJK(ctx, text, maxW, maxLines = Infinity) {
+  const toks = [];
+  // 比整列还宽的 latin 长词 (URL/hash) 先字符级拆开, 否则永不折行
+  for (const raw of tokens(pangu(text))) {
+    if (ctx.measureText(raw).width <= maxW) {
+      toks.push(raw);
+      continue;
+    }
+    let chunk = '';
+    for (const ch of raw) {
+      if (chunk && ctx.measureText(chunk + ch).width > maxW) {
+        toks.push(chunk);
+        chunk = ch;
+      } else chunk += ch;
+    }
+    if (chunk) toks.push(chunk);
+  }
+  const lines = [];
+  let line = '';
+  for (let i = 0; i < toks.length; i++) {
+    const tok = toks[i];
+    if (!line && !tok.trim()) continue; // 空白不领行
+    const test = line + tok;
+    if (line && ctx.measureText(test).width > maxW) {
+      // 折行点恰逢空白: 收行, 空白吞掉
+      if (!tok.trim()) {
+        lines.push(line);
+        line = '';
+        continue;
+      }
+      // 禁则: 该 token 是行首禁标点 → 吸到上一行 (标点悬挂)
+      if (tok.length === 1 && NO_LINE_START.includes(tok)) {
+        lines.push(line + tok);
+        line = '';
+        continue;
+      }
+      // 禁则: 上一行不能以起始标点收尾 → 拖它下来
+      const last = line[line.length - 1];
+      if (last && NO_LINE_END.includes(last)) {
+        lines.push(line.slice(0, -1));
+        line = last + tok;
+        continue;
+      }
+      lines.push(line);
+      line = tok;
+    } else {
+      line = test;
+    }
+  }
+  if (line) lines.push(line);
+  if (lines.length <= maxLines) return lines;
+  const cut = lines.slice(0, maxLines);
+  let lastLine = cut[maxLines - 1];
+  while (lastLine && ctx.measureText(lastLine + '…').width > maxW) {
+    const ts = tokens(lastLine);
+    ts.pop();
+    lastLine = ts.join('');
+  }
+  cut[maxLines - 1] = lastLine + '…';
+  return cut;
+}
+
+/** fitTextCJK(ctx, text, maxW) — 单行: pangu 后超宽则先撤白, 再截断加省略。 */
+export function fitTextCJK(ctx, text, maxW) {
+  let s = pangu(text);
+  if (ctx.measureText(s).width <= maxW) return s;
+  s = String(text); // 撤盘古之白救宽度
+  if (ctx.measureText(s).width <= maxW) return s;
+  while (s && ctx.measureText(s + '…').width > maxW) s = s.slice(0, -1);
+  return s + '…';
+}

--- a/sdf-js/src/present/atoms-2d/presentation/cover.js
+++ b/sdf-js/src/present/atoms-2d/presentation/cover.js
@@ -25,6 +25,7 @@
 // =============================================================================
 
 import { rgbCss, rgbaCss } from '../renderer.js';
+import { pangu } from '../cjk-text.js';
 
 export const spec = {
   type: 'cover',
@@ -58,8 +59,9 @@ export function drawPseudo3D(ctx, args, opts = {}) {
   ];
   const accent = colors[0];
 
-  const title = args.title || '';
-  const subtitle = args.subtitle;
+  // Sprint 94: 盘古之白 — 中西文边界补细空 (「质押1万ANT」→「质押 1 万 ANT」)
+  const title = args.title ? pangu(args.title) : '';
+  const subtitle = args.subtitle ? pangu(args.subtitle) : args.subtitle;
   const author = args.author;
   const date = args.date;
   const version = args.version;


### PR DESCRIPTION
一次性全局受益的 CJK 排版层: 共享引擎 src/present/atoms-2d/cjk-text.js, 6 个最高可见度 atoms 接入。裸 fillText 三宗罪逐条修: CJK 硬切致行首「，。」/ 中西文粘连 / 词中裂行。18 断言单测 + 范本 27 断言不回归 + ANTFUN 式密集中文页 browse 视觉验证通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)