### PR TITLE
Sprint 95: 版式语法 — split / statement 页面骨架 + 内容形状调度 (优化路线图一)

### DIFF
--- a/sdf-js/apps/present/author-2d.js
+++ b/sdf-js/apps/present/author-2d.js
@@ -25,6 +25,7 @@ import {
   mountPaletteOverride,
   mountUnderlayDecor,
 } from '../../src/present/art-mount.js';
+import { layoutForSlot } from '../../src/present/atoms-2d/layout.js';
 import { ATLAS_THEMES } from '../../src/present/themes.js';
 import { exportDeckToPPTX } from '../../src/present/exporters/pptx.js';
 import { exportDeckToPDF } from '../../src/present/exporters/pdf.js';
@@ -279,6 +280,8 @@ function slotRenderOpts(theme, deck, slot) {
     palette: slotPalette(theme, slot),
     decor: slotDecor(deck, slot),
     decorRole: slotRoleOf(slot),
+    // Sprint 95: 版式语法 — 按内容形状调度 banner/split/statement
+    layout: layoutForSlot(slot, slot.sceneData),
   };
   if (artMount && decorVisEl.value !== 'off') {
     Object.assign(base, artMountOpts(artMount, slot, slotRoleOf(slot)) || {});

--- a/sdf-js/scripts/test-layout.mjs
+++ b/sdf-js/scripts/test-layout.mjs
@@ -1,0 +1,239 @@
+// test-layout.mjs — Sprint 95: 版式语法回归测试.
+// 钉住: layoutForSlot 确定性调度 / applySplitLayout 几何重映射 (纯函数) /
+// applyStatementLayout 装裱卡收纳 / renderer 两个新版式的绘制契约。
+import {
+  layoutForSlot,
+  applySplitLayout,
+  applyStatementLayout,
+  statementCardRect,
+  SPLIT_RAIL_FRAC,
+} from '../src/present/atoms-2d/layout.js';
+import { renderSceneDataToCanvas } from '../src/present/atoms-2d/renderer.js';
+
+let passed = 0;
+let failed = 0;
+function ok(cond, msg, extra = '') {
+  if (cond) {
+    passed++;
+    console.log(`  ✓ ${msg}`);
+  } else {
+    failed++;
+    console.log(`  ✗ ${msg}${extra ? ` — ${extra}` : ''}`);
+  }
+}
+
+// ── 1. layoutForSlot 调度 ──
+{
+  const quoteScene = {
+    subjects: [
+      { type: 'cover', args: { title: 'ANTFUN 理念' } },
+      { type: 'quote-pull', args: { quote: '...' } },
+    ],
+  };
+  ok(layoutForSlot({ slotName: 'quote' }, quoteScene) === 'statement', '单 quote 页 → statement');
+  const leadScene = {
+    subjects: [
+      { type: 'cover', args: { title: '第一章' } },
+      { type: 'bullet-list', args: { items: [] } },
+    ],
+  };
+  ok(layoutForSlot({ slotName: 'theme-1-lead' }, leadScene) === 'split', '-lead 轻页 → split');
+  const denseLead = {
+    subjects: [
+      { type: 'cover', args: {} },
+      { type: 'kpi-card', args: {} },
+      { type: 'kpi-card', args: {} },
+      { type: 'kpi-card', args: {} },
+    ],
+  };
+  ok(
+    layoutForSlot({ slotName: 'theme-2-lead' }, denseLead) === 'banner',
+    '-lead 密页 (3+ atoms) 留 banner',
+  );
+  ok(
+    layoutForSlot({ slotName: 'key-figures' }, denseLead) === 'banner',
+    '普通内容页 → banner (现状不变)',
+  );
+  ok(
+    layoutForSlot(
+      { slotName: 'theme-3-lead' },
+      { subjects: [{ type: 'bullet-list', args: {} }] },
+    ) === 'banner',
+    '-lead 无 cover 主体 → banner (rail 无标题可载)',
+  );
+}
+
+// ── 2. applySplitLayout 几何 ──
+{
+  const scene = {
+    subjects: [
+      { type: 'cover', x: 0, y: 0, w: 1280, h: 120, args: { title: 'T' } },
+      { type: 'bullet-list', x: 40, y: 160, w: 1200, h: 520, args: {} },
+    ],
+  };
+  const railW = Math.round(1280 * SPLIT_RAIL_FRAC);
+  const out = applySplitLayout(scene, 1280, 720);
+  const cover = out.subjects.find((s) => s.type === 'cover');
+  const body = out.subjects.find((s) => s.type === 'bullet-list');
+  ok(
+    cover.x === 0 && cover.y === 0 && cover.w === railW && cover.h === 720,
+    'cover 主体占满左 rail',
+  );
+  ok(body.x >= railW, '正文重映射进右列 (x ≥ railW)', `x=${body.x}`);
+  ok(body.x + body.w <= 1280, '正文不出右边界');
+  ok(body.y === 80, '正文上移回收横带空档 (160→80)');
+  ok(scene.subjects[0].w === 1280 && scene.subjects[1].x === 40, '纯函数: 输入不被修改');
+}
+
+// ── 3. applyStatementLayout 装裱卡 ──
+{
+  const scene = {
+    subjects: [
+      { type: 'cover', x: 0, y: 0, w: 1280, h: 120, args: { title: 'ANTFUN 理念' } },
+      { type: 'quote-pull', x: 40, y: 160, w: 1200, h: 520, args: { quote: 'q' } },
+    ],
+  };
+  const { sceneData, kicker, card } = applyStatementLayout(scene, 1280, 720);
+  ok(kicker === 'ANTFUN 理念', 'cover 标题成为 kicker');
+  ok(!sceneData.subjects.some((s) => s.type === 'cover'), 'cover 主体退场');
+  const q = sceneData.subjects[0];
+  ok(
+    q.x >= card.x && q.y >= card.y && q.x + q.w <= card.x + card.w && q.y + q.h <= card.y + card.h,
+    '正文收进装裱卡内',
+  );
+  const ref = statementCardRect(1280, 720);
+  ok(card.x === ref.x && card.w === ref.w, '卡几何与 statementCardRect 一致');
+}
+
+// ── 4. renderer 绘制契约 (mock canvas) ──
+function recCanvas() {
+  const rec = { ops: [], texts: [], aligns: [], images: [] };
+  const ctx = new Proxy(
+    {},
+    {
+      get(t, k) {
+        if (k in t) return t[k];
+        if (k === '__rec') return rec;
+        if (k === 'measureText') return (s) => ({ width: String(s).length * 8 });
+        if (k === 'getImageData') return () => ({ data: new Uint8ClampedArray(4 * 100) });
+        if (k === 'createLinearGradient' || k === 'createRadialGradient')
+          return () => ({ addColorStop: () => {} });
+        if (k === 'fillText')
+          return (s, x, y) => {
+            rec.texts.push(String(s));
+            rec.ops.push(['fillText', String(s), Math.round(x), Math.round(y)]);
+            rec.aligns.push(ctx.textAlign);
+          };
+        if (k === 'drawImage')
+          return (...a) => {
+            rec.images.push(a);
+            rec.ops.push(['drawImage', a.length]);
+          };
+        return (...a) =>
+          rec.ops.push([
+            String(k),
+            ...a.map((v) => (typeof v === 'number' ? Math.round(v) : String(v).slice(0, 24))),
+          ]);
+      },
+      set(t, k, v) {
+        t[k] = v;
+        return true;
+      },
+    },
+  );
+  return { canvas: { width: 1280, height: 720, getContext: () => ctx }, rec };
+}
+const palette = {
+  accent: [200, 80, 40],
+  colors: [[200, 80, 40]],
+  bg: [246, 244, 238],
+  silhouetteColor: [30, 30, 34],
+};
+const fakeArt = { width: 1280, height: 985 };
+
+// split 渲染
+{
+  const { canvas, rec } = recCanvas();
+  await renderSceneDataToCanvas(
+    canvas,
+    {
+      subjects: [
+        { type: 'cover', x: 0, y: 0, w: 1280, h: 120, args: { title: '第一章' } },
+        {
+          type: 'bullet-list',
+          x: 40,
+          y: 160,
+          w: 1200,
+          h: 520,
+          args: { title: '第一章总览', items: [{ label: '要点' }] },
+        },
+      ],
+    },
+    { palette, decorArt: fakeArt, decorRole: 'section', layout: 'split' },
+  );
+  const railW = Math.round(1280 * SPLIT_RAIL_FRAC);
+  const art = rec.images.find((a) => a.length === 9);
+  ok(!!art, 'split: rail 真迹 cover-fit (9 参裁绘)');
+  ok(
+    art && art[7] === railW && art[8] === 720,
+    'split: 真迹裁绘为竖 rail 尺寸',
+    art && `${art[7]}x${art[8]}`,
+  );
+  const ti = rec.texts.indexOf('第一章');
+  ok(ti >= 0 && rec.aligns[ti] === 'center', 'split: rail 标题居中');
+  const tx = rec.ops.find((o) => o[0] === 'fillText' && o[1] === '第一章');
+  ok(tx && tx[2] <= railW, 'split: rail 标题落在 rail 内', tx && `x=${tx[2]}`);
+  ok(!rec.texts.includes('第一章总览'), 'split: 正文标题与 rail 重复时剥除');
+  ok(rec.texts.includes('要点'), 'split: 正文内容保留');
+}
+
+// statement 渲染
+{
+  const { canvas, rec } = recCanvas();
+  await renderSceneDataToCanvas(
+    canvas,
+    {
+      subjects: [
+        { type: 'cover', x: 0, y: 0, w: 1280, h: 120, args: { title: 'ANTFUN 理念' } },
+        {
+          type: 'quote-pull',
+          x: 40,
+          y: 160,
+          w: 1200,
+          h: 520,
+          args: { quote: '收益应当归于建设者', attribution: '创始团队' },
+        },
+      ],
+    },
+    { palette, decorArt: fakeArt, decorRole: 'content', layout: 'statement' },
+  );
+  const full = rec.images.find((a) => a.length === 9 && a[7] === 1280 && a[8] === 720);
+  ok(!!full, 'statement: 真迹全幅 cover-fit');
+  ok(rec.texts.includes('ANTFUN 理念'), 'statement: kicker 小字上卡');
+  const card = statementCardRect(1280, 720);
+  const cardRect = rec.ops.find(
+    (o) => o[0] === 'fillRect' && o[1] === card.x && o[2] === card.y && o[3] === card.w,
+  );
+  ok(!!cardRect, 'statement: 装裱卡按 statementCardRect 绘制');
+  ok(rec.texts.includes('收益应当归于建设者'), 'statement: 引文正文保留');
+}
+
+// 无 art 面 → 静默回落 banner (不抛错, 几何不动)
+{
+  const { canvas, rec } = recCanvas();
+  const r = await renderSceneDataToCanvas(
+    canvas,
+    {
+      subjects: [
+        { type: 'cover', x: 0, y: 0, w: 1280, h: 120, args: { title: 'T' } },
+        { type: 'bullet-list', x: 40, y: 160, w: 1200, h: 520, args: { items: [{ label: 'L' }] } },
+      ],
+    },
+    { palette, layout: 'split' },
+  );
+  ok(r.errors.length === 0, '无 art 面 split 请求: 静默回落, 零错误');
+  ok(rec.texts.includes('L'), '回落后内容照常渲染');
+}
+
+console.log(`\n${passed} passed, ${failed} failed`);
+if (failed) process.exit(1);

--- a/sdf-js/src/present/atoms-2d/layout.js
+++ b/sdf-js/src/present/atoms-2d/layout.js
@@ -1,0 +1,105 @@
+// =============================================================================
+// layout.js — Sprint 95: 版式语法 (layout grammar).
+//
+// 范本 v3 只有一种版式: banner (顶部艺术横带 + 下方正文)。整本 deck 每页
+// 同构 → 单调。本模块引入两个新版式 + 按内容形状的自动调度:
+//
+//   banner    — 现状 (默认): 顶部横带真迹 + 正文。
+//   split     — 左侧竖向艺术 rail (~38%) + 右侧正文列。用于 -lead 章节页
+//               (正文 1-2 个 atom 时): 竖幅真迹完整呼吸, 标题居中其上。
+//   statement — 全幅真迹 + 居中装裱卡。用于引文页 (正文恰好 1 个 quote
+//               atom): 作品即页面, 文字如美术馆标牌。
+//
+// 调度是确定性的 (内容形状 + slot 命名), 不引入随机 — 同一 deck 每次
+// 渲染版式一致。几何变换是纯函数: 不改 deck.json, 只在 paint 时重映射
+// (与 alignSceneData 同一纪律)。
+// =============================================================================
+
+/** 竖 rail 占画布宽度的比例 (split 版式)。 */
+export const SPLIT_RAIL_FRAC = 0.38;
+
+const QUOTE_TYPES = new Set(['quote-pull', 'pull-quote-banner']);
+
+/**
+ * layoutForSlot(slot, sceneData) → 'banner' | 'split' | 'statement'
+ * 按内容形状 + slot 命名确定性调度:
+ *   statement — 正文恰好 1 个 quote 类 atom
+ *   split     — -lead 章节页 且 正文 1-2 个 atom (3+ 的密页留在 banner,
+ *               右列 62% 宽会压垮 KPI 网格)
+ *   banner    — 其余全部 (现状不变)
+ */
+export function layoutForSlot(slot, sceneData) {
+  const subs = (sceneData?.subjects || []).filter((s) => s && typeof s.type === 'string');
+  const body = subs.filter((s) => s.type !== 'cover');
+  if (body.length === 1 && QUOTE_TYPES.has(body[0].type)) return 'statement';
+  const name = String(slot?.slotName || '');
+  if (
+    /-lead$/.test(name) &&
+    body.length >= 1 &&
+    body.length <= 2 &&
+    subs.some((s) => s.type === 'cover')
+  ) {
+    return 'split';
+  }
+  return 'banner';
+}
+
+/**
+ * applySplitLayout(sceneData, W, H) → new sceneData (纯函数, 不改输入)。
+ * cover 主体占满左 rail (0,0,railW,H); 正文主体线性重映射进右列,
+ * 顶部上移回收原横带留下的空档 (y-80, 地板 48)。
+ */
+export function applySplitLayout(sceneData, W, H) {
+  const railW = Math.round(W * SPLIT_RAIL_FRAC);
+  const scale = (W - railW) / W;
+  const subjects = (sceneData?.subjects || []).map((s) => {
+    if (!s || typeof s.type !== 'string') return s;
+    if (s.type === 'cover') return { ...s, x: 0, y: 0, w: railW, h: H };
+    const x = s.x ?? 0;
+    const w = s.w ?? W;
+    const y = s.y ?? 0;
+    return {
+      ...s,
+      x: Math.round(railW + x * scale),
+      w: Math.round(w * scale),
+      y: y >= 140 ? Math.max(48, y - 80) : y,
+    };
+  });
+  return { ...sceneData, subjects };
+}
+
+/**
+ * statementCardRect(W, H) — 居中装裱卡的几何 (全幅真迹之上)。
+ * 卡宽 64% / 高 ≤56%, 上下留出作品呼吸区。
+ */
+export function statementCardRect(W, H) {
+  const cw = Math.round(W * 0.64);
+  const ch = Math.round(Math.min(H * 0.56, H - 192));
+  return { x: Math.round((W - cw) / 2), y: Math.round((H - ch) / 2), w: cw, h: ch };
+}
+
+/**
+ * applyStatementLayout(sceneData, W, H) → { sceneData, kicker } (纯函数)。
+ * cover 主体退场 (其标题成为卡上 kicker 小字); 唯一正文 atom 的 bounds
+ * 收进装裱卡内 (kicker 占用卡顶 52px, 四周 pad 28)。
+ */
+export function applyStatementLayout(sceneData, W, H) {
+  const card = statementCardRect(W, H);
+  const coverSub = (sceneData?.subjects || []).find((s) => s && s.type === 'cover');
+  const kicker = coverSub?.args?.title ? String(coverSub.args.title) : '';
+  const PAD = 28;
+  const topPad = kicker ? 52 + PAD : PAD;
+  const subjects = (sceneData?.subjects || [])
+    .filter((s) => !(s && s.type === 'cover'))
+    .map((s) => {
+      if (!s || typeof s.type !== 'string') return s;
+      return {
+        ...s,
+        x: card.x + PAD,
+        y: card.y + topPad,
+        w: card.w - PAD * 2,
+        h: card.h - topPad - PAD,
+      };
+    });
+  return { sceneData: { ...sceneData, subjects }, kicker, card };
+}

--- a/sdf-js/src/present/atoms-2d/renderer.js
+++ b/sdf-js/src/present/atoms-2d/renderer.js
@@ -18,6 +18,7 @@
 import { renderAtom, isAtom2DType } from './registry.js';
 import { drawDecor } from '../decor/registry.js';
 import { alignSceneData } from '../align.js';
+import { applySplitLayout, applyStatementLayout } from './layout.js';
 
 const DEFAULT_PALETTE = {
   bg: [247, 244, 224],
@@ -89,15 +90,31 @@ export async function renderSceneDataToCanvas(canvas, sceneData, opts = {}) {
     Array.isArray(opts.decorArtStrip) && opts.decorArtStrip.length ? opts.decorArtStrip : null;
   const coverArt = decorArt || (decorArtStrip && decorArtStrip[0]) || null;
   const coverCanvas = !!((decor || coverArt) && isPureCover);
+  // Sprint 95 (版式语法): opts.layout 选择页面骨架 — 'banner' (默认,
+  // 现状) / 'split' (左竖 rail 真迹 + 右正文列) / 'statement' (全幅真迹 +
+  // 居中装裱卡)。两个新版式都需要 art 面 (decor 或 coverArt), 否则静默回
+  // 落 banner — deck.json 几何不动, 重映射只在 paint 时发生。
+  const hasArtSurface = !!(decor || coverArt);
+  const splitCanvas = opts.layout === 'split' && hasArtSurface && !isPureCover;
+  const statementCanvas = opts.layout === 'statement' && hasArtSurface && !isPureCover;
   // Sprint 80 (user: 目录页把图案做到标题栏, 不要放正文): agenda / section
   // pages run the cover-canvas pipeline INSIDE their title banner (the
   // banner is a 'cover' atom with its own bounds) — ink ground → artwork →
   // overlay type, clipped to the band. The BODY stays clean: no under-decor.
-  const bannerCanvas = !!(
-    (decor || coverArt) &&
-    !isPureCover &&
-    (role === 'agenda' || role === 'section')
-  );
+  const bannerCanvas =
+    !splitCanvas &&
+    !statementCanvas &&
+    !!((decor || coverArt) && !isPureCover && (role === 'agenda' || role === 'section'));
+  let statementKicker = '';
+  let statementCard = null;
+  if (splitCanvas) {
+    subjects = applySplitLayout({ ...aligned, subjects }, canvas.width, canvas.height).subjects;
+  } else if (statementCanvas) {
+    const st = applyStatementLayout({ ...aligned, subjects }, canvas.width, canvas.height);
+    subjects = st.sceneData.subjects;
+    statementKicker = st.kicker;
+    statementCard = st.card;
+  }
   const drawArtCover = (img, dx, dy, dw, dh) => {
     const iw = img.width || img.videoWidth || 1;
     const ih = img.height || img.videoHeight || 1;
@@ -149,10 +166,16 @@ export async function renderSceneDataToCanvas(canvas, sceneData, opts = {}) {
       });
     }
   }
+  // Sprint 95: statement 全幅真迹之下 underlay 无意义, 恒跳过; split 与
+  // banner 同律 — art 面已在 rail, 正文默认干净, decorUnder 显式请求才画。
   // Sprint 84: mounted pages can ask for the subtle body underlay TOO
   // (opts.decorUnder) — banner art + body elements in the mount's palette,
   // instead of clean-but-voiceless content pages.
-  const wantUnder = bannerCanvas ? opts.decorUnder === true : !coverArt && !bannerCanvas;
+  const wantUnder = statementCanvas
+    ? false
+    : bannerCanvas || splitCanvas
+      ? opts.decorUnder === true
+      : !coverArt && !bannerCanvas;
   if (decor && !isPureCover && wantUnder) {
     drawDecor(ctx, decor, {
       palette,
@@ -170,7 +193,8 @@ export async function renderSceneDataToCanvas(canvas, sceneData, opts = {}) {
   // carry the page. opts.bannerTitle overrides everything when provided.
   let bannerTitle = opts.bannerTitle || null;
   let bannerSubtitle = opts.bannerSubtitle || null;
-  if (bannerCanvas) {
+  // Sprint 95: split 的 rail 标题与 banner 同享 hoist/查重/小字剥除文法
+  if (bannerCanvas || splitCanvas) {
     subjects = subjects.slice(); // never mutate the caller's array
     const coverSub = subjects.find((c2) => c2 && c2.type === 'cover');
     const refTitle = String(opts.bannerTitle || coverSub?.args?.title || '').replace(/\s/g, '');
@@ -210,6 +234,46 @@ export async function renderSceneDataToCanvas(canvas, sceneData, opts = {}) {
     }
   }
 
+  // Sprint 95 statement: 作品即页面 — 全幅真迹 + 居中装裱卡 (paper 底 +
+  // 投影 + accent 短划 + kicker 小字 = 美术馆标牌), 正文 atom 已被
+  // applyStatementLayout 收进卡内。
+  if (statementCanvas) {
+    if (coverArt) {
+      drawArtCover(coverArt, 0, 0, canvas.width, canvas.height);
+    } else {
+      const ink = (palette.silhouetteColor || [30, 27, 30]).map((c) => Math.round(c * 0.3));
+      ctx.fillStyle = `rgb(${ink[0]}, ${ink[1]}, ${ink[2]})`;
+      ctx.fillRect(0, 0, canvas.width, canvas.height);
+      drawDecor(ctx, decor, {
+        palette,
+        x: 0,
+        y: 0,
+        w: canvas.width,
+        h: canvas.height,
+        intensity: decor.intensity || 'artwork',
+      });
+    }
+    const c = statementCard;
+    ctx.save();
+    ctx.shadowColor = 'rgba(0, 0, 0, 0.5)';
+    ctx.shadowBlur = 28;
+    ctx.shadowOffsetY = 8;
+    ctx.fillStyle = rgbCss(palette.bg);
+    ctx.fillRect(c.x, c.y, c.w, c.h);
+    ctx.restore();
+    if (statementKicker) {
+      const ink = palette.silhouetteColor || [30, 27, 30];
+      ctx.fillStyle = rgbCss(palette.accent || (palette.colors && palette.colors[0]) || ink);
+      ctx.fillRect(c.x + c.w / 2 - 24, c.y + 30, 48, 3);
+      ctx.fillStyle = rgbaCss(ink, 0.75);
+      ctx.font = '700 16px Inter, system-ui, sans-serif';
+      ctx.textAlign = 'center';
+      ctx.textBaseline = 'top';
+      ctx.fillText(statementKicker, c.x + c.w / 2, c.y + 44);
+      ctx.textAlign = 'left';
+    }
+  }
+
   let rendered = 0;
   let skipped = 0;
   const errors = [];
@@ -225,8 +289,10 @@ export async function renderSceneDataToCanvas(canvas, sceneData, opts = {}) {
       skipped++;
       continue;
     }
-    const isBannerAtom = bannerCanvas && s.type === 'cover';
+    const isBannerAtom = (bannerCanvas || splitCanvas) && s.type === 'cover';
     if (isBannerAtom) {
+      // split: cover 主体即左 rail (applySplitLayout 已置 0,0,railW,H) —
+      // 竖幅 cover-fit 裁绘, 大画布优先, 无变体时退 strip 首件 / decor 引擎
       // mini cover-canvas clipped to the banner band
       const bx = s.x ?? 0;
       const by = s.y ?? 0;
@@ -242,7 +308,9 @@ export async function renderSceneDataToCanvas(canvas, sceneData, opts = {}) {
         // remains only as a fallback when no large exists
         drawArtCover(decorArt, bx, by, bw, bh);
       } else if (decorArtStrip) {
-        drawArtStrip(bx, by, bw, bh);
+        // 竖 rail 不适合横向胶片条 — 取首件小画布 cover-fit 竖裁
+        if (splitCanvas) drawArtCover(decorArtStrip[0], bx, by, bw, bh);
+        else drawArtStrip(bx, by, bw, bh);
       } else {
         const ink = (palette.silhouetteColor || [30, 27, 30]).map((c) => Math.round(c * 0.3));
         ctx.fillStyle = `rgb(${ink[0]}, ${ink[1]}, ${ink[2]})`;

--- a/sdf-js/src/present/exporters/pdf.js
+++ b/sdf-js/src/present/exporters/pdf.js
@@ -12,6 +12,7 @@
 import { renderSceneDataToCanvas } from '../atoms-2d/renderer.js';
 import { slotPalette, slotRoleOf } from '../retheme.js';
 import { artMountOpts, mountPaletteOverride, mountUnderlayDecor } from '../art-mount.js';
+import { layoutForSlot } from '../atoms-2d/layout.js';
 
 const JSPDF_CDN = 'https://esm.sh/jspdf@2.5.2';
 let jsPDF = null;
@@ -73,6 +74,7 @@ export async function exportDeckToPDF(deck, opts = {}) {
           ? mountPaletteOverride(slotPalette(deck.theme, slot), opts.artMount)
           : slotPalette(deck.theme, slot),
         decorRole: slotRoleOf(slot),
+        layout: layoutForSlot(slot, slot.sceneData),
         decor: deck.decor
           ? (opts.artMount ? mountUnderlayDecor : (d) => d)(
               { ...deck.decor, seed: (deck.decor.seed ?? 1) + slot.slotIdx },

--- a/sdf-js/src/present/exporters/pptx.js
+++ b/sdf-js/src/present/exporters/pptx.js
@@ -20,6 +20,7 @@
 import { renderSceneDataToCanvas } from '../atoms-2d/renderer.js';
 import { slotPalette, slotRoleOf } from '../retheme.js';
 import { artMountOpts, mountPaletteOverride, mountUnderlayDecor } from '../art-mount.js';
+import { layoutForSlot } from '../atoms-2d/layout.js';
 
 // pptxgenjs loaded from esm.sh on first call (matches pdfjs CDN pattern in
 // src/parser/pdf.js — no build step / bundler required).
@@ -89,6 +90,7 @@ export async function exportDeckToPPTX(deck, opts = {}) {
           ? mountPaletteOverride(slotPalette(deck.theme, slot), opts.artMount)
           : slotPalette(deck.theme, slot),
         decorRole: slotRoleOf(slot),
+        layout: layoutForSlot(slot, slot.sceneData),
         decor: deck.decor
           ? (opts.artMount ? mountUnderlayDecor : (d) => d)(
               { ...deck.decor, seed: (deck.decor.seed ?? 1) + slot.slotIdx },


### PR DESCRIPTION
最大空间的版式 sprint: deck 从单一 banner 语法升级为三版式语法 (banner/split/statement), 按内容形状确定性调度。-lead 章节页竖 rail 真迹, 引文页美术馆标牌式装裱卡。26 断言回归 + 既有 45 断言不回归 + browse 视觉验证。

🤖 Generated with [Claude Code](https://claude.com/claude-code)