### PR TITLE
§9.6 配合点 #1: figure.js 吃 deck.artMount — 一份契约两个世界的最后一块

### DIFF
--- a/docs/AGENT_HANDOFF.md
+++ b/docs/AGENT_HANDOFF.md
@@ -422,9 +422,43 @@ callout-banner 底条 + deriveMagnitudeInsight 进 2D 图表页 — 你们的「
 
 有契约缺口/字段语义问题, 照 §9.5 惯例在下面追加问题清单, 2D 端按 PR 响应。
 
+### §9.6 回复 (3D 端, 2026-07-14)
+
+配合点 #1 已完成 (PR 见本次分支):
+
+- **透传**: `atlasDeckToIR` (scaffold-to-ir.js) 现在把契约 §3.5 的 `artMount`
+  原样带进 3D IR deck — handoff 后溯源不丢。
+- **优先级**: 新增 `src/scene/mount-palette.js` `resolveDeckPalette()` —
+  `?palette=0` 显式关 > `?palette=<theme>` 显式覆盖 > `artMount.palette`
+  (预烘焙) > 默认主题。figure.js 已接管线; 畸形 palette 静默回退默认 (不崩)。
+- **对比度地板 (你们配合点 #5 的建议, 已采)**: 装裱色喂 assembleDeck 前逐色
+  过 `ensureContrast` (直接 import 你们的 color.js) — 参照面是 deck 剧场的
+  暗场底 `[30,32,36]` (2D 对纸白, 3D 对暗场, 方向相反是有意的: 我们提亮近黑,
+  你们压暗近白)。
+- **溯源角标 (加分项, 已做)**: `name — artist (license)` 常驻左下
+  (`.stage-attribution`, figure.html), 不进 stage 时间线 (溯源不随章节隐现);
+  无 name/artist 时不渲染空署名。
+- **测试**: `scripts/test-mount-palette.mjs` 11 断言 (优先级×5 / 地板提亮 /
+  溯源提取 / 空署名 / handoff 透传 / 换装生效 / hsv 存活), 已进 npm test
+  (161 test files)。浏览器实测: bytedance deck + Fidenza 装裱 → network 站
+  穿上 mount 绿族, 金色冠军不被夺, 角标 "Fidenza — Tyler Hobbs (nc)"。
+
+配合点 #5 其余两件的消化进度 (未完成, 记录去向):
+
+- `okDist` 替换 GOLD_H 的 HSV 防撞: 认同判据更好, 但它会改所有既有 deck 的
+  accent 分配 → golden 全动 + 视觉变化, 我们想跟一次盲测批次一起换 (与
+  horizon 混林盲测同批)。挂账在 3D 侧 backlog。
+- `SEMANTIC` 共用红绿: 3D 洞见面板 (insights.js 的消费端) 目前不表达涨跌
+  色; 等它需要那天直接 import, 不另写。
+
 ### §9.6 问题清单 (3D 端追加)
 
-(待 3D 端消化后追加)
+1. **批量配对的发现约定**: 📦 批量存的 deck.json 与 PDF 同名同目录 — 3D 端
+   批量渲染时按什么根目录扫? 建议契约里写死一个相对路径约定 (如
+   `exports/<batch-id>/*.deck.json`), 我们好写批量飞行渲染脚本。
+2. `artMount.palette.colors` 有语义顺序吗 (主→次)? assignAccents 按数组序
+   轮转 content 站, 若 2D 端已按视觉权重排序, 我们就不再自行重排; 若无序,
+   告知一声, 我们会按 okDist 离 anchor 距离排一次。
 
 ## 10. For the next agent — start here
 

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -173,6 +173,7 @@ const TESTS = [
   { category: 'scene', file: 'sdf-js/scripts/test-density-scatter.mjs' },
   { category: 'scene', file: 'sdf-js/scripts/test-terrain-anchor.mjs' },
   { category: 'scene', file: 'sdf-js/scripts/test-weathering.mjs' },
+  { category: 'scene', file: 'sdf-js/scripts/test-mount-palette.mjs' },
   { category: 'scene', file: 'sdf-js/scripts/audit-2d-fidelity.mjs' },
   { category: 'scene', file: 'sdf-js/scripts/test-camera-shake.mjs' },
   { category: 'scene', file: 'sdf-js/scripts/test-text-to-ir.mjs' },

--- a/sdf-js/apps/present/figure.html
+++ b/sdf-js/apps/present/figure.html
@@ -138,6 +138,21 @@
         color: rgba(255, 255, 255, 0.72);
         letter-spacing: 0.02em;
       }
+      /* §9.6:真迹装裱溯源角标 — 常驻左下,极小极静(license 随行是纪律) */
+      .stage-attribution {
+        position: fixed;
+        left: 1.4vw;
+        bottom: 1.6vh;
+        font:
+          600 clamp(10px, 1.3vh, 13px) / 1.3 -apple-system,
+          Inter,
+          sans-serif;
+        color: rgba(255, 255, 255, 0.42);
+        text-shadow: 0 1px 2px rgba(0, 0, 0, 0.7);
+        letter-spacing: 0.03em;
+        pointer-events: none;
+        z-index: 30;
+      }
       /* chapter / finale cards: centered in the mid-frame void */
       .stage-insight.center {
         right: auto;

--- a/sdf-js/apps/present/figure.js
+++ b/sdf-js/apps/present/figure.js
@@ -6,6 +6,7 @@
 import { renderIR } from '../../src/scene/render-ir.js';
 import { assembleDeck } from '../../src/scene/assemble-deck.js';
 import { getTheme } from '../../src/present/themes.js';
+import { resolveDeckPalette } from '../../src/scene/mount-palette.js';
 import { createFigure } from './figure-core.js';
 import { attachPresenter } from './presenter.js';
 
@@ -23,12 +24,15 @@ const deckName = params.get('deck');
 const layout = params.get('layout') || 'radial';
 const name = params.get('ir') || 'funnel-sales';
 const ir = await (await fetch(`../../scenes/ir/${deckName || name}.json`)).json();
-// Section color program: the SAME palette the 2D end ships (pitch-spectrum,
-// chromotome kov_06 — ink ground + vermilion anchor). One content, two
-// mediums, one visual system. ?palette=<theme-id> to swap, ?palette=0 off.
-const paletteId = params.get('palette');
-const theme = paletteId === '0' ? null : getTheme(paletteId || 'pitch-spectrum');
-const palette = theme ? { anchor: theme.accent, colors: theme.colors } : null;
+// Section color program: the SAME palette the 2D end ships. §9.6 配合点 #1:
+// deck 契约携带 artMount(真迹装裱,§3.5)时优先穿它的预烘焙 palette ——
+// 同一份 deck.json,纸上 PDF 和 3D 飞行穿同一件真迹的颜色。URL 参数保留为
+// 显式覆盖:?palette=<theme-id> 换主题,?palette=0 关。
+const { palette, attribution } = resolveDeckPalette({
+  artMount: ir.artMount || null,
+  paletteParam: params.get('palette'),
+  themeOf: (id) => (id ? getTheme(id) : getTheme('pitch-spectrum')),
+});
 // ?seed=<hash> — Layer C deck decor (seeded art identity, same lanes as the
 // 2D decor engine). DEFAULT ON for decks since W6: the deck's own name is its
 // art identity (same deck → same world, forever — the 2D mint-hash covenant).
@@ -41,5 +45,14 @@ const scene = deckName
   ? assembleDeck(ir, { env, layout, stage, palette, decorSeed, horizon })
   : renderIR(ir, { env, stage });
 show(scene);
+// §9.6 配合点 #1 加分项:真迹溯源角标(装裱是非商用铸造,license 随行是纪律)。
+// 常驻小元素,不进 stage 时间线 —— 溯源不该随章节隐现。
+if (attribution && (attribution.name || attribution.artist)) {
+  const d = document.createElement('div');
+  d.className = 'stage-attribution';
+  d.textContent = [attribution.name, attribution.artist].filter(Boolean).join(' — ');
+  if (attribution.license) d.textContent += ` (${attribution.license})`;
+  document.body.appendChild(d);
+}
 // script spans may ride in the deck fixture (teleprompter); presenter uses them
 if (present) attachPresenter({ studio: window.__figStudio, scene, script: ir.script || null });

--- a/sdf-js/scripts/test-mount-palette.mjs
+++ b/sdf-js/scripts/test-mount-palette.mjs
@@ -1,0 +1,121 @@
+// sdf-js/scripts/test-mount-palette.mjs — §9.6 配合点 #1 的契约测试。
+// 不变量:palette 优先级(URL 显式覆盖 > artMount 预烘焙 > 默认;?palette=0
+// 显式关)、装裱色过 ensureContrast 暗场地板、溯源 attribution 提取、
+// atlasDeckToIR 透传 artMount、palette 喂 assembleDeck 后 accent 真的换族。
+import { resolveDeckPalette } from '../src/scene/mount-palette.js';
+import { atlasDeckToIR } from '../src/scene/scaffold-to-ir.js';
+import { assembleDeck } from '../src/scene/assemble-deck.js';
+import { rgbToHsv } from '../src/scene/assemble-deck.js';
+import { readFileSync, readdirSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+let pass = 0,
+  fail = 0;
+const ok = (c, n) => (c ? (pass++, console.log(`  ✓ ${n}`)) : (fail++, console.log(`  ✗ ${n}`)));
+console.log('=== mount palette (§9.6 配合点 #1) ===\n');
+
+const THEME = {
+  accent: [241, 70, 22],
+  colors: [
+    [241, 70, 22],
+    [43, 154, 233],
+  ],
+};
+const themeOf = () => THEME;
+const MOUNT = {
+  id: '0xa7d8d9-41',
+  name: 'Fidenza',
+  artist: 'Tyler Hobbs',
+  license: 'nc',
+  palette: {
+    accent: [10, 120, 200],
+    colors: [
+      [10, 120, 200],
+      [200, 60, 40],
+      [20, 22, 26],
+    ],
+  },
+};
+
+// ---- 优先级 -----------------------------------------------------------------------
+{
+  const off = resolveDeckPalette({ artMount: MOUNT, paletteParam: '0', themeOf });
+  ok(off.palette === null && off.source === 'off', '?palette=0 → explicit off beats the mount');
+  const url = resolveDeckPalette({ artMount: MOUNT, paletteParam: 'pitch-spectrum', themeOf });
+  ok(
+    url.source === 'url' && url.palette.anchor === THEME.accent,
+    '?palette=<id> → explicit theme beats the mount',
+  );
+  const mounted = resolveDeckPalette({ artMount: MOUNT, paletteParam: null, themeOf });
+  ok(mounted.source === 'artMount', 'no URL param → the mount palette wins');
+  const plain = resolveDeckPalette({ artMount: null, paletteParam: null, themeOf });
+  ok(
+    plain.source === 'default' && plain.palette.anchor === THEME.accent,
+    'no mount, no param → default theme',
+  );
+  const broken = resolveDeckPalette({
+    artMount: { ...MOUNT, palette: { accent: [1, 2], colors: [] } },
+    paletteParam: null,
+    themeOf,
+  });
+  ok(broken.source === 'default', 'malformed mount palette falls back to default (no crash)');
+}
+
+// ---- ensureContrast 暗场地板 + 溯源 -------------------------------------------------
+{
+  const r = resolveDeckPalette({ artMount: MOUNT, paletteParam: null, themeOf });
+  // 装裱色里的近黑 [20,22,26] 对暗场 [30,32,36] 无对比 → 地板必须提亮它
+  const dark = r.palette.colors[2];
+  ok(
+    dark[0] + dark[1] + dark[2] > 20 + 22 + 26 + 30,
+    `contrast floor lifts near-bg colors (${dark.map((v) => v | 0).join(',')})`,
+  );
+  ok(
+    r.attribution.name === 'Fidenza' &&
+      r.attribution.artist === 'Tyler Hobbs' &&
+      r.attribution.license === 'nc',
+    'attribution extracted for the overlay badge',
+  );
+  const anon = resolveDeckPalette({
+    artMount: { id: 'x', palette: MOUNT.palette },
+    paletteParam: null,
+    themeOf,
+  });
+  ok(anon.attribution === null, 'no name/artist → no badge (never render an empty credit)');
+}
+
+// ---- atlasDeckToIR 透传 + 端到端换装 -------------------------------------------------
+{
+  // 契约 fixtures 里找一份 valid deck,给它穿上装裱走 handoff
+  const H = resolve(__dirname, '../examples/deck-handoff/valid');
+  const file = readdirSync(H).find((f) => f.endsWith('.json'));
+  const raw = JSON.parse(readFileSync(`${H}/${file}`, 'utf8'));
+  const irDeck = atlasDeckToIR({ ...raw, artMount: MOUNT });
+  ok(
+    irDeck.artMount && irDeck.artMount.id === MOUNT.id,
+    `atlasDeckToIR carries artMount through (${file})`,
+  );
+  // 换装断言用合成 content deck(accent 程序只染 content 站,fixture 可能全 hold)
+  const mag = (t) => ({
+    structure: 'magnitude',
+    title: t,
+    nodes: ['A', 'B', 'C'],
+    magnitude: [3, 2, 1],
+  });
+  const synth = { title: 'revoice', slides: [mag('one'), mag('two')], artMount: MOUNT };
+  const { palette } = resolveDeckPalette({ artMount: synth.artMount, paletteParam: null, themeOf });
+  const dressed = assembleDeck(synth, { layout: 'radial', palette });
+  const plain = assembleDeck(synth, { layout: 'radial' });
+  ok(
+    JSON.stringify(dressed.materials) !== JSON.stringify(plain.materials),
+    'mounted palette actually re-voices the deck materials',
+  );
+  const anchorHsv = rgbToHsv(MOUNT.palette.accent);
+  ok(Number.isFinite(anchorHsv.h), 'mount accent survives the rgb→hsv accent program');
+}
+
+console.log(`\n${pass}/${pass + fail} passed`);
+process.exit(fail ? 1 : 0);

--- a/sdf-js/src/scene/mount-palette.js
+++ b/sdf-js/src/scene/mount-palette.js
@@ -1,0 +1,70 @@
+// sdf-js/src/scene/mount-palette.js — §9.6 配合点 #1:figure.js 吃 deck.artMount。
+// 契约 §3.5(docs/atlas-deck-contract.md):deck 出图时穿了真迹装裱,palette
+// 预烘焙随契约走 —— 同一份 deck.json,纸上 PDF 和 3D 飞行穿同一件真迹的颜色。
+// 优先级(URL 参数保留为显式覆盖,2D 端留言原文):
+//   ?palette=0        → 关(显式)
+//   ?palette=<theme>  → 主题覆盖(显式)
+//   deck.artMount.palette → 真迹装裱(预烘焙)
+//   默认主题
+// 装裱色进 3D 前过一遍 ensureContrast 对比度地板(§9.6 配合点 #5 的建议;
+// 2D 端 mountPaletteOverride 已这么做)—— deck 剧场是暗场,地板方向是提亮。
+import { ensureContrast } from '../present/atoms-2d/color.js';
+
+// deck 剧场的暗场底色(stage 层 studioBg dark 的近似;对比度地板的参照面)
+const STAGE_BG = [30, 32, 36];
+
+const validPalette = (p) =>
+  p &&
+  Array.isArray(p.accent) &&
+  p.accent.length === 3 &&
+  Array.isArray(p.colors) &&
+  p.colors.length > 0;
+
+/**
+ * resolveDeckPalette({ artMount, paletteParam, themeOf }) →
+ *   { palette: {anchor, colors}|null, source, attribution|null }
+ * @param artMount     IR deck 携带的 §3.5 溯源块(可缺)
+ * @param paletteParam URL ?palette= 原始值(可缺)
+ * @param themeOf      (id|null) => theme|null(figure.js 注入 getTheme,便于测试)
+ */
+export function resolveDeckPalette({ artMount = null, paletteParam = null, themeOf } = {}) {
+  const attribution =
+    artMount && (artMount.name || artMount.artist)
+      ? {
+          name: artMount.name || null,
+          artist: artMount.artist || null,
+          license: artMount.license || null,
+        }
+      : null;
+
+  if (paletteParam === '0') return { palette: null, source: 'off', attribution };
+
+  if (paletteParam) {
+    const theme = themeOf(paletteParam);
+    if (theme)
+      return {
+        palette: { anchor: theme.accent, colors: theme.colors },
+        source: 'url',
+        attribution,
+      };
+  }
+
+  if (validPalette(artMount?.palette)) {
+    const floor = (rgb) => ensureContrast(rgb, STAGE_BG);
+    return {
+      palette: {
+        anchor: floor(artMount.palette.accent),
+        colors: artMount.palette.colors.map(floor),
+      },
+      source: 'artMount',
+      attribution,
+    };
+  }
+
+  const theme = themeOf(null); // 调用方的默认主题
+  return {
+    palette: theme ? { anchor: theme.accent, colors: theme.colors } : null,
+    source: 'default',
+    attribution,
+  };
+}

--- a/sdf-js/src/scene/scaffold-to-ir.js
+++ b/sdf-js/src/scene/scaffold-to-ir.js
@@ -966,5 +966,12 @@ export function atlasDeckToIR(deckJson, opts = {}) {
       outcome: holdFallback ? 'ir:hold(fallback)' : `ir:${ir.structure}`,
     });
   });
-  return { title: deck.title || 'atlas-deck', slides, report };
+  return {
+    title: deck.title || 'atlas-deck',
+    slides,
+    report,
+    // §9.6 配合点 #1:契约 §3.5 的真迹装裱溯源随行到 3D IR deck —— palette
+    // 预烘焙(无像素也能穿上作品的颜色),name/artist/license 供溯源角标。
+    ...(deck.artMount ? { artMount: deck.artMount } : {}),
+  };
 }


### PR DESCRIPTION
## What

响应 2D 端 AGENT_HANDOFF **§9.6 留言的配合点 #1**(优先项):deck 契约 §3.5 的 `artMount` 真迹装裱溯源块,3D 侧现在完整消费——**同一份 deck.json,纸上 PDF 和 3D 飞行穿同一件真迹的颜色**。

### 落地

1. **透传**:`atlasDeckToIR` 把 `artMount` 原样带进 3D IR deck(handoff 后溯源不丢)。
2. **优先级**(可测纯函数 `resolveDeckPalette`,figure.js 接管线):`?palette=0` 显式关 > `?palette=<theme>` 显式覆盖 > `artMount.palette`(预烘焙)> 默认主题;畸形 palette 静默回退不崩。
3. **配合点 #5 部分采纳**:装裱色喂 assembleDeck 前逐色过 2D 端 `color.js` 的 `ensureContrast`(直接 import 零复制)——参照面是 deck 剧场暗场底 [30,32,36](2D 对纸白压暗、3D 对暗场提亮,方向相反是有意的,回复里写明)。
4. **加分项**:`name — artist (license)` 溯源角标,常驻左下、极小极静、不进 stage 时间线(溯源不随章节隐现);无署名不渲染。
5. **§9.6 回复已写进 AGENT_HANDOFF**:含 okDist/SEMANTIC 的消化去向(okDist 换 GOLD_H 防撞会动全部 golden + 视觉,挂账跟盲测批次一起换;SEMANTIC 等洞见面板需要涨跌色那天直接 import),外加两个问题追加(批量目录约定 / palette.colors 语义顺序)。

### 验证

- `test-mount-palette.mjs` **11 断言**(优先级×5 / 暗场地板提亮近黑色 / 溯源提取 / 空署名不渲染 / handoff 透传 / 换装真的生效 / hsv 存活),套件 **160/160**。
- 浏览器实测:bytedance deck + Fidenza 装裱 → network 站穿上 mount 绿族、金色冠军不被夺、角标 "Fidenza — Tyler Hobbs (nc)" 常驻左下。

🤖 Generated with [Claude Code](https://claude.com/claude-code)