### PR TITLE
Sprint 100: 批量出厂检 — page-lint 闸门 + 正式批量管线

### DIFF
--- a/docs/AGENT_HANDOFF.md
+++ b/docs/AGENT_HANDOFF.md
@@ -57,6 +57,16 @@
 
 ---
 
+## 1.5 视觉管线两条铁律 (2026-07-14 黑洞页事故后立)
+
+1. **fallback 永不落向极端色**: 视觉代码里"缺数据给默认值继续跑"必须落向
+   可读状态 (纸面/墨色), 永不落向黑/白极端 — `rgbCss(undefined)` 曾静默涂出
+   rgb(0,0,0) 黑洞页。renderer 入口已做 partial-palette 补齐 (防御纵深)。
+2. **批量出 deck 只有一条管线**: `sdf-js/scripts/batch-decks.mjs` (playwright
+   驱动 examples/batch-export.html → 真实 buildDeckPdf 产品代码 + page-lint
+   出厂检)。不要再写临场脚本复刻导出循环 — 抽查脚本与批量脚本不同源时,
+   抽查就是安慰剂 (事故正是这么漏的)。
+
 ## 2. Architecture (the technical spine)
 
 **3-layer (LOCKED 2026-06-19/22):**

--- a/sdf-js/examples/batch-export.html
+++ b/sdf-js/examples/batch-export.html
@@ -1,0 +1,70 @@
+<!doctype html>
+<!-- batch-export.html — headless 批量出 deck 的 harness 页 (Sprint 100).
+     scripts/batch-decks.mjs 用 playwright 驱动本页; 本页只做一件事: 把
+     window.__atlasBatchExport 暴露给 node 侧, 内部走与 in-app 下载完全
+     相同的 buildDeckPdf 产品管线 (含 page-lint 出厂检) — 同源, 零漂移。 -->
+<meta charset="utf-8" />
+<title>Atlas batch export harness</title>
+<body style="margin: 0; font: 12px monospace">
+  <pre id="log">batch-export harness ready</pre>
+  <script type="module">
+    import { buildDeckPdf } from '/src/present/exporters/pdf.js';
+    import { loadArtMount, fetchMintManifest } from '/src/present/art-mount.js';
+
+    const log = (m) => (document.getElementById('log').textContent += '\n' + m);
+    const MINT_BASE = '/examples/original-mints/cache/';
+    let manifest = null;
+
+    async function loadDeck(deckDir) {
+      const man = await fetch(`${deckDir}/deck.json`).then((r) => r.json());
+      const slots = [];
+      for (const s of man.slots.filter((x) => x.liftFile)) {
+        const j = await fetch(`${deckDir}/${s.liftFile}`).then((r) => r.json());
+        slots.push({
+          slotIdx: s.slotIdx,
+          slotName: s.slotName,
+          slotTitle: s.slotTitle,
+          sceneData: j.sceneData ?? j,
+        });
+      }
+      return { manifest: man, slots };
+    }
+
+    /**
+     * cfg: { deckDir, mountId, title }
+     * → { ok, pdfB64?, pageCount?, lint, mountName? , error? }
+     */
+    window.__atlasBatchExport = async (cfg) => {
+      try {
+        if (!manifest) manifest = await fetchMintManifest(MINT_BASE);
+        const entry = manifest.find((m) => m.id === cfg.mountId);
+        if (!entry) return { ok: false, error: `mount ${cfg.mountId} not in manifest` };
+        const mount = await loadArtMount(entry, MINT_BASE);
+        const { manifest: deckMan, slots } = await loadDeck(cfg.deckDir);
+        const deck = {
+          title: cfg.title || deckMan.title || 'Atlas Deck',
+          theme: deckMan.theme || 'editorial-spectrum',
+          scaffold: deckMan.scaffold || { id: 'atlas-deck', label: 'Atlas Deck' },
+          decor: deckMan.decor,
+          slots,
+        };
+        const { pdf, pageCount, lint } = await buildDeckPdf(deck, {
+          artMount: mount,
+          lint: true,
+          onProgress: (m) => log(`${cfg.mountId} — ${m}`),
+        });
+        if (!lint.ok) return { ok: false, error: 'page-lint', lint };
+        return {
+          ok: true,
+          pdfB64: pdf.output('datauristring').split(',')[1],
+          pageCount,
+          lint,
+          mountName: entry.name,
+        };
+      } catch (e) {
+        return { ok: false, error: String((e && e.stack) || e).slice(0, 500) };
+      }
+    };
+    window.__harnessReady = true;
+  </script>
+</body>

--- a/sdf-js/package-lock.json
+++ b/sdf-js/package-lock.json
@@ -1,0 +1,29 @@
+{
+  "name": "sdf-js",
+  "version": "0.0.1",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "sdf-js",
+      "version": "0.0.1",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "devDependencies": {
+        "playwright-core": "^1.61.1"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    }
+  }
+}

--- a/sdf-js/package.json
+++ b/sdf-js/package.json
@@ -7,5 +7,8 @@
   "scripts": {
     "serve": "python3 dev-server.py 8001"
   },
-  "license": "SEE LICENSE IN LICENSE.md"
+  "license": "SEE LICENSE IN LICENSE.md",
+  "devDependencies": {
+    "playwright-core": "^1.61.1"
+  }
 }

--- a/sdf-js/scripts/batch-decks.mjs
+++ b/sdf-js/scripts/batch-decks.mjs
@@ -1,0 +1,171 @@
+// =============================================================================
+// batch-decks.mjs — 批量出 deck 的正式管线 (Sprint 100, 收编临场脚本).
+//
+// 2026-07-14 黑洞页事故的结构性修复: 此前每批 PDF 都靠 /tmp 下手写脚本
+// 复刻导出管线, 抽查脚本与批量脚本还是两份代码 — 抽查过了, 批量全军
+// 覆没。本脚本是唯一的批量入口:
+//   - playwright 驱动 examples/batch-export.html, 走与 in-app 下载完全
+//     相同的 buildDeckPdf 产品代码 (含 page-lint 出厂检, 黑洞页拦截)
+//   - 选池全池随机 (user 裁定: 随机搭配才有意思, 不偏爱新件)
+//   - 落盘 ~/Downloads/atlas-<name>-batchN/ 单独文件夹 (user 裁定),
+//     每份 PDF 旁存同名 .deck.json 溯源契约 (§3.5.1 配对约定)
+//
+// Usage:
+//   node sdf-js/scripts/batch-decks.mjs \
+//     --deck sdf-js/examples/scaffold-pipeline/tether-bp \
+//     --count 10 [--name tetherbp] [--title "ANTFUN × Tether"] [--mounts id1,id2]
+// =============================================================================
+import { readFileSync, writeFileSync, existsSync, mkdirSync } from 'node:fs';
+import { createServer } from 'node:http';
+import { extname, join, resolve, basename } from 'node:path';
+import { homedir } from 'node:os';
+import { chromium } from 'playwright-core';
+import { serializeDeck } from '../src/present/deck-io.js';
+import { validateDeck } from '../src/present/deck-spec.js';
+import { mountProvenance } from '../src/present/art-mount.js';
+
+const SDF_ROOT = resolve(new URL('..', import.meta.url).pathname);
+const CHROME = '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome';
+
+const args = process.argv.slice(2);
+const arg = (name, fb = null) => {
+  const i = args.indexOf(name);
+  return i > -1 ? args[i + 1] : fb;
+};
+const DECK_DIR = arg('--deck');
+const COUNT = Number(arg('--count', 10));
+if (!DECK_DIR || !existsSync(join(DECK_DIR, 'deck.json'))) {
+  console.error('usage: batch-decks.mjs --deck <dir with deck.json> --count N [--name slug]');
+  process.exit(2);
+}
+const NAME = arg('--name', basename(resolve(DECK_DIR)).replace(/[^\w-]+/g, ''));
+const TITLE = arg('--title', null);
+
+// ── 输出文件夹: ~/Downloads/atlas-<name>-batchN (自动递增, 每批独立) ──
+let batchN = 1;
+let OUT;
+do {
+  OUT = join(homedir(), 'Downloads', `atlas-${NAME}-batch${batchN}`);
+  batchN++;
+} while (existsSync(OUT));
+mkdirSync(OUT, { recursive: true });
+
+// ── 选池: 全池随机 (不偏爱新件, 不查 used 清单) ──
+const manifest = JSON.parse(
+  readFileSync(join(SDF_ROOT, 'examples/original-mints/cache/manifest.json'), 'utf8'),
+);
+const okPool = manifest.filter((e) => e.status === 'ok');
+let picks;
+if (arg('--mounts')) {
+  const ids = arg('--mounts').split(',');
+  picks = ids.map((id) => okPool.find((e) => e.id === id)).filter(Boolean);
+} else {
+  const pool = [...okPool];
+  for (let i = pool.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [pool[i], pool[j]] = [pool[j], pool[i]];
+  }
+  picks = pool.slice(0, Math.min(COUNT, pool.length));
+}
+console.log(`批量出 deck: ${NAME} × ${picks.length} → ${OUT}`);
+picks.forEach((e) => console.log(`  · ${e.id} — ${e.name} (${e.artist || '?'})`));
+
+// ── 静态服务器 (repo root = sdf-js/, 不依赖 dev-server.py 在跑) ──
+const MIME = {
+  '.html': 'text/html',
+  '.js': 'text/javascript',
+  '.mjs': 'text/javascript',
+  '.json': 'application/json',
+  '.png': 'image/png',
+  '.jpg': 'image/jpeg',
+  '.css': 'text/css',
+  '.svg': 'image/svg+xml',
+};
+const server = createServer((req, res) => {
+  const path = decodeURIComponent(new URL(req.url, 'http://x').pathname);
+  const file = join(SDF_ROOT, path);
+  if (!file.startsWith(SDF_ROOT) || !existsSync(file)) {
+    res.writeHead(404).end('not found');
+    return;
+  }
+  res.writeHead(200, {
+    'Content-Type': MIME[extname(file)] || 'application/octet-stream',
+    'Cache-Control': 'no-store',
+  });
+  res.end(readFileSync(file));
+});
+await new Promise((r) => server.listen(0, '127.0.0.1', r));
+const PORT = server.address().port;
+
+// deckDir 相对 repo root 的 URL 路径
+const deckDirUrl =
+  '/' +
+  resolve(DECK_DIR)
+    .slice(SDF_ROOT.length + 1)
+    .replaceAll('\\', '/');
+
+const browser = await chromium.launch({ executablePath: CHROME, headless: true });
+const page = await browser.newPage({ viewport: { width: 1400, height: 900 } });
+page.on('pageerror', (e) => console.error('  [page]', String(e).slice(0, 120)));
+await page.goto(`http://127.0.0.1:${PORT}/examples/batch-export.html`, { waitUntil: 'load' });
+await page.waitForFunction(() => window.__harnessReady === true, null, { timeout: 15000 });
+
+// deck 元数据 (契约用) — node 侧读一次
+const deckMan = JSON.parse(readFileSync(join(DECK_DIR, 'deck.json'), 'utf8'));
+const contractSlots = deckMan.slots
+  .filter((s) => s.liftFile)
+  .map((s) => {
+    const j = JSON.parse(readFileSync(join(DECK_DIR, s.liftFile), 'utf8'));
+    return {
+      slotIdx: s.slotIdx,
+      slotName: s.slotName,
+      slotTitle: s.slotTitle,
+      sceneData: j.sceneData ?? j,
+    };
+  });
+
+let done = 0;
+let lintFailures = 0;
+for (const entry of picks) {
+  const label = `atlas-${NAME}-${entry.id}`;
+  process.stdout.write(`[${done + 1}/${picks.length}] ${entry.id} ${entry.name} … `);
+  const res = await page.evaluate((cfg) => window.__atlasBatchExport(cfg), {
+    deckDir: deckDirUrl,
+    mountId: entry.id,
+    title: TITLE,
+  });
+  if (!res || !res.ok) {
+    if (res?.error === 'page-lint') {
+      lintFailures++;
+      console.log(`✗ 出厂检不合格 — ${JSON.stringify(res.lint.pages)}`);
+    } else {
+      console.log(`✗ ${res?.error || 'unknown error'}`);
+    }
+    continue;
+  }
+  writeFileSync(join(OUT, `${label}.pdf`), Buffer.from(res.pdfB64, 'base64'));
+  const contract = serializeDeck({
+    title: TITLE || deckMan.title || 'Atlas Deck',
+    theme: deckMan.theme,
+    scaffold: deckMan.scaffold || { id: NAME, label: NAME },
+    decor: deckMan.decor,
+    artMount: mountProvenance(entry),
+    slots: contractSlots,
+  });
+  const v = validateDeck(contract);
+  if (!v.ok) {
+    console.log(`✗ 契约校验失败: ${v.errors[0]}`);
+    continue;
+  }
+  writeFileSync(join(OUT, `${label}.deck.json`), JSON.stringify(contract, null, 1));
+  console.log(`✓ ${res.pageCount} 页`);
+  done++;
+}
+
+await browser.close();
+server.close();
+console.log(
+  `\n完成 ${done}/${picks.length} → ${OUT}` +
+    (lintFailures ? `  (⚠ ${lintFailures} 份被出厂检拦下)` : ''),
+);
+process.exit(done === picks.length ? 0 : 1);

--- a/sdf-js/scripts/test-page-lint.mjs
+++ b/sdf-js/scripts/test-page-lint.mjs
@@ -1,0 +1,98 @@
+// test-page-lint.mjs — 视觉闸门回归: 黑洞/空白/无对比 拦截, 正常页/艺术页放行.
+import { lintPage, pageKindOf, pageStats } from '../src/present/page-lint.js';
+
+let passed = 0;
+let failed = 0;
+function ok(cond, msg, extra = '') {
+  if (cond) {
+    passed++;
+    console.log(`  ✓ ${msg}`);
+  } else {
+    failed++;
+    console.log(`  ✗ ${msg}${extra ? ` — ${extra}` : ''}`);
+  }
+}
+
+// 合成 ImageData: 生成器 f(x,y) → [r,g,b]
+function synth(w, h, f) {
+  const data = new Uint8ClampedArray(w * h * 4);
+  for (let y = 0; y < h; y++)
+    for (let x = 0; x < w; x++) {
+      const [r, g, b] = f(x, y);
+      const o = (y * w + x) * 4;
+      data[o] = r;
+      data[o + 1] = g;
+      data[o + 2] = b;
+      data[o + 3] = 255;
+    }
+  return { data, width: w, height: h };
+}
+
+// ── 灾难形态拦截 ──
+{
+  // 黑洞页 (事故复刻): 90% 近黑 + 一条白 band
+  const img = synth(128, 72, (x, y) => (y < 8 ? [230, 228, 224] : [8, 8, 10]));
+  const r = lintPage(img, 'content');
+  ok(!r.ok && r.issues.some((i) => i.startsWith('black-hole')), '黑洞正文页被拦', r.issues.join());
+  // 同一页若是 art 页 (全幅深色真迹) — 放行
+  const ra = lintPage(img, 'art');
+  ok(ra.ok, '深色艺术页放行 (kind=art)');
+}
+{
+  // 空白页: 全纸色
+  const img = synth(128, 72, () => [246, 244, 238]);
+  const r = lintPage(img, 'art');
+  ok(!r.ok && r.issues.some((i) => i.startsWith('blank-page')), '空白页被拦 (art 页也不允许空白)');
+}
+{
+  // 无对比度: 两个近似灰
+  const img = synth(128, 72, (x) => (x % 2 ? [128, 128, 128] : [138, 138, 138]));
+  const r = lintPage(img, 'content');
+  ok(!r.ok && r.issues.some((i) => i.startsWith('no-contrast')), '无对比度页被拦');
+}
+
+// ── 正常形态放行 ──
+{
+  // 典型正文页: 纸面 + 深墨文字块 + 彩色卡片
+  const img = synth(128, 72, (x, y) => {
+    if (y < 10) return [40, 40, 46]; // 顶部深色横带 (art crop)
+    if (y > 20 && y < 40 && x > 10 && x < 60) return [30, 30, 34]; // 文字块
+    if (y > 45 && x > 70) return [200, 80, 40]; // accent 卡
+    return [246, 244, 238];
+  });
+  const r = lintPage(img, 'content');
+  ok(r.ok, '正常正文页放行', r.issues.join());
+}
+{
+  // 全幅彩色真迹封面
+  const img = synth(128, 72, (x, y) => [(x * 5) % 255, (y * 7) % 255, ((x + y) * 3) % 255]);
+  ok(lintPage(img, 'art').ok, '彩色全幅艺术页放行');
+}
+
+// ── pageKindOf 归类 ──
+ok(pageKindOf({ _transition: { index: 0 } }, 'banner') === 'art', '转场页 = art');
+ok(
+  pageKindOf({ sceneData: { subjects: [{ type: 'cover' }] } }, 'banner') === 'art',
+  '纯 cover = art',
+);
+ok(
+  pageKindOf({ sceneData: { subjects: [{ type: 'cover' }, { type: 'kpi-card' }] } }, 'banner') ===
+    'content',
+  'banner 正文页 = content',
+);
+ok(
+  pageKindOf(
+    { sceneData: { subjects: [{ type: 'cover' }, { type: 'quote-pull' }] } },
+    'statement',
+  ) === 'art',
+  'statement = art',
+);
+
+// ── stats 采样健壮性 ──
+{
+  const s = pageStats(synth(1280, 720, () => [128, 128, 128]));
+  ok(Number.isFinite(s.std) && Number.isFinite(s.contrast), '大画布抽样有限值');
+}
+
+console.log(`\n${passed} passed, ${failed} failed`);
+if (failed) process.exit(1);

--- a/sdf-js/src/present/exporters/pdf.js
+++ b/sdf-js/src/present/exporters/pdf.js
@@ -7,6 +7,11 @@
 //
 // PDF is for distribution / archival / printing. PPTX is for editing.
 // Both share the same canvas-render pipeline from atoms-2d.
+//
+// Sprint 100 (批量出厂检): 核心循环拆成 buildDeckPdf — headless 批量脚本
+// (scripts/batch-decks.mjs) 与 in-app 下载共用同一段代码, 临场脚本复刻管线
+// 导致的漂移 (2026-07-14 黑洞页事故) 从结构上封死。opts.lint 打开渲染后
+// 视觉闸门 (page-lint.js): 黑洞/空白/无对比页在出厂前 fail loud。
 // =============================================================================
 
 import { renderSceneDataToCanvas } from '../atoms-2d/renderer.js';
@@ -18,6 +23,7 @@ import {
   insertTransitions,
 } from '../art-mount.js';
 import { layoutForSlot } from '../atoms-2d/layout.js';
+import { lintPage, pageKindOf } from '../page-lint.js';
 
 const JSPDF_CDN = 'https://esm.sh/jspdf@2.5.2';
 let jsPDF = null;
@@ -30,25 +36,29 @@ async function loadJsPDF() {
   return jsPDF;
 }
 
+// Landscape A4-ish at 1280:720 aspect (16:9). Use mm units.
+// 280mm × 157.5mm matches 16:9 nicely and fits Letter/A4 landscape.
+const PAGE_W_MM = 280;
+const PAGE_H_MM = 157.5;
+
 /**
- * Export the assembled deck to a PDF file and trigger browser download.
- * Same input shape as exportDeckToPPTX.
+ * buildDeckPdf(deck, opts) → { pdf, pageCount, lint }
+ * The canonical deck→PDF pipeline WITHOUT the download side-effect —
+ * consumed by exportDeckToPDF (in-app save) and the headless batch runner.
  *
  * @param {import('./pptx.js').ExportDeckInput} deck
  * @param {object} [opts]
- * @param {string} [opts.filename]
  * @param {(msg: string, pct: number) => void} [opts.onProgress]
- * @returns {Promise<{filename: string, pageCount: number, bytes: number}>}
+ * @param {object} [opts.artMount]  — loaded mount (see art-mount.js)
+ * @param {boolean} [opts.lint]     — run page-lint per page; issues collected
+ *   in the returned lint report; lint.ok === false means出厂不合格
+ * @returns {Promise<{pdf: object, pageCount: number,
+ *   lint: {ok: boolean, pages: Array<{slotName: string, issues: string[]}>}}>}
  */
-export async function exportDeckToPDF(deck, opts = {}) {
+export async function buildDeckPdf(deck, opts = {}) {
   const onProgress = opts.onProgress || (() => {});
   const JsPDF = await loadJsPDF();
   onProgress('jspdf loaded', 5);
-
-  // Landscape A4-ish at 1280:720 aspect (16:9). Use mm units.
-  // 280mm × 157.5mm matches 16:9 nicely and fits Letter/A4 landscape.
-  const PAGE_W_MM = 280;
-  const PAGE_H_MM = 157.5;
 
   const pdf = new JsPDF({
     orientation: 'landscape',
@@ -67,6 +77,7 @@ export async function exportDeckToPDF(deck, opts = {}) {
   // 会插, in-app 导出与批量脚本从此同一产物
   const slots = opts.artMount ? insertTransitions(deck.slots, opts.artMount) : deck.slots;
   const total = slots.length;
+  const lintPages = [];
   for (let i = 0; i < total; i++) {
     const slot = slots[i];
     onProgress(`Rendering page ${i + 1}/${total} (${slot.slotName})`, 5 + (i / total) * 90);
@@ -74,6 +85,7 @@ export async function exportDeckToPDF(deck, opts = {}) {
     const canvas = document.createElement('canvas');
     canvas.width = 1280;
     canvas.height = 720;
+    const layout = layoutForSlot(slot, slot.sceneData);
     // Unified slide painter (Sprint 41): same renderer as the on-screen
     // preview — decoration layer included, per-atom errors non-fatal.
     try {
@@ -82,7 +94,7 @@ export async function exportDeckToPDF(deck, opts = {}) {
           ? mountPaletteOverride(slotPalette(deck.theme, slot), opts.artMount)
           : slotPalette(deck.theme, slot),
         decorRole: slotRoleOf(slot),
-        layout: layoutForSlot(slot, slot.sceneData),
+        layout,
         decor: deck.decor
           ? (opts.artMount ? mountUnderlayDecor : (d) => d)(
               { ...deck.decor, seed: (deck.decor.seed ?? 1) + slot.slotIdx },
@@ -96,6 +108,13 @@ export async function exportDeckToPDF(deck, opts = {}) {
       console.error(`[pdf] slide render failed:`, e);
     }
 
+    if (opts.lint) {
+      const ctx = canvas.getContext('2d');
+      const img = ctx.getImageData(0, 0, canvas.width, canvas.height);
+      const r = lintPage(img, pageKindOf(slot, layout));
+      if (!r.ok) lintPages.push({ slotName: slot.slotName, issues: r.issues });
+    }
+
     const pngDataURL = canvas.toDataURL('image/png');
 
     if (i > 0) pdf.addPage([PAGE_W_MM, PAGE_H_MM], 'landscape');
@@ -103,11 +122,30 @@ export async function exportDeckToPDF(deck, opts = {}) {
   }
 
   onProgress('Encoding PDF...', 96);
+  return { pdf, pageCount: total, lint: { ok: lintPages.length === 0, pages: lintPages } };
+}
+
+/**
+ * Export the assembled deck to a PDF file and trigger browser download.
+ * Same input shape as exportDeckToPPTX.
+ *
+ * @param {import('./pptx.js').ExportDeckInput} deck
+ * @param {object} [opts]
+ * @param {string} [opts.filename]
+ * @param {(msg: string, pct: number) => void} [opts.onProgress]
+ * @returns {Promise<{filename: string, pageCount: number, bytes: number}>}
+ */
+export async function exportDeckToPDF(deck, opts = {}) {
+  const onProgress = opts.onProgress || (() => {});
+  const { pdf, pageCount, lint } = await buildDeckPdf(deck, opts);
+  if (opts.lint && !lint.ok) {
+    const detail = lint.pages.map((p) => `${p.slotName}: ${p.issues.join(', ')}`).join('; ');
+    throw new Error(`page-lint failed — ${detail}`);
+  }
   const filename = opts.filename || `${deck.scaffold?.id || 'atlas-deck'}-${todayIsoDate()}.pdf`;
   pdf.save(filename);
-
   onProgress('Done', 100);
-  return { filename, pageCount: total, bytes: -1 };
+  return { filename, pageCount, bytes: -1 };
 }
 
 function todayIsoDate() {

--- a/sdf-js/src/present/page-lint.js
+++ b/sdf-js/src/present/page-lint.js
@@ -1,0 +1,70 @@
+// =============================================================================
+// page-lint.js — 渲染后视觉闸门 (2026-07-14 黑洞页事故的出厂检).
+//
+// 教训: 10 份 PDF 出厂没有任何"这页是不是黑洞"的自动检查, user 翻 PDF 才
+// 发现整批内页黑底黑字。本模块是烟雾报警器, 不是设计评委 — 阈值宽松,
+// 只拦三类灾难: 黑洞页 / 空白页 / 无对比度页。
+//
+// 页面分两类 (调用方按 layout/role 声明):
+//   'art'     — 封面/转场/statement: 全幅真迹, 允许整页深色, 只查空白
+//   'content' — banner/split 正文页: 正文必须落在纸面上, 深色占比设上限
+//
+// 纯函数, 吃 ImageData 形状 ({data, width, height}), browser/node 通用。
+// =============================================================================
+
+/** 页面亮度统计 — 均匀抽样至多 ~16k 像素, 足够烟雾报警。 */
+export function pageStats(img) {
+  const { data, width, height } = img;
+  const n = width * height;
+  const step = Math.max(1, Math.floor(n / 16384));
+  const lums = [];
+  let dark = 0;
+  let light = 0;
+  for (let i = 0; i < n; i += step) {
+    const o = i * 4;
+    const lum = 0.2126 * data[o] + 0.7152 * data[o + 1] + 0.0722 * data[o + 2];
+    lums.push(lum);
+    if (lum < 40) dark++;
+    else if (lum > 215) light++;
+  }
+  lums.sort((a, b) => a - b);
+  const q = (p) => lums[Math.min(lums.length - 1, Math.floor(p * lums.length))];
+  const mean = lums.reduce((a, b) => a + b, 0) / lums.length;
+  const std = Math.sqrt(lums.reduce((a, b) => a + (b - mean) * (b - mean), 0) / lums.length);
+  return {
+    std,
+    contrast: q(0.97) - q(0.03),
+    darkFrac: dark / lums.length,
+    lightFrac: light / lums.length,
+  };
+}
+
+/**
+ * lintPage(img, kind) → { ok, issues: string[], stats }
+ * kind: 'art' | 'content' (默认 'content')
+ */
+export function lintPage(img, kind = 'content') {
+  const s = pageStats(img);
+  const issues = [];
+  // 空白页: 几乎无信号 (全同色)。art 页也不允许 — 空白说明没画出来
+  if (s.std < 4 && s.contrast < 12) issues.push(`blank-page (std=${s.std.toFixed(1)})`);
+  // 无对比度: 有像素但拉不开 — 文字必然不可读
+  else if (s.contrast < 24) issues.push(`no-contrast (contrast=${s.contrast.toFixed(0)})`);
+  // 黑洞页: 正文页深色占比过高 (2026-07-14 事故形态: ~90% 近黑)
+  if (kind === 'content' && s.darkFrac > 0.62) {
+    issues.push(`black-hole (darkFrac=${(s.darkFrac * 100).toFixed(0)}%)`);
+  }
+  return { ok: issues.length === 0, issues, stats: s };
+}
+
+/**
+ * pageKindOf(slot, layout) — 按 slot/版式归类。
+ * 转场页与纯 cover 页 = 'art'; statement 全幅真迹 = 'art'; 其余 'content'。
+ */
+export function pageKindOf(slot, layout) {
+  if (slot?._transition) return 'art';
+  if (layout === 'statement') return 'art';
+  const subs = slot?.sceneData?.subjects || [];
+  if (subs.length > 0 && subs.every((s) => s?.type === 'cover')) return 'art';
+  return 'content';
+}


### PR DESCRIPTION
黑洞页事故的结构性封堵: 渲染后视觉 lint (黑洞/空白/无对比拦截) + buildDeckPdf 同源重构 + repo 正式批量脚本 (playwright 驱动真产品代码, 全池随机, 独立文件夹, 契约配对)。11 断言 + 冒烟 2 份全流程通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)