### PR TITLE
fix: 黑洞页三层修复 + 灰度装裱 accent 对比地板 (对抗迭代两轮)

### DIFF
--- a/sdf-js/scripts/test-color.mjs
+++ b/sdf-js/scripts/test-color.mjs
@@ -191,5 +191,57 @@ const basePalette = {
   );
 }
 
+// ── 7. 黑洞页回归 (2026-07-14 事故: theme 对象 → getTheme null → 黑底黑字) ──
+{
+  const { getTheme } = await import('../src/present/themes.js');
+  const t = getTheme('editorial-spectrum');
+  ok(!!t, 'getTheme(id) 正常路径');
+  ok(getTheme(t) === t, 'getTheme(已解析对象) 原样返回');
+  ok(getTheme({ id: 'editorial-spectrum' }).id === 'editorial-spectrum', 'getTheme({id}) 回查');
+  // renderer partial palette 防御纵深: 缺 bg/silhouette 不再涂成 rgb(0,0,0)
+  const rec = { fills: [] };
+  const ctx = new Proxy(
+    {},
+    {
+      get(tg, k) {
+        if (k in tg) return tg[k];
+        if (k === 'measureText') return (x) => ({ width: String(x).length * 8 });
+        if (k === 'getImageData') return () => ({ data: new Uint8ClampedArray(400) });
+        if (k === 'createLinearGradient' || k === 'createRadialGradient')
+          return () => ({ addColorStop: () => {} });
+        if (k === 'fillRect') return () => rec.fills.push(String(ctx.fillStyle));
+        return () => {};
+      },
+      set(tg, k, v) {
+        tg[k] = v;
+        return true;
+      },
+    },
+  );
+  const canvas = { width: 100, height: 100, getContext: () => ctx };
+  await renderSceneDataToCanvas(canvas, { subjects: [] }, { palette: { accent: [1, 2, 3] } });
+  ok(rec.fills.length > 0 && rec.fills[0] !== 'rgb(0,0,0)', 'partial palette 底色回落纸面, 非黑洞');
+}
+
+// ── 8. 灰度装裱 accent 地板 (对抗 round 2) ──
+{
+  const grey = {
+    palette: {
+      accent: [199, 199, 199],
+      colors: [
+        [199, 199, 199],
+        [119, 119, 119],
+      ],
+    },
+  };
+  const base = { bg: [246, 244, 238], silhouetteColor: [30, 30, 34] };
+  const out = mountPaletteOverride(base, grey);
+  ok(
+    Math.abs(rgbToOklab(out.accent)[0] - rgbToOklab(base.bg)[0]) >= 0.33,
+    '浅灰 accent 压到 ΔL≥0.34 (标题级数字可读)',
+    `accent=${out.accent}`,
+  );
+}
+
 console.log(`\n${passed} passed, ${failed} failed`);
 if (failed) process.exit(1);

--- a/sdf-js/src/present/art-mount.js
+++ b/sdf-js/src/present/art-mount.js
@@ -132,7 +132,10 @@ export function extractMountPalette(img, { maxColors = 6 } = {}) {
 export function mountPaletteOverride(basePalette, mount) {
   if (!mount?.palette?.accent) return basePalette;
   const bg = basePalette?.bg || [248, 246, 240];
-  const accent = ensureContrast(mount.palette.accent, bg);
+  // Round 2 (灰度装裱对抗, 2026-07-14): accent 承载标题级数字, 对比地板
+  // 提到 ΔL 0.34 — 灰阶 mount 的浅灰 accent 压到可读深度; 彩色 mount
+  // 的中深色 accent 天然 ≥0.34, 不受影响
+  const accent = ensureContrast(mount.palette.accent, bg, 0.34);
   const colors = Array.isArray(mount.palette.colors)
     ? [accent, ...mount.palette.colors.slice(1)]
     : mount.palette.colors;

--- a/sdf-js/src/present/atoms-2d/renderer.js
+++ b/sdf-js/src/present/atoms-2d/renderer.js
@@ -41,7 +41,10 @@ export async function renderSceneDataToCanvas(canvas, sceneData, opts = {}) {
   const ctx = canvas.getContext('2d');
   if (!ctx) throw new Error('atoms-2d/renderer: canvas has no 2D context');
 
-  const palette = opts.palette || DEFAULT_PALETTE;
+  // 防御纵深 (2026-07-14 黑洞页事故): 上游 theme 解析失败时 palette 可能
+  // 缺 bg/silhouetteColor — rgbCss(undefined) 会静默涂成 rgb(0,0,0), 整页
+  // 黑底 + 暗字隐形。partial palette 一律用默认补齐, 缺字段不再是黑洞。
+  const palette = { ...DEFAULT_PALETTE, ...(opts.palette || {}) };
   const deckStyle = opts.style;
 
   // Fill background

--- a/sdf-js/src/present/themes.js
+++ b/sdf-js/src/present/themes.js
@@ -366,6 +366,12 @@ export function getAtlasThemes() {
  * @returns {ThemePreset | null}
  */
 export function getTheme(id) {
+  // deck.json 契约里 theme 可以是对象 (§2) — 已解析的主题原样返回,
+  // 或按其 id 回查; 只认字符串会让调用方拿到 null → 黑洞页 (2026-07-14)
+  if (id && typeof id === 'object') {
+    if (Array.isArray(id.bg) || Array.isArray(id.accent)) return id;
+    return ATLAS_THEMES.find((t) => t.id === id.id) || null;
+  }
   return ATLAS_THEMES.find((t) => t.id === id) || null;
 }
 


### PR DESCRIPTION
R1: theme 对象过 getTheme 返回 null → partial palette → rgbCss(undefined)=rgb(0,0,0) 黑洞页; getTheme 容错 + renderer palette 补齐双保险。R2: 灰度 mount 浅灰 accent 地板 0.22→0.34, 标题数字可读, 彩色不受影响。+5 断言。

🤖 Generated with [Claude Code](https://claude.com/claude-code)