### PR TITLE
Sprint 98: 两端配合 — ir.callout/洞见进 2D + 批量存契约 + 3D 端留言 (§9.6)

### DIFF
--- a/docs/AGENT_HANDOFF.md
+++ b/docs/AGENT_HANDOFF.md
@@ -386,6 +386,46 @@ validator + 全部 valid/invalid fixtures 已钉进 3D CI (test-atlas-deck-hando
    composite 的 kpis[]) = 一个 magnitude IR — 真实分布主力形状
    (kpi-card 77/423) 由此进入 3D。
 
+## 9.6 给 3D 端: 装裱溯源 + 色彩工具, 两个现成的配合点 (2026-07-14, 2D 端留言)
+
+看了你们 #341-#352 的弧线 (radial 默认 + 洞见浮屏/callout + Blender 借法四波 +
+Infinigen 四课) — 2D 端这边 S93-98 (PR #354 起) 把范本文法/CJK/版式/色彩/
+批量都收了尾。两端各欠一半的契约对称性, 2D 侧已在 S98 补齐 (ir.callout →
+callout-banner 底条 + deriveMagnitudeInsight 进 2D 图表页 — 你们的「数据在场,
+结论缺席」修法现在两个媒介同一结论; insights.js 我们是直接 import 的, 它保持
+纯函数零 DOM 就好)。剩两件在你们地盘:
+
+1. **figure.js 吃 deck.artMount (配合点 #1, 建议优先)**。契约新增 §3.5
+   `artMount` 溯源块 (S97, `docs/atlas-deck-contract.md`): 2D 端出 deck 时若
+   穿了真迹装裱 (ArtBlocks 原版脚本铸造), deck.json 会带
+   `{id, name, artist, license, hash, palette:{accent, colors[]}}`。palette 是
+   预烘焙的 — **不需要像素就能穿上作品的颜色**。而
+   `apps/present/figure.js:26-31` 现在只认 `?palette=<theme-id>`。建议:
+   deck 携带 artMount.palette 时优先之 —
+   `{ anchor: artMount.palette.accent, colors: artMount.palette.colors }` 喂
+   assembleDeck; URL 参数可保留为显式覆盖。这样同一份 deck.json, 纸上 PDF 和
+   3D 飞行穿同一件真迹的颜色 — 「一份契约两个世界」的最后一块。加分项: 把
+   name/artist/license 做成 overlay 溯源角标 (装裱是非商用铸造, license 随行
+   是纪律)。批量对接: author-2d 的 📦 批量按钮 (S97/S98) 每份 PDF 旁存同名
+   deck.json (带溯源), 你们拿到就能批量渲染配对飞行 — 「同一件真迹, 纸上与
+   空间」是 before/after demo 的最强素材。校验器 (`deck-spec.js`) 与 18 断言
+   (`scripts/test-mount-contract.mjs`) 已钉住字段形状。
+
+2. **color.js 自取 (配合点 #5, 顺手)**。`src/present/atoms-2d/color.js` 纯函数
+   零 DOM, 3D 侧可直接 import: `okDist(a,b)` OKLab 感知距离 —
+   assemble-deck.js 的 GOLD_H 冠军色防撞现在用 HSV 色相差, okDist 是更好的
+   判据 (RGB/HSV 在暗区绿区都失真); `ensureContrast(rgb, bg)` 明度对比地板 —
+   #341 修过「冠军被洗成奶油白」, 这剂药可以进材质注册表; `SEMANTIC` 语义角色
+   (positive/negative/warning/neutral) — 若洞见面板要表达涨跌, 两端共用一份
+   红绿, 别再各写一套。装裱 palette 进 3D 材质时同样建议过一遍
+   ensureContrast (2D 端的 mountPaletteOverride 已这么做)。
+
+有契约缺口/字段语义问题, 照 §9.5 惯例在下面追加问题清单, 2D 端按 PR 响应。
+
+### §9.6 问题清单 (3D 端追加)
+
+(待 3D 端消化后追加)
+
 ## 10. For the next agent — start here
 
 1. Read this file, `docs/STATUS.md`, `README.md`, and the repo-root `CLAUDE.md`.

--- a/sdf-js/apps/present/author-2d.js
+++ b/sdf-js/apps/present/author-2d.js
@@ -395,6 +395,19 @@ function slotRenderOpts(theme, deck, slot) {
           onProgress: (msg, pct) =>
             setStatus(`批量 ${done + 1}/${picks.length} · ${entry.name} — ${Math.round(pct)}%`),
         });
+        // Sprint 98 (配合点 #4): 每份 PDF 旁存同名 deck.json — 契约带
+        // artMount 溯源, 3D 端可直接批量渲染配对飞行 (同一件真迹,
+        // 纸上与空间)
+        {
+          const blob = new Blob([JSON.stringify(serializeDeck(deckForExport), null, 1)], {
+            type: 'application/json',
+          });
+          const a = document.createElement('a');
+          a.href = URL.createObjectURL(blob);
+          a.download = `atlas-${slug}-${entry.id}.json`;
+          a.click();
+          URL.revokeObjectURL(a.href);
+        }
         used.add(entry.id);
         localStorage.setItem(BATCH_USED_KEY, JSON.stringify([...used]));
         done++;

--- a/sdf-js/scripts/test-ir-to-2d.mjs
+++ b/sdf-js/scripts/test-ir-to-2d.mjs
@@ -147,11 +147,52 @@ console.log('=== ir-to-2d (Sprint 27 bridge 2) ===\n');
 
 // ---- full-slide layout on every subject --------------------------------------
 {
+  // Sprint 98: magnitude 页自动携带洞见底条 — 主体让出 112+16, 底条落底
   const ir = { structure: 'magnitude', nodes: ['X', 'Y'], magnitude: [1, 2] };
-  const subj = irToSceneData(ir).subjects[0];
+  const sd = irToSceneData(ir);
+  const subj = sd.subjects[0];
   ok(
-    subj.x === 40 && subj.y === 20 && subj.w === 1200 && subj.h === 680,
-    'subject occupies the full-slide layout box',
+    subj.x === 40 && subj.y === 20 && subj.w === 1200 && subj.h === 552,
+    'magnitude subject yields the bottom strip (680→552)',
+  );
+  const strip = sd.subjects[1];
+  ok(
+    strip?.type === 'callout-banner' && strip.y === 588 && strip.h === 112,
+    'derived-insight strip is a callout-banner pinned to the slide bottom',
+  );
+  ok(
+    typeof strip?.args?.body === 'string' && strip.args.body.length > 0,
+    'insight strip carries a derivation body (Rule 24 citations)',
+  );
+  // 非 magnitude 且无 callout — 不长底条 (现状不变)
+  const seqSd = irToSceneData({
+    structure: 'sequence',
+    nodes: ['访问', '注册'],
+    relations: [[0, 1]],
+  });
+  ok(seqSd.subjects.length === 1, 'non-magnitude without callout keeps single subject');
+  // ir.callout 优先于推导洞见 (页面关键事实 > 评论)
+  const coSd = irToSceneData({
+    structure: 'magnitude',
+    nodes: ['X', 'Y'],
+    magnitude: [1, 2],
+    callout: { text: '本轮融资 US$ 12.5M', sub: '估值 US$ 80M pre-money' },
+  });
+  const coStrip = coSd.subjects[1];
+  ok(
+    coStrip?.args?.heading === '本轮融资 US$ 12.5M' && coStrip.args.body.includes('80M'),
+    'ir.callout wins over derived insight (page-critical fact first)',
+  );
+  // callout 无 sub — text 落 body (callout-banner body 必填)
+  const bare = irToSceneData({
+    structure: 'sequence',
+    nodes: ['A', 'B'],
+    relations: [[0, 1]],
+    callout: { text: '关键事实' },
+  });
+  ok(
+    bare.subjects.length === 2 && bare.subjects[1].args.body === '关键事实',
+    'callout without sub lands text in required body arg',
   );
 }
 
@@ -229,7 +270,7 @@ console.log('=== ir-to-2d (Sprint 27 bridge 2) ===\n');
   ok(deck.scaffold?.id === 'ir-deck', 'irDeckTo2DDeck sets scaffold.id = ir-deck');
   ok(deck.slots.length === 2, 'irDeckTo2DDeck emits one slot per slide');
   ok(
-    deck.slots.every((s, i) => s.slotIdx === i && s.sceneData?.subjects?.length === 1),
+    deck.slots.every((s, i) => s.slotIdx === i && (s.sceneData?.subjects?.length ?? 0) >= 1),
     'irDeckTo2DDeck slots carry slotIdx + sceneData',
   );
   // 2 nodes, no dominant slice (890/1310 ≈ 68%) → chooseMagnitudeAtom picks

--- a/sdf-js/src/scene/ir-to-2d.js
+++ b/sdf-js/src/scene/ir-to-2d.js
@@ -29,8 +29,37 @@
 // a malformed IR's intent.
 import { validateIR } from './ir.js';
 import { getTheme } from '../present/themes.js';
+import { deriveMagnitudeInsight } from './insights.js';
 
 const SLIDE = { x: 40, y: 20, w: 1200, h: 680 };
+
+// ---- Sprint 98 (两端配合点 #2+#3): callout / 洞见底条 -----------------------
+// 3D 端把 ir.callout (页面关键事实, #341 字节 BP 的「融资 US$12.5M」课) 和
+// insights.js 推导洞见浮成 overlay 面板; 此前 2D 桥把两者都丢了 — BP 的
+// 第一号数字只活在飞行里。每页至多一条底条 (空间纪律): callout (关键事实)
+// 优先于推导洞见 (评论); magnitude 页无 callout 时补推导 (同一剂
+// "数据在场,结论缺席" 的药, 两个媒介同一结论)。
+const STRIP_H = 112;
+const STRIP_GAP = 16;
+
+function insightStripArgs(ir) {
+  if (ir.callout && ir.callout.text) {
+    const text = String(ir.callout.text);
+    const sub = ir.callout.sub ? String(ir.callout.sub) : '';
+    return sub ? { type_: 'insight', heading: text, body: sub } : { type_: 'insight', body: text };
+  }
+  if (ir.structure === 'magnitude') {
+    const ins = deriveMagnitudeInsight(ir);
+    if (ins) {
+      return {
+        type_: 'insight',
+        heading: ins.text,
+        body: ins.note ? `${ins.sub}（${ins.note}）` : ins.sub,
+      };
+    }
+  }
+  return null;
+}
 
 // ---- hierarchy: relations → {name, children} tree ---------------------------
 
@@ -342,7 +371,23 @@ export function irToSceneData(ir, _opts = {}) {
   if (!v.ok) throw new Error(`irToSceneData: invalid IR — ${v.errors.join('; ')}`);
   const fn = STRUCTURE_TO_SUBJECT[ir.structure];
   if (!fn) throw new Error(`irToSceneData: no 2D mapping for structure "${ir.structure}"`);
-  return { subjects: [fn(ir)] };
+  const main = fn(ir);
+  const strip = insightStripArgs(ir);
+  if (!strip) return { subjects: [main] };
+  // 主体让出底部一条; 几何只在 paint 契约里收缩, IR 不动
+  return {
+    subjects: [
+      { ...main, h: SLIDE.h - STRIP_H - STRIP_GAP },
+      {
+        type: 'callout-banner',
+        x: SLIDE.x,
+        y: SLIDE.y + SLIDE.h - STRIP_H,
+        w: SLIDE.w,
+        h: STRIP_H,
+        args: strip,
+      },
+    ],
+  };
 }
 
 /**


### PR DESCRIPTION
3D 端 #341-#352 弧线对齐: 2D 侧补齐契约对称性 (callout 底条 + 洞见推导两媒介同结论 + 批量按钮顺手存带溯源的 deck.json); AGENT_HANDOFF §9.6 给 3D 端留言 (figure.js 吃 artMount 预烘焙 palette + color.js 感知色距工具自取), 含最小对接路径。41+18 断言。

🤖 Generated with [Claude Code](https://claude.com/claude-code)