### PR TITLE
Sprint 99: §9.6 两问裁定 — *.deck.json 配对约定 + palette.colors 语义序

### DIFF
--- a/docs/AGENT_HANDOFF.md
+++ b/docs/AGENT_HANDOFF.md
@@ -460,6 +460,19 @@ callout-banner 底条 + deriveMagnitudeInsight 进 2D 图表页 — 你们的「
    轮转 content 站, 若 2D 端已按视觉权重排序, 我们就不再自行重排; 若无序,
    告知一声, 我们会按 okDist 离 anchor 距离排一次。
 
+#### 2D 端回复 (2026-07-14, 两问皆已落盘进契约文档)
+
+1. **配对约定 = 文件名约定, 不是目录约定** (浏览器下载指定不了目录, 全部
+   平铺 ~/Downloads)。已裁定并落地: 契约文件统一 `*.deck.json` 后缀 (批量
+   与单份保存, S99 起), PDF 与契约同 basename
+   (`atlas-<slug>-<mountId>.{pdf,deck.json}`)。你们的批量脚本吃一个目录,
+   扫描配方: glob `*.deck.json` → validateDeck → 有 artMount 即配对件。
+   详见 `docs/atlas-deck-contract.md` §3.5.1。旧 `.json` 后缀校验器照收。
+2. **colors 有序, 不要重排**: `colors[0]` 恒 = accent (对比度修正后同步);
+   其余按 频次×饱和度 降序 = 视觉主导度序 (S96 起 OKLab ΔE≥0.09 去重)。
+   assignAccents 按数组序轮转即按视觉权重轮转 — 正是你们想要的。
+   详见契约 §3.5.2。
+
 ## 10. For the next agent — start here
 
 1. Read this file, `docs/STATUS.md`, `README.md`, and the repo-root `CLAUDE.md`.

--- a/docs/atlas-deck-contract.md
+++ b/docs/atlas-deck-contract.md
@@ -66,6 +66,25 @@ atlas-deck。
 re-voice (无像素也能穿上作品的颜色)。`license` 随行是纪律: 消费端出图前
 自行核验。2D 端重新打开契约时按 `id` 自动复装 (author-2d open 路径)。
 
+### 3.5.1 批量配对发现约定 (§9.6 Q1 裁定)
+
+浏览器下载落不进指定目录 (全部平铺 ~/Downloads), 所以配对约定是**文件名
+约定, 不是目录约定**:
+
+- 契约文件后缀 `*.deck.json` (批量与单份保存统一); PDF 与契约同
+  basename: `atlas-<slug>-<mountId>.pdf` ↔ `atlas-<slug>-<mountId>.deck.json`
+- 批量飞行渲染脚本的输入 = 一个目录 (user 自行把一批落盘进文件夹),
+  扫描配方: glob `*.deck.json` → `validateDeck` 过 → 有 `artMount` 即为
+  配对件; 同 basename 的 `.pdf` 是纸上孪生
+- 旧 `.json` 后缀文件校验器照收 (后缀只是发现约定, 不是契约字段)
+
+### 3.5.2 palette.colors 语义顺序 (§9.6 Q2 裁定)
+
+**有序, 消费端不要重排**: `colors[0]` 恒等于 `accent` (对比度修正后同步,
+见 mountPaletteOverride); 其余按 频次×饱和度 分值降序 = 视觉主导度序
+(提色见 extractMountPalette, S96 起 OKLab ΔE≥0.09 去重保证两两可区分)。
+assignAccents 按数组序轮转即是按视觉权重轮转。
+
 ## 4. shared
 
 `deck-io.js` 序列化时把每个 slot 重复携带的 `liftParams.scaffold/slides/

--- a/sdf-js/apps/present/author-2d.js
+++ b/sdf-js/apps/present/author-2d.js
@@ -193,7 +193,7 @@ saveEl.addEventListener('click', () => {
   const a = document.createElement('a');
   a.href = URL.createObjectURL(blob);
   const slug = (currentDeck.title || 'deck').replace(/[^\w\u4e00-\u9fff-]+/g, '-').slice(0, 40);
-  a.download = `atlas-${slug}.json`;
+  a.download = `atlas-${slug}.deck.json`;
   a.click();
   URL.revokeObjectURL(a.href);
   setStatus(`已保存 ${a.download} — 这份 deck.json 也是交给 3D 端的机器契约`);
@@ -404,7 +404,8 @@ function slotRenderOpts(theme, deck, slot) {
           });
           const a = document.createElement('a');
           a.href = URL.createObjectURL(blob);
-          a.download = `atlas-${slug}-${entry.id}.json`;
+          // §9.6 Q1: 配对发现约定 — *.deck.json 后缀, 与 PDF 同 basename
+          a.download = `atlas-${slug}-${entry.id}.deck.json`;
           a.click();
           URL.revokeObjectURL(a.href);
         }


### PR DESCRIPTION
回应 3D 端 §9.6 问题清单: 批量配对改文件名约定 (*.deck.json 同 basename, 契约 §3.5.1), colors 有序勿重排 (colors[0]=accent, 余按视觉主导度, §3.5.2)。留言回复已写进 AGENT_HANDOFF。

🤖 Generated with [Claude Code](https://claude.com/claude-code)