### PR TITLE
Playback pause: Space / P freeze the fly-through

### DIFF
--- a/sdf-js/apps/present/figure-core.js
+++ b/sdf-js/apps/present/figure-core.js
@@ -173,8 +173,51 @@ export function createFigure({
     'opacity:0;pointer-events:none;transition:opacity 0.45s ease;';
   replayBtn.addEventListener('click', () => {
     if (studio.setSequenceTime) studio.setSequenceTime(0);
+    setPaused(false); // replay always resumes — a paused replay reads as "broken"
   });
   if (!present) document.body.appendChild(replayBtn);
+
+  // ---- pause / resume (auto-play only) ---------------------------------------
+  // Space or P freezes the fly-through in place (the one-clock engine freezes
+  // build-ins + postfx with it, exactly like presenter mode's beat-hold). A
+  // corner glyph confirms the state — pressing a key with no visible response
+  // reads as "the key doesn't work" (user report 2026-07-15). Presenter mode
+  // owns its own clock, so it never gets this handler.
+  let paused = false;
+  const pauseGlyph = document.createElement('div');
+  pauseGlyph.id = 'pause-glyph';
+  pauseGlyph.textContent = '❙❙';
+  pauseGlyph.style.cssText =
+    'position:fixed;left:22px;bottom:20px;z-index:60;' +
+    'font:600 20px/1 -apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;' +
+    'color:#f3f6fb;background:rgba(16,20,30,0.6);border:1px solid rgba(255,255,255,0.2);' +
+    'width:38px;height:38px;border-radius:50%;display:flex;align-items:center;' +
+    'justify-content:center;letter-spacing:1px;pointer-events:none;' +
+    'backdrop-filter:blur(6px);-webkit-backdrop-filter:blur(6px);' +
+    'opacity:0;transition:opacity 0.25s ease;';
+  if (!present) document.body.appendChild(pauseGlyph);
+  function setPaused(p) {
+    if (p === paused || !studio.setSequencePaused) return;
+    paused = p;
+    studio.setSequencePaused(p);
+    pauseGlyph.style.opacity = p ? '1' : '0';
+    if (!p && studio.requestRender) studio.requestRender(); // revive the loop on resume
+  }
+  if (!present) {
+    window.addEventListener(
+      'keydown',
+      (e) => {
+        // never fight a text field (prompt / api-key box)
+        const t = e.target;
+        if (t && (t.tagName === 'INPUT' || t.tagName === 'TEXTAREA' || t.isContentEditable)) return;
+        if (e.key === ' ' || e.key === 'p' || e.key === 'P') {
+          e.preventDefault(); // Space would otherwise scroll the page
+          setPaused(!paused);
+        }
+      },
+      true, // capture: win over any bubble-phase consumer (fly controls etc.)
+    );
+  }
 
   let items = [];
   let els = [];


### PR DESCRIPTION
## 你报的“按 P 没反应”

暂停键此前只接在 `deck-player.js` 那条播放路径上;你实际在跑的 `figure.html` 自动播放路径(`?deck=…&layout=theater&tone=white`)只有 Replay 按钮,没有暂停。

现在 **Space 或 P** 切换 `studio.setSequencePaused`——冻结整个单时钟世界(镜头、build-in 动画、postfx),和 presenter 模式的定格完全一致。左下角一个 **❙❙** 圆形指示器确认状态(按了键没有可见反馈会读成“坏了”)。细节:Space 已 `preventDefault` 不会滚页;输入框内不拦截;Replay 永远恢复播放(暂停态的 replay 会显得卡住);presenter 模式自管时钟,不加这个处理器。

## 验证

浏览器实测(2015 deck):暂停后墙钟走 800ms、序列时钟纹丝不动(frozenDelta=0);第二次按键恢复正常走;指示器跟随状态显隐。截图确认 ❙❙ 可见、画面定格。套件 163/163。

🤖 Generated with [Claude Code](https://claude.com/claude-code)