### PR TITLE
Sprint 97: 批量出 deck 产品化 — 📦 按钮 + 契约 artMount 溯源 (优化路线图五)

### DIFF
--- a/docs/atlas-deck-contract.md
+++ b/docs/atlas-deck-contract.md
@@ -52,6 +52,20 @@ atlas-deck。
 `src/present/decor/registry.js` 头注 (hash 定决策 / v 定代码 / 序号定
 收藏位置)。
 
+## 3.5 artMount (真迹装裱溯源, Sprint 97)
+
+```jsonc
+{ "id": "0xa7d8d9-41", "name": "Fidenza", "artist": "Tyler Hobbs",
+  "license": "nc", "hash": "0x…",
+  "palette": { "accent": [10,120,200], "colors": [[10,120,200], …] } }
+```
+
+可选。deck 出图时穿了哪件真迹装裱 (ArtBlocks 原版脚本铸造, 非商用)。
+**图像本体不进契约** — deck.json 是机器契约不是资产包; `id` 可回查
+`examples/original-mints/cache/` 复载图像, `palette` 预烘焙供 3D 端直接
+re-voice (无像素也能穿上作品的颜色)。`license` 随行是纪律: 消费端出图前
+自行核验。2D 端重新打开契约时按 `id` 自动复装 (author-2d open 路径)。
+
 ## 4. shared
 
 `deck-io.js` 序列化时把每个 slot 重复携带的 `liftParams.scaffold/slides/

--- a/sdf-js/apps/present/author-2d.html
+++ b/sdf-js/apps/present/author-2d.html
@@ -395,6 +395,14 @@
         </select>
         <button id="export-pptx" disabled>⬇ PPTX</button>
         <button id="export-pdf" disabled>⬇ PDF</button>
+        <button
+          id="batch-pdf"
+          hidden
+          disabled
+          title="批量出 deck: 从优质装裱池随机选 N 件真迹, 每件出一份完整 PDF (含转场页)"
+        >
+          📦 批量
+        </button>
       </div>
     </div>
     <script type="module" src="./author-2d.js"></script>

--- a/sdf-js/apps/present/author-2d.js
+++ b/sdf-js/apps/present/author-2d.js
@@ -24,6 +24,7 @@ import {
   fetchMintManifest,
   mountPaletteOverride,
   mountUnderlayDecor,
+  mountProvenance,
 } from '../../src/present/art-mount.js';
 import { layoutForSlot } from '../../src/present/atoms-2d/layout.js';
 import { ATLAS_THEMES } from '../../src/present/themes.js';
@@ -76,6 +77,7 @@ const keyEl = document.getElementById('key');
 const slidesEl = document.getElementById('slides');
 const exportPptxEl = document.getElementById('export-pptx');
 const exportPdfEl = document.getElementById('export-pdf');
+const batchPdfEl = document.getElementById('batch-pdf');
 const modeEl = document.getElementById('mode');
 const themeEl = document.getElementById('theme');
 
@@ -176,6 +178,7 @@ async function adoptDeck(deck, note) {
   await renderDeck(currentDeck);
   exportPptxEl.disabled = false;
   exportPdfEl.disabled = false;
+  batchPdfEl.disabled = false;
   saveEl.disabled = false;
   syncThemeSelect();
   syncProvenance();
@@ -205,6 +208,11 @@ openFileEl.addEventListener('change', async () => {
     const deck = deserializeDeck(await file.text());
     await adoptDeck(deck, `已打开 ${file.name} — ${deck.slots.length} 页`);
     autosave();
+    // Sprint 97: 契约带 artMount 溯源且本地 cache 有此真迹 → 自动复装
+    if (deck.artMount?.id && artMountEl.querySelector(`option[value="${deck.artMount.id}"]`)) {
+      artMountEl.value = deck.artMount.id;
+      artMountEl.dispatchEvent(new Event('change'));
+    }
   } catch (e) {
     setStatus(`打开失败: ${e.message}`, true);
   }
@@ -308,17 +316,19 @@ function slotRenderOpts(theme, deck, slot) {
   artMountEl.hidden = false;
   artMountEl.addEventListener('change', async () => {
     const id = artMountEl.value;
+    const entry = id ? oks.find((m) => m.id === id) : null;
     try {
-      artMount = id
-        ? await loadArtMount(
-            oks.find((m) => m.id === id),
-            MINT_BASE,
-          )
-        : null;
+      artMount = entry ? await loadArtMount(entry, MINT_BASE) : null;
     } catch (e) {
       artMount = null;
       artMountEl.value = '';
       return setStatus(`装裱加载失败: ${e.message}`, true);
+    }
+    // Sprint 97: 装裱溯源进 deck.json 契约 — 3D 端由此知道装裱的存在;
+    // 重新打开时按 id 自动复装 (下方 open 路径)
+    if (currentDeck) {
+      currentDeck.artMount = artMount ? mountProvenance(entry) : undefined;
+      autosave();
     }
     const qs = new URLSearchParams(location.search);
     if (id) qs.set('art', id);
@@ -337,6 +347,66 @@ function slotRenderOpts(theme, deck, slot) {
     artMountEl.value = want;
     artMountEl.dispatchEvent(new Event('change'));
   }
+
+  // ── Sprint 97: 批量出 deck (选池 → 装裱 → PDF×N) ──────────────────────
+  // 此前每批 20 份都是临场脚本; 现在是一个按钮。规则沿用批量生产的裁定:
+  // 随机选 (user: 原来随机挺好), 排除已用 (localStorage), 池耗尽自动重置。
+  const BATCH_USED_KEY = 'atlas-batch-used-mounts';
+  batchPdfEl.hidden = false;
+  batchPdfEl.addEventListener('click', async () => {
+    if (!currentDeck) return;
+    const n = parseInt(window.prompt('批量出多少份? (每份一个随机装裱真迹)', '10'), 10);
+    if (!Number.isInteger(n) || n < 1) return;
+    let used;
+    try {
+      used = new Set(JSON.parse(localStorage.getItem(BATCH_USED_KEY) || '[]'));
+    } catch {
+      used = new Set();
+    }
+    let pool = oks.filter((m) => !used.has(m.id));
+    if (pool.length < n) {
+      used.clear(); // 池耗尽 — 重置轮换
+      pool = oks.slice();
+    }
+    // 随机取 n 件 (Fisher-Yates 前缀)
+    for (let i = pool.length - 1; i > 0; i--) {
+      const j = Math.floor(Math.random() * (i + 1));
+      [pool[i], pool[j]] = [pool[j], pool[i]];
+    }
+    const picks = pool.slice(0, Math.min(n, pool.length));
+    batchPdfEl.disabled = true;
+    exportPdfEl.disabled = true;
+    let done = 0;
+    try {
+      for (const entry of picks) {
+        setStatus(`批量 ${done + 1}/${picks.length} — 装裱 ${entry.name}…`);
+        const m = await loadArtMount(entry, MINT_BASE);
+        const deckForExport = {
+          ...currentDeck,
+          artMount: mountProvenance(entry),
+          ...(decorVisEl.value === 'off' ? { decor: undefined } : {}),
+        };
+        const slug = (currentDeck.title || 'deck')
+          .replace(/[^\w\u4e00-\u9fff-]+/g, '-')
+          .slice(0, 30);
+        await exportDeckToPDF(deckForExport, {
+          artMount: m,
+          filename: `atlas-${slug}-${entry.id}.pdf`,
+          onProgress: (msg, pct) =>
+            setStatus(`批量 ${done + 1}/${picks.length} · ${entry.name} — ${Math.round(pct)}%`),
+        });
+        used.add(entry.id);
+        localStorage.setItem(BATCH_USED_KEY, JSON.stringify([...used]));
+        done++;
+      }
+      setStatus(`批量完成 — ${done} 份 PDF 已下载 (池余 ${oks.length - used.size} 件未用)`);
+    } catch (e) {
+      setStatus(`批量中断于第 ${done + 1} 份: ${e.message}`, true);
+    } finally {
+      batchPdfEl.disabled = !currentDeck;
+      exportPdfEl.disabled = !currentDeck;
+    }
+  });
 })();
 
 function reopenUrl(hash, v, serial) {

--- a/sdf-js/scripts/test-mount-contract.mjs
+++ b/sdf-js/scripts/test-mount-contract.mjs
@@ -1,0 +1,126 @@
+// test-mount-contract.mjs — Sprint 97: 批量产品化回归测试.
+// 钉住: deck.json 契约 artMount 溯源 (validator + 序列化双向) / 转场页
+// 走 artMountOpts 中枢 (导出与临场脚本同律)。
+import { validateDeck, DECK_FORMAT, DECK_FORMAT_VERSION } from '../src/present/deck-spec.js';
+import { serializeDeck, deserializeDeck } from '../src/present/deck-io.js';
+import { mountProvenance, artMountOpts, insertTransitions } from '../src/present/art-mount.js';
+
+let passed = 0;
+let failed = 0;
+function ok(cond, msg, extra = '') {
+  if (cond) {
+    passed++;
+    console.log(`  ✓ ${msg}`);
+  } else {
+    failed++;
+    console.log(`  ✗ ${msg}${extra ? ` — ${extra}` : ''}`);
+  }
+}
+
+const baseDeck = () => ({
+  format: DECK_FORMAT,
+  version: DECK_FORMAT_VERSION,
+  title: 'T',
+  theme: { id: 'x', bg: [246, 244, 238], accent: [200, 80, 40] },
+  slots: [{ slotIdx: 0, slotName: 'cover', sceneData: { subjects: [] } }],
+});
+
+// ── 1. validator: artMount 溯源 ──
+{
+  const good = {
+    ...baseDeck(),
+    artMount: {
+      id: '0xa7d8d9-41',
+      name: 'Fidenza',
+      artist: 'Tyler Hobbs',
+      license: 'nc',
+      hash: '0xabc',
+      palette: { accent: [10, 120, 200], colors: [[10, 120, 200]] },
+    },
+  };
+  ok(validateDeck(good).ok, '完整溯源块通过校验');
+  ok(validateDeck(baseDeck()).ok, '无 artMount 仍通过 (可选字段)');
+  ok(!validateDeck({ ...baseDeck(), artMount: 'Fidenza' }).ok, '字符串 artMount 被拒');
+  ok(!validateDeck({ ...baseDeck(), artMount: {} }).ok, '缺 id 被拒');
+  ok(
+    !validateDeck({ ...baseDeck(), artMount: { id: 'x', palette: { accent: [999, 0, 0] } } }).ok,
+    '越界 palette.accent 被拒',
+  );
+}
+
+// ── 2. deck-io 双向 ──
+{
+  const deck = {
+    title: 'T',
+    theme: { id: 'x' },
+    scaffold: { id: 's' },
+    decor: undefined,
+    artMount: { id: '0xtest-1', name: 'P', artist: 'A', license: 'nc' },
+    slots: [{ slotIdx: 0, slotName: 'cover', sceneData: { subjects: [] } }],
+  };
+  const json = serializeDeck(deck);
+  ok(json.artMount?.id === '0xtest-1', 'serializeDeck 带出溯源');
+  ok(json.format === DECK_FORMAT && validateDeck(json).ok, '序列化产物过校验');
+  const back = deserializeDeck(JSON.stringify(json));
+  ok(back.artMount?.id === '0xtest-1' && back.artMount.name === 'P', 'deserializeDeck 复原溯源');
+  const bare = deserializeDeck(JSON.stringify(serializeDeck({ ...deck, artMount: undefined })));
+  ok(bare.artMount === undefined, '无溯源 deck round-trip 不长出字段');
+}
+
+// ── 3. mountProvenance ──
+{
+  const entry = {
+    id: 'L38',
+    name: 'Ringers',
+    artist: 'Dmitri Cherniak',
+    license: 'nd',
+    hash: '0xdead',
+    palette: { accent: [1, 2, 3] },
+    files: { large: 'x.png' },
+    status: 'ok',
+  };
+  const p = mountProvenance(entry);
+  ok(p.id === 'L38' && p.artist === 'Dmitri Cherniak' && p.hash === '0xdead', '取最小溯源字段');
+  ok(!('files' in p) && !('status' in p), '图像/状态等资产字段不进契约');
+  ok(mountProvenance(null) === undefined, 'null entry → undefined');
+}
+
+// ── 4. 转场页走 artMountOpts 中枢 ──
+{
+  const mount = {
+    id: 'x',
+    name: 'X',
+    cover: { width: 10, height: 10 },
+    strip: [],
+    variants: [
+      { width: 1, height: 1 },
+      { width: 2, height: 2 },
+    ],
+  };
+  const slots = [
+    { slotIdx: 0, slotName: 'cover', sceneData: { subjects: [] } },
+    {
+      slotIdx: 1,
+      slotName: 'agenda',
+      sceneData: {
+        subjects: [{ type: 'agenda-list', args: { items: [{ label: '节A' }, { label: '节B' }] } }],
+      },
+    },
+    { slotIdx: 3, slotName: 'theme-1-lead', sceneData: { subjects: [] } },
+    { slotIdx: 5, slotName: 'theme-2-lead', sceneData: { subjects: [] } },
+  ];
+  const out = insertTransitions(slots, mount);
+  const trans = out.filter((s) => s._transition);
+  ok(trans.length === 2, '转场页按节边界合成');
+  const o0 = artMountOpts(mount, trans[0], 'content');
+  ok(o0.decorRole === 'cover', '转场 slot 经 artMountOpts → 封面角色');
+  ok(o0.decorArt === mount.variants[0], '转场 art = 对应变体');
+  ok(o0.decorUnder === undefined && o0.decorArtStrip === undefined, '转场页无 underlay 无胶片条');
+  const o1 = artMountOpts(mount, trans[1], 'content');
+  ok(o1.decorArt === mount.variants[1], '第二转场轮换第二变体');
+  const normal = artMountOpts(mount, slots[2], 'content');
+  ok(normal.decorRole === 'section' && normal.decorUnder === true, '普通内页规则不受影响');
+}
+
+console.log(`\n${passed} passed, ${failed} failed`);
+if (failed) process.exit(1);

--- a/sdf-js/src/present/art-mount.js
+++ b/sdf-js/src/present/art-mount.js
@@ -28,6 +28,12 @@ import { pickDistinct, ensureContrast } from './atoms-2d/color.js';
  */
 export function artMountOpts(mount, slot, baseRole) {
   if (!mount || !mount.cover) return null;
+  // Sprint 97 (批量产品化): 转场页 (insertTransitions 合成) = 封面式纯
+  // cover — 全幅变体真迹, 无横带无 underlay。此前只有临场脚本知道这条
+  // 规则; 收进中枢后 author-2d / pdf / pptx 自动同律。
+  if (slot?._transition) {
+    return { decorRole: 'cover', decorArt: transitionArt(mount, slot) };
+  }
   const role = baseRole === 'cover' || baseRole === 'agenda' ? baseRole : 'section';
   const out = { decorRole: role, decorArt: mount.cover };
   if (role === 'section') out.decorUnder = true;
@@ -35,6 +41,25 @@ export function artMountOpts(mount, slot, baseRole) {
     const k = (slot.slotIdx ?? 0) % mount.strip.length;
     out.decorArtStrip = mount.strip.slice(k).concat(mount.strip.slice(0, k));
   }
+  return out;
+}
+
+/**
+ * mountProvenance(entry) — deck.json 契约的 artMount 溯源块 (Sprint 97)。
+ * manifest entry → 可序列化的最小出处: 3D 端 (吃 deck.json) 由此知道装裱
+ * 的存在 — id 可回查 cache, palette 预烘焙可直接 re-voice, license 随行。
+ * 图像本体不进契约 (deck.json 是机器契约不是资产包)。
+ */
+export function mountProvenance(entry) {
+  if (!entry?.id) return undefined;
+  const out = {
+    id: entry.id,
+    name: entry.name,
+    artist: entry.artist,
+    license: entry.license,
+  };
+  if (entry.hash) out.hash = entry.hash;
+  if (entry.palette) out.palette = entry.palette;
   return out;
 }
 

--- a/sdf-js/src/present/deck-io.js
+++ b/sdf-js/src/present/deck-io.js
@@ -35,6 +35,8 @@ export function serializeDeck(deck) {
     theme: deck.theme,
     scaffold: deck.scaffold,
     decor: deck.decor,
+    // Sprint 97: 装裱溯源随契约走 — 3D 端由此知道装裱的存在
+    artMount: deck.artMount,
     shared,
     slots: deck.slots.map((s) => ({
       ...s,
@@ -65,6 +67,7 @@ export function deserializeDeck(data) {
     theme: data.theme,
     scaffold: data.scaffold,
     decor: data.decor,
+    artMount: data.artMount,
     slots: (data.slots || []).map((s) => ({
       ...s,
       liftParams: s.liftParams

--- a/sdf-js/src/present/deck-spec.js
+++ b/sdf-js/src/present/deck-spec.js
@@ -90,6 +90,26 @@ export function validateDeck(data, { knownAtomTypes = null } = {}) {
     }
   }
 
+  // ── artMount (optional provenance — Sprint 97 批量产品化): the deck was
+  // dressed in an authentic generative artwork. 3D consumers can re-voice
+  // from the prebaked palette / re-load the piece by id; images themselves
+  // never enter the contract. ──
+  const am = data.artMount;
+  if (am != null) {
+    if (!isObj(am)) err('artMount must be an object when present');
+    else {
+      if (!isStr(am.id)) err('artMount.id must be a string');
+      if (am.name != null && !isStr(am.name)) err('artMount.name must be a string when present');
+      if (am.license != null && !isStr(am.license))
+        err('artMount.license must be a string when present');
+      if (am.palette != null) {
+        if (!isObj(am.palette)) err('artMount.palette must be an object when present');
+        else if (am.palette.accent != null && !isRgb(am.palette.accent))
+          err('artMount.palette.accent must be [r,g,b] 0-255');
+      }
+    }
+  }
+
   // ── shared block (hoisted liftParams state; see deck-io.js) ──
   if (data.shared != null && !isObj(data.shared)) err('shared must be an object when present');
 

--- a/sdf-js/src/present/exporters/pdf.js
+++ b/sdf-js/src/present/exporters/pdf.js
@@ -11,7 +11,12 @@
 
 import { renderSceneDataToCanvas } from '../atoms-2d/renderer.js';
 import { slotPalette, slotRoleOf } from '../retheme.js';
-import { artMountOpts, mountPaletteOverride, mountUnderlayDecor } from '../art-mount.js';
+import {
+  artMountOpts,
+  mountPaletteOverride,
+  mountUnderlayDecor,
+  insertTransitions,
+} from '../art-mount.js';
 import { layoutForSlot } from '../atoms-2d/layout.js';
 
 const JSPDF_CDN = 'https://esm.sh/jspdf@2.5.2';
@@ -58,9 +63,12 @@ export async function exportDeckToPDF(deck, opts = {}) {
     subject: deck.scaffold?.label || 'deck',
   });
 
-  const total = deck.slots.length;
+  // Sprint 97 (批量产品化): 装裱导出自动合成转场页 — 此前只有临场脚本
+  // 会插, in-app 导出与批量脚本从此同一产物
+  const slots = opts.artMount ? insertTransitions(deck.slots, opts.artMount) : deck.slots;
+  const total = slots.length;
   for (let i = 0; i < total; i++) {
-    const slot = deck.slots[i];
+    const slot = slots[i];
     onProgress(`Rendering page ${i + 1}/${total} (${slot.slotName})`, 5 + (i / total) * 90);
 
     const canvas = document.createElement('canvas');

--- a/sdf-js/src/present/exporters/pptx.js
+++ b/sdf-js/src/present/exporters/pptx.js
@@ -19,7 +19,12 @@
 
 import { renderSceneDataToCanvas } from '../atoms-2d/renderer.js';
 import { slotPalette, slotRoleOf } from '../retheme.js';
-import { artMountOpts, mountPaletteOverride, mountUnderlayDecor } from '../art-mount.js';
+import {
+  artMountOpts,
+  mountPaletteOverride,
+  mountUnderlayDecor,
+  insertTransitions,
+} from '../art-mount.js';
 import { layoutForSlot } from '../atoms-2d/layout.js';
 
 // pptxgenjs loaded from esm.sh on first call (matches pdfjs CDN pattern in
@@ -73,9 +78,12 @@ export async function exportDeckToPPTX(deck, opts = {}) {
   const SLIDE_W_IN = 13.333;
   const SLIDE_H_IN = 7.5;
 
-  const total = deck.slots.length;
+  // Sprint 97 (批量产品化): 装裱导出自动合成转场页 — 此前只有临场脚本
+  // 会插, in-app 导出与批量脚本从此同一产物
+  const slots = opts.artMount ? insertTransitions(deck.slots, opts.artMount) : deck.slots;
+  const total = slots.length;
   for (let i = 0; i < total; i++) {
-    const slot = deck.slots[i];
+    const slot = slots[i];
     onProgress(`Rendering slot ${i + 1}/${total} (${slot.slotName})`, 5 + (i / total) * 90);
 
     // Render slot to offscreen canvas → PNG dataURL


### PR DESCRIPTION
手工批量流程按钮化 (随机选池/排除已用/逐份 PDF); 转场页规则收进 artMountOpts 中枢, in-app 导出与临场脚本产物一致; deck.json 契约补 artMount 溯源块 (3D 端可见装裱, palette 预烘焙可 re-voice), 打开契约自动复装。18 断言 + 既有契约测试不回归。

🤖 Generated with [Claude Code](https://claude.com/claude-code)