### PR TITLE
Sprint 101: 五轮严格对抗 — 九处渲染质量修复

### DIFF
--- a/sdf-js/apps/present/author-2d.js
+++ b/sdf-js/apps/present/author-2d.js
@@ -25,6 +25,8 @@ import {
   mountPaletteOverride,
   mountUnderlayDecor,
   mountProvenance,
+  agendaLabelsOf,
+  themeSlotBannerTitle,
 } from '../../src/present/art-mount.js';
 import { layoutForSlot } from '../../src/present/atoms-2d/layout.js';
 import { ATLAS_THEMES } from '../../src/present/themes.js';
@@ -291,6 +293,9 @@ function slotRenderOpts(theme, deck, slot) {
     // Sprint 95: 版式语法 — 按内容形状调度 banner/split/statement
     layout: layoutForSlot(slot, slot.sceneData),
   };
+  // 对抗 R4: theme 页占位符页题 → agenda 第 N 条 (与导出器同律)
+  const tbt = themeSlotBannerTitle(slot, agendaLabelsOf(deck.slots || []));
+  if (tbt) base.bannerTitle = tbt;
   if (artMount && decorVisEl.value !== 'off') {
     Object.assign(base, artMountOpts(artMount, slot, slotRoleOf(slot)) || {});
     // Sprint 84: the deck speaks the artwork's colors — accents/numbers

--- a/sdf-js/scripts/test-layout.mjs
+++ b/sdf-js/scripts/test-layout.mjs
@@ -37,7 +37,21 @@ function ok(cond, msg, extra = '') {
       { type: 'bullet-list', args: { items: [] } },
     ],
   };
-  ok(layoutForSlot({ slotName: 'theme-1-lead' }, leadScene) === 'split', '-lead 轻页 → split');
+  ok(
+    layoutForSlot({ slotName: 'theme-1-lead' }, leadScene) === 'split',
+    '-lead 单 atom 页 → split',
+  );
+  const twoAtomLead = {
+    subjects: [
+      { type: 'cover', args: {} },
+      { type: 'icon-grid', args: {} },
+      { type: 'bullet-list', args: {} },
+    ],
+  };
+  ok(
+    layoutForSlot({ slotName: 'theme-9-lead' }, twoAtomLead) === 'banner',
+    '-lead 双 atom 页留 banner (R3: 右列会压碎多列 atom)',
+  );
   const denseLead = {
     subjects: [
       { type: 'cover', args: {} },

--- a/sdf-js/scripts/test-mount-contract.mjs
+++ b/sdf-js/scripts/test-mount-contract.mjs
@@ -122,5 +122,33 @@ const baseDeck = () => ({
   ok(normal.decorRole === 'section' && normal.decorUnder === true, '普通内页规则不受影响');
 }
 
+// ── 5. theme 页题: 占位符 → agenda 条目, 真标题不被覆盖 (对抗 R4/R5) ──
+{
+  const { agendaLabelsOf, themeSlotBannerTitle } = await import('../src/present/art-mount.js');
+  const slots = [
+    {
+      slotName: 'agenda',
+      sceneData: {
+        subjects: [
+          { type: 'agenda-list', args: { items: [{ label: '主题一' }, { label: '主题二' }] } },
+        ],
+      },
+    },
+  ];
+  const labels = agendaLabelsOf(slots);
+  ok(labels.join() === '主题一,主题二', 'agendaLabelsOf 提取目录条目');
+  const ph = {
+    slotName: 'theme-2-lead',
+    sceneData: { subjects: [{ type: 'cover', args: { title: 'Theme 2 — Lead' } }] },
+  };
+  ok(themeSlotBannerTitle(ph, labels) === '主题二', '占位符页题 → agenda 第 N 条');
+  const real = {
+    slotName: 'theme-2-lead',
+    sceneData: { subjects: [{ type: 'cover', args: { title: '团队长归因:双网络结构' } }] },
+  };
+  ok(themeSlotBannerTitle(real, labels) === null, '真页题不被覆盖 (R5 回归教训)');
+  ok(themeSlotBannerTitle({ slotName: 'summary' }, labels) === null, '非 theme 槽位不介入');
+}
+
 console.log(`\n${passed} passed, ${failed} failed`);
 if (failed) process.exit(1);

--- a/sdf-js/src/present/art-mount.js
+++ b/sdf-js/src/present/art-mount.js
@@ -296,9 +296,9 @@ export function mountUnderlayDecor(baseDecor, mount, mode = 'hetero') {
  * section title, centered like the deck cover. Returns a NEW slot list;
  * synthetic slots carry _transition: {index} so renderers can pick art.
  */
-export function insertTransitions(slots, mount) {
-  if (!mount) return slots;
-  const agenda = slots.find((s) => s.slotName === 'agenda');
+/** agendaLabelsOf(slots) — deck 目录条目 (转场页与 theme 页题的共同来源)。 */
+export function agendaLabelsOf(slots) {
+  const agenda = (slots || []).find((s) => s.slotName === 'agenda');
   const labels = [];
   if (agenda?.sceneData?.subjects) {
     for (const sub of agenda.sceneData.subjects) {
@@ -307,6 +307,28 @@ export function insertTransitions(slots, mount) {
       }
     }
   }
+  return labels;
+}
+
+/**
+ * themeSlotBannerTitle(slot, agendaLabels) → string | null — 对抗 R4:
+ * 管线烤出的 "Theme N — Lead/Detail" 占位符不配上横带; theme 页的真页题
+ * 是 agenda 第 N 条 (与转场页同源同律)。非 theme 槽位返回 null。
+ */
+export function themeSlotBannerTitle(slot, agendaLabels) {
+  const m = /^theme-(\d+)-(lead|detail)$/.exec(String(slot?.slotName || ''));
+  if (!m) return null;
+  // 只救占位符 — 手工修好的真页题 (ANTFUN 范本) 不许被 agenda 覆盖
+  const cover = (slot?.sceneData?.subjects || []).find((s2) => s2?.type === 'cover');
+  const cur = String(cover?.args?.title || '').trim();
+  const isPlaceholder = !cur || /^(theme\s*\d+\s*[—–-]+\s*(lead|detail)|slide\s*\d+)$/i.test(cur);
+  if (!isPlaceholder) return null;
+  return agendaLabels[Number(m[1]) - 1] || null;
+}
+
+export function insertTransitions(slots, mount) {
+  if (!mount) return slots;
+  const labels = agendaLabelsOf(slots);
   const isBoundary = (s, i) =>
     /-lead$/.test(s.slotName || '') || ((s.slotName || '') === 'risk-matrix' && labels.length > 5);
   const out = [];

--- a/sdf-js/src/present/atoms-2d/charts/diagrams/comparison-table.js
+++ b/sdf-js/src/present/atoms-2d/charts/diagrams/comparison-table.js
@@ -52,8 +52,11 @@ export function drawPseudo3D(ctx, args, opts = {}) {
   const bg = palette.bg || [248, 246, 240];
   const accent = palette.accent || palette.colors?.[0] || [60, 140, 200];
 
-  const cols = Array.isArray(args.columns) ? args.columns.slice(0, 5) : [];
-  const rows = Array.isArray(args.features) ? args.features.slice(0, 12) : [];
+  // 对抗 R2 (2026-07-14): lift LLM 常烤出 name 而非 label — 字段名沉默
+  // 失配曾让整张矩阵表头/行标签全空 (validator 不报未知键)。宽容读法。
+  const alias = (o) => (o && typeof o === 'object' ? { ...o, label: o.label ?? o.name } : o);
+  const cols = Array.isArray(args.columns) ? args.columns.slice(0, 5).map(alias) : [];
+  const rows = Array.isArray(args.features) ? args.features.slice(0, 12).map(alias) : [];
   const title = args.title ? String(args.title) : '';
 
   if (cols.length === 0 || rows.length === 0) return;

--- a/sdf-js/src/present/atoms-2d/charts/diagrams/mountain-path.js
+++ b/sdf-js/src/present/atoms-2d/charts/diagrams/mountain-path.js
@@ -80,6 +80,10 @@ export function drawPseudo3D(ctx, args, opts = {}) {
     ctx.fillText(args.title, x + PAD, plotTop);
     plotTop += titleFs + PAD * 0.5;
   }
+  // 对抗 R1 (2026-07-14): summit 标签画在 peakY - 0.09*plotH - 6, 落点在
+  // plotTop 之上 — 与标题行相撞 (Partnership Path Forward × 峰顶标签)。
+  // summit 非空时预留一条独立行带, 山体整体下移。
+  if (summit) plotTop += Math.round(h * 0.052) + 10;
 
   const plotH = y + h - plotTop - PAD;
   const cx = x + w / 2;

--- a/sdf-js/src/present/atoms-2d/charts/diagrams/process-arrows.js
+++ b/sdf-js/src/present/atoms-2d/charts/diagrams/process-arrows.js
@@ -160,8 +160,14 @@ export function drawPseudo3D(ctx, args, opts = {}) {
     }
     const labelY = hasSub ? centerY - labelFontSize * 0.6 : centerY;
 
+    // 对抗 R3 (2026-07-14): 淡彩 mount 的浅 tint 箭头上白字半隐形 —
+    // 按箭头底色亮度切墨 (亮箭头用深墨, 深箭头用白)
+    const fillLum = (0.2126 * fillColor[0] + 0.7152 * fillColor[1] + 0.0722 * fillColor[2]) / 255;
+    const stepInk = fillLum > 0.62 ? 'rgba(30,32,38,0.92)' : 'rgba(255,255,255,0.97)';
+    const stepSubInk = fillLum > 0.62 ? 'rgba(30,32,38,0.66)' : 'rgba(255,255,255,0.75)';
+
     ctx.save();
-    ctx.fillStyle = 'rgba(255,255,255,0.97)';
+    ctx.fillStyle = stepInk;
     ctx.font = `700 ${labelFontSize}px Inter, system-ui, sans-serif`;
     ctx.textAlign = 'center';
     ctx.textBaseline = 'middle';
@@ -176,7 +182,7 @@ export function drawPseudo3D(ctx, args, opts = {}) {
         ctx.font = `500 ${subFont}px Inter, system-ui, sans-serif`;
       }
       ctx.save();
-      ctx.fillStyle = 'rgba(255,255,255,0.75)';
+      ctx.fillStyle = stepSubInk;
       ctx.font = `500 ${subFont}px Inter, system-ui, sans-serif`;
       ctx.textAlign = 'center';
       ctx.textBaseline = 'middle';

--- a/sdf-js/src/present/atoms-2d/charts/layers/layer-stack.js
+++ b/sdf-js/src/present/atoms-2d/charts/layers/layer-stack.js
@@ -16,6 +16,7 @@
 // =============================================================================
 
 import { rgbCss, rgbaCss } from '../../renderer.js';
+import { wrapCJK } from '../../cjk-text.js';
 
 export const spec = {
   type: 'layer-stack',
@@ -126,22 +127,33 @@ export function drawPseudo3D(ctx, args, opts = {}) {
     // width (Sprint 71: a long CJK label on a narrow tapered layer spilled
     // past the canvas edge; the label never gets to leave its layer)
     if (layer.label) {
-      let label = String(layer.label);
       let fs = Math.round(layerH * 0.35);
       ctx.font = `700 ${fs}px Inter, system-ui, sans-serif`;
       const maxLabelW = layerW - 16;
-      while (fs > 11 && ctx.measureText(label).width > maxLabelW) {
+      while (fs > 11 && ctx.measureText(String(layer.label)).width > maxLabelW) {
         fs -= 1;
         ctx.font = `700 ${fs}px Inter, system-ui, sans-serif`;
       }
-      while (label.length > 1 && ctx.measureText(label + '…').width > maxLabelW) {
-        label = label.slice(0, -1);
+      // 对抗 R4 (2026-07-14): 长 CJK 标签「新增多层次可配置网…」被省略号
+      // 腰斩 — 层块够高时折两行 (禁则断行), 实在放不下才回省略号
+      let lines = [String(layer.label)];
+      if (ctx.measureText(String(layer.label)).width > maxLabelW) {
+        if (layerH >= fs * 2.4) {
+          lines = wrapCJK(ctx, layer.label, maxLabelW, 2);
+        } else {
+          let label = String(layer.label);
+          while (label.length > 1 && ctx.measureText(label + '…').width > maxLabelW) {
+            label = label.slice(0, -1);
+          }
+          lines = [label + '…'];
+        }
       }
-      if (label !== String(layer.label)) label += '…';
       ctx.fillStyle = 'rgba(255,255,255,0.96)';
       ctx.textAlign = 'center';
       ctx.textBaseline = 'middle';
-      ctx.fillText(label, stackCX, layerCY);
+      const lh = fs * 1.15;
+      const y0 = layerCY - ((lines.length - 1) * lh) / 2;
+      lines.forEach((ln, li) => ctx.fillText(ln, stackCX, y0 + li * lh));
     }
 
     // Sublabel to right of stack (Inter 500, softer) — CONFINED to the

--- a/sdf-js/src/present/atoms-2d/icons/icon-grid.js
+++ b/sdf-js/src/present/atoms-2d/icons/icon-grid.js
@@ -172,14 +172,17 @@ export function drawPseudo3D(ctx, args, opts = {}) {
     }
     // plain: no badge
 
-    // ---- Icon path (white on circle/square; badge-color on plain) ----
+    // ---- Icon path (white on circle/square; badge-color otherwise) ----
+    // 对抗 R5 (2026-07-14): lift LLM 烤出未知 iconStyle ('card') — badge
+    // 不画但图标仍走白色分支 → 纸面上白图标隐形。只有真画了 badge 才用白。
+    const hasBadge = iconStyle === 'circle' || iconStyle === 'square';
     drawIconCentered(
       ctx,
       resolved,
       cellCx,
       iconCy,
       iconR * 0.85,
-      iconStyle === 'plain' ? badgeColor : [255, 255, 255],
+      hasBadge ? [255, 255, 255] : badgeColor,
     );
 
     // ---- Label below ----

--- a/sdf-js/src/present/atoms-2d/layout.js
+++ b/sdf-js/src/present/atoms-2d/layout.js
@@ -33,12 +33,9 @@ export function layoutForSlot(slot, sceneData) {
   const body = subs.filter((s) => s.type !== 'cover');
   if (body.length === 1 && QUOTE_TYPES.has(body[0].type)) return 'statement';
   const name = String(slot?.slotName || '');
-  if (
-    /-lead$/.test(name) &&
-    body.length >= 1 &&
-    body.length <= 2 &&
-    subs.some((s) => s.type === 'cover')
-  ) {
+  // 对抗 R3 (2026-07-14): 双 atom 正文进 62% 右列会把多列 atom 压碎
+  // (icon 卡标签截断成 3 字) — split 收紧到单 atom 正文
+  if (/-lead$/.test(name) && body.length === 1 && subs.some((s) => s.type === 'cover')) {
     return 'split';
   }
   return 'banner';

--- a/sdf-js/src/present/atoms-2d/renderer.js
+++ b/sdf-js/src/present/atoms-2d/renderer.js
@@ -186,7 +186,11 @@ export async function renderSceneDataToCanvas(canvas, sceneData, opts = {}) {
       y: 0,
       w: canvas.width,
       h: canvas.height,
-      intensity: decor.intensity || UNDER_INTENSITY[role] || 'subtle',
+      // 对抗 R2 (2026-07-14): 装裱提升的内页 (decorUnder 显式请求) 用
+      // subtle — bold 底纹压在小字 atoms 上是"脏"的主源; 艺术声音保留,
+      // 密度让位给可读性
+      intensity:
+        decor.intensity || (opts.decorUnder ? 'subtle' : UNDER_INTENSITY[role] || 'subtle'),
     });
   }
   // Sprint 90 (user: 目录页 Overview 小字与"核心主题"冲突 — 标题上提):
@@ -200,6 +204,22 @@ export async function renderSceneDataToCanvas(canvas, sceneData, opts = {}) {
   if (bannerCanvas || splitCanvas) {
     subjects = subjects.slice(); // never mutate the caller's array
     const coverSub = subjects.find((c2) => c2 && c2.type === 'cover');
+    // 对抗 R1 (2026-07-14): 管线烤出的槽位名占位符 ("Theme 2 — Lead" /
+    // "Slide 3") 不配上横带 — 正文第一个有题 atom 的标题才是页题。
+    // hoist 后该 atom 剥掉自己的标题 (与 agenda hoist 同律)。
+    const PLACEHOLDER_RE = /^(theme\s*\d+\s*[—–-]+\s*(lead|detail)|slide\s*\d+)$/i;
+    if (!bannerTitle && PLACEHOLDER_RE.test(String(coverSub?.args?.title || '').trim())) {
+      const idx = subjects.findIndex(
+        (s2) => s2 && s2.type !== 'cover' && typeof s2.args?.title === 'string' && s2.args.title,
+      );
+      if (idx >= 0) {
+        bannerTitle = subjects[idx].args.title;
+        subjects[idx] = {
+          ...subjects[idx],
+          args: { ...subjects[idx].args, title: undefined },
+        };
+      }
+    }
     const refTitle = String(opts.bannerTitle || coverSub?.args?.title || '').replace(/\s/g, '');
     for (let i = 0; i < subjects.length; i++) {
       const s2 = subjects[i];

--- a/sdf-js/src/present/exporters/pdf.js
+++ b/sdf-js/src/present/exporters/pdf.js
@@ -21,6 +21,8 @@ import {
   mountPaletteOverride,
   mountUnderlayDecor,
   insertTransitions,
+  agendaLabelsOf,
+  themeSlotBannerTitle,
 } from '../art-mount.js';
 import { layoutForSlot } from '../atoms-2d/layout.js';
 import { lintPage, pageKindOf } from '../page-lint.js';
@@ -77,6 +79,8 @@ export async function buildDeckPdf(deck, opts = {}) {
   // 会插, in-app 导出与批量脚本从此同一产物
   const slots = opts.artMount ? insertTransitions(deck.slots, opts.artMount) : deck.slots;
   const total = slots.length;
+  // 对抗 R4: theme-N-lead/detail 的占位符页题 → agenda 第 N 条 (与转场页同源)
+  const agendaLabels = agendaLabelsOf(deck.slots);
   const lintPages = [];
   for (let i = 0; i < total; i++) {
     const slot = slots[i];
@@ -103,6 +107,9 @@ export async function buildDeckPdf(deck, opts = {}) {
           : undefined,
         // Sprint 82: 真迹装裱 — screen and file must show the same mount
         ...(artMountOpts(opts.artMount, slot, slotRoleOf(slot)) || {}),
+        ...(themeSlotBannerTitle(slot, agendaLabels)
+          ? { bannerTitle: themeSlotBannerTitle(slot, agendaLabels) }
+          : {}),
       });
     } catch (e) {
       console.error(`[pdf] slide render failed:`, e);

--- a/sdf-js/src/present/exporters/pptx.js
+++ b/sdf-js/src/present/exporters/pptx.js
@@ -24,6 +24,8 @@ import {
   mountPaletteOverride,
   mountUnderlayDecor,
   insertTransitions,
+  agendaLabelsOf,
+  themeSlotBannerTitle,
 } from '../art-mount.js';
 import { layoutForSlot } from '../atoms-2d/layout.js';
 
@@ -82,6 +84,7 @@ export async function exportDeckToPPTX(deck, opts = {}) {
   // 会插, in-app 导出与批量脚本从此同一产物
   const slots = opts.artMount ? insertTransitions(deck.slots, opts.artMount) : deck.slots;
   const total = slots.length;
+  const agendaLabels = agendaLabelsOf(deck.slots);
   for (let i = 0; i < total; i++) {
     const slot = slots[i];
     onProgress(`Rendering slot ${i + 1}/${total} (${slot.slotName})`, 5 + (i / total) * 90);
@@ -107,6 +110,9 @@ export async function exportDeckToPPTX(deck, opts = {}) {
           : undefined,
         // Sprint 82: 真迹装裱 — screen and file must show the same mount
         ...(artMountOpts(opts.artMount, slot, slotRoleOf(slot)) || {}),
+        ...(themeSlotBannerTitle(slot, agendaLabels)
+          ? { bannerTitle: themeSlotBannerTitle(slot, agendaLabels) }
+          : {}),
       });
     } catch (e) {
       console.error(`[pptx] slide render failed:`, e);


### PR DESCRIPTION
对最新两批 PDF 的五轮对抗迭代: 占位符页题(R1/R4)/矩阵标签全空(R2)/split 压碎(R3)/淡tint白字(R3)/白图标(R5) 等九处修复, 其中两处是沉默失配家族 (label≠name / 未知 iconStyle)。R5 抓回了对抗中自己造的回归。全部有断言与全尺寸视觉复核。

🤖 Generated with [Claude Code](https://claude.com/claude-code)