### PR TITLE
Analytic tier: support translate.x build-in channel (kill the stone fallback)

### DIFF
--- a/sdf-js/scripts/test-analytic-renderer.mjs
+++ b/sdf-js/scripts/test-analytic-renderer.mjs
@@ -53,6 +53,25 @@ console.log('=== analytic white-model renderer ===\n');
   ok(r.fragSource.includes('smoothstep(0.20, 0.80, u_time)'), 't → u_time baked');
 }
 
+// ---- x-channel flight (evolution past→present) ----------------------------------
+// 2026-07-14 regression: x was a baked constant — the evolution orbs' horizontal
+// flight dropped WHOLE WINDOWS to the stone raymarcher (slow warm, heavy frame).
+{
+  const r = compileAnalyticFrag([
+    {
+      id: 'fly',
+      type: 'sphere',
+      args: { radius: 0.6 },
+      transform: { translate: [-3.9, 2, 0] },
+      animation: [
+        { channel: 'transform.translate.x', expr: '3.900 - 7.800 * smoothstep(4.20, 4.90, t)' },
+      ],
+    },
+  ]);
+  ok(r.ok, 'x-channel build-in accepted (no raymarch fallback)');
+  ok(r.fragSource.includes('float tx0 = (3.900'), 'x rides a per-frame GLSL expr');
+}
+
 // ---- scope rejection ----------------------------------------------------------
 {
   const bad1 = compileAnalyticFrag([{ id: 'v', type: 'venn-3d', args: {} }]);
@@ -106,7 +125,9 @@ console.log('=== analytic white-model renderer ===\n');
 
 // ---- real-deck coverage -----------------------------------------------------------
 {
-  const deck = JSON.parse(readFileSync(new URL('../scenes/ir/bytedance-bp.json', import.meta.url), 'utf8'));
+  const deck = JSON.parse(
+    readFileSync(new URL('../scenes/ir/bytedance-bp.json', import.meta.url), 'utf8'),
+  );
   const scene = assembleDeck(deck, { env: 'studio', stage: true });
   let okCount = 0;
   let fallback = [];
@@ -120,6 +141,10 @@ console.log('=== analytic white-model renderer ===\n');
     okCount >= scene.deckWindows.length - 4,
     `bytedance-bp: ${okCount}/${scene.deckWindows.length} windows analytic (fallback: ${fallback.join('; ') || 'none'})`,
   );
+  // The -4 slack above is for exotic PRIMS only — an animation CHANNEL must
+  // never cost a window its analytic tier (that's how the x-flight regression
+  // slipped through green tests while the browser fell to stone).
+  ok(!fallback.some((f) => /channel/.test(f)), 'no window falls back over an animation channel');
 }
 
 console.log(`\n${pass} passed, ${fail} failed`);

--- a/sdf-js/src/render/analytic.js
+++ b/sdf-js/src/render/analytic.js
@@ -22,8 +22,8 @@
 //   • types outside box/rounded_box/sphere/capsule/ellipsoid/cylinder
 //     (unions flatten; funnel-3d etc. reject)
 //   • rotations other than yaw
-//   • animation channels other than transform.translate.y/z whose exprs are
-//     not GLSL-safe (smoothstep/sin/numbers only)
+//   • animation channels other than transform.translate.x/y/z, or exprs that
+//     are not GLSL-safe (smoothstep/sin/numbers only)
 // =============================================================================
 
 const SUPPORTED = new Set([
@@ -84,7 +84,8 @@ function flatten(subjects) {
           },
           material: c.material || s.material,
           animation: s.animation, // parent build-in moves the assembly
-          _childOffY: ct[1], // parent-channel anim replaces parent Y; child offset rides on top
+          _childOffX: ct[0], // parent-channel anim replaces the parent's coord;
+          _childOffY: ct[1], // the child offset rides on top
           _childOffZ: ct[2],
         });
       }
@@ -267,12 +268,15 @@ export function compileAnalyticFrag(subjects, opts = {}) {
     const glow = m.glow ?? 0;
 
     // animated translate channels → GLSL exprs (else baked constants)
+    let tx = flt(T[0]);
     let ty = flt(T[1]);
     let tz = flt(T[2]);
     for (const an of s.animation || []) {
       const g = exprToGLSL(an.expr);
       if (!g) return { ok: false, reason: `animation expr (${s.id})` };
-      if (an.channel === 'transform.translate.y')
+      if (an.channel === 'transform.translate.x')
+        tx = s._childOffX != null ? `(${g}) + ${flt(s._childOffX)}` : `(${g})`;
+      else if (an.channel === 'transform.translate.y')
         ty = s._childOffY != null ? `(${g}) + ${flt(s._childOffY)}` : `(${g})`;
       else if (an.channel === 'transform.translate.z')
         tz = s._childOffZ != null ? `(${g}) + ${flt(s._childOffZ)}` : `(${g})`;
@@ -280,7 +284,7 @@ export function compileAnalyticFrag(subjects, opts = {}) {
     }
 
     const k = idx++;
-    let localRo = `ro - vec3(${flt(T[0])}, ty${k}, tz${k})`;
+    let localRo = `ro - vec3(tx${k}, ty${k}, tz${k})`;
     let localRd = 'rd';
     let nBack = `n${k}`;
     if (yaw !== 0) {
@@ -295,7 +299,7 @@ export function compileAnalyticFrag(subjects, opts = {}) {
     // proxy sphere for the occlusion sum (also drives the floor contact shadow)
     let proxyR;
     let hitStmt;
-    body += `  {\n    float ty${k} = ${ty};\n    float tz${k} = ${tz};\n`;
+    body += `  {\n    float tx${k} = ${tx};\n    float ty${k} = ${ty};\n    float tz${k} = ${tz};\n`;
     body += `    vec3 q = ${localRo};\n    vec3 dq = ${localRd};\n    vec3 n${k} = vec3(0.0);\n`;
     if (s.type === 'sphere') {
       proxyR = a.radius ?? 0.5;
@@ -359,7 +363,7 @@ export function compileAnalyticFrag(subjects, opts = {}) {
     // Skip tiny/huge proxies: breadcrumbs don't shade, horizon hills would
     // darken the whole stage.
     if (proxyR > 0.15 && proxyR < 8.0) {
-      occBody += `  { float ty${k} = ${ty}; float tz${k} = ${tz}; if (hitId != ${flt(k)}) { vec4 sp = vec4(${flt(T[0])}, ty${k}, tz${k}, ${flt(proxyR)}); occ += sphOcc(pos, nor, sp); sha *= sphSoftShadow(pos, sunDir, sp, 5.0); } }\n`;
+      occBody += `  { float tx${k} = ${tx}; float ty${k} = ${ty}; float tz${k} = ${tz}; if (hitId != ${flt(k)}) { vec4 sp = vec4(tx${k}, ty${k}, tz${k}, ${flt(proxyR)}); occ += sphOcc(pos, nor, sp); sha *= sphSoftShadow(pos, sunDir, sp, 5.0); } }\n`;
     }
   }
 


### PR DESCRIPTION
## 你报的"页面加载不出来"的根因

页面其实能加载,但 boot 卡在 "warming shaders" **~53 秒**,读起来就是死了。根因是 #368 的回归:evolution 的球在 `transform.translate.x` 通道上飞,而 **analytic 编译器只认识 y/z**——x 是烘死的常量,遇到 x 通道整窗拒绝、回退 stone raymarcher:编译重(warm 变慢)、每帧也重。

## 修法

对称补上第三条腿:x 通道跟 y/z 一样编译成逐帧 GLSL 表达式;union 展平的 child offset 补 `_childOffX`;**遮蔽/接触阴影的 proxy 球心也跟着动画 x 走**(原来钉在静态常量上,飞行的球会把影子留在原地)。

## 实测(theater deck)

- 24/24 窗口全 analytic(此前 21 + 3 个 stone 回退)
- warm **52.7s → 29.0s**
- 控制台零 fallback 警告

## 测试

新增 x 通道接受断言 + **"动画通道永远不许让窗口掉出 analytic 层"**(覆盖测试原有 -4 宽容度是给奇异 prim 的——这次回归正是从这个宽容度里穿绿灯溜过去的)。套件 163/163。

⚠️ 剩余体感:boot 仍要 ~30s 暖 shader(每窗一个 program,driver 管线特化躲不掉)——这是已知代价,进度条会走;如果你觉得还是太慢,下一步可以做"先播 window 0 边播边暖"的方案,另开工作。

🤖 Generated with [Claude Code](https://claude.com/claude-code)