### PR TITLE
Sprint 96: 色彩语义化 — 角色系统 + OKLab 提色 v2 (优化路线图三)

### DIFF
--- a/sdf-js/scripts/test-color.mjs
+++ b/sdf-js/scripts/test-color.mjs
@@ -1,0 +1,195 @@
+// test-color.mjs — Sprint 96: 色彩语义化回归测试.
+// 钉住: 语义角色不被艺术色覆盖 / OKLab 感知距离 / series 可区分 / accent
+// 对比度地板 / atoms 消费 palette.semantic。
+import {
+  SEMANTIC,
+  semanticColor,
+  rgbToOklab,
+  okDist,
+  pickDistinct,
+  ensureContrast,
+} from '../src/present/atoms-2d/color.js';
+import { mountPaletteOverride } from '../src/present/art-mount.js';
+import { renderSceneDataToCanvas } from '../src/present/atoms-2d/renderer.js';
+
+let passed = 0;
+let failed = 0;
+function ok(cond, msg, extra = '') {
+  if (cond) {
+    passed++;
+    console.log(`  ✓ ${msg}`);
+  } else {
+    failed++;
+    console.log(`  ✗ ${msg}${extra ? ` — ${extra}` : ''}`);
+  }
+}
+
+// ── 1. semanticColor 角色 ──
+ok(semanticColor({}, 'positive') === SEMANTIC.positive, '无定制: 统一默认 (positive)');
+ok(semanticColor(null, 'negative') === SEMANTIC.negative, 'null palette 不炸');
+ok(semanticColor({}, 'unknown-role') === SEMANTIC.neutral, '未知角色回落 neutral');
+{
+  const custom = { semantic: { positive: [1, 2, 3] } };
+  ok(semanticColor(custom, 'positive').join() === '1,2,3', '主题可经 palette.semantic 定制');
+  ok(semanticColor(custom, 'negative') === SEMANTIC.negative, '未定制的角色仍走默认');
+}
+
+// ── 2. OKLab ──
+{
+  const [L] = rgbToOklab([255, 255, 255]);
+  ok(Math.abs(L - 1) < 0.01, '白色 L≈1', `L=${L.toFixed(3)}`);
+  const [L0] = rgbToOklab([0, 0, 0]);
+  ok(Math.abs(L0) < 0.01, '黑色 L≈0');
+  ok(
+    Math.abs(okDist([200, 30, 30], [30, 160, 60]) - okDist([30, 160, 60], [200, 30, 30])) < 1e-9,
+    '距离对称',
+  );
+  ok(
+    okDist([200, 30, 30], [30, 160, 60]) > okDist([100, 100, 100], [110, 110, 110]),
+    '红绿远 > 近灰',
+  );
+}
+
+// ── 3. pickDistinct series 可区分 ──
+{
+  const cands = [
+    [200, 40, 40],
+    [205, 45, 42], // 与首个几乎同色 — 应被拒
+    [40, 90, 170],
+    [42, 92, 172], // 与上一个几乎同色 — 应被拒
+    [40, 160, 90],
+    [230, 180, 40],
+  ];
+  const picked = pickDistinct(cands, 6, 0.09);
+  ok(picked.length === 4, '近似色被 OKLab 去重 (6→4)', `got ${picked.length}`);
+  const allApart = picked.every((a, i) => picked.every((b, j) => i === j || okDist(a, b) >= 0.09));
+  ok(allApart, '选中 series 两两 ΔE ≥ 0.09');
+  ok(picked[0] === cands[0], '输入序 = 优先级序 (首色保留)');
+}
+
+// ── 4. ensureContrast ──
+{
+  const paper = [246, 244, 238];
+  const pale = [235, 230, 210]; // 与纸底几乎同明度
+  const fixed = ensureContrast(pale, paper);
+  ok(
+    Math.abs(rgbToOklab(fixed)[0] - rgbToOklab(paper)[0]) >= 0.2,
+    '过淡 accent 被压暗到对比达标',
+    `ΔL=${Math.abs(rgbToOklab(fixed)[0] - rgbToOklab(paper)[0]).toFixed(2)}`,
+  );
+  const strong = [150, 40, 30];
+  ok(ensureContrast(strong, paper) === strong, '对比已达标: 原样返回 (零改动)');
+  const darkBg = [24, 24, 30];
+  const darkAccent = [40, 38, 50];
+  const lifted = ensureContrast(darkAccent, darkBg);
+  ok(rgbToOklab(lifted)[0] > rgbToOklab(darkAccent)[0], '暗底过暗 accent 被提亮');
+}
+
+// ── 5. mountPaletteOverride 语义纪律 ──
+{
+  const base = {
+    accent: [10, 10, 10],
+    colors: [[10, 10, 10]],
+    bg: [246, 244, 238],
+    silhouetteColor: [30, 30, 34],
+    semantic: { positive: [7, 7, 7] },
+  };
+  const mount = {
+    palette: {
+      accent: [235, 230, 210],
+      colors: [
+        [235, 230, 210],
+        [40, 90, 170],
+      ],
+    },
+  };
+  const out = mountPaletteOverride(base, mount);
+  ok(out.semantic === base.semantic, '语义色随 base 透传, 艺术色不覆盖');
+  ok(out.bg === base.bg && out.silhouetteColor === base.silhouetteColor, '底色/墨色不动');
+  ok(out.accent.join() !== '235,230,210', '过淡艺术 accent 被 ensureContrast 修正');
+  ok(out.colors[0] === out.accent, 'colors[0] 与修正后 accent 同步 (atoms 双读法)');
+  ok(out.colors[1].join() === '40,90,170', '其余 series 色保留');
+}
+
+// ── 6. atoms 消费 palette.semantic (mock canvas) ──
+function recCanvas() {
+  const rec = { fills: [], texts: [] };
+  const ctx = new Proxy(
+    {},
+    {
+      get(t, k) {
+        if (k in t) return t[k];
+        if (k === '__rec') return rec;
+        if (k === 'measureText') return (s) => ({ width: String(s).length * 8 });
+        if (k === 'getImageData') return () => ({ data: new Uint8ClampedArray(4 * 100) });
+        if (k === 'createLinearGradient' || k === 'createRadialGradient')
+          return () => ({ addColorStop: () => {} });
+        if (k === 'fillText') return (s) => rec.texts.push(String(s));
+        return () => {};
+      },
+      set(t, k, v) {
+        if (k === 'fillStyle') rec.fills.push(String(v));
+        t[k] = v;
+        return true;
+      },
+    },
+  );
+  return { canvas: { width: 1280, height: 720, getContext: () => ctx }, rec };
+}
+const basePalette = {
+  accent: [200, 80, 40],
+  colors: [[200, 80, 40]],
+  bg: [246, 244, 238],
+  silhouetteColor: [30, 30, 34],
+};
+
+// kpi-card trend pill: 默认语义绿 / 定制语义色生效
+{
+  const { canvas, rec } = recCanvas();
+  await renderSceneDataToCanvas(
+    canvas,
+    {
+      subjects: [
+        {
+          type: 'kpi-card',
+          x: 40,
+          y: 40,
+          w: 400,
+          h: 240,
+          args: { value: '90%', label: '留存率', trend: 'up', trendValue: '+12%' },
+        },
+      ],
+    },
+    { palette: basePalette },
+  );
+  ok(
+    rec.fills.some((f) => f.includes('40,160,100') || f.includes('40, 160, 100')),
+    'kpi 上涨 pill = 统一语义绿',
+  );
+}
+{
+  const { canvas, rec } = recCanvas();
+  await renderSceneDataToCanvas(
+    canvas,
+    {
+      subjects: [
+        {
+          type: 'kpi-card',
+          x: 40,
+          y: 40,
+          w: 400,
+          h: 240,
+          args: { value: '90%', label: '留存率', trend: 'down', trendValue: '-3%' },
+        },
+      ],
+    },
+    { palette: { ...basePalette, semantic: { negative: [9, 8, 7] } } },
+  );
+  ok(
+    rec.fills.some((f) => f.includes('9,8,7') || f.includes('9, 8, 7')),
+    'palette.semantic 定制下跌色被 kpi 消费',
+  );
+}
+
+console.log(`\n${passed} passed, ${failed} failed`);
+if (failed) process.exit(1);

--- a/sdf-js/src/present/art-mount.js
+++ b/sdf-js/src/present/art-mount.js
@@ -14,6 +14,8 @@
 // author-2d, the exporters and any future surface stay in lockstep.
 // =============================================================================
 
+import { pickDistinct, ensureContrast } from './atoms-2d/color.js';
+
 /**
  * artMountOpts(mount, slot, baseRole) → partial renderSceneDataToCanvas opts.
  * Content pages are promoted to 'section' so EVERY page carries the banner
@@ -75,12 +77,12 @@ export function extractMountPalette(img, { maxColors = 6 } = {}) {
         score: e.n * (1 + e.sat / e.n / 128),
       }))
       .sort((a, b) => b.score - a.score);
-    const dist = (a, b) => Math.hypot(a[0] - b[0], a[1] - b[1], a[2] - b[2]);
-    const picked = [];
-    for (const cnd of cands) {
-      if (picked.every((p) => dist(p, cnd.rgb) > 60)) picked.push(cnd.rgb);
-      if (picked.length >= maxColors) break;
-    }
+    // Sprint 96 (提色 v2): 去重从 RGB 欧氏距离换 OKLab ΔE — 感知均匀,
+    // 图表相邻 series 色保证可区分 (RGB 距离在暗区/绿区严重失真)
+    const picked = pickDistinct(
+      cands.map((c2) => c2.rgb),
+      maxColors,
+    );
     if (!picked.length) return null;
     const satOf = ([r, g, b]) => Math.max(r, g, b) - Math.min(r, g, b);
     // accent: most saturated pick with enough presence (top half of ranking)
@@ -96,10 +98,20 @@ export function extractMountPalette(img, { maxColors = 6 } = {}) {
  * mountPaletteOverride(basePalette, mount) → the deck palette re-voiced in
  * the artwork's colors. Accent AND colors[] are replaced (atoms read either);
  * ink/bg/silhouette stay with the theme so text contrast is untouched.
+ * Sprint 96 (色彩语义化):
+ *   - palette.semantic (涨跌红绿/警示/中性) 随 basePalette 原样透传, 艺术
+ *     色永不覆盖 — 语义色是「含义」不是「装饰」。
+ *   - accent 过 ensureContrast: 提出的主色对纸底明度差不足时压暗/提亮,
+ *     数字与标题永远可读 (「给角色找对比度达标的槽位」)。
  */
 export function mountPaletteOverride(basePalette, mount) {
   if (!mount?.palette?.accent) return basePalette;
-  return { ...basePalette, accent: mount.palette.accent, colors: mount.palette.colors };
+  const bg = basePalette?.bg || [248, 246, 240];
+  const accent = ensureContrast(mount.palette.accent, bg);
+  const colors = Array.isArray(mount.palette.colors)
+    ? [accent, ...mount.palette.colors.slice(1)]
+    : mount.palette.colors;
+  return { ...basePalette, accent, colors };
 }
 
 const loadImage = (url) =>

--- a/sdf-js/src/present/atoms-2d/charts/data/dashboard-multi-kpi.js
+++ b/sdf-js/src/present/atoms-2d/charts/data/dashboard-multi-kpi.js
@@ -23,6 +23,7 @@
 // =============================================================================
 
 import { rgbCss, rgbaCss } from '../../renderer.js';
+import { semanticColor } from '../../color.js';
 
 export const spec = {
   type: 'dashboard-multi-kpi-composite',
@@ -98,7 +99,7 @@ export function drawPseudo3D(ctx, args, opts = {}) {
     const ty = plotTop + row * (tileH + TILE_GAP);
     const kpi = kpis[i];
     const color = kpi.color || groupColors[i % groupColors.length];
-    drawKpiTile(ctx, tx, ty, tileW, tileH, kpi, color, fg, bg);
+    drawKpiTile(ctx, tx, ty, tileW, tileH, kpi, color, fg, bg, palette);
   }
 }
 
@@ -121,7 +122,7 @@ function computeLayout(N) {
 // ---------------------------------------------------------------------------
 // Draw one KPI mini-card tile
 // ---------------------------------------------------------------------------
-function drawKpiTile(ctx, x, y, w, h, kpi, accentColor, fg, bg) {
+function drawKpiTile(ctx, x, y, w, h, kpi, accentColor, fg, bg, palette) {
   const radius = Math.min(w, h) * TILE_RADIUS_FRAC;
 
   // ---- Card background with drop shadow ----
@@ -159,7 +160,7 @@ function drawKpiTile(ctx, x, y, w, h, kpi, accentColor, fg, bg) {
   const hasTrend = kpi.trend && kpi.trendValue;
   let pillBottom = y + 10;
   if (hasTrend) {
-    pillBottom = drawTrendPill(ctx, kpi.trend, kpi.trendValue, x + w - 10, y + 10);
+    pillBottom = drawTrendPill(ctx, kpi.trend, kpi.trendValue, x + w - 10, y + 10, palette);
   }
 
   // ---- Hero value ----
@@ -191,7 +192,7 @@ function drawKpiTile(ctx, x, y, w, h, kpi, accentColor, fg, bg) {
 // ---------------------------------------------------------------------------
 // Trend pill helper
 // ---------------------------------------------------------------------------
-function drawTrendPill(ctx, trend, value, rightX, topY) {
+function drawTrendPill(ctx, trend, value, rightX, topY, palette) {
   const text = String(value);
   ctx.font = '700 11px Inter, system-ui, sans-serif';
   const textW = ctx.measureText(text).width;
@@ -202,13 +203,13 @@ function drawTrendPill(ctx, trend, value, rightX, topY) {
   let pillColor;
   let arrowChar;
   if (trend === 'up') {
-    pillColor = [40, 160, 100];
+    pillColor = semanticColor(palette, 'positive');
     arrowChar = '↑';
   } else if (trend === 'down') {
-    pillColor = [200, 80, 80];
+    pillColor = semanticColor(palette, 'negative');
     arrowChar = '↓';
   } else {
-    pillColor = [150, 150, 150];
+    pillColor = semanticColor(palette, 'neutral');
     arrowChar = '→';
   }
 

--- a/sdf-js/src/present/atoms-2d/charts/data/kpi-card.js
+++ b/sdf-js/src/present/atoms-2d/charts/data/kpi-card.js
@@ -31,6 +31,7 @@
 // =============================================================================
 
 import { rgbCss, rgbaCss } from '../../renderer.js';
+import { semanticColor } from '../../color.js';
 import { pangu } from '../../cjk-text.js';
 import { resolveIcon } from '../../../../icons/index.js';
 
@@ -485,13 +486,13 @@ function drawTrendPill(ctx, trend, value, rightX, topY, palette) {
   let pillColor;
   let arrowChar;
   if (trend === 'up') {
-    pillColor = [40, 160, 100];
+    pillColor = semanticColor(palette, 'positive');
     arrowChar = '↑';
   } else if (trend === 'down') {
-    pillColor = [200, 80, 80];
+    pillColor = semanticColor(palette, 'negative');
     arrowChar = '↓';
   } else {
-    pillColor = [150, 150, 150];
+    pillColor = semanticColor(palette, 'neutral');
     arrowChar = '→';
   }
 

--- a/sdf-js/src/present/atoms-2d/charts/data/stat-banner.js
+++ b/sdf-js/src/present/atoms-2d/charts/data/stat-banner.js
@@ -12,6 +12,7 @@
 // =============================================================================
 
 import { rgbCss, rgbaCss } from '../../renderer.js';
+import { semanticColor } from '../../color.js';
 
 export const spec = {
   type: 'stat-banner',
@@ -157,7 +158,12 @@ export function drawPseudo3D(ctx, args, opts = {}) {
   // label collided even at min font size, in which case it moves to the
   // top-right corner, above the label line.
   if (trend) {
-    const chipBg = dir === 'up' ? [50, 200, 130] : dir === 'down' ? [220, 80, 60] : [140, 155, 170];
+    const chipBg =
+      dir === 'up'
+        ? semanticColor(palette, 'positive')
+        : dir === 'down'
+          ? semanticColor(palette, 'negative')
+          : semanticColor(palette, 'neutral');
     const chipText = trend;
     const chipX = x + w - PAD - chipW;
     const chipY = chipMode === 'top-right' ? bannerY + topPad : chipYInline;

--- a/sdf-js/src/present/atoms-2d/charts/data/stat-grid-large.js
+++ b/sdf-js/src/present/atoms-2d/charts/data/stat-grid-large.js
@@ -11,6 +11,7 @@
 // =============================================================================
 
 import { rgbCss, rgbaCss } from '../../renderer.js';
+import { semanticColor } from '../../color.js';
 
 export const spec = {
   type: 'stat-grid-large',
@@ -175,7 +176,11 @@ export function drawPseudo3D(ctx, args, opts = {}) {
       const chipR = chipH / 2;
       const dir = s.trendDirection || 'up';
       const chipBg =
-        dir === 'up' ? [50, 200, 130] : dir === 'down' ? [220, 80, 60] : [140, 155, 170];
+        dir === 'up'
+          ? semanticColor(palette, 'positive')
+          : dir === 'down'
+            ? semanticColor(palette, 'negative')
+            : semanticColor(palette, 'neutral');
 
       ctx.fillStyle = rgbCss(chipBg);
       ctx.beginPath();

--- a/sdf-js/src/present/atoms-2d/charts/data/stat-with-icon.js
+++ b/sdf-js/src/present/atoms-2d/charts/data/stat-with-icon.js
@@ -14,6 +14,7 @@
 // =============================================================================
 
 import { rgbCss, rgbaCss } from '../../renderer.js';
+import { semanticColor } from '../../color.js';
 import { resolveIcon } from '../../../../icons/index.js';
 
 export const spec = {
@@ -161,7 +162,11 @@ export function drawPseudo3D(ctx, args, opts = {}) {
     if (!hasSublabel) curY += h * 0.02;
     const dir = args.trendDirection ?? 'up';
     const chipColor =
-      dir === 'up' ? [40, 160, 100] : dir === 'down' ? [200, 80, 80] : [140, 155, 170];
+      dir === 'up'
+        ? semanticColor(palette, 'positive')
+        : dir === 'down'
+          ? semanticColor(palette, 'negative')
+          : semanticColor(palette, 'neutral');
     const chipText = args.trend;
     const chipFontSize = Math.round(chipH * 0.6);
     ctx.font = `700 ${chipFontSize}px Inter, system-ui`;

--- a/sdf-js/src/present/atoms-2d/charts/diagrams/comparison-table.js
+++ b/sdf-js/src/present/atoms-2d/charts/diagrams/comparison-table.js
@@ -9,6 +9,7 @@
 // =============================================================================
 
 import { rgbCss, rgbaCss } from '../../renderer.js';
+import { semanticColor } from '../../color.js';
 
 export const spec = {
   type: 'comparison-table',
@@ -149,10 +150,16 @@ export function drawPseudo3D(ctx, args, opts = {}) {
 
       if (val === true || val === 'true' || val === 1) {
         // Green check mark
-        drawCheck(ctx, cellCX, cellCY, fontSize * 1.1, isHighlight ? accent : [50, 160, 80]);
+        drawCheck(
+          ctx,
+          cellCX,
+          cellCY,
+          fontSize * 1.1,
+          isHighlight ? accent : semanticColor(palette, 'positive'),
+        );
       } else if (val === false || val === 'false' || val === 0) {
         // Gray cross
-        drawCross(ctx, cellCX, cellCY, fontSize * 0.9, [170, 175, 180]);
+        drawCross(ctx, cellCX, cellCY, fontSize * 0.9, semanticColor(palette, 'neutral'));
       } else if (val != null) {
         // Text value
         ctx.save();

--- a/sdf-js/src/present/atoms-2d/charts/diagrams/risk-heatmap.js
+++ b/sdf-js/src/present/atoms-2d/charts/diagrams/risk-heatmap.js
@@ -7,6 +7,7 @@
 // =============================================================================
 
 import { rgbCss, rgbaCss } from '../../renderer.js';
+import { semanticColor } from '../../color.js';
 
 export const spec = {
   type: 'risk-heatmap',
@@ -37,13 +38,13 @@ const AXIS_LABEL_W = 32;
 const AXIS_LABEL_H = 28;
 
 // severity = likelihood × impact (1-25), color by zone
-function cellColor(col, row) {
+function cellColor(col, row, palette) {
   // col = likelihood (0-4 = very low to very high), row = impact (0-4 = very low to very high)
   const severity = (col + 1) * (row + 1); // 1..25
-  if (severity >= 20) return [210, 60, 50]; // critical — red
-  if (severity >= 13) return [230, 140, 40]; // high — orange
-  if (severity >= 6) return [220, 200, 50]; // medium — yellow
-  return [80, 170, 90]; // low — green
+  if (severity >= 20) return semanticColor(palette, 'negative'); // critical
+  if (severity >= 13) return semanticColor(palette, 'warning'); // high
+  if (severity >= 6) return [220, 200, 50]; // medium — yellow (warning 与 positive 之间的过渡档)
+  return semanticColor(palette, 'positive'); // low
 }
 
 export function drawPseudo3D(ctx, args, opts = {}) {
@@ -97,7 +98,7 @@ export function drawPseudo3D(ctx, args, opts = {}) {
     for (let rowI = 0; rowI < 5; rowI++) {
       // rowI=0 is top in canvas coords, but impact increases bottom→top
       const impactLevel = 4 - rowI; // 4=very high impact at top
-      const color = cellColor(col, impactLevel);
+      const color = cellColor(col, impactLevel, palette);
       const cx = gridX + col * cellW;
       const cy = gridY + rowI * cellH;
 

--- a/sdf-js/src/present/atoms-2d/color.js
+++ b/sdf-js/src/present/atoms-2d/color.js
@@ -1,0 +1,94 @@
+// =============================================================================
+// color.js — Sprint 96: 色彩语义化 (提色 v2).
+//
+// 两个问题, 一个模块:
+//   1. 语义色角色 — 涨跌红绿 / 风险警示 / 中性灰是「含义」不是「装饰」,
+//      不能被艺术提色覆盖。此前 7 个 atoms 各自硬编码 (红绿共三种写法),
+//      现在统一走 semanticColor(palette, role): 主题可经 palette.semantic
+//      定制, 装裱提色 (mountPaletteOverride) 永不触碰。
+//   2. 感知均匀距离 — 图表相邻 series 色的可区分性以 OKLab ΔE 度量
+//      (RGB 欧氏距离在暗区/绿区严重失真), 提色去重与 series 选色共用。
+//
+// API:
+//   SEMANTIC                        — 统一默认角色色 (此前三种红绿的收敛)
+//   semanticColor(palette, role)    — 'positive'|'negative'|'warning'|'neutral'
+//   rgbToOklab(rgb) / okDist(a, b)  — 感知色距
+//   pickDistinct(cands, k, minDist) — 贪心选 k 个两两可区分的颜色
+//   ensureContrast(rgb, bg)         — 明度对比不足时向反方向推 L
+// =============================================================================
+
+/** 统一语义角色默认色 — 主题/调用方可经 palette.semantic 覆盖。 */
+export const SEMANTIC = {
+  positive: [40, 160, 100], // 涨 / 达成 / 对勾
+  negative: [204, 70, 60], // 跌 / 风险 / 叉
+  warning: [230, 150, 40], // 警示 / 高风险 (次于 critical)
+  neutral: [145, 152, 160], // 持平 / 缺省 / 停用
+};
+
+/**
+ * semanticColor(palette, role) → [r,g,b]。palette.semantic[role] 优先,
+ * 否则统一默认。艺术提色 (mountPaletteOverride) 只换 accent/colors,
+ * semantic 角色永不被覆盖 — 这是本模块的存在理由。
+ */
+export function semanticColor(palette, role) {
+  const c = palette?.semantic?.[role];
+  return Array.isArray(c) && c.length === 3 ? c : SEMANTIC[role] || SEMANTIC.neutral;
+}
+
+/** sRGB [0..255] → OKLab [L, a, b] (L∈[0,1])。Björn Ottosson 2020。 */
+export function rgbToOklab(rgb) {
+  const lin = rgb.map((v) => {
+    const c = v / 255;
+    return c <= 0.04045 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4);
+  });
+  const [r, g, b] = lin;
+  const l = Math.cbrt(0.4122214708 * r + 0.5363325363 * g + 0.0514459929 * b);
+  const m = Math.cbrt(0.2119034982 * r + 0.6806995451 * g + 0.1073969566 * b);
+  const s = Math.cbrt(0.0883024619 * r + 0.2817188376 * g + 0.6299787005 * b);
+  return [
+    0.2104542553 * l + 0.793617785 * m - 0.0040720468 * s,
+    1.9779984951 * l - 2.428592205 * m + 0.4505937099 * s,
+    0.0259040371 * l + 0.7827717662 * m - 0.808675766 * s,
+  ];
+}
+
+/** okDist(a, b) — 两个 sRGB 颜色的 OKLab 欧氏距离 (感知均匀 ΔE)。 */
+export function okDist(a, b) {
+  const [l1, a1, b1] = rgbToOklab(a);
+  const [l2, a2, b2] = rgbToOklab(b);
+  return Math.hypot(l1 - l2, a1 - a2, b1 - b2);
+}
+
+/**
+ * pickDistinct(candidates, k, minDist) — 按给定顺序贪心挑选至多 k 个
+ * 两两 OKLab 距离 ≥ minDist 的颜色 (输入序即优先级序)。
+ * 0.09 ≈ 图表相邻色域的可区分下限 (经验值)。
+ */
+export function pickDistinct(candidates, k = 6, minDist = 0.09) {
+  const picked = [];
+  for (const c of candidates) {
+    if (picked.length >= k) break;
+    if (picked.every((p) => okDist(p, c) >= minDist)) picked.push(c);
+  }
+  return picked;
+}
+
+/**
+ * ensureContrast(rgb, bg, minDL) — accent 等文字/数字承载色对底色的
+ * OKLab 明度差不足 minDL 时, 向远离底色的方向推 L (暗底提亮/亮底压暗),
+ * 色相不动。「给每个角色找对比度达标的槽位」的最小实现。
+ */
+export function ensureContrast(rgb, bg, minDL = 0.22) {
+  const L = rgbToOklab(rgb)[0];
+  const Lbg = rgbToOklab(bg)[0];
+  if (Math.abs(L - Lbg) >= minDL) return rgb;
+  const darken = Lbg >= 0.5; // 亮底 → 压暗; 暗底 → 提亮
+  let out = rgb.slice();
+  for (let i = 0; i < 24; i++) {
+    out = darken
+      ? out.map((v) => Math.max(0, v * 0.92))
+      : out.map((v) => Math.min(255, v * 1.08 + 6));
+    if (Math.abs(rgbToOklab(out)[0] - Lbg) >= minDL) break;
+  }
+  return out.map((v) => Math.round(v));
+}


### PR DESCRIPTION
语义色角色系统: 涨跌红绿/警示/中性统一为 SEMANTIC 角色, 艺术提色永不覆盖; 提色去重换 OKLab 感知距离保证图表 series 可区分; accent 过对比度地板。7 个数据 atoms 接入。22 断言 + 既有 71 断言不回归。

🤖 Generated with [Claude Code](https://claude.com/claude-code)