### PR TITLE
feat: 4D SDF 玩具 — 切片 / 厚投影 / 洋葱层三种观看模式 + 六平面旋转

### DIFF
--- a/sdf-js/apps/fourd/fourd.js
+++ b/sdf-js/apps/fourd/fourd.js
@@ -1,0 +1,389 @@
+// =============================================================================
+// fourd.js — the 4D SDF toy. Exploration, deliberately un-productized.
+// -----------------------------------------------------------------------------
+// A 2D screen shows a 3D world through projection + motion; a (future)
+// spherical volumetric display would show 4D the same way. Until then, the
+// fourth dimension enters intuition through MOTION: sliding the w-slice and
+// spinning the three w-planes (xw / yw / zw) — rotations impossible in 3D.
+//
+// Three viewing modes, one distance field d(x,y,z,w):
+//   slice  — d3(p) = d4(R·(p,w0)): a razor cross-section. The staple
+//            (Miegakure / 4D Toys): shapes grow, morph and vanish as w slides.
+//   thick  — d3(p) = min over w∈[-W,W] of d4: the whole 4D body flattened
+//            into 3D (the "shadow"). Hit points are colored by the w that was
+//            closest — a DEPTH MAP OF THE FOURTH DIMENSION in hue.
+//   onion  — a few translucent slices at once: the poor man's volumetric
+//            display, w expressed as layered ghosts.
+//
+// Everything is a plain WebGL2 raymarcher with the stone white-model shading —
+// zero dependency on the Present pipeline, no perf gate, pure playground.
+// =============================================================================
+
+const canvas = document.getElementById('c');
+const gl = canvas.getContext('webgl2', { antialias: true });
+if (!gl) throw new Error('WebGL2 required');
+
+const FRAG = `#version 300 es
+precision highp float;
+out vec4 fragColor;
+
+uniform vec2  u_res;
+uniform float u_time;
+uniform vec3  u_camPos;
+uniform vec3  u_camTarget;
+uniform mat4  u_rot;    // 4D rotation (composition of the six plane rotations)
+uniform float u_w;      // slice height along the 4th axis
+uniform int   u_shape;
+uniform int   u_mode;   // 0 slice | 1 thick | 2 onion
+
+// ---- 4D primitives ----------------------------------------------------------
+float sdHypersphere(vec4 p, float r) { return length(p) - r; }
+
+float sdTesseract(vec4 p, vec4 h, float rr) {
+  vec4 q = abs(p) - h;
+  return length(max(q, 0.0)) + min(max(max(q.x, q.y), max(q.z, q.w)), 0.0) - rr;
+}
+
+// duocylinder: the product of two discs — |xy| <= r1 AND |zw| <= r2
+float sdDuocylinder(vec4 p, float r1, float r2) {
+  vec2 d = vec2(length(p.xy) - r1, length(p.zw) - r2);
+  return min(max(d.x, d.y), 0.0) + length(max(d, 0.0));
+}
+
+// spheritorus: a 2-sphere swept around a circle that extends into w
+float sdSpheritorus(vec4 p, float R, float r) {
+  return length(vec2(length(p.xyz) - R, p.w)) - r;
+}
+
+// duotorus (inflated Clifford torus): |xy| = r1 circle × |zw| = r2 circle
+float sdDuotorus(vec4 p, float r1, float r2, float r) {
+  return length(vec2(length(p.xy) - r1, length(p.zw) - r2)) - r;
+}
+
+float smin(float a, float b, float k) {
+  float h = clamp(0.5 + 0.5 * (b - a) / k, 0.0, 1.0);
+  return mix(b, a, h) - k * h * (1.0 - h);
+}
+
+float sd4(vec4 q) {
+  vec4 p = u_rot * q;
+  if (u_shape == 0) return sdHypersphere(p, 1.15);
+  if (u_shape == 1) return sdTesseract(p, vec4(0.78), 0.06);
+  if (u_shape == 2) return sdDuocylinder(p, 0.95, 0.95);
+  if (u_shape == 3) return sdSpheritorus(p, 1.0, 0.34);
+  if (u_shape == 4) return sdDuotorus(p, 0.85, 0.85, 0.28);
+  // blend: a hypersphere orbiting THROUGH a tesseract in the w axis — the
+  // union breathes as the sphere passes through the slice
+  float a = sdTesseract(p, vec4(0.62), 0.05);
+  vec4 c = vec4(0.9 * cos(u_time * 0.6), 0.3 * sin(u_time * 0.4), 0.0, 0.9 * sin(u_time * 0.6));
+  float b = sdHypersphere(p - c, 0.55);
+  return smin(a, b, 0.28);
+}
+
+// ---- 3D fields (the three viewing modes) -------------------------------------
+#define THICK 1.6
+float g_hitW; // thick mode: which w was closest at the hit (4th-dim depth)
+
+float mapSlice(vec3 p) { return sd4(vec4(p, u_w)); }
+
+float mapThick(vec3 p) {
+  float best = 1e9;
+  float bw = 0.0;
+  for (int i = 0; i < 13; i++) {
+    float w = mix(-THICK, THICK, float(i) / 12.0);
+    float d = sd4(vec4(p, w));
+    if (d < best) { best = d; bw = w; }
+  }
+  g_hitW = bw;
+  return best;
+}
+
+float map(vec3 p) { return (u_mode == 1) ? mapThick(p) : mapSlice(p); }
+
+vec3 calcN(vec3 p) {
+  const vec2 e = vec2(0.0015, -0.0015);
+  return normalize(
+    e.xyy * map(p + e.xyy) + e.yyx * map(p + e.yyx) + e.yxy * map(p + e.yxy) + e.xxx * map(p + e.xxx));
+}
+
+float calcAO(vec3 p, vec3 n) {
+  float occ = 0.0;
+  float sca = 1.0;
+  for (int i = 0; i < 5; i++) {
+    float h = 0.02 + 0.11 * float(i);
+    occ += (h - map(p + n * h)) * sca;
+    sca *= 0.85;
+  }
+  return clamp(1.0 - 2.2 * occ, 0.0, 1.0);
+}
+
+vec3 hueOfW(float w) {
+  // 4th-dimension depth → hue: -W blue, 0 white-ish, +W vermilion
+  float t = clamp(w / THICK * 0.5 + 0.5, 0.0, 1.0);
+  vec3 cold = vec3(0.35, 0.55, 1.0);
+  vec3 mid = vec3(0.92, 0.93, 0.96);
+  vec3 hot = vec3(1.0, 0.42, 0.2);
+  return t < 0.5 ? mix(cold, mid, t * 2.0) : mix(mid, hot, t * 2.0 - 1.0);
+}
+
+vec3 shade(vec3 p, vec3 rd, float t, vec3 alb) {
+  vec3 n = calcN(p);
+  vec3 sun = normalize(vec3(0.55, 0.7, 0.4));
+  float dif = max(dot(n, sun), 0.0);
+  float ao = calcAO(p, n);
+  vec3 lin = alb * (0.35 + 0.75 * dif) * vec3(1.06, 1.01, 0.94);
+  lin += alb * (0.6 + 0.4 * n.y) * ao * 0.5;
+  lin *= mix(1.0, ao, 0.6);
+  return lin * exp(-0.028 * t);
+}
+
+vec4 marchField(vec3 ro, vec3 rd) { // returns (color, alpha-hit)
+  float t = 0.02;
+  for (int i = 0; i < 160; i++) {
+    vec3 p = ro + rd * t;
+    float d = map(p);
+    if (d < 0.001 * (1.0 + t)) {
+      vec3 alb = (u_mode == 1) ? hueOfW(g_hitW) : vec3(0.88, 0.89, 0.92);
+      return vec4(shade(p, rd, t, alb), 1.0);
+    }
+    if (t > 24.0) break;
+    t += d;
+  }
+  return vec4(0.0);
+}
+
+// onion: N translucent slices composited front-to-back, each its own w-hue
+vec4 marchOnion(vec3 ro, vec3 rd) {
+  vec3 acc = vec3(0.0);
+  float trans = 1.0;
+  for (int layer = 0; layer < 5; layer++) {
+    float w = mix(-1.2, 1.2, float(layer) / 4.0);
+    float t = 0.02;
+    for (int i = 0; i < 90; i++) {
+      vec3 p = ro + rd * t;
+      float d = sd4(vec4(p, w));
+      if (d < 0.0012 * (1.0 + t)) {
+        // cheap per-layer shading: normal via the SLICE field at this w
+        vec3 n;
+        {
+          const vec2 e = vec2(0.002, -0.002);
+          n = normalize(
+            e.xyy * sd4(vec4(p + e.xyy, w)) + e.yyx * sd4(vec4(p + e.yyx, w)) +
+            e.yxy * sd4(vec4(p + e.yxy, w)) + e.xxx * sd4(vec4(p + e.xxx, w)));
+        }
+        vec3 sun = normalize(vec3(0.55, 0.7, 0.4));
+        vec3 col = hueOfW(w) * (0.4 + 0.7 * max(dot(n, sun), 0.0)) * exp(-0.028 * t);
+        float a = 0.42;
+        acc += trans * a * col;
+        trans *= (1.0 - a);
+        break;
+      }
+      if (t > 24.0) break;
+      t += d;
+    }
+    if (trans < 0.04) break;
+  }
+  return vec4(acc, 1.0 - trans);
+}
+
+void main() {
+  vec2 uv = (gl_FragCoord.xy * 2.0 - u_res) / u_res.y;
+  vec3 fwd = normalize(u_camTarget - u_camPos);
+  vec3 right = normalize(cross(fwd, vec3(0.0, 1.0, 0.0)));
+  vec3 up = cross(right, fwd);
+  vec3 rd = normalize(uv.x * right + uv.y * up + 1.7 * fwd);
+  vec3 ro = u_camPos;
+
+  vec3 bg = mix(vec3(0.085, 0.10, 0.13), vec3(0.014, 0.018, 0.028), clamp(uv.y * 0.5 + 0.5, 0.0, 1.0));
+  vec4 s = (u_mode == 2) ? marchOnion(ro, rd) : marchField(ro, rd);
+  vec3 col = mix(bg, s.rgb, s.a);
+
+  // gentle vignette + gamma (self-contained page: no postfx pipeline here)
+  col *= 1.0 - 0.25 * dot(uv * 0.5, uv * 0.5);
+  col = pow(max(col, 0.0), vec3(0.4545));
+  fragColor = vec4(col, 1.0);
+}
+`;
+
+const VERT = `#version 300 es
+in vec2 a_pos;
+void main() { gl_Position = vec4(a_pos, 0.0, 1.0); }
+`;
+
+function compile(type, src) {
+  const sh = gl.createShader(type);
+  gl.shaderSource(sh, src);
+  gl.compileShader(sh);
+  if (!gl.getShaderParameter(sh, gl.COMPILE_STATUS))
+    throw new Error(gl.getShaderInfoLog(sh));
+  return sh;
+}
+const prog = gl.createProgram();
+gl.attachShader(prog, compile(gl.VERTEX_SHADER, VERT));
+gl.attachShader(prog, compile(gl.FRAGMENT_SHADER, FRAG));
+gl.linkProgram(prog);
+if (!gl.getProgramParameter(prog, gl.LINK_STATUS)) throw new Error(gl.getProgramInfoLog(prog));
+gl.useProgram(prog);
+
+const buf = gl.createBuffer();
+gl.bindBuffer(gl.ARRAY_BUFFER, buf);
+gl.bufferData(gl.ARRAY_BUFFER, new Float32Array([-1, -1, 3, -1, -1, 3]), gl.STATIC_DRAW);
+const aPos = gl.getAttribLocation(prog, 'a_pos');
+gl.enableVertexAttribArray(aPos);
+gl.vertexAttribPointer(aPos, 2, gl.FLOAT, false, 0, 0);
+
+const U = {};
+for (const n of ['u_res', 'u_time', 'u_camPos', 'u_camTarget', 'u_rot', 'u_w', 'u_shape', 'u_mode'])
+  U[n] = gl.getUniformLocation(prog, n);
+
+// ---- 4D rotation: compose six plane rotations from absolute angles ------------
+// (build from angles each frame — no incremental drift)
+const PLANES = [
+  [0, 1], // xy
+  [0, 2], // xz
+  [1, 2], // yz
+  [0, 3], // xw
+  [1, 3], // yw
+  [2, 3], // zw
+];
+function rot4(angles) {
+  // column-major 4x4 identity
+  let m = [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1];
+  const mul = (a, b) => {
+    const o = new Array(16).fill(0);
+    for (let c = 0; c < 4; c++)
+      for (let r = 0; r < 4; r++)
+        for (let k = 0; k < 4; k++) o[c * 4 + r] += a[k * 4 + r] * b[c * 4 + k];
+    return o;
+  };
+  angles.forEach((th, i) => {
+    if (!th) return;
+    const [u, v] = PLANES[i];
+    const R = [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1];
+    const c = Math.cos(th);
+    const s = Math.sin(th);
+    R[u * 4 + u] = c;
+    R[v * 4 + v] = c;
+    R[u * 4 + v] = s;
+    R[v * 4 + u] = -s;
+    m = mul(m, R);
+  });
+  return new Float32Array(m);
+}
+
+// ---- state + UI ----------------------------------------------------------------
+const state = {
+  shape: 1,
+  mode: 0,
+  w: 0,
+  wanim: false,
+  speeds: [0, 0, 0, 0.25, 0, 0], // xw gently spinning by default — the 4D hello-world
+  angles: [0, 0, 0, 0, 0, 0],
+  cam: { yaw: 0.6, pitch: 0.35, dist: 5.2 },
+};
+
+const $ = (id) => document.getElementById(id);
+$('shape').onchange = (e) => (state.shape = Number(e.target.value));
+for (const m of [0, 1, 2])
+  $(`mode${m}`).onclick = () => {
+    state.mode = m;
+    for (const k of [0, 1, 2]) $(`mode${k}`).classList.toggle('on', k === m);
+  };
+$('w').oninput = (e) => {
+  state.w = Number(e.target.value);
+  state.wanim = false;
+  $('wanim').checked = false;
+};
+$('wanim').onchange = (e) => (state.wanim = e.target.checked);
+['rxy', 'rxz', 'ryz', 'rxw', 'ryw', 'rzw'].forEach((id, i) => {
+  $(id).oninput = (e) => (state.speeds[i] = Number(e.target.value));
+});
+$('reset').onclick = () => {
+  state.angles = [0, 0, 0, 0, 0, 0];
+  state.speeds = [0, 0, 0, 0, 0, 0];
+  state.w = 0;
+  state.wanim = false;
+  $('wanim').checked = false;
+  $('w').value = '0';
+  ['rxy', 'rxz', 'ryz', 'rxw', 'ryw', 'rzw'].forEach((id) => ($(id).value = '0'));
+};
+
+// orbit camera
+let dragging = false;
+let lastXY = null;
+canvas.addEventListener('pointerdown', (e) => {
+  dragging = true;
+  lastXY = [e.clientX, e.clientY];
+  canvas.setPointerCapture(e.pointerId);
+});
+canvas.addEventListener('pointermove', (e) => {
+  if (!dragging) return;
+  const dx = e.clientX - lastXY[0];
+  const dy = e.clientY - lastXY[1];
+  lastXY = [e.clientX, e.clientY];
+  state.cam.yaw -= dx * 0.006;
+  state.cam.pitch = Math.max(-1.4, Math.min(1.4, state.cam.pitch + dy * 0.006));
+});
+canvas.addEventListener('pointerup', () => (dragging = false));
+canvas.addEventListener(
+  'wheel',
+  (e) => {
+    e.preventDefault();
+    state.cam.dist = Math.max(2.2, Math.min(14, state.cam.dist * (1 + e.deltaY * 0.001)));
+  },
+  { passive: false },
+);
+
+// ---- loop -----------------------------------------------------------------------
+const hud = document.getElementById('hud');
+let frames = 0;
+let fpsLast = performance.now();
+let tPrev = performance.now();
+
+function frame(now) {
+  const dt = Math.min(0.05, (now - tPrev) / 1000);
+  tPrev = now;
+  const t = now / 1000;
+
+  const dpr = Math.min(window.devicePixelRatio || 1, 2);
+  const w = Math.floor(canvas.clientWidth * dpr);
+  const h = Math.floor(canvas.clientHeight * dpr);
+  if (canvas.width !== w || canvas.height !== h) {
+    canvas.width = w;
+    canvas.height = h;
+  }
+  gl.viewport(0, 0, w, h);
+
+  state.angles = state.angles.map((a, i) => a + state.speeds[i] * dt);
+  if (state.wanim) {
+    state.w = Math.sin(t * 0.5) * 1.3;
+    $('w').value = String(state.w.toFixed(2));
+  }
+  document.getElementById('wval').textContent = state.w.toFixed(2);
+
+  const { yaw, pitch, dist } = state.cam;
+  const cp = [
+    Math.sin(yaw) * Math.cos(pitch) * dist,
+    Math.sin(pitch) * dist,
+    Math.cos(yaw) * Math.cos(pitch) * dist,
+  ];
+
+  gl.uniform2f(U.u_res, w, h);
+  gl.uniform1f(U.u_time, t);
+  gl.uniform3f(U.u_camPos, cp[0], cp[1], cp[2]);
+  gl.uniform3f(U.u_camTarget, 0, 0, 0);
+  gl.uniformMatrix4fv(U.u_rot, false, rot4(state.angles));
+  gl.uniform1f(U.u_w, state.w);
+  gl.uniform1i(U.u_shape, state.shape);
+  gl.uniform1i(U.u_mode, state.mode);
+  gl.drawArrays(gl.TRIANGLES, 0, 3);
+
+  frames++;
+  if (now - fpsLast > 500) {
+    hud.textContent = `${(frames / ((now - fpsLast) / 1000)).toFixed(0)} fps`;
+    frames = 0;
+    fpsLast = now;
+  }
+  requestAnimationFrame(frame);
+}
+requestAnimationFrame(frame);

--- a/sdf-js/apps/fourd/index.html
+++ b/sdf-js/apps/fourd/index.html
@@ -1,0 +1,141 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>Atlas 4D — four-dimensional SDF toy</title>
+    <style>
+      html,
+      body {
+        margin: 0;
+        height: 100%;
+        background: #0e0f12;
+        overflow: hidden;
+        font: 500 13px -apple-system, Inter, sans-serif;
+        color: #e8eaf0;
+      }
+      #c {
+        display: block;
+        width: 100%;
+        height: 100%;
+        cursor: grab;
+      }
+      #panel {
+        position: fixed;
+        left: 14px;
+        top: 14px;
+        z-index: 10;
+        background: rgba(16, 18, 24, 0.86);
+        border: 1px solid rgba(255, 255, 255, 0.08);
+        border-radius: 10px;
+        padding: 14px 16px;
+        width: 250px;
+        user-select: none;
+      }
+      #panel h1 {
+        font-size: 14px;
+        margin: 0 0 10px;
+        letter-spacing: 0.06em;
+      }
+      #panel label {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 8px;
+        margin: 7px 0;
+        color: rgba(232, 234, 240, 0.85);
+      }
+      #panel select,
+      #panel input[type='range'] {
+        flex: 1;
+      }
+      #panel .row {
+        display: flex;
+        gap: 6px;
+        margin: 8px 0;
+      }
+      #panel button {
+        flex: 1;
+        background: #22262f;
+        color: #e8eaf0;
+        border: 1px solid rgba(255, 255, 255, 0.12);
+        border-radius: 6px;
+        padding: 5px 0;
+        cursor: pointer;
+        font: 600 12px -apple-system, Inter, sans-serif;
+      }
+      #panel button.on {
+        background: #2d6fd6;
+        border-color: #2d6fd6;
+      }
+      #panel .sect {
+        margin-top: 12px;
+        padding-top: 10px;
+        border-top: 1px solid rgba(255, 255, 255, 0.08);
+        font-size: 11px;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+        color: rgba(232, 234, 240, 0.5);
+      }
+      #wval {
+        width: 44px;
+        text-align: right;
+        font-variant-numeric: tabular-nums;
+        color: #9fc2ff;
+      }
+      #hud {
+        position: fixed;
+        right: 14px;
+        top: 14px;
+        z-index: 10;
+        font: 700 12px ui-monospace, monospace;
+        color: #7fd77f;
+        background: rgba(14, 15, 18, 0.72);
+        padding: 3px 8px;
+        border-radius: 4px;
+      }
+      #hint {
+        position: fixed;
+        left: 50%;
+        bottom: 14px;
+        transform: translateX(-50%);
+        color: rgba(232, 234, 240, 0.45);
+        font-size: 12px;
+        z-index: 10;
+      }
+    </style>
+  </head>
+  <body>
+    <canvas id="c"></canvas>
+    <div id="panel">
+      <h1>ATLAS · 4D</h1>
+      <label>形状
+        <select id="shape">
+          <option value="0">超球 hypersphere</option>
+          <option value="1" selected>超立方 tesseract</option>
+          <option value="2">对偶柱 duocylinder</option>
+          <option value="3">球环 spheritorus</option>
+          <option value="4">四维环 duotorus</option>
+          <option value="5">布尔混合 blend</option>
+        </select>
+      </label>
+      <div class="row">
+        <button id="mode0" class="on">3D 切片</button>
+        <button id="mode1">厚投影</button>
+        <button id="mode2">洋葱层</button>
+      </div>
+      <label>w 切片 <input id="w" type="range" min="-1.6" max="1.6" step="0.01" value="0" /><span id="wval">0.00</span></label>
+      <label><span>w 呼吸动画</span><input id="wanim" type="checkbox" /></label>
+      <div class="sect">旋转平面(速度)</div>
+      <label>xy <input id="rxy" type="range" min="-1" max="1" step="0.05" value="0" /></label>
+      <label>xz <input id="rxz" type="range" min="-1" max="1" step="0.05" value="0" /></label>
+      <label>yz <input id="ryz" type="range" min="-1" max="1" step="0.05" value="0" /></label>
+      <label>xw <input id="rxw" type="range" min="-1" max="1" step="0.05" value="0.25" /></label>
+      <label>yw <input id="ryw" type="range" min="-1" max="1" step="0.05" value="0" /></label>
+      <label>zw <input id="rzw" type="range" min="-1" max="1" step="0.05" value="0" /></label>
+      <div class="row"><button id="reset">复位</button></div>
+    </div>
+    <div id="hud">— fps</div>
+    <div id="hint">拖拽旋转视角 · 滚轮推拉 · xw/yw/zw 是第四维的三个旋转平面 · 厚投影按 w 深度着色</div>
+    <script type="module" src="./fourd.js"></script>
+  </body>
+</html>


### PR DESCRIPTION
## 探索方向(user 拍板:4D,切片与投影都玩,不功利)

一个自足的 WebGL2 raymarcher(零 Present 管线依赖),核心是一个距离场 **d(x,y,z,w)**,让第四维通过**运动**进入直觉。

## 内容

**原语**(5+1):超球 / 超立方 tesseract(圆角 4D box)/ 对偶柱 duocylinder / 球环 spheritorus / 四维环 duotorus(加厚 Clifford 环面)/ 布尔混合(超球沿 w 轴穿越超立方,擦过切片时呼吸)。

**旋转**:全部**六个旋转平面**(xy/xz/yz + 3D 里不存在的 xw/yw/zw),各自独立调速,按绝对角度每帧重组矩阵(零漂移);默认 xw 缓旋是 4D 的 hello-world——切片持续变形。

**三种观看模式**:
| 模式 | 数学 | 看到什么 |
|---|---|---|
| **3D 切片** | d₃(p)=d₄(R·(p,w₀)) | 剃刀截面;拖 w 滑块 = 在第四维穿行(球环:球→环→消失) |
| **厚投影** | min over 13 个 w 采样 | 整个 4D 体压进 3D 的"影子",命中点按最近的 w 染色 = **第四维的深度图**(蓝→暖) |
| **洋葱层** | 5 层半透明切片前后合成 | w 以幽灵层显现——**穷人的体积显示器**(user 球形 3D 显示器脑洞的近似) |

白模着色(stone 配方)、轨道相机、96-121fps。

**入口**:`http://127.0.0.1:8001/apps/fourd/`

## 备注

- 探索项目,未注册 CI 测试;main 到手时基线已红(`test-assemble-deck-golden`,另一终端的 golden 需 `--update`),与本分支无关。
- 下一步候选(玩出感觉再定):时间=w 的形变动画、双 3D 形状构造成 4D 体的 morph、24-cell 等正多胞体、4D 透视相机。

🤖 Generated with [Claude Code](https://claude.com/claude-code)