### PR TITLE
只留镜头动画 + 图表几何对齐原图 + 文本分列 + 飞轮环/概念圆两个新形态

### DIFF
--- a/sdf-js/apps/present/figure-core.js
+++ b/sdf-js/apps/present/figure-core.js
@@ -310,7 +310,9 @@ export function createFigure({
           ? 'stage-title'
           : o.role === 'insight'
             ? 'stage-insight'
-            : 'stage-bullet';
+            : // overlay `side:'right'` opens the RIGHT narration column — a
+              // comparison page needs its two sides' text in TWO places
+              `stage-bullet${o.side === 'right' ? ' side-right' : ''}`;
       d.textContent = o.text;
       // insight panels carry a cited derivation line under the takeaway
       // (Rule 24: derived values name their parents)
@@ -410,7 +412,9 @@ export function createFigure({
       let curCh = -1;
       for (const o of stageItems)
         if (o.role === 'title' && o.revealAt <= t + 0.02 && o._ch > curCh) curCh = o._ch;
-      let slot = 0;
+      // two independent narration columns — each side stacks its own slots so a
+      // comparison page reads as two facing lists, not one merged pile
+      const slots = { left: 0, right: 0 };
       let lastOn = -1;
       for (let i = 0; i < stageItems.length; i++) {
         const o = stageItems[i];
@@ -419,8 +423,9 @@ export function createFigure({
         // seeks honest in both directions.
         const on = o._ch === curCh && o.revealAt <= t + 0.02 && (o.hideAt == null || t < o.hideAt);
         if (o.role === 'screen' && on) {
-          stageEls[i].style.top = `calc(21vh + ${slot} * 9.5vh)`;
-          slot++;
+          const side = o.side === 'right' ? 'right' : 'left';
+          stageEls[i].style.top = `calc(21vh + ${slots[side]} * 9.5vh)`;
+          slots[side]++;
           lastOn = i;
         }
         stageEls[i].classList.toggle('on', on);

--- a/sdf-js/apps/present/figure.html
+++ b/sdf-js/apps/present/figure.html
@@ -98,6 +98,19 @@
       .stage-bullet.on.cur {
         opacity: 1;
       }
+      /* RIGHT narration column (overlay `side:'right'`). A comparison page must
+         put its two sides' text in TWO PLACES — stacking both in the single
+         left column destroys the contrast the page exists to make (user-locked
+         2026-07-15: 文本一定要区分，不要只放在左边). */
+      .stage-bullet.side-right {
+        left: auto;
+        right: 6.5vw;
+        text-align: right;
+        transform: translateX(14px);
+      }
+      .stage-bullet.side-right.on {
+        transform: translateX(0);
+      }
       /* Insight panel — the derived takeaway (R1: the chart finishes the
          derivation for the reader). Bottom-right, opposite the title/bullet
          column; big claim + small cited derivation line. */

--- a/sdf-js/fixtures/golden/assemble-deck-courtyard.json
+++ b/sdf-js/fixtures/golden/assemble-deck-courtyard.json
@@ -1146,12 +1146,6 @@
         "rotate": [0, -1, 0]
       },
       "material": "mat-0",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "3.400 - 0.000 * smoothstep(0.00, 1.00, t) + 0.07 * sin(0.35 * t + 0.00)"
-        }
-      ],
       "collection": "station-0"
     },
     {
@@ -1166,12 +1160,6 @@
         "rotate": [0, -0.5, 0]
       },
       "material": "mat-0",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "2.600 - 0.000 * smoothstep(0.00, 1.00, t) + 0.09 * sin(0.43 * t + 2.10)"
-        }
-      ],
       "collection": "station-0"
     },
     {
@@ -1186,12 +1174,6 @@
         "rotate": [0, 0, 0]
       },
       "material": "mat-0",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "4.600 - 0.000 * smoothstep(0.00, 1.00, t) + 0.11 * sin(0.51 * t + 4.20)"
-        }
-      ],
       "collection": "station-0"
     },
     {
@@ -1206,12 +1188,6 @@
         "rotate": [0, 0.5, 0]
       },
       "material": "mat-0",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "4.000 - 0.000 * smoothstep(0.00, 1.00, t) + 0.13 * sin(0.59 * t + 0.02)"
-        }
-      ],
       "collection": "station-0"
     },
     {
@@ -1226,12 +1202,6 @@
         "rotate": [0, 1, 0]
       },
       "material": "mat-0",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "5.800 - 0.000 * smoothstep(0.00, 1.00, t) + 0.15 * sin(0.67 * t + 2.12)"
-        }
-      ],
       "collection": "station-0"
     },
     {
@@ -1246,12 +1216,6 @@
         "rotate": [0, 1.5, 0]
       },
       "material": "mat-0",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "5.200 - 0.000 * smoothstep(0.00, 1.00, t) + 0.17 * sin(0.75 * t + 4.22)"
-        }
-      ],
       "collection": "station-0"
     },
     {
@@ -1266,12 +1230,6 @@
         "rotate": [0, 2, 0]
       },
       "material": "mat-0",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "7.000 - 0.000 * smoothstep(0.00, 1.00, t) + 0.19 * sin(0.83 * t + 0.04)"
-        }
-      ],
       "collection": "station-0"
     },
     {
@@ -1286,12 +1244,6 @@
         "rotate": [0, 2.5, 0]
       },
       "material": "mat-0",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "6.400 - 0.000 * smoothstep(0.00, 1.00, t) + 0.21 * sin(0.91 * t + 2.14)"
-        }
-      ],
       "collection": "station-0"
     },
     {
@@ -1306,12 +1258,6 @@
         "rotate": [0, 3, 0]
       },
       "material": "mat-0",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "2.000 - 0.000 * smoothstep(0.00, 1.00, t) + 0.23 * sin(0.99 * t + 4.24)"
-        }
-      ],
       "collection": "station-0"
     },
     {
@@ -1346,12 +1292,6 @@
         "rotate": [0, 0, 1.5707963267948966]
       },
       "material": "mat-2",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "3.700 - 0.000 * smoothstep(9.80, 10.80, t) + 0.07 * sin(0.35 * t + -2.33)"
-        }
-      ],
       "collection": "station-1"
     },
     {
@@ -1364,12 +1304,6 @@
         "translate": [6.883194122054976, 6.717749959911059, 65.89795595956114]
       },
       "material": "mat-3",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "8.018 - 1.300 * smoothstep(11.65, 12.20, t) + 0.04 * sin(0.6 * t + -5.88)"
-        }
-      ],
       "collection": "station-1"
     },
     {
@@ -1382,12 +1316,6 @@
         "translate": [5.52054729687729, 5.888298781822307, 65.89795595956114]
       },
       "material": "mat-4",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "7.188 - 1.300 * smoothstep(12.65, 13.20, t) + 0.04 * sin(0.6 * t + -4.18)"
-        }
-      ],
       "collection": "station-1"
     },
     {
@@ -1400,12 +1328,6 @@
         "translate": [4.739003747950957, 4.497620778785201, 65.89795595956114]
       },
       "material": "mat-3",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "5.798 - 1.300 * smoothstep(13.65, 14.20, t) + 0.04 * sin(0.6 * t + -2.48)"
-        }
-      ],
       "collection": "station-1"
     },
     {
@@ -1418,12 +1340,6 @@
         "translate": [4.739003747950957, 2.902379221214799, 65.89795595956114]
       },
       "material": "mat-3",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "4.202 - 1.300 * smoothstep(14.65, 15.20, t) + 0.04 * sin(0.6 * t + -0.78)"
-        }
-      ],
       "collection": "station-1"
     },
     {
@@ -1436,12 +1352,6 @@
         "translate": [5.52054729687729, 1.5117012181776928, 65.89795595956114]
       },
       "material": "mat-3",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "2.812 - 1.300 * smoothstep(15.65, 16.20, t) + 0.04 * sin(0.6 * t + -5.36)"
-        }
-      ],
       "collection": "station-1"
     },
     {
@@ -1454,12 +1364,6 @@
         "translate": [6.883194122054976, 0.6822500400889417, 65.89795595956114]
       },
       "material": "mat-3",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "1.982 - 1.300 * smoothstep(16.65, 17.20, t) + 0.04 * sin(0.6 * t + -3.66)"
-        }
-      ],
       "collection": "station-1"
     },
     {
@@ -1505,12 +1409,6 @@
         "translate": [38.859437570612876, 0.9931034482758622, 57.27477798202504]
       },
       "material": "mat-6",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "-1.293 + 2.286 * smoothstep(24.75, 25.35, t)"
-        }
-      ],
       "pattern": "cracked",
       "collection": "station-2"
     },
@@ -1537,12 +1435,6 @@
         "translate": [37.58943757061288, 1.2413793103448276, 57.27477798202504]
       },
       "material": "mat-7",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "-1.541 + 2.783 * smoothstep(25.85, 26.45, t)"
-        }
-      ],
       "pattern": "cracked",
       "collection": "station-2"
     },
@@ -1569,12 +1461,6 @@
         "translate": [36.31943757061288, 1.6, 57.27477798202504]
       },
       "material": "mat-8",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "-1.900 + 3.500 * smoothstep(26.95, 27.55, t)"
-        }
-      ],
       "pattern": "cracked",
       "collection": "station-2"
     },
@@ -1601,12 +1487,6 @@
         "translate": [35.04943757061288, 1.9034482758620692, 57.27477798202504]
       },
       "material": "mat-9",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "-2.203 + 4.107 * smoothstep(28.05, 28.65, t)"
-        }
-      ],
       "pattern": "cracked",
       "collection": "station-2"
     },
@@ -1633,12 +1513,6 @@
         "translate": [33.77943757061288, 2.1517241379310343, 57.27477798202504]
       },
       "material": "mat-10",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "-2.452 + 4.603 * smoothstep(29.15, 29.75, t)"
-        }
-      ],
       "pattern": "cracked",
       "collection": "station-2"
     },
@@ -1665,12 +1539,6 @@
         "translate": [32.50943757061288, 2.4, 57.27477798202504]
       },
       "material": "mat-11",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "-2.700 + 5.100 * smoothstep(30.25, 30.85, t)"
-        }
-      ],
       "collection": "station-2"
     },
     {
@@ -1776,12 +1644,6 @@
         "translate": [51.31413711788923, 0.14464710547184773, 47.2906201605169]
       },
       "material": "mat-6",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "-0.445 + 0.589 * smoothstep(38.05, 38.65, t)"
-        }
-      ],
       "pattern": "cracked",
       "collection": "station-3"
     },
@@ -1808,12 +1670,6 @@
         "translate": [50.044137117889235, 0.28263283108643933, 47.2906201605169]
       },
       "material": "mat-7",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "-0.583 + 0.865 * smoothstep(39.15, 39.75, t)"
-        }
-      ],
       "pattern": "cracked",
       "collection": "station-3"
     },
@@ -1840,12 +1696,6 @@
         "translate": [48.77413711788923, 0.5443298969072166, 47.2906201605169]
       },
       "material": "mat-8",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "-0.844 + 1.389 * smoothstep(40.25, 40.85, t)"
-        }
-      ],
       "pattern": "cracked",
       "collection": "station-3"
     },
@@ -1872,12 +1722,6 @@
         "translate": [47.504137117889236, 0.9601903251387788, 47.2906201605169]
       },
       "material": "mat-9",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "-1.260 + 2.220 * smoothstep(41.35, 41.95, t)"
-        }
-      ],
       "pattern": "cracked",
       "collection": "station-3"
     },
@@ -1904,12 +1748,6 @@
         "translate": [46.23413711788923, 1.5501982553528946, 47.2906201605169]
       },
       "material": "mat-10",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "-1.850 + 3.400 * smoothstep(42.45, 43.05, t)"
-        }
-      ],
       "pattern": "cracked",
       "collection": "station-3"
     },
@@ -1936,12 +1774,6 @@
         "translate": [44.96413711788924, 2.4, 47.2906201605169]
       },
       "material": "mat-11",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "-2.700 + 5.100 * smoothstep(43.55, 44.15, t)"
-        }
-      ],
       "collection": "station-3"
     },
     {
@@ -2047,12 +1879,6 @@
         "translate": [61.075251114681436, 2.4, 34.66035485216589]
       },
       "material": "mat-11",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "-2.700 + 5.100 * smoothstep(51.35, 51.95, t)"
-        }
-      ],
       "collection": "station-4"
     },
     {
@@ -2078,12 +1904,6 @@
         "translate": [59.80525111468144, 2.2374501992031868, 34.66035485216589]
       },
       "material": "mat-7",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "-2.537 + 4.775 * smoothstep(52.45, 53.05, t)"
-        }
-      ],
       "pattern": "cracked",
       "collection": "station-4"
     },
@@ -2110,12 +1930,6 @@
         "translate": [58.53525111468144, 1.4151394422310757, 34.66035485216589]
       },
       "material": "mat-8",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "-1.715 + 3.130 * smoothstep(53.55, 54.15, t)"
-        }
-      ],
       "pattern": "cracked",
       "collection": "station-4"
     },
@@ -2142,12 +1956,6 @@
         "translate": [57.26525111468144, 1.2430278884462151, 34.66035485216589]
       },
       "material": "mat-9",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "-1.543 + 2.786 * smoothstep(54.65, 55.25, t)"
-        }
-      ],
       "pattern": "cracked",
       "collection": "station-4"
     },
@@ -2174,12 +1982,6 @@
         "translate": [55.99525111468144, 0.7362549800796813, 34.66035485216589]
       },
       "material": "mat-10",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "-1.036 + 1.773 * smoothstep(55.75, 56.35, t)"
-        }
-      ],
       "pattern": "cracked",
       "collection": "station-4"
     },
@@ -2206,12 +2008,6 @@
         "translate": [54.72525111468144, 0.6501992031872509, 34.66035485216589]
       },
       "material": "mat-13",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "-0.950 + 1.600 * smoothstep(56.85, 57.45, t)"
-        }
-      ],
       "pattern": "cracked",
       "collection": "station-4"
     },
@@ -2318,12 +2114,6 @@
         "translate": [67.59660451107118, 2.4, 20.090698092409873]
       },
       "material": "mat-11",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "-2.700 + 5.100 * smoothstep(64.65, 65.25, t)"
-        }
-      ],
       "collection": "station-5"
     },
     {
@@ -2349,12 +2139,6 @@
         "translate": [66.32660451107118, 2.2072538860103625, 20.090698092409873]
       },
       "material": "mat-7",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "-2.507 + 4.715 * smoothstep(65.75, 66.35, t)"
-        }
-      ],
       "pattern": "cracked",
       "collection": "station-5"
     },
@@ -2381,12 +2165,6 @@
         "translate": [65.05660451107119, 1.5015544041450775, 20.090698092409873]
       },
       "material": "mat-8",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "-1.802 + 3.303 * smoothstep(66.85, 67.45, t)"
-        }
-      ],
       "pattern": "cracked",
       "collection": "station-5"
     },
@@ -2413,12 +2191,6 @@
         "translate": [63.78660451107118, 1.2590673575129532, 20.090698092409873]
       },
       "material": "mat-9",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "-1.559 + 2.818 * smoothstep(67.95, 68.55, t)"
-        }
-      ],
       "pattern": "cracked",
       "collection": "station-5"
     },
@@ -2445,12 +2217,6 @@
         "translate": [62.51660451107118, 1.0290155440414508, 20.090698092409873]
       },
       "material": "mat-10",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "-1.329 + 2.358 * smoothstep(69.05, 69.65, t)"
-        }
-      ],
       "pattern": "cracked",
       "collection": "station-5"
     },
@@ -2477,12 +2243,6 @@
         "translate": [61.24660451107118, 0.9699481865284973, 20.090698092409873]
       },
       "material": "mat-13",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "-1.270 + 2.240 * smoothstep(70.15, 70.75, t)"
-        }
-      ],
       "pattern": "cracked",
       "collection": "station-5"
     },
@@ -2615,12 +2375,6 @@
         "translate": [70.93830037849284, 4.3, 4.396882959222102]
       },
       "material": "mat-14",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "0.950 + 3.350 * smoothstep(79.20, 79.95, t) + 0.05 * sin(0.5 * t + -38.15)"
-        }
-      ],
       "collection": "station-6"
     },
     {
@@ -2633,12 +2387,6 @@
         "translate": [67.33830037849285, 4.3, 4.396882959222102]
       },
       "material": "mat-3",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "0.950 + 3.350 * smoothstep(80.30, 81.05, t) + 0.05 * sin(0.5 * t + -36.05)"
-        }
-      ],
       "collection": "station-6"
     },
     {
@@ -2651,12 +2399,6 @@
         "translate": [63.738300378492845, 4.3, 4.396882959222102]
       },
       "material": "mat-3",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "0.950 + 3.350 * smoothstep(81.40, 82.15, t) + 0.05 * sin(0.5 * t + -33.95)"
-        }
-      ],
       "collection": "station-6"
     },
     {
@@ -2670,12 +2412,6 @@
         "translate": [74.23830037849285, 2.175, 4.396882959222102]
       },
       "material": "mat-15",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "0.175 + 2.000 * smoothstep(78.10, 78.80, t)"
-        }
-      ],
       "collection": "station-6"
     },
     {
@@ -2688,12 +2424,6 @@
         "translate": [74.23830037849285, 3.4999999999999996, 4.396882959222102]
       },
       "material": "mat-15",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "1.500 + 2.000 * smoothstep(78.10, 78.80, t)"
-        }
-      ],
       "collection": "station-6"
     },
     {
@@ -2706,12 +2436,6 @@
         "translate": [74.23830037849285, 3.7199999999999998, 4.396882959222102]
       },
       "material": "mat-15",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "1.720 + 2.000 * smoothstep(78.10, 78.80, t)"
-        }
-      ],
       "collection": "station-6"
     },
     {
@@ -2724,12 +2448,6 @@
         "translate": [74.23830037849285, 3.9399999999999995, 4.396882959222102]
       },
       "material": "mat-15",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "1.940 + 2.000 * smoothstep(78.10, 78.80, t)"
-        }
-      ],
       "collection": "station-6"
     },
     {
@@ -2742,12 +2460,6 @@
         "translate": [74.23830037849285, 4.159999999999999, 4.396882959222102]
       },
       "material": "mat-15",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "2.160 + 2.000 * smoothstep(78.10, 78.80, t)"
-        }
-      ],
       "collection": "station-6"
     },
     {
@@ -3108,12 +2820,6 @@
         "translate": [-39.65425698760238, 0.06, -52.14819290743584]
       },
       "material": "mat-6",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "-0.360 + 0.420 * smoothstep(146.75, 147.35, t)"
-        }
-      ],
       "pattern": "cracked",
       "collection": "station-14"
     },
@@ -3140,12 +2846,6 @@
         "translate": [-40.92425698760238, 0.1945945945945946, -52.14819290743584]
       },
       "material": "mat-7",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "-0.495 + 0.689 * smoothstep(147.85, 148.45, t)"
-        }
-      ],
       "pattern": "cracked",
       "collection": "station-14"
     },
@@ -3172,12 +2872,6 @@
         "translate": [-42.19425698760238, 0.5837837837837838, -52.14819290743584]
       },
       "material": "mat-8",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "-0.884 + 1.468 * smoothstep(148.95, 149.55, t)"
-        }
-      ],
       "pattern": "cracked",
       "collection": "station-14"
     },
@@ -3204,12 +2898,6 @@
         "translate": [-43.464256987602376, 1.1027027027027028, -52.14819290743584]
       },
       "material": "mat-9",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "-1.403 + 2.505 * smoothstep(150.05, 150.65, t)"
-        }
-      ],
       "pattern": "cracked",
       "collection": "station-14"
     },
@@ -3236,12 +2924,6 @@
         "translate": [-44.73425698760238, 1.945945945945946, -52.14819290743584]
       },
       "material": "mat-10",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "-2.246 + 4.192 * smoothstep(151.15, 151.75, t)"
-        }
-      ],
       "pattern": "cracked",
       "collection": "station-14"
     },
@@ -3268,12 +2950,6 @@
         "translate": [-46.004256987602375, 2.4, -52.14819290743584]
       },
       "material": "mat-11",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "-2.700 + 5.100 * smoothstep(152.25, 152.85, t)"
-        }
-      ],
       "collection": "station-14"
     },
     {
@@ -3379,12 +3055,6 @@
         "translate": [-50.06990201163957, 2.4, -40.62924361635775]
       },
       "material": "mat-6",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "-2.700 + 5.100 * smoothstep(160.05, 160.65, t)"
-        }
-      ],
       "pattern": "cracked",
       "collection": "station-15"
     },
@@ -3411,12 +3081,6 @@
         "translate": [-51.33990201163957, 2.3564356435643563, -40.62924361635775]
       },
       "material": "mat-18",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "-2.656 + 5.013 * smoothstep(161.15, 161.75, t)"
-        }
-      ],
       "pattern": "cracked",
       "collection": "station-15"
     },
@@ -3443,12 +3107,6 @@
         "translate": [-52.60990201163957, 2.2376237623762374, -40.62924361635775]
       },
       "material": "mat-19",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "-2.538 + 4.775 * smoothstep(162.25, 162.85, t)"
-        }
-      ],
       "pattern": "cracked",
       "collection": "station-15"
     },
@@ -3475,12 +3133,6 @@
         "translate": [-53.87990201163957, 2.1425742574257423, -40.62924361635775]
       },
       "material": "mat-20",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "-2.443 + 4.585 * smoothstep(163.35, 163.95, t)"
-        }
-      ],
       "pattern": "cracked",
       "collection": "station-15"
     },
@@ -3507,12 +3159,6 @@
         "translate": [-55.149902011639576, 2.023762376237624, -40.62924361635775]
       },
       "material": "mat-21",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "-2.324 + 4.348 * smoothstep(164.45, 165.05, t)"
-        }
-      ],
       "pattern": "cracked",
       "collection": "station-15"
     },
@@ -3539,12 +3185,6 @@
         "translate": [-56.41990201163957, 1.881188118811881, -40.62924361635775]
       },
       "material": "mat-22",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "-2.181 + 4.062 * smoothstep(165.55, 166.15, t)"
-        }
-      ],
       "pattern": "cracked",
       "collection": "station-15"
     },
@@ -3571,12 +3211,6 @@
         "translate": [-57.689902011639575, 1.786138613861386, -40.62924361635775]
       },
       "material": "mat-11",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "-2.086 + 3.872 * smoothstep(166.65, 167.25, t)"
-        }
-      ],
       "collection": "station-15"
     },
     {
@@ -3671,12 +3305,6 @@
         "rotate": [0, 0, 1.5707963267948966]
       },
       "material": "mat-2",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "3.700 - 0.000 * smoothstep(172.80, 173.80, t) + 0.07 * sin(0.35 * t + -59.38)"
-        }
-      ],
       "collection": "station-16"
     },
     {
@@ -3689,12 +3317,6 @@
         "translate": [-62.218894650180104, 6.717749959911059, -28.03691864627405]
       },
       "material": "mat-4",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "8.018 - 1.300 * smoothstep(174.65, 175.20, t) + 0.04 * sin(0.6 * t + -103.68)"
-        }
-      ],
       "collection": "station-16"
     },
     {
@@ -3707,12 +3329,6 @@
         "translate": [-64.18334507974913, 5.003591609722465, -28.03691864627405]
       },
       "material": "mat-3",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "6.304 - 1.300 * smoothstep(175.65, 176.20, t) + 0.04 * sin(0.6 * t + -101.98)"
-        }
-      ],
       "collection": "station-16"
     },
     {
@@ -3725,12 +3341,6 @@
         "translate": [-64.18334507974913, 2.3964083902775357, -28.03691864627405]
       },
       "material": "mat-3",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "3.696 - 1.300 * smoothstep(176.65, 177.20, t) + 0.04 * sin(0.6 * t + -100.28)"
-        }
-      ],
       "collection": "station-16"
     },
     {
@@ -3743,12 +3353,6 @@
         "translate": [-62.218894650180104, 0.6822500400889417, -28.03691864627405]
       },
       "material": "mat-3",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "1.982 - 1.300 * smoothstep(177.65, 178.20, t) + 0.04 * sin(0.6 * t + -98.58)"
-        }
-      ],
       "collection": "station-16"
     },
     {
@@ -3781,12 +3385,6 @@
         "translate": [-67.14440524909041, 8.240083449326644, -11.753228582027454]
       },
       "material": "mat-23",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "9.340 - 1.1 * smoothstep(183.25, 183.75, t) + 0.018 * sin(1.3 * t + -237.90)"
-        }
-      ],
       "collection": "station-17"
     },
     {
@@ -3799,12 +3397,6 @@
         "translate": [-69.05104567679271, 6.556638433341682, -11.140020676369602]
       },
       "material": "mat-24",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "7.657 - 1.1 * smoothstep(183.37, 183.87, t) + 0.018 * sin(1.3 * t + -235.80)"
-        }
-      ],
       "collection": "station-17"
     },
     {
@@ -3817,12 +3409,6 @@
         "translate": [-67.69686716905743, 5.410462203579505, -13.619947371853245]
       },
       "material": "mat-24",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "6.510 - 1.1 * smoothstep(183.49, 183.99, t) + 0.018 * sin(1.3 * t + -233.70)"
-        }
-      ],
       "collection": "station-17"
     },
     {
@@ -3835,12 +3421,6 @@
         "translate": [-66.48713741517813, 4.034705367679379, -11.542956118622739]
       },
       "material": "mat-25",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "5.135 - 1.1 * smoothstep(183.61, 184.11, t) + 0.018 * sin(1.3 * t + -231.60)"
-        }
-      ],
       "collection": "station-17"
     },
     {
@@ -3853,12 +3433,6 @@
         "translate": [-69.61415489211042, 3.0535128331174013, -11.66771069729212]
       },
       "material": "mat-11",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "4.154 - 1.1 * smoothstep(183.73, 184.23, t) + 0.018 * sin(1.3 * t + -229.50)"
-        }
-      ],
       "collection": "station-17"
     },
     {
@@ -3871,12 +3445,6 @@
         "translate": [-64.83020550910504, 2.3752519777557772, -13.03639980567093]
       },
       "material": "mat-24",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "3.475 - 1.1 * smoothstep(183.85, 184.35, t) + 0.018 * sin(1.3 * t + -227.40)"
-        }
-      ],
       "collection": "station-17"
     },
     {
@@ -3889,12 +3457,6 @@
         "translate": [-68.60590814964672, 1.4770305268093469, -9.79001282612937]
       },
       "material": "mat-24",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "2.577 - 1.1 * smoothstep(183.97, 184.47, t) + 0.018 * sin(1.3 * t + -225.30)"
-        }
-      ],
       "collection": "station-17"
     },
     {
@@ -3907,12 +3469,6 @@
         "translate": [-66.98718168144276, 0.6000000000000001, -12.161201662556477]
       },
       "material": "mat-24",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "1.700 - 1.1 * smoothstep(184.09, 184.59, t) + 0.018 * sin(1.3 * t + -223.20)"
-        }
-      ],
       "collection": "station-17"
     },
     {
@@ -3927,12 +3483,6 @@
         "translate": [-67.14440524909041, 8.240083449326644, -11.753228582027454]
       },
       "material": "mat-26",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "9.340 - 1.1 * smoothstep(184.41, 184.86, t)"
-        }
-      ],
       "collection": "station-17"
     },
     {
@@ -3947,12 +3497,6 @@
         "translate": [-69.05104567679271, 6.556638433341682, -11.140020676369602]
       },
       "material": "mat-26",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "7.657 - 1.1 * smoothstep(184.55, 185.00, t)"
-        }
-      ],
       "collection": "station-17"
     },
     {
@@ -3967,12 +3511,6 @@
         "translate": [-67.69686716905743, 5.410462203579505, -13.619947371853245]
       },
       "material": "mat-26",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "6.510 - 1.1 * smoothstep(184.69, 185.14, t)"
-        }
-      ],
       "collection": "station-17"
     },
     {
@@ -3987,12 +3525,6 @@
         "translate": [-66.48713741517813, 4.034705367679379, -11.542956118622739]
       },
       "material": "mat-26",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "5.135 - 1.1 * smoothstep(184.83, 185.28, t)"
-        }
-      ],
       "collection": "station-17"
     },
     {
@@ -4007,12 +3539,6 @@
         "translate": [-69.61415489211042, 3.0535128331174013, -11.66771069729212]
       },
       "material": "mat-26",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "4.154 - 1.1 * smoothstep(184.97, 185.42, t)"
-        }
-      ],
       "collection": "station-17"
     },
     {
@@ -4027,12 +3553,6 @@
         "translate": [-68.60590814964672, 1.4770305268093469, -9.79001282612937]
       },
       "material": "mat-26",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "2.577 - 1.1 * smoothstep(185.11, 185.56, t)"
-        }
-      ],
       "collection": "station-17"
     },
     {
@@ -4047,12 +3567,6 @@
         "translate": [-66.98718168144276, 0.6000000000000001, -12.161201662556477]
       },
       "material": "mat-26",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "1.700 - 1.1 * smoothstep(185.25, 185.70, t)"
-        }
-      ],
       "collection": "station-17"
     },
     {
@@ -4067,12 +3581,6 @@
         "translate": [-64.83020550910504, 2.3752519777557772, -13.03639980567093]
       },
       "material": "mat-26",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "3.475 - 1.1 * smoothstep(185.39, 185.84, t)"
-        }
-      ],
       "collection": "station-17"
     },
     {
@@ -4086,12 +3594,6 @@
         "rotate": [0, 0, 0]
       },
       "material": "mat-27",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "4.405 - 0.000 * smoothstep(183.00, 184.00, t) + 0.05 * sin(0.30 * t + -54.90)"
-        }
-      ],
       "collection": "station-17"
     },
     {
@@ -4105,12 +3607,6 @@
         "rotate": [0, 0.9, 0]
       },
       "material": "mat-27",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "4.400 - 0.000 * smoothstep(183.00, 184.00, t) + 0.07 * sin(0.35 * t + -62.75)"
-        }
-      ],
       "collection": "station-17"
     },
     {
@@ -4124,12 +3620,6 @@
         "rotate": [0, 1.8, 0]
       },
       "material": "mat-27",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "3.630 - 0.000 * smoothstep(183.00, 184.00, t) + 0.09 * sin(0.40 * t + -70.60)"
-        }
-      ],
       "collection": "station-17"
     },
     {
@@ -4143,12 +3633,6 @@
         "rotate": [0, 2.7, 0]
       },
       "material": "mat-27",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "4.223 - 0.000 * smoothstep(183.00, 184.00, t) + 0.05 * sin(0.45 * t + -78.45)"
-        }
-      ],
       "collection": "station-17"
     },
     {
@@ -4162,12 +3646,6 @@
         "rotate": [0, 0.5, 0]
       },
       "material": "mat-27",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "3.084 - 0.000 * smoothstep(183.00, 184.00, t) + 0.07 * sin(0.50 * t + -86.30)"
-        }
-      ],
       "collection": "station-17"
     },
     {
@@ -4181,12 +3659,6 @@
         "rotate": [0, 1.4, 0]
       },
       "material": "mat-27",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "3.818 - 0.000 * smoothstep(183.00, 184.00, t) + 0.09 * sin(0.30 * t + -54.68)"
-        }
-      ],
       "collection": "station-17"
     },
     {
@@ -4200,12 +3672,6 @@
         "rotate": [0, 2.3000000000000003, 0]
       },
       "material": "mat-27",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "2.743 - 0.000 * smoothstep(183.00, 184.00, t) + 0.05 * sin(0.35 * t + -62.53)"
-        }
-      ],
       "collection": "station-17"
     },
     {
@@ -4219,12 +3685,6 @@
         "rotate": [0, 0.09999999999999964, 0]
       },
       "material": "mat-27",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "3.248 - 0.000 * smoothstep(183.00, 184.00, t) + 0.07 * sin(0.40 * t + -70.38)"
-        }
-      ],
       "collection": "station-17"
     },
     {
@@ -4238,12 +3698,6 @@
         "rotate": [0, 1, 0]
       },
       "material": "mat-27",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "2.515 - 0.000 * smoothstep(183.00, 184.00, t) + 0.09 * sin(0.45 * t + -78.23)"
-        }
-      ],
       "collection": "station-17"
     },
     {
@@ -4257,12 +3711,6 @@
         "rotate": [0, 1.8999999999999995, 0]
       },
       "material": "mat-27",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "2.626 - 0.000 * smoothstep(183.00, 184.00, t) + 0.05 * sin(0.50 * t + -86.08)"
-        }
-      ],
       "collection": "station-17"
     },
     {
@@ -4276,12 +3724,6 @@
         "rotate": [0, 2.8, 0]
       },
       "material": "mat-27",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "2.275 - 0.000 * smoothstep(183.00, 184.00, t) + 0.07 * sin(0.30 * t + -54.46)"
-        }
-      ],
       "collection": "station-17"
     },
     {
@@ -4295,12 +3737,6 @@
         "rotate": [0, 0.6000000000000001, 0]
       },
       "material": "mat-27",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "2.074 - 0.000 * smoothstep(183.00, 184.00, t) + 0.09 * sin(0.35 * t + -62.31)"
-        }
-      ],
       "collection": "station-17"
     },
     {
@@ -4314,12 +3750,6 @@
         "rotate": [0, 1.5000000000000004, 0]
       },
       "material": "mat-27",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "1.917 - 0.000 * smoothstep(183.00, 184.00, t) + 0.05 * sin(0.40 * t + -70.16)"
-        }
-      ],
       "collection": "station-17"
     },
     {
@@ -4333,12 +3763,6 @@
         "rotate": [0, 2.400000000000001, 0]
       },
       "material": "mat-27",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "1.675 - 0.000 * smoothstep(183.00, 184.00, t) + 0.07 * sin(0.45 * t + -78.01)"
-        }
-      ],
       "collection": "station-17"
     },
     {
@@ -4352,12 +3776,6 @@
         "rotate": [0, 0.1999999999999993, 0]
       },
       "material": "mat-27",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "1.390 - 0.000 * smoothstep(183.00, 184.00, t) + 0.09 * sin(0.50 * t + -85.86)"
-        }
-      ],
       "collection": "station-17"
     },
     {
@@ -4371,12 +3789,6 @@
         "rotate": [0, 1.0999999999999996, 0]
       },
       "material": "mat-27",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "1.443 - 0.000 * smoothstep(183.00, 184.00, t) + 0.05 * sin(0.30 * t + -54.24)"
-        }
-      ],
       "collection": "station-17"
     },
     {
@@ -4390,12 +3802,6 @@
         "rotate": [0, 2, 0]
       },
       "material": "mat-27",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "0.717 - 0.000 * smoothstep(183.00, 184.00, t) + 0.07 * sin(0.35 * t + -62.09)"
-        }
-      ],
       "collection": "station-17"
     },
     {
@@ -4409,12 +3815,6 @@
         "rotate": [0, 2.9000000000000004, 0]
       },
       "material": "mat-27",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "1.316 - 0.000 * smoothstep(183.00, 184.00, t) + 0.09 * sin(0.40 * t + -69.94)"
-        }
-      ],
       "collection": "station-17"
     },
     {
@@ -4428,12 +3828,6 @@
         "rotate": [0, 0.6999999999999988, 0]
       },
       "material": "mat-27",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "-0.006 - 0.000 * smoothstep(183.00, 184.00, t) + 0.05 * sin(0.45 * t + -77.79)"
-        }
-      ],
       "collection": "station-17"
     },
     {
@@ -4447,12 +3841,6 @@
         "rotate": [0, 1.600000000000001, 0]
       },
       "material": "mat-27",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "1.174 - 0.000 * smoothstep(183.00, 184.00, t) + 0.07 * sin(0.50 * t + -85.64)"
-        }
-      ],
       "collection": "station-17"
     },
     {
@@ -4466,12 +3854,6 @@
         "rotate": [0, 2.4999999999999996, 0]
       },
       "material": "mat-27",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "-0.644 - 0.000 * smoothstep(183.00, 184.00, t) + 0.09 * sin(0.30 * t + -54.02)"
-        }
-      ],
       "collection": "station-17"
     },
     {
@@ -4485,12 +3867,6 @@
         "rotate": [0, 0.3000000000000016, 0]
       },
       "material": "mat-27",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "0.879 - 0.000 * smoothstep(183.00, 184.00, t) + 0.05 * sin(0.35 * t + -61.87)"
-        }
-      ],
       "collection": "station-17"
     },
     {
@@ -4622,12 +3998,6 @@
         "translate": [-49.24676840288956, 3.15, 46.13604967369212]
       },
       "material": "mat-28",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "4.150 - 1 * smoothstep(212.15, 212.70, t)"
-        }
-      ],
       "collection": "station-20"
     },
     {
@@ -4661,12 +4031,6 @@
         "translate": [-49.24676840288956, 2, 44.23604967369212]
       },
       "material": "mat-29",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "3.000 - 1 * smoothstep(213.65, 214.20, t)"
-        }
-      ],
       "collection": "station-20"
     },
     {
@@ -4700,12 +4064,6 @@
         "translate": [-47.601320135699126, 2, 47.08604967369212]
       },
       "material": "mat-29",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "3.000 - 1 * smoothstep(213.65, 214.20, t)"
-        }
-      ],
       "collection": "station-20"
     },
     {
@@ -4739,12 +4097,6 @@
         "translate": [-50.89221667007999, 2, 47.08604967369212]
       },
       "material": "mat-29",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "3.000 - 1 * smoothstep(213.65, 214.20, t)"
-        }
-      ],
       "collection": "station-20"
     },
     {
@@ -4778,12 +4130,6 @@
         "translate": [-48.10387652640919, 0.8500000000000001, 47.7777592038827]
       },
       "material": "mat-30",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "1.850 - 1 * smoothstep(215.15, 215.70, t)"
-        }
-      ],
       "collection": "station-20"
     },
     {
@@ -4882,12 +4228,6 @@
         "translate": [-36.122273056211235, 3.2199999999999998, 56.75267614562741]
       },
       "material": "mat-33",
-      "animation": [
-        {
-          "channel": "transform.translate.z",
-          "expr": "58.813 - 2.060 * smoothstep(223.05, 223.50, t)"
-        }
-      ],
       "collection": "station-21"
     },
     {
@@ -4901,12 +4241,6 @@
         "translate": [-36.122273056211235, 1.7999999999999998, 56.75267614562741]
       },
       "material": "mat-33",
-      "animation": [
-        {
-          "channel": "transform.translate.z",
-          "expr": "58.813 - 2.060 * smoothstep(223.95, 224.40, t)"
-        }
-      ],
       "collection": "station-21"
     },
     {
@@ -4920,12 +4254,6 @@
         "translate": [-37.94227305621123, 3.2199999999999998, 56.75267614562741]
       },
       "material": "mat-33",
-      "animation": [
-        {
-          "channel": "transform.translate.z",
-          "expr": "58.813 - 2.060 * smoothstep(224.85, 225.30, t)"
-        }
-      ],
       "collection": "station-21"
     },
     {
@@ -4939,12 +4267,6 @@
         "translate": [-37.94227305621123, 1.7999999999999998, 56.75267614562741]
       },
       "material": "mat-4",
-      "animation": [
-        {
-          "channel": "transform.translate.z",
-          "expr": "58.813 - 2.060 * smoothstep(225.75, 226.20, t)"
-        }
-      ],
       "collection": "station-21"
     },
     {
@@ -4958,12 +4280,6 @@
         "rotate": [0, -0.9, 0]
       },
       "material": "mat-12",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "3.310 - 0.000 * smoothstep(221.80, 222.80, t) + 0.06 * sin(0.30 * t + -66.54)"
-        }
-      ],
       "collection": "station-21"
     },
     {
@@ -4977,12 +4293,6 @@
         "rotate": [0, -0.4, 0]
       },
       "material": "mat-12",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "2.110 - 0.000 * smoothstep(221.80, 222.80, t) + 0.08 * sin(0.37 * t + -79.87)"
-        }
-      ],
       "collection": "station-21"
     },
     {
@@ -4996,12 +4306,6 @@
         "rotate": [0, 0.09999999999999998, 0]
       },
       "material": "mat-12",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "4.710 - 0.000 * smoothstep(221.80, 222.80, t) + 0.10 * sin(0.44 * t + -93.19)"
-        }
-      ],
       "collection": "station-21"
     },
     {
@@ -5015,12 +4319,6 @@
         "rotate": [0, 0.6, 0]
       },
       "material": "mat-12",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "4.110 - 0.000 * smoothstep(221.80, 222.80, t) + 0.12 * sin(0.51 * t + -112.80)"
-        }
-      ],
       "collection": "station-21"
     },
     {
@@ -5066,12 +4364,6 @@
         "translate": [-21.47566753935023, 0.24, 63.53277804260237]
       },
       "material": "mat-6",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "-0.540 + 0.780 * smoothstep(232.95, 233.55, t)"
-        }
-      ],
       "pattern": "cracked",
       "collection": "station-22"
     },
@@ -5098,12 +4390,6 @@
         "translate": [-22.74566753935023, 1.2, 63.53277804260237]
       },
       "material": "mat-20",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "-1.500 + 2.700 * smoothstep(234.05, 234.65, t)"
-        }
-      ],
       "pattern": "cracked",
       "collection": "station-22"
     },
@@ -5130,12 +4416,6 @@
         "translate": [-24.01566753935023, 2.4, 63.53277804260237]
       },
       "material": "mat-11",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "-2.700 + 5.100 * smoothstep(235.15, 235.75, t)"
-        }
-      ],
       "collection": "station-22"
     },
     {
@@ -5832,6 +5112,7 @@
       "text": "① 即将爆发的个性化数字媒体市场",
       "anchor": [6.883194122054976, 6.717749959911059, 65.89795595956114],
       "role": "screen",
+      "side": "right",
       "revealAt": 12.25,
       "hideAt": 20.8
     },
@@ -5846,6 +5127,7 @@
       "text": "② 独创的个性化资讯发现引擎",
       "anchor": [5.52054729687729, 5.888298781822307, 65.89795595956114],
       "role": "screen",
+      "side": "right",
       "revealAt": 13.25,
       "hideAt": 20.8
     },
@@ -5860,6 +5142,7 @@
       "text": "③ 领先于世界同类产品的功能和技术",
       "anchor": [4.739003747950957, 4.497620778785201, 65.89795595956114],
       "role": "screen",
+      "side": "right",
       "revealAt": 14.25,
       "hideAt": 20.8
     },
@@ -5874,6 +5157,7 @@
       "text": "④ 行业领先的用户粘度和自然增长",
       "anchor": [4.739003747950957, 2.902379221214799, 65.89795595956114],
       "role": "screen",
+      "side": "right",
       "revealAt": 15.25,
       "hideAt": 20.8
     },
@@ -5888,6 +5172,7 @@
       "text": "⑤ 完善的多产品布局,覆盖移动终端和 PC 端",
       "anchor": [5.52054729687729, 1.5117012181776928, 65.89795595956114],
       "role": "screen",
+      "side": "right",
       "revealAt": 16.25,
       "hideAt": 20.8
     },
@@ -5902,6 +5187,7 @@
       "text": "⑥ 具有丰富创业经验和技术功底的团队",
       "anchor": [6.883194122054976, 0.6822500400889417, 65.89795595956114],
       "role": "screen",
+      "side": "right",
       "revealAt": 17.25,
       "hideAt": 20.8
     },
@@ -6387,6 +5673,7 @@
       "text": "编辑挑选·连续阅读",
       "anchor": [70.93830037849284, 0.19999999999999996, 4.896882959222102],
       "role": "screen",
+      "side": "left",
       "revealAt": 76.70000000000002,
       "hideAt": 85.70000000000002
     },
@@ -6394,6 +5681,7 @@
       "text": "浏览/搜索/媒体转载",
       "anchor": [67.33830037849285, 0.19999999999999996, 4.896882959222102],
       "role": "screen",
+      "side": "left",
       "revealAt": 76.9,
       "hideAt": 85.70000000000002
     },
@@ -6401,6 +5689,7 @@
       "text": "PC",
       "anchor": [63.738300378492845, 0.19999999999999996, 4.896882959222102],
       "role": "screen",
+      "side": "left",
       "revealAt": 77.10000000000001,
       "hideAt": 85.70000000000002
     },
@@ -6408,6 +5697,7 @@
       "text": "个性化·社交化·碎片阅读",
       "anchor": [70.93830037849284, 5.3, 4.796882959222103],
       "role": "screen",
+      "side": "right",
       "revealAt": 80.05000000000001,
       "hideAt": 85.70000000000002
     },
@@ -6415,6 +5705,7 @@
       "text": "关注/推荐/转发",
       "anchor": [67.33830037849285, 5.3, 4.796882959222103],
       "role": "screen",
+      "side": "right",
       "revealAt": 81.15,
       "hideAt": 85.70000000000002
     },
@@ -6422,6 +5713,7 @@
       "text": "移动终端",
       "anchor": [63.738300378492845, 5.3, 4.796882959222103],
       "role": "screen",
+      "side": "right",
       "revealAt": 82.25000000000001,
       "hideAt": 85.70000000000002
     },
@@ -6794,6 +6086,7 @@
       "text": "① 独创的数据处理和推荐技术底框架",
       "anchor": [-62.218894650180104, 6.717749959911059, -28.03691864627405],
       "role": "screen",
+      "side": "right",
       "revealAt": 175.24999999999994,
       "hideAt": 181.79999999999995
     },
@@ -6808,6 +6101,7 @@
       "text": "② 自然语言、多媒体信息处理",
       "anchor": [-64.18334507974913, 5.003591609722465, -28.03691864627405],
       "role": "screen",
+      "side": "right",
       "revealAt": 176.24999999999994,
       "hideAt": 181.79999999999995
     },
@@ -6822,6 +6116,7 @@
       "text": "③ 高维度用户兴趣建模",
       "anchor": [-64.18334507974913, 2.3964083902775357, -28.03691864627405],
       "role": "screen",
+      "side": "right",
       "revealAt": 177.24999999999994,
       "hideAt": 181.79999999999995
     },
@@ -6836,6 +6131,7 @@
       "text": "④ 高性能的实时大规模数据运算",
       "anchor": [-62.218894650180104, 0.6822500400889417, -28.03691864627405],
       "role": "screen",
+      "side": "right",
       "revealAt": 178.24999999999994,
       "hideAt": 181.79999999999995
     },
@@ -7048,6 +6344,7 @@
       "text": "扩充信息类型和来源",
       "anchor": [-36.122273056211235, 2.88, 56.61267614562741],
       "role": "screen",
+      "side": "left",
       "align": "center",
       "revealAt": 223.54999999999993,
       "hideAt": 230.09999999999994
@@ -7056,6 +6353,7 @@
       "text": "深挖用户特征·升级推荐系统",
       "anchor": [-36.122273056211235, 1.4599999999999997, 56.61267614562741],
       "role": "screen",
+      "side": "left",
       "align": "center",
       "revealAt": 224.44999999999993,
       "hideAt": 230.09999999999994
@@ -7064,6 +6362,7 @@
       "text": "强化社区互动",
       "anchor": [-37.94227305621123, 2.88, 56.61267614562741],
       "role": "screen",
+      "side": "right",
       "align": "center",
       "revealAt": 225.34999999999994,
       "hideAt": 230.09999999999994
@@ -7072,6 +6371,7 @@
       "text": "国际化与商业化尝试",
       "anchor": [-37.94227305621123, 1.4599999999999997, 56.61267614562741],
       "role": "screen",
+      "side": "right",
       "align": "center",
       "revealAt": 226.24999999999991,
       "hideAt": 230.09999999999994

--- a/sdf-js/fixtures/golden/assemble-deck-grid.json
+++ b/sdf-js/fixtures/golden/assemble-deck-grid.json
@@ -1137,12 +1137,6 @@
         "rotate": [0, -1, 0]
       },
       "material": "mat-0",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "3.400 - 0.000 * smoothstep(0.00, 1.00, t) + 0.07 * sin(0.35 * t + 0.00)"
-        }
-      ],
       "collection": "station-0"
     },
     {
@@ -1157,12 +1151,6 @@
         "rotate": [0, -0.5, 0]
       },
       "material": "mat-0",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "2.600 - 0.000 * smoothstep(0.00, 1.00, t) + 0.09 * sin(0.43 * t + 2.10)"
-        }
-      ],
       "collection": "station-0"
     },
     {
@@ -1177,12 +1165,6 @@
         "rotate": [0, 0, 0]
       },
       "material": "mat-0",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "4.600 - 0.000 * smoothstep(0.00, 1.00, t) + 0.11 * sin(0.51 * t + 4.20)"
-        }
-      ],
       "collection": "station-0"
     },
     {
@@ -1197,12 +1179,6 @@
         "rotate": [0, 0.5, 0]
       },
       "material": "mat-0",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "4.000 - 0.000 * smoothstep(0.00, 1.00, t) + 0.13 * sin(0.59 * t + 0.02)"
-        }
-      ],
       "collection": "station-0"
     },
     {
@@ -1217,12 +1193,6 @@
         "rotate": [0, 1, 0]
       },
       "material": "mat-0",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "5.800 - 0.000 * smoothstep(0.00, 1.00, t) + 0.15 * sin(0.67 * t + 2.12)"
-        }
-      ],
       "collection": "station-0"
     },
     {
@@ -1237,12 +1207,6 @@
         "rotate": [0, 1.5, 0]
       },
       "material": "mat-0",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "5.200 - 0.000 * smoothstep(0.00, 1.00, t) + 0.17 * sin(0.75 * t + 4.22)"
-        }
-      ],
       "collection": "station-0"
     },
     {
@@ -1257,12 +1221,6 @@
         "rotate": [0, 2, 0]
       },
       "material": "mat-0",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "7.000 - 0.000 * smoothstep(0.00, 1.00, t) + 0.19 * sin(0.83 * t + 0.04)"
-        }
-      ],
       "collection": "station-0"
     },
     {
@@ -1277,12 +1235,6 @@
         "rotate": [0, 2.5, 0]
       },
       "material": "mat-0",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "6.400 - 0.000 * smoothstep(0.00, 1.00, t) + 0.21 * sin(0.91 * t + 2.14)"
-        }
-      ],
       "collection": "station-0"
     },
     {
@@ -1297,12 +1249,6 @@
         "rotate": [0, 3, 0]
       },
       "material": "mat-0",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "2.000 - 0.000 * smoothstep(0.00, 1.00, t) + 0.23 * sin(0.99 * t + 4.24)"
-        }
-      ],
       "collection": "station-0"
     },
     {
@@ -1337,12 +1283,6 @@
         "rotate": [0, 0, 1.5707963267948966]
       },
       "material": "mat-2",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "3.700 - 0.000 * smoothstep(7.60, 8.60, t) + 0.07 * sin(0.35 * t + -1.56)"
-        }
-      ],
       "collection": "station-1"
     },
     {
@@ -1355,12 +1295,6 @@
         "translate": [15.69684708965934, 6.717749959911059, -1.2]
       },
       "material": "mat-3",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "8.018 - 1.300 * smoothstep(9.45, 10.00, t) + 0.04 * sin(0.6 * t + -4.56)"
-        }
-      ],
       "collection": "station-1"
     },
     {
@@ -1373,12 +1307,6 @@
         "translate": [14.334200264481655, 5.888298781822307, -1.2]
       },
       "material": "mat-4",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "7.188 - 1.300 * smoothstep(10.45, 11.00, t) + 0.04 * sin(0.6 * t + -2.86)"
-        }
-      ],
       "collection": "station-1"
     },
     {
@@ -1391,12 +1319,6 @@
         "translate": [13.55265671555532, 4.497620778785201, -1.2]
       },
       "material": "mat-3",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "5.798 - 1.300 * smoothstep(11.45, 12.00, t) + 0.04 * sin(0.6 * t + -1.16)"
-        }
-      ],
       "collection": "station-1"
     },
     {
@@ -1409,12 +1331,6 @@
         "translate": [13.55265671555532, 2.902379221214799, -1.2]
       },
       "material": "mat-3",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "4.202 - 1.300 * smoothstep(12.45, 13.00, t) + 0.04 * sin(0.6 * t + 0.54)"
-        }
-      ],
       "collection": "station-1"
     },
     {
@@ -1427,12 +1343,6 @@
         "translate": [14.334200264481655, 1.5117012181776928, -1.2]
       },
       "material": "mat-3",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "2.812 - 1.300 * smoothstep(13.45, 14.00, t) + 0.04 * sin(0.6 * t + -4.04)"
-        }
-      ],
       "collection": "station-1"
     },
     {
@@ -1445,12 +1355,6 @@
         "translate": [15.69684708965934, 0.6822500400889417, -1.2]
       },
       "material": "mat-3",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "1.982 - 1.300 * smoothstep(14.45, 15.00, t) + 0.04 * sin(0.6 * t + -2.34)"
-        }
-      ],
       "collection": "station-1"
     },
     {
@@ -1496,12 +1400,6 @@
         "translate": [35.175, 0.9931034482758622, 0]
       },
       "material": "mat-6",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "-1.293 + 2.286 * smoothstep(21.45, 22.05, t)"
-        }
-      ],
       "pattern": "cracked",
       "collection": "station-2"
     },
@@ -1528,12 +1426,6 @@
         "translate": [33.905, 1.2413793103448276, 0]
       },
       "material": "mat-7",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "-1.541 + 2.783 * smoothstep(22.55, 23.15, t)"
-        }
-      ],
       "pattern": "cracked",
       "collection": "station-2"
     },
@@ -1560,12 +1452,6 @@
         "translate": [32.635, 1.6, 0]
       },
       "material": "mat-8",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "-1.900 + 3.500 * smoothstep(23.65, 24.25, t)"
-        }
-      ],
       "pattern": "cracked",
       "collection": "station-2"
     },
@@ -1592,12 +1478,6 @@
         "translate": [31.365, 1.9034482758620692, 0]
       },
       "material": "mat-9",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "-2.203 + 4.107 * smoothstep(24.75, 25.35, t)"
-        }
-      ],
       "pattern": "cracked",
       "collection": "station-2"
     },
@@ -1624,12 +1504,6 @@
         "translate": [30.095, 2.1517241379310343, 0]
       },
       "material": "mat-10",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "-2.452 + 4.603 * smoothstep(25.85, 26.45, t)"
-        }
-      ],
       "pattern": "cracked",
       "collection": "station-2"
     },
@@ -1656,12 +1530,6 @@
         "translate": [28.825, 2.4, 0]
       },
       "material": "mat-11",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "-2.700 + 5.100 * smoothstep(26.95, 27.55, t)"
-        }
-      ],
       "collection": "station-2"
     },
     {
@@ -1767,12 +1635,6 @@
         "translate": [51.175, 0.14464710547184773, 0]
       },
       "material": "mat-6",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "-0.445 + 0.589 * smoothstep(34.75, 35.35, t)"
-        }
-      ],
       "pattern": "cracked",
       "collection": "station-3"
     },
@@ -1799,12 +1661,6 @@
         "translate": [49.905, 0.28263283108643933, 0]
       },
       "material": "mat-7",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "-0.583 + 0.865 * smoothstep(35.85, 36.45, t)"
-        }
-      ],
       "pattern": "cracked",
       "collection": "station-3"
     },
@@ -1831,12 +1687,6 @@
         "translate": [48.635, 0.5443298969072166, 0]
       },
       "material": "mat-8",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "-0.844 + 1.389 * smoothstep(36.95, 37.55, t)"
-        }
-      ],
       "pattern": "cracked",
       "collection": "station-3"
     },
@@ -1863,12 +1713,6 @@
         "translate": [47.365, 0.9601903251387788, 0]
       },
       "material": "mat-9",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "-1.260 + 2.220 * smoothstep(38.05, 38.65, t)"
-        }
-      ],
       "pattern": "cracked",
       "collection": "station-3"
     },
@@ -1895,12 +1739,6 @@
         "translate": [46.095, 1.5501982553528946, 0]
       },
       "material": "mat-10",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "-1.850 + 3.400 * smoothstep(39.15, 39.75, t)"
-        }
-      ],
       "pattern": "cracked",
       "collection": "station-3"
     },
@@ -1927,12 +1765,6 @@
         "translate": [44.825, 2.4, 0]
       },
       "material": "mat-11",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "-2.700 + 5.100 * smoothstep(40.25, 40.85, t)"
-        }
-      ],
       "collection": "station-3"
     },
     {
@@ -2038,12 +1870,6 @@
         "translate": [67.175, 2.4, 0]
       },
       "material": "mat-11",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "-2.700 + 5.100 * smoothstep(48.05, 48.65, t)"
-        }
-      ],
       "collection": "station-4"
     },
     {
@@ -2069,12 +1895,6 @@
         "translate": [65.905, 2.2374501992031868, 0]
       },
       "material": "mat-7",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "-2.537 + 4.775 * smoothstep(49.15, 49.75, t)"
-        }
-      ],
       "pattern": "cracked",
       "collection": "station-4"
     },
@@ -2101,12 +1921,6 @@
         "translate": [64.635, 1.4151394422310757, 0]
       },
       "material": "mat-8",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "-1.715 + 3.130 * smoothstep(50.25, 50.85, t)"
-        }
-      ],
       "pattern": "cracked",
       "collection": "station-4"
     },
@@ -2133,12 +1947,6 @@
         "translate": [63.365, 1.2430278884462151, 0]
       },
       "material": "mat-9",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "-1.543 + 2.786 * smoothstep(51.35, 51.95, t)"
-        }
-      ],
       "pattern": "cracked",
       "collection": "station-4"
     },
@@ -2165,12 +1973,6 @@
         "translate": [62.095, 0.7362549800796813, 0]
       },
       "material": "mat-10",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "-1.036 + 1.773 * smoothstep(52.45, 53.05, t)"
-        }
-      ],
       "pattern": "cracked",
       "collection": "station-4"
     },
@@ -2197,12 +1999,6 @@
         "translate": [60.825, 0.6501992031872509, 0]
       },
       "material": "mat-13",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "-0.950 + 1.600 * smoothstep(53.55, 54.15, t)"
-        }
-      ],
       "pattern": "cracked",
       "collection": "station-4"
     },
@@ -2309,12 +2105,6 @@
         "translate": [3.175, 2.4, -16]
       },
       "material": "mat-11",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "-2.700 + 5.100 * smoothstep(61.35, 61.95, t)"
-        }
-      ],
       "collection": "station-5"
     },
     {
@@ -2340,12 +2130,6 @@
         "translate": [1.905, 2.2072538860103625, -16]
       },
       "material": "mat-7",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "-2.507 + 4.715 * smoothstep(62.45, 63.05, t)"
-        }
-      ],
       "pattern": "cracked",
       "collection": "station-5"
     },
@@ -2372,12 +2156,6 @@
         "translate": [0.635, 1.5015544041450775, -16]
       },
       "material": "mat-8",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "-1.802 + 3.303 * smoothstep(63.55, 64.15, t)"
-        }
-      ],
       "pattern": "cracked",
       "collection": "station-5"
     },
@@ -2404,12 +2182,6 @@
         "translate": [-0.635, 1.2590673575129532, -16]
       },
       "material": "mat-9",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "-1.559 + 2.818 * smoothstep(64.65, 65.25, t)"
-        }
-      ],
       "pattern": "cracked",
       "collection": "station-5"
     },
@@ -2436,12 +2208,6 @@
         "translate": [-1.905, 1.0290155440414508, -16]
       },
       "material": "mat-10",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "-1.329 + 2.358 * smoothstep(65.75, 66.35, t)"
-        }
-      ],
       "pattern": "cracked",
       "collection": "station-5"
     },
@@ -2468,12 +2234,6 @@
         "translate": [-3.175, 0.9699481865284973, -16]
       },
       "material": "mat-13",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "-1.270 + 2.240 * smoothstep(66.85, 67.45, t)"
-        }
-      ],
       "pattern": "cracked",
       "collection": "station-5"
     },
@@ -2606,12 +2366,6 @@
         "translate": [19.6, 4.3, -16]
       },
       "material": "mat-14",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "0.950 + 3.350 * smoothstep(75.90, 76.65, t) + 0.05 * sin(0.5 * t + -36.50)"
-        }
-      ],
       "collection": "station-6"
     },
     {
@@ -2624,12 +2378,6 @@
         "translate": [16, 4.3, -16]
       },
       "material": "mat-3",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "0.950 + 3.350 * smoothstep(77.00, 77.75, t) + 0.05 * sin(0.5 * t + -34.40)"
-        }
-      ],
       "collection": "station-6"
     },
     {
@@ -2642,12 +2390,6 @@
         "translate": [12.4, 4.3, -16]
       },
       "material": "mat-3",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "0.950 + 3.350 * smoothstep(78.10, 78.85, t) + 0.05 * sin(0.5 * t + -32.30)"
-        }
-      ],
       "collection": "station-6"
     },
     {
@@ -2661,12 +2403,6 @@
         "translate": [22.9, 2.175, -16]
       },
       "material": "mat-15",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "0.175 + 2.000 * smoothstep(74.80, 75.50, t)"
-        }
-      ],
       "collection": "station-6"
     },
     {
@@ -2679,12 +2415,6 @@
         "translate": [22.9, 3.4999999999999996, -16]
       },
       "material": "mat-15",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "1.500 + 2.000 * smoothstep(74.80, 75.50, t)"
-        }
-      ],
       "collection": "station-6"
     },
     {
@@ -2697,12 +2427,6 @@
         "translate": [22.9, 3.7199999999999998, -16]
       },
       "material": "mat-15",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "1.720 + 2.000 * smoothstep(74.80, 75.50, t)"
-        }
-      ],
       "collection": "station-6"
     },
     {
@@ -2715,12 +2439,6 @@
         "translate": [22.9, 3.9399999999999995, -16]
       },
       "material": "mat-15",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "1.940 + 2.000 * smoothstep(74.80, 75.50, t)"
-        }
-      ],
       "collection": "station-6"
     },
     {
@@ -2733,12 +2451,6 @@
         "translate": [22.9, 4.159999999999999, -16]
       },
       "material": "mat-15",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "2.160 + 2.000 * smoothstep(74.80, 75.50, t)"
-        }
-      ],
       "collection": "station-6"
     },
     {
@@ -3099,12 +2811,6 @@
         "translate": [67.175, 0.06, -32]
       },
       "material": "mat-6",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "-0.360 + 0.420 * smoothstep(141.25, 141.85, t)"
-        }
-      ],
       "pattern": "cracked",
       "collection": "station-14"
     },
@@ -3131,12 +2837,6 @@
         "translate": [65.905, 0.1945945945945946, -32]
       },
       "material": "mat-7",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "-0.495 + 0.689 * smoothstep(142.35, 142.95, t)"
-        }
-      ],
       "pattern": "cracked",
       "collection": "station-14"
     },
@@ -3163,12 +2863,6 @@
         "translate": [64.635, 0.5837837837837838, -32]
       },
       "material": "mat-8",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "-0.884 + 1.468 * smoothstep(143.45, 144.05, t)"
-        }
-      ],
       "pattern": "cracked",
       "collection": "station-14"
     },
@@ -3195,12 +2889,6 @@
         "translate": [63.365, 1.1027027027027028, -32]
       },
       "material": "mat-9",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "-1.403 + 2.505 * smoothstep(144.55, 145.15, t)"
-        }
-      ],
       "pattern": "cracked",
       "collection": "station-14"
     },
@@ -3227,12 +2915,6 @@
         "translate": [62.095, 1.945945945945946, -32]
       },
       "material": "mat-10",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "-2.246 + 4.192 * smoothstep(145.65, 146.25, t)"
-        }
-      ],
       "pattern": "cracked",
       "collection": "station-14"
     },
@@ -3259,12 +2941,6 @@
         "translate": [60.825, 2.4, -32]
       },
       "material": "mat-11",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "-2.700 + 5.100 * smoothstep(146.75, 147.35, t)"
-        }
-      ],
       "collection": "station-14"
     },
     {
@@ -3370,12 +3046,6 @@
         "translate": [3.81, 2.4, -48]
       },
       "material": "mat-6",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "-2.700 + 5.100 * smoothstep(154.55, 155.15, t)"
-        }
-      ],
       "pattern": "cracked",
       "collection": "station-15"
     },
@@ -3402,12 +3072,6 @@
         "translate": [2.54, 2.3564356435643563, -48]
       },
       "material": "mat-18",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "-2.656 + 5.013 * smoothstep(155.65, 156.25, t)"
-        }
-      ],
       "pattern": "cracked",
       "collection": "station-15"
     },
@@ -3434,12 +3098,6 @@
         "translate": [1.27, 2.2376237623762374, -48]
       },
       "material": "mat-19",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "-2.538 + 4.775 * smoothstep(156.75, 157.35, t)"
-        }
-      ],
       "pattern": "cracked",
       "collection": "station-15"
     },
@@ -3466,12 +3124,6 @@
         "translate": [0, 2.1425742574257423, -48]
       },
       "material": "mat-20",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "-2.443 + 4.585 * smoothstep(157.85, 158.45, t)"
-        }
-      ],
       "pattern": "cracked",
       "collection": "station-15"
     },
@@ -3498,12 +3150,6 @@
         "translate": [-1.27, 2.023762376237624, -48]
       },
       "material": "mat-21",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "-2.324 + 4.348 * smoothstep(158.95, 159.55, t)"
-        }
-      ],
       "pattern": "cracked",
       "collection": "station-15"
     },
@@ -3530,12 +3176,6 @@
         "translate": [-2.54, 1.881188118811881, -48]
       },
       "material": "mat-22",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "-2.181 + 4.062 * smoothstep(160.05, 160.65, t)"
-        }
-      ],
       "pattern": "cracked",
       "collection": "station-15"
     },
@@ -3562,12 +3202,6 @@
         "translate": [-3.81, 1.786138613861386, -48]
       },
       "material": "mat-11",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "-2.086 + 3.872 * smoothstep(161.15, 161.75, t)"
-        }
-      ],
       "collection": "station-15"
     },
     {
@@ -3662,12 +3296,6 @@
         "rotate": [0, 0, 1.5707963267948966]
       },
       "material": "mat-2",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "3.700 - 0.000 * smoothstep(167.30, 168.30, t) + 0.07 * sin(0.35 * t + -57.45)"
-        }
-      ],
       "collection": "station-16"
     },
     {
@@ -3680,12 +3308,6 @@
         "translate": [15.69684708965934, 6.717749959911059, -49.2]
       },
       "material": "mat-4",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "8.018 - 1.300 * smoothstep(169.15, 169.70, t) + 0.04 * sin(0.6 * t + -100.38)"
-        }
-      ],
       "collection": "station-16"
     },
     {
@@ -3698,12 +3320,6 @@
         "translate": [13.732396660090313, 5.003591609722465, -49.2]
       },
       "material": "mat-3",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "6.304 - 1.300 * smoothstep(170.15, 170.70, t) + 0.04 * sin(0.6 * t + -98.68)"
-        }
-      ],
       "collection": "station-16"
     },
     {
@@ -3716,12 +3332,6 @@
         "translate": [13.732396660090313, 2.3964083902775357, -49.2]
       },
       "material": "mat-3",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "3.696 - 1.300 * smoothstep(171.15, 171.70, t) + 0.04 * sin(0.6 * t + -96.98)"
-        }
-      ],
       "collection": "station-16"
     },
     {
@@ -3734,12 +3344,6 @@
         "translate": [15.69684708965934, 0.6822500400889417, -49.2]
       },
       "material": "mat-3",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "1.982 - 1.300 * smoothstep(172.15, 172.70, t) + 0.04 * sin(0.6 * t + -95.28)"
-        }
-      ],
       "collection": "station-16"
     },
     {
@@ -3772,12 +3376,6 @@
         "translate": [31.342732166087718, 8.240083449326644, -48.21027246340471]
       },
       "material": "mat-23",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "9.340 - 1.1 * smoothstep(177.75, 178.25, t) + 0.018 * sin(1.3 * t + -230.75)"
-        }
-      ],
       "collection": "station-17"
     },
     {
@@ -3790,12 +3388,6 @@
         "translate": [29.43609173838541, 6.556638433341682, -47.59706455774686]
       },
       "material": "mat-24",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "7.657 - 1.1 * smoothstep(177.87, 178.37, t) + 0.018 * sin(1.3 * t + -228.65)"
-        }
-      ],
       "collection": "station-17"
     },
     {
@@ -3808,12 +3400,6 @@
         "translate": [30.790270246120695, 5.410462203579505, -50.0769912532305]
       },
       "material": "mat-24",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "6.510 - 1.1 * smoothstep(177.99, 178.49, t) + 0.018 * sin(1.3 * t + -226.55)"
-        }
-      ],
       "collection": "station-17"
     },
     {
@@ -3826,12 +3412,6 @@
         "translate": [32, 4.034705367679379, -48]
       },
       "material": "mat-25",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "5.135 - 1.1 * smoothstep(178.11, 178.61, t) + 0.018 * sin(1.3 * t + -224.45)"
-        }
-      ],
       "collection": "station-17"
     },
     {
@@ -3844,12 +3424,6 @@
         "translate": [28.872982523067705, 3.0535128331174013, -48.12475457866938]
       },
       "material": "mat-11",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "4.154 - 1.1 * smoothstep(178.23, 178.73, t) + 0.018 * sin(1.3 * t + -222.35)"
-        }
-      ],
       "collection": "station-17"
     },
     {
@@ -3862,12 +3436,6 @@
         "translate": [33.656931906073076, 2.3752519777557772, -49.49344368704819]
       },
       "material": "mat-24",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "3.475 - 1.1 * smoothstep(178.35, 178.85, t) + 0.018 * sin(1.3 * t + -220.25)"
-        }
-      ],
       "collection": "station-17"
     },
     {
@@ -3880,12 +3448,6 @@
         "translate": [29.881229265531402, 1.4770305268093469, -46.24705670750663]
       },
       "material": "mat-24",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "2.577 - 1.1 * smoothstep(178.47, 178.97, t) + 0.018 * sin(1.3 * t + -218.15)"
-        }
-      ],
       "collection": "station-17"
     },
     {
@@ -3898,12 +3460,6 @@
         "translate": [31.499955733735366, 0.6000000000000001, -48.61824554393374]
       },
       "material": "mat-24",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "1.700 - 1.1 * smoothstep(178.59, 179.09, t) + 0.018 * sin(1.3 * t + -216.05)"
-        }
-      ],
       "collection": "station-17"
     },
     {
@@ -3918,12 +3474,6 @@
         "translate": [31.342732166087718, 8.240083449326644, -48.21027246340471]
       },
       "material": "mat-26",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "9.340 - 1.1 * smoothstep(178.91, 179.36, t)"
-        }
-      ],
       "collection": "station-17"
     },
     {
@@ -3938,12 +3488,6 @@
         "translate": [29.43609173838541, 6.556638433341682, -47.59706455774686]
       },
       "material": "mat-26",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "7.657 - 1.1 * smoothstep(179.05, 179.50, t)"
-        }
-      ],
       "collection": "station-17"
     },
     {
@@ -3958,12 +3502,6 @@
         "translate": [30.790270246120695, 5.410462203579505, -50.0769912532305]
       },
       "material": "mat-26",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "6.510 - 1.1 * smoothstep(179.19, 179.64, t)"
-        }
-      ],
       "collection": "station-17"
     },
     {
@@ -3978,12 +3516,6 @@
         "translate": [32, 4.034705367679379, -48]
       },
       "material": "mat-26",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "5.135 - 1.1 * smoothstep(179.33, 179.78, t)"
-        }
-      ],
       "collection": "station-17"
     },
     {
@@ -3998,12 +3530,6 @@
         "translate": [28.872982523067705, 3.0535128331174013, -48.12475457866938]
       },
       "material": "mat-26",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "4.154 - 1.1 * smoothstep(179.47, 179.92, t)"
-        }
-      ],
       "collection": "station-17"
     },
     {
@@ -4018,12 +3544,6 @@
         "translate": [29.881229265531402, 1.4770305268093469, -46.24705670750663]
       },
       "material": "mat-26",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "2.577 - 1.1 * smoothstep(179.61, 180.06, t)"
-        }
-      ],
       "collection": "station-17"
     },
     {
@@ -4038,12 +3558,6 @@
         "translate": [31.499955733735366, 0.6000000000000001, -48.61824554393374]
       },
       "material": "mat-26",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "1.700 - 1.1 * smoothstep(179.75, 180.20, t)"
-        }
-      ],
       "collection": "station-17"
     },
     {
@@ -4058,12 +3572,6 @@
         "translate": [33.656931906073076, 2.3752519777557772, -49.49344368704819]
       },
       "material": "mat-26",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "3.475 - 1.1 * smoothstep(179.89, 180.34, t)"
-        }
-      ],
       "collection": "station-17"
     },
     {
@@ -4077,12 +3585,6 @@
         "rotate": [0, 0, 0]
       },
       "material": "mat-27",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "4.405 - 0.000 * smoothstep(177.50, 178.50, t) + 0.05 * sin(0.30 * t + -53.25)"
-        }
-      ],
       "collection": "station-17"
     },
     {
@@ -4096,12 +3598,6 @@
         "rotate": [0, 0.9, 0]
       },
       "material": "mat-27",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "4.400 - 0.000 * smoothstep(177.50, 178.50, t) + 0.07 * sin(0.35 * t + -60.82)"
-        }
-      ],
       "collection": "station-17"
     },
     {
@@ -4115,12 +3611,6 @@
         "rotate": [0, 1.8, 0]
       },
       "material": "mat-27",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "3.630 - 0.000 * smoothstep(177.50, 178.50, t) + 0.09 * sin(0.40 * t + -68.40)"
-        }
-      ],
       "collection": "station-17"
     },
     {
@@ -4134,12 +3624,6 @@
         "rotate": [0, 2.7, 0]
       },
       "material": "mat-27",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "4.223 - 0.000 * smoothstep(177.50, 178.50, t) + 0.05 * sin(0.45 * t + -75.97)"
-        }
-      ],
       "collection": "station-17"
     },
     {
@@ -4153,12 +3637,6 @@
         "rotate": [0, 0.5, 0]
       },
       "material": "mat-27",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "3.084 - 0.000 * smoothstep(177.50, 178.50, t) + 0.07 * sin(0.50 * t + -83.55)"
-        }
-      ],
       "collection": "station-17"
     },
     {
@@ -4172,12 +3650,6 @@
         "rotate": [0, 1.4, 0]
       },
       "material": "mat-27",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "3.818 - 0.000 * smoothstep(177.50, 178.50, t) + 0.09 * sin(0.30 * t + -53.03)"
-        }
-      ],
       "collection": "station-17"
     },
     {
@@ -4191,12 +3663,6 @@
         "rotate": [0, 2.3000000000000003, 0]
       },
       "material": "mat-27",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "2.743 - 0.000 * smoothstep(177.50, 178.50, t) + 0.05 * sin(0.35 * t + -60.60)"
-        }
-      ],
       "collection": "station-17"
     },
     {
@@ -4210,12 +3676,6 @@
         "rotate": [0, 0.09999999999999964, 0]
       },
       "material": "mat-27",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "3.248 - 0.000 * smoothstep(177.50, 178.50, t) + 0.07 * sin(0.40 * t + -68.18)"
-        }
-      ],
       "collection": "station-17"
     },
     {
@@ -4229,12 +3689,6 @@
         "rotate": [0, 1, 0]
       },
       "material": "mat-27",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "2.515 - 0.000 * smoothstep(177.50, 178.50, t) + 0.09 * sin(0.45 * t + -75.75)"
-        }
-      ],
       "collection": "station-17"
     },
     {
@@ -4248,12 +3702,6 @@
         "rotate": [0, 1.8999999999999995, 0]
       },
       "material": "mat-27",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "2.626 - 0.000 * smoothstep(177.50, 178.50, t) + 0.05 * sin(0.50 * t + -83.33)"
-        }
-      ],
       "collection": "station-17"
     },
     {
@@ -4267,12 +3715,6 @@
         "rotate": [0, 2.8, 0]
       },
       "material": "mat-27",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "2.275 - 0.000 * smoothstep(177.50, 178.50, t) + 0.07 * sin(0.30 * t + -52.81)"
-        }
-      ],
       "collection": "station-17"
     },
     {
@@ -4286,12 +3728,6 @@
         "rotate": [0, 0.6000000000000001, 0]
       },
       "material": "mat-27",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "2.074 - 0.000 * smoothstep(177.50, 178.50, t) + 0.09 * sin(0.35 * t + -60.38)"
-        }
-      ],
       "collection": "station-17"
     },
     {
@@ -4305,12 +3741,6 @@
         "rotate": [0, 1.5000000000000004, 0]
       },
       "material": "mat-27",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "1.917 - 0.000 * smoothstep(177.50, 178.50, t) + 0.05 * sin(0.40 * t + -67.96)"
-        }
-      ],
       "collection": "station-17"
     },
     {
@@ -4324,12 +3754,6 @@
         "rotate": [0, 2.400000000000001, 0]
       },
       "material": "mat-27",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "1.675 - 0.000 * smoothstep(177.50, 178.50, t) + 0.07 * sin(0.45 * t + -75.53)"
-        }
-      ],
       "collection": "station-17"
     },
     {
@@ -4343,12 +3767,6 @@
         "rotate": [0, 0.1999999999999993, 0]
       },
       "material": "mat-27",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "1.390 - 0.000 * smoothstep(177.50, 178.50, t) + 0.09 * sin(0.50 * t + -83.11)"
-        }
-      ],
       "collection": "station-17"
     },
     {
@@ -4362,12 +3780,6 @@
         "rotate": [0, 1.0999999999999996, 0]
       },
       "material": "mat-27",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "1.443 - 0.000 * smoothstep(177.50, 178.50, t) + 0.05 * sin(0.30 * t + -52.59)"
-        }
-      ],
       "collection": "station-17"
     },
     {
@@ -4381,12 +3793,6 @@
         "rotate": [0, 2, 0]
       },
       "material": "mat-27",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "0.717 - 0.000 * smoothstep(177.50, 178.50, t) + 0.07 * sin(0.35 * t + -60.16)"
-        }
-      ],
       "collection": "station-17"
     },
     {
@@ -4400,12 +3806,6 @@
         "rotate": [0, 2.9000000000000004, 0]
       },
       "material": "mat-27",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "1.316 - 0.000 * smoothstep(177.50, 178.50, t) + 0.09 * sin(0.40 * t + -67.74)"
-        }
-      ],
       "collection": "station-17"
     },
     {
@@ -4419,12 +3819,6 @@
         "rotate": [0, 0.6999999999999988, 0]
       },
       "material": "mat-27",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "-0.006 - 0.000 * smoothstep(177.50, 178.50, t) + 0.05 * sin(0.45 * t + -75.31)"
-        }
-      ],
       "collection": "station-17"
     },
     {
@@ -4438,12 +3832,6 @@
         "rotate": [0, 1.600000000000001, 0]
       },
       "material": "mat-27",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "1.174 - 0.000 * smoothstep(177.50, 178.50, t) + 0.07 * sin(0.50 * t + -82.89)"
-        }
-      ],
       "collection": "station-17"
     },
     {
@@ -4457,12 +3845,6 @@
         "rotate": [0, 2.4999999999999996, 0]
       },
       "material": "mat-27",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "-0.644 - 0.000 * smoothstep(177.50, 178.50, t) + 0.09 * sin(0.30 * t + -52.37)"
-        }
-      ],
       "collection": "station-17"
     },
     {
@@ -4476,12 +3858,6 @@
         "rotate": [0, 0.3000000000000016, 0]
       },
       "material": "mat-27",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "0.879 - 0.000 * smoothstep(177.50, 178.50, t) + 0.05 * sin(0.35 * t + -59.94)"
-        }
-      ],
       "collection": "station-17"
     },
     {
@@ -4613,12 +3989,6 @@
         "translate": [0, 3.15, -64]
       },
       "material": "mat-28",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "4.150 - 1 * smoothstep(205.55, 206.10, t)"
-        }
-      ],
       "collection": "station-20"
     },
     {
@@ -4652,12 +4022,6 @@
         "translate": [1.1634144591899854e-16, 2, -65.9]
       },
       "material": "mat-29",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "3.000 - 1 * smoothstep(207.05, 207.60, t)"
-        }
-      ],
       "collection": "station-20"
     },
     {
@@ -4691,12 +4055,6 @@
         "translate": [1.6454482671904336, 2, -63.05]
       },
       "material": "mat-29",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "3.000 - 1 * smoothstep(207.05, 207.60, t)"
-        }
-      ],
       "collection": "station-20"
     },
     {
@@ -4730,12 +4088,6 @@
         "translate": [-1.6454482671904331, 2, -63.05]
       },
       "material": "mat-29",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "3.000 - 1 * smoothstep(207.05, 207.60, t)"
-        }
-      ],
       "collection": "station-20"
     },
     {
@@ -4769,12 +4121,6 @@
         "translate": [1.1428918764803693, 0.8500000000000001, -62.35829046980942]
       },
       "material": "mat-30",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "1.850 - 1 * smoothstep(208.55, 209.10, t)"
-        }
-      ],
       "collection": "station-20"
     },
     {
@@ -4873,12 +4219,6 @@
         "translate": [16.91, 3.2199999999999998, -63.66]
       },
       "material": "mat-33",
-      "animation": [
-        {
-          "channel": "transform.translate.z",
-          "expr": "-61.600 - 2.060 * smoothstep(216.45, 216.90, t)"
-        }
-      ],
       "collection": "station-21"
     },
     {
@@ -4892,12 +4232,6 @@
         "translate": [16.91, 1.7999999999999998, -63.66]
       },
       "material": "mat-33",
-      "animation": [
-        {
-          "channel": "transform.translate.z",
-          "expr": "-61.600 - 2.060 * smoothstep(217.35, 217.80, t)"
-        }
-      ],
       "collection": "station-21"
     },
     {
@@ -4911,12 +4245,6 @@
         "translate": [15.09, 3.2199999999999998, -63.66]
       },
       "material": "mat-33",
-      "animation": [
-        {
-          "channel": "transform.translate.z",
-          "expr": "-61.600 - 2.060 * smoothstep(218.25, 218.70, t)"
-        }
-      ],
       "collection": "station-21"
     },
     {
@@ -4930,12 +4258,6 @@
         "translate": [15.09, 1.7999999999999998, -63.66]
       },
       "material": "mat-4",
-      "animation": [
-        {
-          "channel": "transform.translate.z",
-          "expr": "-61.600 - 2.060 * smoothstep(219.15, 219.60, t)"
-        }
-      ],
       "collection": "station-21"
     },
     {
@@ -4949,12 +4271,6 @@
         "rotate": [0, -0.9, 0]
       },
       "material": "mat-12",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "3.310 - 0.000 * smoothstep(215.20, 216.20, t) + 0.06 * sin(0.30 * t + -64.56)"
-        }
-      ],
       "collection": "station-21"
     },
     {
@@ -4968,12 +4284,6 @@
         "rotate": [0, -0.4, 0]
       },
       "material": "mat-12",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "2.110 - 0.000 * smoothstep(215.20, 216.20, t) + 0.08 * sin(0.37 * t + -77.42)"
-        }
-      ],
       "collection": "station-21"
     },
     {
@@ -4987,12 +4297,6 @@
         "rotate": [0, 0.09999999999999998, 0]
       },
       "material": "mat-12",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "4.710 - 0.000 * smoothstep(215.20, 216.20, t) + 0.10 * sin(0.44 * t + -90.29)"
-        }
-      ],
       "collection": "station-21"
     },
     {
@@ -5006,12 +4310,6 @@
         "rotate": [0, 0.6, 0]
       },
       "material": "mat-12",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "4.110 - 0.000 * smoothstep(215.20, 216.20, t) + 0.12 * sin(0.51 * t + -109.43)"
-        }
-      ],
       "collection": "station-21"
     },
     {
@@ -5057,12 +4355,6 @@
         "translate": [33.27, 0.24, -64]
       },
       "material": "mat-6",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "-0.540 + 0.780 * smoothstep(226.35, 226.95, t)"
-        }
-      ],
       "pattern": "cracked",
       "collection": "station-22"
     },
@@ -5089,12 +4381,6 @@
         "translate": [32, 1.2, -64]
       },
       "material": "mat-20",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "-1.500 + 2.700 * smoothstep(227.45, 228.05, t)"
-        }
-      ],
       "pattern": "cracked",
       "collection": "station-22"
     },
@@ -5121,12 +4407,6 @@
         "translate": [30.73, 2.4, -64]
       },
       "material": "mat-11",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "-2.700 + 5.100 * smoothstep(228.55, 229.15, t)"
-        }
-      ],
       "collection": "station-22"
     },
     {
@@ -5667,6 +4947,7 @@
       "text": "① 即将爆发的个性化数字媒体市场",
       "anchor": [15.69684708965934, 6.717749959911059, -1.2],
       "role": "screen",
+      "side": "right",
       "revealAt": 10.05,
       "hideAt": 18.6
     },
@@ -5681,6 +4962,7 @@
       "text": "② 独创的个性化资讯发现引擎",
       "anchor": [14.334200264481655, 5.888298781822307, -1.2],
       "role": "screen",
+      "side": "right",
       "revealAt": 11.05,
       "hideAt": 18.6
     },
@@ -5695,6 +4977,7 @@
       "text": "③ 领先于世界同类产品的功能和技术",
       "anchor": [13.55265671555532, 4.497620778785201, -1.2],
       "role": "screen",
+      "side": "right",
       "revealAt": 12.05,
       "hideAt": 18.6
     },
@@ -5709,6 +4992,7 @@
       "text": "④ 行业领先的用户粘度和自然增长",
       "anchor": [13.55265671555532, 2.902379221214799, -1.2],
       "role": "screen",
+      "side": "right",
       "revealAt": 13.05,
       "hideAt": 18.6
     },
@@ -5723,6 +5007,7 @@
       "text": "⑤ 完善的多产品布局,覆盖移动终端和 PC 端",
       "anchor": [14.334200264481655, 1.5117012181776928, -1.2],
       "role": "screen",
+      "side": "right",
       "revealAt": 14.05,
       "hideAt": 18.6
     },
@@ -5737,6 +5022,7 @@
       "text": "⑥ 具有丰富创业经验和技术功底的团队",
       "anchor": [15.69684708965934, 0.6822500400889417, -1.2],
       "role": "screen",
+      "side": "right",
       "revealAt": 15.05,
       "hideAt": 18.6
     },
@@ -6222,6 +5508,7 @@
       "text": "编辑挑选·连续阅读",
       "anchor": [19.6, 0.19999999999999996, -15.5],
       "role": "screen",
+      "side": "left",
       "revealAt": 73.40000000000002,
       "hideAt": 82.40000000000002
     },
@@ -6229,6 +5516,7 @@
       "text": "浏览/搜索/媒体转载",
       "anchor": [16, 0.19999999999999996, -15.5],
       "role": "screen",
+      "side": "left",
       "revealAt": 73.60000000000001,
       "hideAt": 82.40000000000002
     },
@@ -6236,6 +5524,7 @@
       "text": "PC",
       "anchor": [12.4, 0.19999999999999996, -15.5],
       "role": "screen",
+      "side": "left",
       "revealAt": 73.80000000000001,
       "hideAt": 82.40000000000002
     },
@@ -6243,6 +5532,7 @@
       "text": "个性化·社交化·碎片阅读",
       "anchor": [19.6, 5.3, -15.6],
       "role": "screen",
+      "side": "right",
       "revealAt": 76.75000000000001,
       "hideAt": 82.40000000000002
     },
@@ -6250,6 +5540,7 @@
       "text": "关注/推荐/转发",
       "anchor": [16, 5.3, -15.6],
       "role": "screen",
+      "side": "right",
       "revealAt": 77.85000000000001,
       "hideAt": 82.40000000000002
     },
@@ -6257,6 +5548,7 @@
       "text": "移动终端",
       "anchor": [12.4, 5.3, -15.6],
       "role": "screen",
+      "side": "right",
       "revealAt": 78.95000000000002,
       "hideAt": 82.40000000000002
     },
@@ -6629,6 +5921,7 @@
       "text": "① 独创的数据处理和推荐技术底框架",
       "anchor": [15.69684708965934, 6.717749959911059, -49.2],
       "role": "screen",
+      "side": "right",
       "revealAt": 169.74999999999997,
       "hideAt": 176.29999999999998
     },
@@ -6643,6 +5936,7 @@
       "text": "② 自然语言、多媒体信息处理",
       "anchor": [13.732396660090313, 5.003591609722465, -49.2],
       "role": "screen",
+      "side": "right",
       "revealAt": 170.74999999999997,
       "hideAt": 176.29999999999998
     },
@@ -6657,6 +5951,7 @@
       "text": "③ 高维度用户兴趣建模",
       "anchor": [13.732396660090313, 2.3964083902775357, -49.2],
       "role": "screen",
+      "side": "right",
       "revealAt": 171.74999999999997,
       "hideAt": 176.29999999999998
     },
@@ -6671,6 +5966,7 @@
       "text": "④ 高性能的实时大规模数据运算",
       "anchor": [15.69684708965934, 0.6822500400889417, -49.2],
       "role": "screen",
+      "side": "right",
       "revealAt": 172.74999999999997,
       "hideAt": 176.29999999999998
     },
@@ -6883,6 +6179,7 @@
       "text": "扩充信息类型和来源",
       "anchor": [16.91, 2.88, -63.8],
       "role": "screen",
+      "side": "left",
       "align": "center",
       "revealAt": 216.94999999999996,
       "hideAt": 223.49999999999997
@@ -6891,6 +6188,7 @@
       "text": "深挖用户特征·升级推荐系统",
       "anchor": [16.91, 1.4599999999999997, -63.8],
       "role": "screen",
+      "side": "left",
       "align": "center",
       "revealAt": 217.84999999999997,
       "hideAt": 223.49999999999997
@@ -6899,6 +6197,7 @@
       "text": "强化社区互动",
       "anchor": [15.09, 2.88, -63.8],
       "role": "screen",
+      "side": "right",
       "align": "center",
       "revealAt": 218.74999999999997,
       "hideAt": 223.49999999999997
@@ -6907,6 +6206,7 @@
       "text": "国际化与商业化尝试",
       "anchor": [15.09, 1.4599999999999997, -63.8],
       "role": "screen",
+      "side": "right",
       "align": "center",
       "revealAt": 219.64999999999995,
       "hideAt": 223.49999999999997

--- a/sdf-js/fixtures/golden/assemble-deck-line.json
+++ b/sdf-js/fixtures/golden/assemble-deck-line.json
@@ -1137,12 +1137,6 @@
         "rotate": [0, -1, 0]
       },
       "material": "mat-0",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "3.400 - 0.000 * smoothstep(0.00, 1.00, t) + 0.07 * sin(0.35 * t + 0.00)"
-        }
-      ],
       "collection": "station-0"
     },
     {
@@ -1157,12 +1151,6 @@
         "rotate": [0, -0.5, 0]
       },
       "material": "mat-0",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "2.600 - 0.000 * smoothstep(0.00, 1.00, t) + 0.09 * sin(0.43 * t + 2.10)"
-        }
-      ],
       "collection": "station-0"
     },
     {
@@ -1177,12 +1165,6 @@
         "rotate": [0, 0, 0]
       },
       "material": "mat-0",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "4.600 - 0.000 * smoothstep(0.00, 1.00, t) + 0.11 * sin(0.51 * t + 4.20)"
-        }
-      ],
       "collection": "station-0"
     },
     {
@@ -1197,12 +1179,6 @@
         "rotate": [0, 0.5, 0]
       },
       "material": "mat-0",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "4.000 - 0.000 * smoothstep(0.00, 1.00, t) + 0.13 * sin(0.59 * t + 0.02)"
-        }
-      ],
       "collection": "station-0"
     },
     {
@@ -1217,12 +1193,6 @@
         "rotate": [0, 1, 0]
       },
       "material": "mat-0",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "5.800 - 0.000 * smoothstep(0.00, 1.00, t) + 0.15 * sin(0.67 * t + 2.12)"
-        }
-      ],
       "collection": "station-0"
     },
     {
@@ -1237,12 +1207,6 @@
         "rotate": [0, 1.5, 0]
       },
       "material": "mat-0",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "5.200 - 0.000 * smoothstep(0.00, 1.00, t) + 0.17 * sin(0.75 * t + 4.22)"
-        }
-      ],
       "collection": "station-0"
     },
     {
@@ -1257,12 +1221,6 @@
         "rotate": [0, 2, 0]
       },
       "material": "mat-0",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "7.000 - 0.000 * smoothstep(0.00, 1.00, t) + 0.19 * sin(0.83 * t + 0.04)"
-        }
-      ],
       "collection": "station-0"
     },
     {
@@ -1277,12 +1235,6 @@
         "rotate": [0, 2.5, 0]
       },
       "material": "mat-0",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "6.400 - 0.000 * smoothstep(0.00, 1.00, t) + 0.21 * sin(0.91 * t + 2.14)"
-        }
-      ],
       "collection": "station-0"
     },
     {
@@ -1297,12 +1249,6 @@
         "rotate": [0, 3, 0]
       },
       "material": "mat-0",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "2.000 - 0.000 * smoothstep(0.00, 1.00, t) + 0.23 * sin(0.99 * t + 4.24)"
-        }
-      ],
       "collection": "station-0"
     },
     {
@@ -1337,12 +1283,6 @@
         "rotate": [0, 0, 1.5707963267948966]
       },
       "material": "mat-2",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "3.700 - 0.000 * smoothstep(7.60, 8.60, t) + 0.07 * sin(0.35 * t + -1.56)"
-        }
-      ],
       "collection": "station-1"
     },
     {
@@ -1355,12 +1295,6 @@
         "translate": [15.69684708965934, 6.717749959911059, -1.2]
       },
       "material": "mat-3",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "8.018 - 1.300 * smoothstep(9.45, 10.00, t) + 0.04 * sin(0.6 * t + -4.56)"
-        }
-      ],
       "collection": "station-1"
     },
     {
@@ -1373,12 +1307,6 @@
         "translate": [14.334200264481655, 5.888298781822307, -1.2]
       },
       "material": "mat-4",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "7.188 - 1.300 * smoothstep(10.45, 11.00, t) + 0.04 * sin(0.6 * t + -2.86)"
-        }
-      ],
       "collection": "station-1"
     },
     {
@@ -1391,12 +1319,6 @@
         "translate": [13.55265671555532, 4.497620778785201, -1.2]
       },
       "material": "mat-3",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "5.798 - 1.300 * smoothstep(11.45, 12.00, t) + 0.04 * sin(0.6 * t + -1.16)"
-        }
-      ],
       "collection": "station-1"
     },
     {
@@ -1409,12 +1331,6 @@
         "translate": [13.55265671555532, 2.902379221214799, -1.2]
       },
       "material": "mat-3",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "4.202 - 1.300 * smoothstep(12.45, 13.00, t) + 0.04 * sin(0.6 * t + 0.54)"
-        }
-      ],
       "collection": "station-1"
     },
     {
@@ -1427,12 +1343,6 @@
         "translate": [14.334200264481655, 1.5117012181776928, -1.2]
       },
       "material": "mat-3",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "2.812 - 1.300 * smoothstep(13.45, 14.00, t) + 0.04 * sin(0.6 * t + -4.04)"
-        }
-      ],
       "collection": "station-1"
     },
     {
@@ -1445,12 +1355,6 @@
         "translate": [15.69684708965934, 0.6822500400889417, -1.2]
       },
       "material": "mat-3",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "1.982 - 1.300 * smoothstep(14.45, 15.00, t) + 0.04 * sin(0.6 * t + -2.34)"
-        }
-      ],
       "collection": "station-1"
     },
     {
@@ -1496,12 +1400,6 @@
         "translate": [35.175, 0.9931034482758622, 0]
       },
       "material": "mat-6",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "-1.293 + 2.286 * smoothstep(21.45, 22.05, t)"
-        }
-      ],
       "pattern": "cracked",
       "collection": "station-2"
     },
@@ -1528,12 +1426,6 @@
         "translate": [33.905, 1.2413793103448276, 0]
       },
       "material": "mat-7",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "-1.541 + 2.783 * smoothstep(22.55, 23.15, t)"
-        }
-      ],
       "pattern": "cracked",
       "collection": "station-2"
     },
@@ -1560,12 +1452,6 @@
         "translate": [32.635, 1.6, 0]
       },
       "material": "mat-8",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "-1.900 + 3.500 * smoothstep(23.65, 24.25, t)"
-        }
-      ],
       "pattern": "cracked",
       "collection": "station-2"
     },
@@ -1592,12 +1478,6 @@
         "translate": [31.365, 1.9034482758620692, 0]
       },
       "material": "mat-9",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "-2.203 + 4.107 * smoothstep(24.75, 25.35, t)"
-        }
-      ],
       "pattern": "cracked",
       "collection": "station-2"
     },
@@ -1624,12 +1504,6 @@
         "translate": [30.095, 2.1517241379310343, 0]
       },
       "material": "mat-10",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "-2.452 + 4.603 * smoothstep(25.85, 26.45, t)"
-        }
-      ],
       "pattern": "cracked",
       "collection": "station-2"
     },
@@ -1656,12 +1530,6 @@
         "translate": [28.825, 2.4, 0]
       },
       "material": "mat-11",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "-2.700 + 5.100 * smoothstep(26.95, 27.55, t)"
-        }
-      ],
       "collection": "station-2"
     },
     {
@@ -1767,12 +1635,6 @@
         "translate": [51.175, 0.14464710547184773, 0]
       },
       "material": "mat-6",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "-0.445 + 0.589 * smoothstep(34.75, 35.35, t)"
-        }
-      ],
       "pattern": "cracked",
       "collection": "station-3"
     },
@@ -1799,12 +1661,6 @@
         "translate": [49.905, 0.28263283108643933, 0]
       },
       "material": "mat-7",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "-0.583 + 0.865 * smoothstep(35.85, 36.45, t)"
-        }
-      ],
       "pattern": "cracked",
       "collection": "station-3"
     },
@@ -1831,12 +1687,6 @@
         "translate": [48.635, 0.5443298969072166, 0]
       },
       "material": "mat-8",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "-0.844 + 1.389 * smoothstep(36.95, 37.55, t)"
-        }
-      ],
       "pattern": "cracked",
       "collection": "station-3"
     },
@@ -1863,12 +1713,6 @@
         "translate": [47.365, 0.9601903251387788, 0]
       },
       "material": "mat-9",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "-1.260 + 2.220 * smoothstep(38.05, 38.65, t)"
-        }
-      ],
       "pattern": "cracked",
       "collection": "station-3"
     },
@@ -1895,12 +1739,6 @@
         "translate": [46.095, 1.5501982553528946, 0]
       },
       "material": "mat-10",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "-1.850 + 3.400 * smoothstep(39.15, 39.75, t)"
-        }
-      ],
       "pattern": "cracked",
       "collection": "station-3"
     },
@@ -1927,12 +1765,6 @@
         "translate": [44.825, 2.4, 0]
       },
       "material": "mat-11",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "-2.700 + 5.100 * smoothstep(40.25, 40.85, t)"
-        }
-      ],
       "collection": "station-3"
     },
     {
@@ -2038,12 +1870,6 @@
         "translate": [67.175, 2.4, 0]
       },
       "material": "mat-11",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "-2.700 + 5.100 * smoothstep(48.05, 48.65, t)"
-        }
-      ],
       "collection": "station-4"
     },
     {
@@ -2069,12 +1895,6 @@
         "translate": [65.905, 2.2374501992031868, 0]
       },
       "material": "mat-7",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "-2.537 + 4.775 * smoothstep(49.15, 49.75, t)"
-        }
-      ],
       "pattern": "cracked",
       "collection": "station-4"
     },
@@ -2101,12 +1921,6 @@
         "translate": [64.635, 1.4151394422310757, 0]
       },
       "material": "mat-8",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "-1.715 + 3.130 * smoothstep(50.25, 50.85, t)"
-        }
-      ],
       "pattern": "cracked",
       "collection": "station-4"
     },
@@ -2133,12 +1947,6 @@
         "translate": [63.365, 1.2430278884462151, 0]
       },
       "material": "mat-9",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "-1.543 + 2.786 * smoothstep(51.35, 51.95, t)"
-        }
-      ],
       "pattern": "cracked",
       "collection": "station-4"
     },
@@ -2165,12 +1973,6 @@
         "translate": [62.095, 0.7362549800796813, 0]
       },
       "material": "mat-10",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "-1.036 + 1.773 * smoothstep(52.45, 53.05, t)"
-        }
-      ],
       "pattern": "cracked",
       "collection": "station-4"
     },
@@ -2197,12 +1999,6 @@
         "translate": [60.825, 0.6501992031872509, 0]
       },
       "material": "mat-13",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "-0.950 + 1.600 * smoothstep(53.55, 54.15, t)"
-        }
-      ],
       "pattern": "cracked",
       "collection": "station-4"
     },
@@ -2309,12 +2105,6 @@
         "translate": [83.175, 2.4, 0]
       },
       "material": "mat-11",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "-2.700 + 5.100 * smoothstep(61.35, 61.95, t)"
-        }
-      ],
       "collection": "station-5"
     },
     {
@@ -2340,12 +2130,6 @@
         "translate": [81.905, 2.2072538860103625, 0]
       },
       "material": "mat-7",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "-2.507 + 4.715 * smoothstep(62.45, 63.05, t)"
-        }
-      ],
       "pattern": "cracked",
       "collection": "station-5"
     },
@@ -2372,12 +2156,6 @@
         "translate": [80.635, 1.5015544041450775, 0]
       },
       "material": "mat-8",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "-1.802 + 3.303 * smoothstep(63.55, 64.15, t)"
-        }
-      ],
       "pattern": "cracked",
       "collection": "station-5"
     },
@@ -2404,12 +2182,6 @@
         "translate": [79.365, 1.2590673575129532, 0]
       },
       "material": "mat-9",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "-1.559 + 2.818 * smoothstep(64.65, 65.25, t)"
-        }
-      ],
       "pattern": "cracked",
       "collection": "station-5"
     },
@@ -2436,12 +2208,6 @@
         "translate": [78.095, 1.0290155440414508, 0]
       },
       "material": "mat-10",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "-1.329 + 2.358 * smoothstep(65.75, 66.35, t)"
-        }
-      ],
       "pattern": "cracked",
       "collection": "station-5"
     },
@@ -2468,12 +2234,6 @@
         "translate": [76.825, 0.9699481865284973, 0]
       },
       "material": "mat-13",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "-1.270 + 2.240 * smoothstep(66.85, 67.45, t)"
-        }
-      ],
       "pattern": "cracked",
       "collection": "station-5"
     },
@@ -2606,12 +2366,6 @@
         "translate": [99.6, 4.3, 0]
       },
       "material": "mat-14",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "0.950 + 3.350 * smoothstep(75.90, 76.65, t) + 0.05 * sin(0.5 * t + -36.50)"
-        }
-      ],
       "collection": "station-6"
     },
     {
@@ -2624,12 +2378,6 @@
         "translate": [96, 4.3, 0]
       },
       "material": "mat-3",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "0.950 + 3.350 * smoothstep(77.00, 77.75, t) + 0.05 * sin(0.5 * t + -34.40)"
-        }
-      ],
       "collection": "station-6"
     },
     {
@@ -2642,12 +2390,6 @@
         "translate": [92.4, 4.3, 0]
       },
       "material": "mat-3",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "0.950 + 3.350 * smoothstep(78.10, 78.85, t) + 0.05 * sin(0.5 * t + -32.30)"
-        }
-      ],
       "collection": "station-6"
     },
     {
@@ -2661,12 +2403,6 @@
         "translate": [102.9, 2.175, 0]
       },
       "material": "mat-15",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "0.175 + 2.000 * smoothstep(74.80, 75.50, t)"
-        }
-      ],
       "collection": "station-6"
     },
     {
@@ -2679,12 +2415,6 @@
         "translate": [102.9, 3.4999999999999996, 0]
       },
       "material": "mat-15",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "1.500 + 2.000 * smoothstep(74.80, 75.50, t)"
-        }
-      ],
       "collection": "station-6"
     },
     {
@@ -2697,12 +2427,6 @@
         "translate": [102.9, 3.7199999999999998, 0]
       },
       "material": "mat-15",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "1.720 + 2.000 * smoothstep(74.80, 75.50, t)"
-        }
-      ],
       "collection": "station-6"
     },
     {
@@ -2715,12 +2439,6 @@
         "translate": [102.9, 3.9399999999999995, 0]
       },
       "material": "mat-15",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "1.940 + 2.000 * smoothstep(74.80, 75.50, t)"
-        }
-      ],
       "collection": "station-6"
     },
     {
@@ -2733,12 +2451,6 @@
         "translate": [102.9, 4.159999999999999, 0]
       },
       "material": "mat-15",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "2.160 + 2.000 * smoothstep(74.80, 75.50, t)"
-        }
-      ],
       "collection": "station-6"
     },
     {
@@ -3099,12 +2811,6 @@
         "translate": [227.175, 0.06, 0]
       },
       "material": "mat-6",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "-0.360 + 0.420 * smoothstep(141.25, 141.85, t)"
-        }
-      ],
       "pattern": "cracked",
       "collection": "station-14"
     },
@@ -3131,12 +2837,6 @@
         "translate": [225.905, 0.1945945945945946, 0]
       },
       "material": "mat-7",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "-0.495 + 0.689 * smoothstep(142.35, 142.95, t)"
-        }
-      ],
       "pattern": "cracked",
       "collection": "station-14"
     },
@@ -3163,12 +2863,6 @@
         "translate": [224.635, 0.5837837837837838, 0]
       },
       "material": "mat-8",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "-0.884 + 1.468 * smoothstep(143.45, 144.05, t)"
-        }
-      ],
       "pattern": "cracked",
       "collection": "station-14"
     },
@@ -3195,12 +2889,6 @@
         "translate": [223.365, 1.1027027027027028, 0]
       },
       "material": "mat-9",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "-1.403 + 2.505 * smoothstep(144.55, 145.15, t)"
-        }
-      ],
       "pattern": "cracked",
       "collection": "station-14"
     },
@@ -3227,12 +2915,6 @@
         "translate": [222.095, 1.945945945945946, 0]
       },
       "material": "mat-10",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "-2.246 + 4.192 * smoothstep(145.65, 146.25, t)"
-        }
-      ],
       "pattern": "cracked",
       "collection": "station-14"
     },
@@ -3259,12 +2941,6 @@
         "translate": [220.825, 2.4, 0]
       },
       "material": "mat-11",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "-2.700 + 5.100 * smoothstep(146.75, 147.35, t)"
-        }
-      ],
       "collection": "station-14"
     },
     {
@@ -3370,12 +3046,6 @@
         "translate": [243.81, 2.4, 0]
       },
       "material": "mat-6",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "-2.700 + 5.100 * smoothstep(154.55, 155.15, t)"
-        }
-      ],
       "pattern": "cracked",
       "collection": "station-15"
     },
@@ -3402,12 +3072,6 @@
         "translate": [242.54, 2.3564356435643563, 0]
       },
       "material": "mat-18",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "-2.656 + 5.013 * smoothstep(155.65, 156.25, t)"
-        }
-      ],
       "pattern": "cracked",
       "collection": "station-15"
     },
@@ -3434,12 +3098,6 @@
         "translate": [241.27, 2.2376237623762374, 0]
       },
       "material": "mat-19",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "-2.538 + 4.775 * smoothstep(156.75, 157.35, t)"
-        }
-      ],
       "pattern": "cracked",
       "collection": "station-15"
     },
@@ -3466,12 +3124,6 @@
         "translate": [240, 2.1425742574257423, 0]
       },
       "material": "mat-20",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "-2.443 + 4.585 * smoothstep(157.85, 158.45, t)"
-        }
-      ],
       "pattern": "cracked",
       "collection": "station-15"
     },
@@ -3498,12 +3150,6 @@
         "translate": [238.73, 2.023762376237624, 0]
       },
       "material": "mat-21",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "-2.324 + 4.348 * smoothstep(158.95, 159.55, t)"
-        }
-      ],
       "pattern": "cracked",
       "collection": "station-15"
     },
@@ -3530,12 +3176,6 @@
         "translate": [237.46, 1.881188118811881, 0]
       },
       "material": "mat-22",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "-2.181 + 4.062 * smoothstep(160.05, 160.65, t)"
-        }
-      ],
       "pattern": "cracked",
       "collection": "station-15"
     },
@@ -3562,12 +3202,6 @@
         "translate": [236.19, 1.786138613861386, 0]
       },
       "material": "mat-11",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "-2.086 + 3.872 * smoothstep(161.15, 161.75, t)"
-        }
-      ],
       "collection": "station-15"
     },
     {
@@ -3662,12 +3296,6 @@
         "rotate": [0, 0, 1.5707963267948966]
       },
       "material": "mat-2",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "3.700 - 0.000 * smoothstep(167.30, 168.30, t) + 0.07 * sin(0.35 * t + -57.45)"
-        }
-      ],
       "collection": "station-16"
     },
     {
@@ -3680,12 +3308,6 @@
         "translate": [255.69684708965934, 6.717749959911059, -1.2]
       },
       "material": "mat-4",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "8.018 - 1.300 * smoothstep(169.15, 169.70, t) + 0.04 * sin(0.6 * t + -100.38)"
-        }
-      ],
       "collection": "station-16"
     },
     {
@@ -3698,12 +3320,6 @@
         "translate": [253.7323966600903, 5.003591609722465, -1.2]
       },
       "material": "mat-3",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "6.304 - 1.300 * smoothstep(170.15, 170.70, t) + 0.04 * sin(0.6 * t + -98.68)"
-        }
-      ],
       "collection": "station-16"
     },
     {
@@ -3716,12 +3332,6 @@
         "translate": [253.7323966600903, 2.3964083902775357, -1.2]
       },
       "material": "mat-3",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "3.696 - 1.300 * smoothstep(171.15, 171.70, t) + 0.04 * sin(0.6 * t + -96.98)"
-        }
-      ],
       "collection": "station-16"
     },
     {
@@ -3734,12 +3344,6 @@
         "translate": [255.69684708965934, 0.6822500400889417, -1.2]
       },
       "material": "mat-3",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "1.982 - 1.300 * smoothstep(172.15, 172.70, t) + 0.04 * sin(0.6 * t + -95.28)"
-        }
-      ],
       "collection": "station-16"
     },
     {
@@ -3772,12 +3376,6 @@
         "translate": [271.3427321660877, 8.240083449326644, -0.21027246340471484]
       },
       "material": "mat-23",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "9.340 - 1.1 * smoothstep(177.75, 178.25, t) + 0.018 * sin(1.3 * t + -230.75)"
-        }
-      ],
       "collection": "station-17"
     },
     {
@@ -3790,12 +3388,6 @@
         "translate": [269.4360917383854, 6.556638433341682, 0.4029354422531373]
       },
       "material": "mat-24",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "7.657 - 1.1 * smoothstep(177.87, 178.37, t) + 0.018 * sin(1.3 * t + -228.65)"
-        }
-      ],
       "collection": "station-17"
     },
     {
@@ -3808,12 +3400,6 @@
         "translate": [270.7902702461207, 5.410462203579505, -2.0769912532305064]
       },
       "material": "mat-24",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "6.510 - 1.1 * smoothstep(177.99, 178.49, t) + 0.018 * sin(1.3 * t + -226.55)"
-        }
-      ],
       "collection": "station-17"
     },
     {
@@ -3826,12 +3412,6 @@
         "translate": [272, 4.034705367679379, 0]
       },
       "material": "mat-25",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "5.135 - 1.1 * smoothstep(178.11, 178.61, t) + 0.018 * sin(1.3 * t + -224.45)"
-        }
-      ],
       "collection": "station-17"
     },
     {
@@ -3844,12 +3424,6 @@
         "translate": [268.8729825230677, 3.0535128331174013, -0.12475457866938144]
       },
       "material": "mat-11",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "4.154 - 1.1 * smoothstep(178.23, 178.73, t) + 0.018 * sin(1.3 * t + -222.35)"
-        }
-      ],
       "collection": "station-17"
     },
     {
@@ -3862,12 +3436,6 @@
         "translate": [273.65693190607305, 2.3752519777557772, -1.493443687048192]
       },
       "material": "mat-24",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "3.475 - 1.1 * smoothstep(178.35, 178.85, t) + 0.018 * sin(1.3 * t + -220.25)"
-        }
-      ],
       "collection": "station-17"
     },
     {
@@ -3880,12 +3448,6 @@
         "translate": [269.8812292655314, 1.4770305268093469, 1.7529432924933686]
       },
       "material": "mat-24",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "2.577 - 1.1 * smoothstep(178.47, 178.97, t) + 0.018 * sin(1.3 * t + -218.15)"
-        }
-      ],
       "collection": "station-17"
     },
     {
@@ -3898,12 +3460,6 @@
         "translate": [271.49995573373536, 0.6000000000000001, -0.6182455439337382]
       },
       "material": "mat-24",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "1.700 - 1.1 * smoothstep(178.59, 179.09, t) + 0.018 * sin(1.3 * t + -216.05)"
-        }
-      ],
       "collection": "station-17"
     },
     {
@@ -3918,12 +3474,6 @@
         "translate": [271.3427321660877, 8.240083449326644, -0.21027246340471484]
       },
       "material": "mat-26",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "9.340 - 1.1 * smoothstep(178.91, 179.36, t)"
-        }
-      ],
       "collection": "station-17"
     },
     {
@@ -3938,12 +3488,6 @@
         "translate": [269.4360917383854, 6.556638433341682, 0.4029354422531373]
       },
       "material": "mat-26",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "7.657 - 1.1 * smoothstep(179.05, 179.50, t)"
-        }
-      ],
       "collection": "station-17"
     },
     {
@@ -3958,12 +3502,6 @@
         "translate": [270.7902702461207, 5.410462203579505, -2.0769912532305064]
       },
       "material": "mat-26",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "6.510 - 1.1 * smoothstep(179.19, 179.64, t)"
-        }
-      ],
       "collection": "station-17"
     },
     {
@@ -3978,12 +3516,6 @@
         "translate": [272, 4.034705367679379, 0]
       },
       "material": "mat-26",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "5.135 - 1.1 * smoothstep(179.33, 179.78, t)"
-        }
-      ],
       "collection": "station-17"
     },
     {
@@ -3998,12 +3530,6 @@
         "translate": [268.8729825230677, 3.0535128331174013, -0.12475457866938144]
       },
       "material": "mat-26",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "4.154 - 1.1 * smoothstep(179.47, 179.92, t)"
-        }
-      ],
       "collection": "station-17"
     },
     {
@@ -4018,12 +3544,6 @@
         "translate": [269.8812292655314, 1.4770305268093469, 1.7529432924933686]
       },
       "material": "mat-26",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "2.577 - 1.1 * smoothstep(179.61, 180.06, t)"
-        }
-      ],
       "collection": "station-17"
     },
     {
@@ -4038,12 +3558,6 @@
         "translate": [271.49995573373536, 0.6000000000000001, -0.6182455439337382]
       },
       "material": "mat-26",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "1.700 - 1.1 * smoothstep(179.75, 180.20, t)"
-        }
-      ],
       "collection": "station-17"
     },
     {
@@ -4058,12 +3572,6 @@
         "translate": [273.65693190607305, 2.3752519777557772, -1.493443687048192]
       },
       "material": "mat-26",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "3.475 - 1.1 * smoothstep(179.89, 180.34, t)"
-        }
-      ],
       "collection": "station-17"
     },
     {
@@ -4077,12 +3585,6 @@
         "rotate": [0, 0, 0]
       },
       "material": "mat-27",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "4.405 - 0.000 * smoothstep(177.50, 178.50, t) + 0.05 * sin(0.30 * t + -53.25)"
-        }
-      ],
       "collection": "station-17"
     },
     {
@@ -4096,12 +3598,6 @@
         "rotate": [0, 0.9, 0]
       },
       "material": "mat-27",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "4.400 - 0.000 * smoothstep(177.50, 178.50, t) + 0.07 * sin(0.35 * t + -60.82)"
-        }
-      ],
       "collection": "station-17"
     },
     {
@@ -4115,12 +3611,6 @@
         "rotate": [0, 1.8, 0]
       },
       "material": "mat-27",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "3.630 - 0.000 * smoothstep(177.50, 178.50, t) + 0.09 * sin(0.40 * t + -68.40)"
-        }
-      ],
       "collection": "station-17"
     },
     {
@@ -4134,12 +3624,6 @@
         "rotate": [0, 2.7, 0]
       },
       "material": "mat-27",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "4.223 - 0.000 * smoothstep(177.50, 178.50, t) + 0.05 * sin(0.45 * t + -75.97)"
-        }
-      ],
       "collection": "station-17"
     },
     {
@@ -4153,12 +3637,6 @@
         "rotate": [0, 0.5, 0]
       },
       "material": "mat-27",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "3.084 - 0.000 * smoothstep(177.50, 178.50, t) + 0.07 * sin(0.50 * t + -83.55)"
-        }
-      ],
       "collection": "station-17"
     },
     {
@@ -4172,12 +3650,6 @@
         "rotate": [0, 1.4, 0]
       },
       "material": "mat-27",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "3.818 - 0.000 * smoothstep(177.50, 178.50, t) + 0.09 * sin(0.30 * t + -53.03)"
-        }
-      ],
       "collection": "station-17"
     },
     {
@@ -4191,12 +3663,6 @@
         "rotate": [0, 2.3000000000000003, 0]
       },
       "material": "mat-27",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "2.743 - 0.000 * smoothstep(177.50, 178.50, t) + 0.05 * sin(0.35 * t + -60.60)"
-        }
-      ],
       "collection": "station-17"
     },
     {
@@ -4210,12 +3676,6 @@
         "rotate": [0, 0.09999999999999964, 0]
       },
       "material": "mat-27",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "3.248 - 0.000 * smoothstep(177.50, 178.50, t) + 0.07 * sin(0.40 * t + -68.18)"
-        }
-      ],
       "collection": "station-17"
     },
     {
@@ -4229,12 +3689,6 @@
         "rotate": [0, 1, 0]
       },
       "material": "mat-27",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "2.515 - 0.000 * smoothstep(177.50, 178.50, t) + 0.09 * sin(0.45 * t + -75.75)"
-        }
-      ],
       "collection": "station-17"
     },
     {
@@ -4248,12 +3702,6 @@
         "rotate": [0, 1.8999999999999995, 0]
       },
       "material": "mat-27",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "2.626 - 0.000 * smoothstep(177.50, 178.50, t) + 0.05 * sin(0.50 * t + -83.33)"
-        }
-      ],
       "collection": "station-17"
     },
     {
@@ -4267,12 +3715,6 @@
         "rotate": [0, 2.8, 0]
       },
       "material": "mat-27",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "2.275 - 0.000 * smoothstep(177.50, 178.50, t) + 0.07 * sin(0.30 * t + -52.81)"
-        }
-      ],
       "collection": "station-17"
     },
     {
@@ -4286,12 +3728,6 @@
         "rotate": [0, 0.6000000000000001, 0]
       },
       "material": "mat-27",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "2.074 - 0.000 * smoothstep(177.50, 178.50, t) + 0.09 * sin(0.35 * t + -60.38)"
-        }
-      ],
       "collection": "station-17"
     },
     {
@@ -4305,12 +3741,6 @@
         "rotate": [0, 1.5000000000000004, 0]
       },
       "material": "mat-27",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "1.917 - 0.000 * smoothstep(177.50, 178.50, t) + 0.05 * sin(0.40 * t + -67.96)"
-        }
-      ],
       "collection": "station-17"
     },
     {
@@ -4324,12 +3754,6 @@
         "rotate": [0, 2.400000000000001, 0]
       },
       "material": "mat-27",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "1.675 - 0.000 * smoothstep(177.50, 178.50, t) + 0.07 * sin(0.45 * t + -75.53)"
-        }
-      ],
       "collection": "station-17"
     },
     {
@@ -4343,12 +3767,6 @@
         "rotate": [0, 0.1999999999999993, 0]
       },
       "material": "mat-27",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "1.390 - 0.000 * smoothstep(177.50, 178.50, t) + 0.09 * sin(0.50 * t + -83.11)"
-        }
-      ],
       "collection": "station-17"
     },
     {
@@ -4362,12 +3780,6 @@
         "rotate": [0, 1.0999999999999996, 0]
       },
       "material": "mat-27",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "1.443 - 0.000 * smoothstep(177.50, 178.50, t) + 0.05 * sin(0.30 * t + -52.59)"
-        }
-      ],
       "collection": "station-17"
     },
     {
@@ -4381,12 +3793,6 @@
         "rotate": [0, 2, 0]
       },
       "material": "mat-27",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "0.717 - 0.000 * smoothstep(177.50, 178.50, t) + 0.07 * sin(0.35 * t + -60.16)"
-        }
-      ],
       "collection": "station-17"
     },
     {
@@ -4400,12 +3806,6 @@
         "rotate": [0, 2.9000000000000004, 0]
       },
       "material": "mat-27",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "1.316 - 0.000 * smoothstep(177.50, 178.50, t) + 0.09 * sin(0.40 * t + -67.74)"
-        }
-      ],
       "collection": "station-17"
     },
     {
@@ -4419,12 +3819,6 @@
         "rotate": [0, 0.6999999999999988, 0]
       },
       "material": "mat-27",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "-0.006 - 0.000 * smoothstep(177.50, 178.50, t) + 0.05 * sin(0.45 * t + -75.31)"
-        }
-      ],
       "collection": "station-17"
     },
     {
@@ -4438,12 +3832,6 @@
         "rotate": [0, 1.600000000000001, 0]
       },
       "material": "mat-27",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "1.174 - 0.000 * smoothstep(177.50, 178.50, t) + 0.07 * sin(0.50 * t + -82.89)"
-        }
-      ],
       "collection": "station-17"
     },
     {
@@ -4457,12 +3845,6 @@
         "rotate": [0, 2.4999999999999996, 0]
       },
       "material": "mat-27",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "-0.644 - 0.000 * smoothstep(177.50, 178.50, t) + 0.09 * sin(0.30 * t + -52.37)"
-        }
-      ],
       "collection": "station-17"
     },
     {
@@ -4476,12 +3858,6 @@
         "rotate": [0, 0.3000000000000016, 0]
       },
       "material": "mat-27",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "0.879 - 0.000 * smoothstep(177.50, 178.50, t) + 0.05 * sin(0.35 * t + -59.94)"
-        }
-      ],
       "collection": "station-17"
     },
     {
@@ -4613,12 +3989,6 @@
         "translate": [320, 3.15, 0]
       },
       "material": "mat-28",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "4.150 - 1 * smoothstep(205.55, 206.10, t)"
-        }
-      ],
       "collection": "station-20"
     },
     {
@@ -4652,12 +4022,6 @@
         "translate": [320, 2, -1.9]
       },
       "material": "mat-29",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "3.000 - 1 * smoothstep(207.05, 207.60, t)"
-        }
-      ],
       "collection": "station-20"
     },
     {
@@ -4691,12 +4055,6 @@
         "translate": [321.64544826719043, 2, 0.9499999999999996]
       },
       "material": "mat-29",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "3.000 - 1 * smoothstep(207.05, 207.60, t)"
-        }
-      ],
       "collection": "station-20"
     },
     {
@@ -4730,12 +4088,6 @@
         "translate": [318.35455173280957, 2, 0.9500000000000006]
       },
       "material": "mat-29",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "3.000 - 1 * smoothstep(207.05, 207.60, t)"
-        }
-      ],
       "collection": "station-20"
     },
     {
@@ -4769,12 +4121,6 @@
         "translate": [321.14289187648035, 0.8500000000000001, 1.6417095301905795]
       },
       "material": "mat-30",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "1.850 - 1 * smoothstep(208.55, 209.10, t)"
-        }
-      ],
       "collection": "station-20"
     },
     {
@@ -4873,12 +4219,6 @@
         "translate": [336.91, 3.2199999999999998, 0.34]
       },
       "material": "mat-33",
-      "animation": [
-        {
-          "channel": "transform.translate.z",
-          "expr": "2.400 - 2.060 * smoothstep(216.45, 216.90, t)"
-        }
-      ],
       "collection": "station-21"
     },
     {
@@ -4892,12 +4232,6 @@
         "translate": [336.91, 1.7999999999999998, 0.34]
       },
       "material": "mat-33",
-      "animation": [
-        {
-          "channel": "transform.translate.z",
-          "expr": "2.400 - 2.060 * smoothstep(217.35, 217.80, t)"
-        }
-      ],
       "collection": "station-21"
     },
     {
@@ -4911,12 +4245,6 @@
         "translate": [335.09, 3.2199999999999998, 0.34]
       },
       "material": "mat-33",
-      "animation": [
-        {
-          "channel": "transform.translate.z",
-          "expr": "2.400 - 2.060 * smoothstep(218.25, 218.70, t)"
-        }
-      ],
       "collection": "station-21"
     },
     {
@@ -4930,12 +4258,6 @@
         "translate": [335.09, 1.7999999999999998, 0.34]
       },
       "material": "mat-4",
-      "animation": [
-        {
-          "channel": "transform.translate.z",
-          "expr": "2.400 - 2.060 * smoothstep(219.15, 219.60, t)"
-        }
-      ],
       "collection": "station-21"
     },
     {
@@ -4949,12 +4271,6 @@
         "rotate": [0, -0.9, 0]
       },
       "material": "mat-12",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "3.310 - 0.000 * smoothstep(215.20, 216.20, t) + 0.06 * sin(0.30 * t + -64.56)"
-        }
-      ],
       "collection": "station-21"
     },
     {
@@ -4968,12 +4284,6 @@
         "rotate": [0, -0.4, 0]
       },
       "material": "mat-12",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "2.110 - 0.000 * smoothstep(215.20, 216.20, t) + 0.08 * sin(0.37 * t + -77.42)"
-        }
-      ],
       "collection": "station-21"
     },
     {
@@ -4987,12 +4297,6 @@
         "rotate": [0, 0.09999999999999998, 0]
       },
       "material": "mat-12",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "4.710 - 0.000 * smoothstep(215.20, 216.20, t) + 0.10 * sin(0.44 * t + -90.29)"
-        }
-      ],
       "collection": "station-21"
     },
     {
@@ -5006,12 +4310,6 @@
         "rotate": [0, 0.6, 0]
       },
       "material": "mat-12",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "4.110 - 0.000 * smoothstep(215.20, 216.20, t) + 0.12 * sin(0.51 * t + -109.43)"
-        }
-      ],
       "collection": "station-21"
     },
     {
@@ -5057,12 +4355,6 @@
         "translate": [353.27, 0.24, 0]
       },
       "material": "mat-6",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "-0.540 + 0.780 * smoothstep(226.35, 226.95, t)"
-        }
-      ],
       "pattern": "cracked",
       "collection": "station-22"
     },
@@ -5089,12 +4381,6 @@
         "translate": [352, 1.2, 0]
       },
       "material": "mat-20",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "-1.500 + 2.700 * smoothstep(227.45, 228.05, t)"
-        }
-      ],
       "pattern": "cracked",
       "collection": "station-22"
     },
@@ -5121,12 +4407,6 @@
         "translate": [350.73, 2.4, 0]
       },
       "material": "mat-11",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "-2.700 + 5.100 * smoothstep(228.55, 229.15, t)"
-        }
-      ],
       "collection": "station-22"
     },
     {
@@ -5667,6 +4947,7 @@
       "text": "① 即将爆发的个性化数字媒体市场",
       "anchor": [15.69684708965934, 6.717749959911059, -1.2],
       "role": "screen",
+      "side": "right",
       "revealAt": 10.05,
       "hideAt": 18.6
     },
@@ -5681,6 +4962,7 @@
       "text": "② 独创的个性化资讯发现引擎",
       "anchor": [14.334200264481655, 5.888298781822307, -1.2],
       "role": "screen",
+      "side": "right",
       "revealAt": 11.05,
       "hideAt": 18.6
     },
@@ -5695,6 +4977,7 @@
       "text": "③ 领先于世界同类产品的功能和技术",
       "anchor": [13.55265671555532, 4.497620778785201, -1.2],
       "role": "screen",
+      "side": "right",
       "revealAt": 12.05,
       "hideAt": 18.6
     },
@@ -5709,6 +4992,7 @@
       "text": "④ 行业领先的用户粘度和自然增长",
       "anchor": [13.55265671555532, 2.902379221214799, -1.2],
       "role": "screen",
+      "side": "right",
       "revealAt": 13.05,
       "hideAt": 18.6
     },
@@ -5723,6 +5007,7 @@
       "text": "⑤ 完善的多产品布局,覆盖移动终端和 PC 端",
       "anchor": [14.334200264481655, 1.5117012181776928, -1.2],
       "role": "screen",
+      "side": "right",
       "revealAt": 14.05,
       "hideAt": 18.6
     },
@@ -5737,6 +5022,7 @@
       "text": "⑥ 具有丰富创业经验和技术功底的团队",
       "anchor": [15.69684708965934, 0.6822500400889417, -1.2],
       "role": "screen",
+      "side": "right",
       "revealAt": 15.05,
       "hideAt": 18.6
     },
@@ -6222,6 +5508,7 @@
       "text": "编辑挑选·连续阅读",
       "anchor": [99.6, 0.19999999999999996, 0.5],
       "role": "screen",
+      "side": "left",
       "revealAt": 73.40000000000002,
       "hideAt": 82.40000000000002
     },
@@ -6229,6 +5516,7 @@
       "text": "浏览/搜索/媒体转载",
       "anchor": [96, 0.19999999999999996, 0.5],
       "role": "screen",
+      "side": "left",
       "revealAt": 73.60000000000001,
       "hideAt": 82.40000000000002
     },
@@ -6236,6 +5524,7 @@
       "text": "PC",
       "anchor": [92.4, 0.19999999999999996, 0.5],
       "role": "screen",
+      "side": "left",
       "revealAt": 73.80000000000001,
       "hideAt": 82.40000000000002
     },
@@ -6243,6 +5532,7 @@
       "text": "个性化·社交化·碎片阅读",
       "anchor": [99.6, 5.3, 0.4],
       "role": "screen",
+      "side": "right",
       "revealAt": 76.75000000000001,
       "hideAt": 82.40000000000002
     },
@@ -6250,6 +5540,7 @@
       "text": "关注/推荐/转发",
       "anchor": [96, 5.3, 0.4],
       "role": "screen",
+      "side": "right",
       "revealAt": 77.85000000000001,
       "hideAt": 82.40000000000002
     },
@@ -6257,6 +5548,7 @@
       "text": "移动终端",
       "anchor": [92.4, 5.3, 0.4],
       "role": "screen",
+      "side": "right",
       "revealAt": 78.95000000000002,
       "hideAt": 82.40000000000002
     },
@@ -6629,6 +5921,7 @@
       "text": "① 独创的数据处理和推荐技术底框架",
       "anchor": [255.69684708965934, 6.717749959911059, -1.2],
       "role": "screen",
+      "side": "right",
       "revealAt": 169.74999999999997,
       "hideAt": 176.29999999999998
     },
@@ -6643,6 +5936,7 @@
       "text": "② 自然语言、多媒体信息处理",
       "anchor": [253.7323966600903, 5.003591609722465, -1.2],
       "role": "screen",
+      "side": "right",
       "revealAt": 170.74999999999997,
       "hideAt": 176.29999999999998
     },
@@ -6657,6 +5951,7 @@
       "text": "③ 高维度用户兴趣建模",
       "anchor": [253.7323966600903, 2.3964083902775357, -1.2],
       "role": "screen",
+      "side": "right",
       "revealAt": 171.74999999999997,
       "hideAt": 176.29999999999998
     },
@@ -6671,6 +5966,7 @@
       "text": "④ 高性能的实时大规模数据运算",
       "anchor": [255.69684708965934, 0.6822500400889417, -1.2],
       "role": "screen",
+      "side": "right",
       "revealAt": 172.74999999999997,
       "hideAt": 176.29999999999998
     },
@@ -6883,6 +6179,7 @@
       "text": "扩充信息类型和来源",
       "anchor": [336.91, 2.88, 0.2],
       "role": "screen",
+      "side": "left",
       "align": "center",
       "revealAt": 216.94999999999996,
       "hideAt": 223.49999999999997
@@ -6891,6 +6188,7 @@
       "text": "深挖用户特征·升级推荐系统",
       "anchor": [336.91, 1.4599999999999997, 0.2],
       "role": "screen",
+      "side": "left",
       "align": "center",
       "revealAt": 217.84999999999997,
       "hideAt": 223.49999999999997
@@ -6899,6 +6197,7 @@
       "text": "强化社区互动",
       "anchor": [335.09, 2.88, 0.2],
       "role": "screen",
+      "side": "right",
       "align": "center",
       "revealAt": 218.74999999999997,
       "hideAt": 223.49999999999997
@@ -6907,6 +6206,7 @@
       "text": "国际化与商业化尝试",
       "anchor": [335.09, 1.4599999999999997, 0.2],
       "role": "screen",
+      "side": "right",
       "align": "center",
       "revealAt": 219.64999999999995,
       "hideAt": 223.49999999999997

--- a/sdf-js/fixtures/golden/assemble-deck-radial.json
+++ b/sdf-js/fixtures/golden/assemble-deck-radial.json
@@ -1137,12 +1137,6 @@
         "rotate": [0, -1, 0]
       },
       "material": "mat-0",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "3.400 - 0.000 * smoothstep(0.00, 1.00, t) + 0.07 * sin(0.35 * t + 0.00)"
-        }
-      ],
       "collection": "station-0"
     },
     {
@@ -1157,12 +1151,6 @@
         "rotate": [0, -0.5, 0]
       },
       "material": "mat-0",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "2.600 - 0.000 * smoothstep(0.00, 1.00, t) + 0.09 * sin(0.43 * t + 2.10)"
-        }
-      ],
       "collection": "station-0"
     },
     {
@@ -1177,12 +1165,6 @@
         "rotate": [0, 0, 0]
       },
       "material": "mat-0",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "4.600 - 0.000 * smoothstep(0.00, 1.00, t) + 0.11 * sin(0.51 * t + 4.20)"
-        }
-      ],
       "collection": "station-0"
     },
     {
@@ -1197,12 +1179,6 @@
         "rotate": [0, 0.5, 0]
       },
       "material": "mat-0",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "4.000 - 0.000 * smoothstep(0.00, 1.00, t) + 0.13 * sin(0.59 * t + 0.02)"
-        }
-      ],
       "collection": "station-0"
     },
     {
@@ -1217,12 +1193,6 @@
         "rotate": [0, 1, 0]
       },
       "material": "mat-0",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "5.800 - 0.000 * smoothstep(0.00, 1.00, t) + 0.15 * sin(0.67 * t + 2.12)"
-        }
-      ],
       "collection": "station-0"
     },
     {
@@ -1237,12 +1207,6 @@
         "rotate": [0, 1.5, 0]
       },
       "material": "mat-0",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "5.200 - 0.000 * smoothstep(0.00, 1.00, t) + 0.17 * sin(0.75 * t + 4.22)"
-        }
-      ],
       "collection": "station-0"
     },
     {
@@ -1257,12 +1221,6 @@
         "rotate": [0, 2, 0]
       },
       "material": "mat-0",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "7.000 - 0.000 * smoothstep(0.00, 1.00, t) + 0.19 * sin(0.83 * t + 0.04)"
-        }
-      ],
       "collection": "station-0"
     },
     {
@@ -1277,12 +1235,6 @@
         "rotate": [0, 2.5, 0]
       },
       "material": "mat-0",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "6.400 - 0.000 * smoothstep(0.00, 1.00, t) + 0.21 * sin(0.91 * t + 2.14)"
-        }
-      ],
       "collection": "station-0"
     },
     {
@@ -1297,12 +1249,6 @@
         "rotate": [0, 3, 0]
       },
       "material": "mat-0",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "2.000 - 0.000 * smoothstep(0.00, 1.00, t) + 0.23 * sin(0.99 * t + 4.24)"
-        }
-      ],
       "collection": "station-0"
     },
     {
@@ -1337,12 +1283,6 @@
         "rotate": [0, 0, 1.5707963267948966]
       },
       "material": "mat-2",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "3.700 - 0.000 * smoothstep(7.60, 8.60, t) + 0.07 * sin(0.35 * t + -1.56)"
-        }
-      ],
       "collection": "station-1"
     },
     {
@@ -1355,12 +1295,6 @@
         "translate": [15.498579321292716, 6.717749959911059, 55.197120953775176]
       },
       "material": "mat-3",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "8.018 - 1.300 * smoothstep(9.45, 10.00, t) + 0.04 * sin(0.6 * t + -4.56)"
-        }
-      ],
       "collection": "station-1"
     },
     {
@@ -1373,12 +1307,6 @@
         "translate": [14.135932496115032, 5.888298781822307, 55.197120953775176]
       },
       "material": "mat-4",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "7.188 - 1.300 * smoothstep(10.45, 11.00, t) + 0.04 * sin(0.6 * t + -2.86)"
-        }
-      ],
       "collection": "station-1"
     },
     {
@@ -1391,12 +1319,6 @@
         "translate": [13.354388947188697, 4.497620778785201, 55.197120953775176]
       },
       "material": "mat-3",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "5.798 - 1.300 * smoothstep(11.45, 12.00, t) + 0.04 * sin(0.6 * t + -1.16)"
-        }
-      ],
       "collection": "station-1"
     },
     {
@@ -1409,12 +1331,6 @@
         "translate": [13.354388947188697, 2.902379221214799, 55.197120953775176]
       },
       "material": "mat-3",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "4.202 - 1.300 * smoothstep(12.45, 13.00, t) + 0.04 * sin(0.6 * t + 0.54)"
-        }
-      ],
       "collection": "station-1"
     },
     {
@@ -1427,12 +1343,6 @@
         "translate": [14.135932496115032, 1.5117012181776928, 55.197120953775176]
       },
       "material": "mat-3",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "2.812 - 1.300 * smoothstep(13.45, 14.00, t) + 0.04 * sin(0.6 * t + -4.04)"
-        }
-      ],
       "collection": "station-1"
     },
     {
@@ -1445,12 +1355,6 @@
         "translate": [15.498579321292716, 0.6822500400889417, 55.197120953775176]
       },
       "material": "mat-3",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "1.982 - 1.300 * smoothstep(14.45, 15.00, t) + 0.04 * sin(0.6 * t + -2.34)"
-        }
-      ],
       "collection": "station-1"
     },
     {
@@ -1496,12 +1400,6 @@
         "translate": [33.60652227176139, 0.9931034482758622, 50.042506388252356]
       },
       "material": "mat-6",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "-1.293 + 2.286 * smoothstep(21.45, 22.05, t)"
-        }
-      ],
       "pattern": "cracked",
       "collection": "station-2"
     },
@@ -1528,12 +1426,6 @@
         "translate": [32.336522271761396, 1.2413793103448276, 50.042506388252356]
       },
       "material": "mat-7",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "-1.541 + 2.783 * smoothstep(22.55, 23.15, t)"
-        }
-      ],
       "pattern": "cracked",
       "collection": "station-2"
     },
@@ -1560,12 +1452,6 @@
         "translate": [31.066522271761396, 1.6, 50.042506388252356]
       },
       "material": "mat-8",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "-1.900 + 3.500 * smoothstep(23.65, 24.25, t)"
-        }
-      ],
       "pattern": "cracked",
       "collection": "station-2"
     },
@@ -1592,12 +1478,6 @@
         "translate": [29.796522271761393, 1.9034482758620692, 50.042506388252356]
       },
       "material": "mat-9",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "-2.203 + 4.107 * smoothstep(24.75, 25.35, t)"
-        }
-      ],
       "pattern": "cracked",
       "collection": "station-2"
     },
@@ -1624,12 +1504,6 @@
         "translate": [28.526522271761394, 2.1517241379310343, 50.042506388252356]
       },
       "material": "mat-10",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "-2.452 + 4.603 * smoothstep(25.85, 26.45, t)"
-        }
-      ],
       "pattern": "cracked",
       "collection": "station-2"
     },
@@ -1656,12 +1530,6 @@
         "translate": [27.256522271761394, 2.4, 50.042506388252356]
       },
       "material": "mat-11",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "-2.700 + 5.100 * smoothstep(26.95, 27.55, t)"
-        }
-      ],
       "collection": "station-2"
     },
     {
@@ -1767,12 +1635,6 @@
         "translate": [45.97934551994386, 0.14464710547184773, 39.97646805314658]
       },
       "material": "mat-6",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "-0.445 + 0.589 * smoothstep(34.75, 35.35, t)"
-        }
-      ],
       "pattern": "cracked",
       "collection": "station-3"
     },
@@ -1799,12 +1661,6 @@
         "translate": [44.70934551994387, 0.28263283108643933, 39.97646805314658]
       },
       "material": "mat-7",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "-0.583 + 0.865 * smoothstep(35.85, 36.45, t)"
-        }
-      ],
       "pattern": "cracked",
       "collection": "station-3"
     },
@@ -1831,12 +1687,6 @@
         "translate": [43.43934551994386, 0.5443298969072166, 39.97646805314658]
       },
       "material": "mat-8",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "-0.844 + 1.389 * smoothstep(36.95, 37.55, t)"
-        }
-      ],
       "pattern": "cracked",
       "collection": "station-3"
     },
@@ -1863,12 +1713,6 @@
         "translate": [42.16934551994387, 0.9601903251387788, 39.97646805314658]
       },
       "material": "mat-9",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "-1.260 + 2.220 * smoothstep(38.05, 38.65, t)"
-        }
-      ],
       "pattern": "cracked",
       "collection": "station-3"
     },
@@ -1895,12 +1739,6 @@
         "translate": [40.899345519943864, 1.5501982553528946, 39.97646805314658]
       },
       "material": "mat-10",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "-1.850 + 3.400 * smoothstep(39.15, 39.75, t)"
-        }
-      ],
       "pattern": "cracked",
       "collection": "station-3"
     },
@@ -1927,12 +1765,6 @@
         "translate": [39.62934551994387, 2.4, 39.97646805314658]
       },
       "material": "mat-11",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "-2.700 + 5.100 * smoothstep(40.25, 40.85, t)"
-        }
-      ],
       "collection": "station-3"
     },
     {
@@ -2038,12 +1870,6 @@
         "translate": [55.17756627776315, 2.4, 26.945557962711373]
       },
       "material": "mat-11",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "-2.700 + 5.100 * smoothstep(48.05, 48.65, t)"
-        }
-      ],
       "collection": "station-4"
     },
     {
@@ -2069,12 +1895,6 @@
         "translate": [53.90756627776315, 2.2374501992031868, 26.945557962711373]
       },
       "material": "mat-7",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "-2.537 + 4.775 * smoothstep(49.15, 49.75, t)"
-        }
-      ],
       "pattern": "cracked",
       "collection": "station-4"
     },
@@ -2101,12 +1921,6 @@
         "translate": [52.63756627776315, 1.4151394422310757, 26.945557962711373]
       },
       "material": "mat-8",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "-1.715 + 3.130 * smoothstep(50.25, 50.85, t)"
-        }
-      ],
       "pattern": "cracked",
       "collection": "station-4"
     },
@@ -2133,12 +1947,6 @@
         "translate": [51.36756627776315, 1.2430278884462151, 26.945557962711373]
       },
       "material": "mat-9",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "-1.543 + 2.786 * smoothstep(51.35, 51.95, t)"
-        }
-      ],
       "pattern": "cracked",
       "collection": "station-4"
     },
@@ -2165,12 +1973,6 @@
         "translate": [50.09756627776315, 0.7362549800796813, 26.945557962711373]
       },
       "material": "mat-10",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "-1.036 + 1.773 * smoothstep(52.45, 53.05, t)"
-        }
-      ],
       "pattern": "cracked",
       "collection": "station-4"
     },
@@ -2197,12 +1999,6 @@
         "translate": [48.827566277763154, 0.6501992031872509, 26.945557962711373]
       },
       "material": "mat-13",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "-0.950 + 1.600 * smoothstep(53.55, 54.15, t)"
-        }
-      ],
       "pattern": "cracked",
       "collection": "station-4"
     },
@@ -2309,12 +2105,6 @@
         "translate": [60.51899459067182, 2.4, 11.916219105907269]
       },
       "material": "mat-11",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "-2.700 + 5.100 * smoothstep(61.35, 61.95, t)"
-        }
-      ],
       "collection": "station-5"
     },
     {
@@ -2340,12 +2130,6 @@
         "translate": [59.24899459067182, 2.2072538860103625, 11.916219105907269]
       },
       "material": "mat-7",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "-2.507 + 4.715 * smoothstep(62.45, 63.05, t)"
-        }
-      ],
       "pattern": "cracked",
       "collection": "station-5"
     },
@@ -2372,12 +2156,6 @@
         "translate": [57.97899459067182, 1.5015544041450775, 11.916219105907269]
       },
       "material": "mat-8",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "-1.802 + 3.303 * smoothstep(63.55, 64.15, t)"
-        }
-      ],
       "pattern": "cracked",
       "collection": "station-5"
     },
@@ -2404,12 +2182,6 @@
         "translate": [56.70899459067182, 1.2590673575129532, 11.916219105907269]
       },
       "material": "mat-9",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "-1.559 + 2.818 * smoothstep(64.65, 65.25, t)"
-        }
-      ],
       "pattern": "cracked",
       "collection": "station-5"
     },
@@ -2436,12 +2208,6 @@
         "translate": [55.43899459067182, 1.0290155440414508, 11.916219105907269]
       },
       "material": "mat-10",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "-1.329 + 2.358 * smoothstep(65.75, 66.35, t)"
-        }
-      ],
       "pattern": "cracked",
       "collection": "station-5"
     },
@@ -2468,12 +2234,6 @@
         "translate": [54.16899459067182, 0.9699481865284973, 11.916219105907269]
       },
       "material": "mat-13",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "-1.270 + 2.240 * smoothstep(66.85, 67.45, t)"
-        }
-      ],
       "pattern": "cracked",
       "collection": "station-5"
     },
@@ -2606,12 +2366,6 @@
         "translate": [62.03248115611, 4.3, -3.996891208906867]
       },
       "material": "mat-14",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "0.950 + 3.350 * smoothstep(75.90, 76.65, t) + 0.05 * sin(0.5 * t + -36.50)"
-        }
-      ],
       "collection": "station-6"
     },
     {
@@ -2624,12 +2378,6 @@
         "translate": [58.43248115611, 4.3, -3.996891208906867]
       },
       "material": "mat-3",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "0.950 + 3.350 * smoothstep(77.00, 77.75, t) + 0.05 * sin(0.5 * t + -34.40)"
-        }
-      ],
       "collection": "station-6"
     },
     {
@@ -2642,12 +2390,6 @@
         "translate": [54.83248115611, 4.3, -3.996891208906867]
       },
       "material": "mat-3",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "0.950 + 3.350 * smoothstep(78.10, 78.85, t) + 0.05 * sin(0.5 * t + -32.30)"
-        }
-      ],
       "collection": "station-6"
     },
     {
@@ -2661,12 +2403,6 @@
         "translate": [65.33248115611, 2.175, -3.996891208906867]
       },
       "material": "mat-15",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "0.175 + 2.000 * smoothstep(74.80, 75.50, t)"
-        }
-      ],
       "collection": "station-6"
     },
     {
@@ -2679,12 +2415,6 @@
         "translate": [65.33248115611, 3.4999999999999996, -3.996891208906867]
       },
       "material": "mat-15",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "1.500 + 2.000 * smoothstep(74.80, 75.50, t)"
-        }
-      ],
       "collection": "station-6"
     },
     {
@@ -2697,12 +2427,6 @@
         "translate": [65.33248115611, 3.7199999999999998, -3.996891208906867]
       },
       "material": "mat-15",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "1.720 + 2.000 * smoothstep(74.80, 75.50, t)"
-        }
-      ],
       "collection": "station-6"
     },
     {
@@ -2715,12 +2439,6 @@
         "translate": [65.33248115611, 3.9399999999999995, -3.996891208906867]
       },
       "material": "mat-15",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "1.940 + 2.000 * smoothstep(74.80, 75.50, t)"
-        }
-      ],
       "collection": "station-6"
     },
     {
@@ -2733,12 +2451,6 @@
         "translate": [65.33248115611, 4.159999999999999, -3.996891208906867]
       },
       "material": "mat-15",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "2.160 + 2.000 * smoothstep(74.80, 75.50, t)"
-        }
-      ],
       "collection": "station-6"
     },
     {
@@ -3099,12 +2811,6 @@
         "translate": [-33.78720183839145, 0.06, -45.43264936863136]
       },
       "material": "mat-6",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "-0.360 + 0.420 * smoothstep(141.25, 141.85, t)"
-        }
-      ],
       "pattern": "cracked",
       "collection": "station-14"
     },
@@ -3131,12 +2837,6 @@
         "translate": [-35.05720183839144, 0.1945945945945946, -45.43264936863136]
       },
       "material": "mat-7",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "-0.495 + 0.689 * smoothstep(142.35, 142.95, t)"
-        }
-      ],
       "pattern": "cracked",
       "collection": "station-14"
     },
@@ -3163,12 +2863,6 @@
         "translate": [-36.327201838391446, 0.5837837837837838, -45.43264936863136]
       },
       "material": "mat-8",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "-0.884 + 1.468 * smoothstep(143.45, 144.05, t)"
-        }
-      ],
       "pattern": "cracked",
       "collection": "station-14"
     },
@@ -3195,12 +2889,6 @@
         "translate": [-37.59720183839144, 1.1027027027027028, -45.43264936863136]
       },
       "material": "mat-9",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "-1.403 + 2.505 * smoothstep(144.55, 145.15, t)"
-        }
-      ],
       "pattern": "cracked",
       "collection": "station-14"
     },
@@ -3227,12 +2915,6 @@
         "translate": [-38.867201838391445, 1.945945945945946, -45.43264936863136]
       },
       "material": "mat-10",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "-2.246 + 4.192 * smoothstep(145.65, 146.25, t)"
-        }
-      ],
       "pattern": "cracked",
       "collection": "station-14"
     },
@@ -3259,12 +2941,6 @@
         "translate": [-40.13720183839144, 2.4, -45.43264936863136]
       },
       "material": "mat-11",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "-2.700 + 5.100 * smoothstep(146.75, 147.35, t)"
-        }
-      ],
       "collection": "station-14"
     },
     {
@@ -3370,12 +3046,6 @@
         "translate": [-44.03912523339169, 2.4, -33.775600776213984]
       },
       "material": "mat-6",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "-2.700 + 5.100 * smoothstep(154.55, 155.15, t)"
-        }
-      ],
       "pattern": "cracked",
       "collection": "station-15"
     },
@@ -3402,12 +3072,6 @@
         "translate": [-45.30912523339169, 2.3564356435643563, -33.775600776213984]
       },
       "material": "mat-18",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "-2.656 + 5.013 * smoothstep(155.65, 156.25, t)"
-        }
-      ],
       "pattern": "cracked",
       "collection": "station-15"
     },
@@ -3434,12 +3098,6 @@
         "translate": [-46.579125233391686, 2.2376237623762374, -33.775600776213984]
       },
       "material": "mat-19",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "-2.538 + 4.775 * smoothstep(156.75, 157.35, t)"
-        }
-      ],
       "pattern": "cracked",
       "collection": "station-15"
     },
@@ -3466,12 +3124,6 @@
         "translate": [-47.84912523339169, 2.1425742574257423, -33.775600776213984]
       },
       "material": "mat-20",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "-2.443 + 4.585 * smoothstep(157.85, 158.45, t)"
-        }
-      ],
       "pattern": "cracked",
       "collection": "station-15"
     },
@@ -3498,12 +3150,6 @@
         "translate": [-49.11912523339169, 2.023762376237624, -33.775600776213984]
       },
       "material": "mat-21",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "-2.324 + 4.348 * smoothstep(158.95, 159.55, t)"
-        }
-      ],
       "pattern": "cracked",
       "collection": "station-15"
     },
@@ -3530,12 +3176,6 @@
         "translate": [-50.38912523339169, 1.881188118811881, -33.775600776213984]
       },
       "material": "mat-22",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "-2.181 + 4.062 * smoothstep(160.05, 160.65, t)"
-        }
-      ],
       "pattern": "cracked",
       "collection": "station-15"
     },
@@ -3562,12 +3202,6 @@
         "translate": [-51.65912523339169, 1.786138613861386, -33.775600776213984]
       },
       "material": "mat-11",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "-2.086 + 3.872 * smoothstep(161.15, 161.75, t)"
-        }
-      ],
       "collection": "station-15"
     },
     {
@@ -3662,12 +3296,6 @@
         "rotate": [0, 0, 1.5707963267948966]
       },
       "material": "mat-2",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "3.700 - 0.000 * smoothstep(167.30, 168.30, t) + 0.07 * sin(0.35 * t + -57.45)"
-        }
-      ],
       "collection": "station-16"
     },
     {
@@ -3680,12 +3308,6 @@
         "translate": [-55.49045081535453, 6.717749959911059, -20.81357038731703]
       },
       "material": "mat-4",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "8.018 - 1.300 * smoothstep(169.15, 169.70, t) + 0.04 * sin(0.6 * t + -100.38)"
-        }
-      ],
       "collection": "station-16"
     },
     {
@@ -3698,12 +3320,6 @@
         "translate": [-57.45490124492356, 5.003591609722465, -20.81357038731703]
       },
       "material": "mat-3",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "6.304 - 1.300 * smoothstep(170.15, 170.70, t) + 0.04 * sin(0.6 * t + -98.68)"
-        }
-      ],
       "collection": "station-16"
     },
     {
@@ -3716,12 +3332,6 @@
         "translate": [-57.45490124492356, 2.3964083902775357, -20.81357038731703]
       },
       "material": "mat-3",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "3.696 - 1.300 * smoothstep(171.15, 171.70, t) + 0.04 * sin(0.6 * t + -96.98)"
-        }
-      ],
       "collection": "station-16"
     },
     {
@@ -3734,12 +3344,6 @@
         "translate": [-55.49045081535453, 0.6822500400889417, -20.81357038731703]
       },
       "material": "mat-3",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "1.982 - 1.300 * smoothstep(172.15, 172.70, t) + 0.04 * sin(0.6 * t + -95.28)"
-        }
-      ],
       "collection": "station-16"
     },
     {
@@ -3772,12 +3376,6 @@
         "translate": [-59.08974899002229, 8.240083449326644, -4.207163672311558]
       },
       "material": "mat-23",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "9.340 - 1.1 * smoothstep(177.75, 178.25, t) + 0.018 * sin(1.3 * t + -230.75)"
-        }
-      ],
       "collection": "station-17"
     },
     {
@@ -3790,12 +3388,6 @@
         "translate": [-60.99638941772459, 6.556638433341682, -3.5939557666537056]
       },
       "material": "mat-24",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "7.657 - 1.1 * smoothstep(177.87, 178.37, t) + 0.018 * sin(1.3 * t + -228.65)"
-        }
-      ],
       "collection": "station-17"
     },
     {
@@ -3808,12 +3400,6 @@
         "translate": [-59.642210909989316, 5.410462203579505, -6.07388246213735]
       },
       "material": "mat-24",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "6.510 - 1.1 * smoothstep(177.99, 178.49, t) + 0.018 * sin(1.3 * t + -226.55)"
-        }
-      ],
       "collection": "station-17"
     },
     {
@@ -3826,12 +3412,6 @@
         "translate": [-58.43248115611001, 4.034705367679379, -3.996891208906843]
       },
       "material": "mat-25",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "5.135 - 1.1 * smoothstep(178.11, 178.61, t) + 0.018 * sin(1.3 * t + -224.45)"
-        }
-      ],
       "collection": "station-17"
     },
     {
@@ -3844,12 +3424,6 @@
         "translate": [-61.5594986330423, 3.0535128331174013, -4.121645787576225]
       },
       "material": "mat-11",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "4.154 - 1.1 * smoothstep(178.23, 178.73, t) + 0.018 * sin(1.3 * t + -222.35)"
-        }
-      ],
       "collection": "station-17"
     },
     {
@@ -3862,12 +3436,6 @@
         "translate": [-56.77554925003693, 2.3752519777557772, -5.490334895955035]
       },
       "material": "mat-24",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "3.475 - 1.1 * smoothstep(178.35, 178.85, t) + 0.018 * sin(1.3 * t + -220.25)"
-        }
-      ],
       "collection": "station-17"
     },
     {
@@ -3880,12 +3448,6 @@
         "translate": [-60.551251890578605, 1.4770305268093469, -2.2439479164134744]
       },
       "material": "mat-24",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "2.577 - 1.1 * smoothstep(178.47, 178.97, t) + 0.018 * sin(1.3 * t + -218.15)"
-        }
-      ],
       "collection": "station-17"
     },
     {
@@ -3898,12 +3460,6 @@
         "translate": [-58.932525422374646, 0.6000000000000001, -4.615136752840582]
       },
       "material": "mat-24",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "1.700 - 1.1 * smoothstep(178.59, 179.09, t) + 0.018 * sin(1.3 * t + -216.05)"
-        }
-      ],
       "collection": "station-17"
     },
     {
@@ -3918,12 +3474,6 @@
         "translate": [-59.08974899002229, 8.240083449326644, -4.207163672311558]
       },
       "material": "mat-26",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "9.340 - 1.1 * smoothstep(178.91, 179.36, t)"
-        }
-      ],
       "collection": "station-17"
     },
     {
@@ -3938,12 +3488,6 @@
         "translate": [-60.99638941772459, 6.556638433341682, -3.5939557666537056]
       },
       "material": "mat-26",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "7.657 - 1.1 * smoothstep(179.05, 179.50, t)"
-        }
-      ],
       "collection": "station-17"
     },
     {
@@ -3958,12 +3502,6 @@
         "translate": [-59.642210909989316, 5.410462203579505, -6.07388246213735]
       },
       "material": "mat-26",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "6.510 - 1.1 * smoothstep(179.19, 179.64, t)"
-        }
-      ],
       "collection": "station-17"
     },
     {
@@ -3978,12 +3516,6 @@
         "translate": [-58.43248115611001, 4.034705367679379, -3.996891208906843]
       },
       "material": "mat-26",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "5.135 - 1.1 * smoothstep(179.33, 179.78, t)"
-        }
-      ],
       "collection": "station-17"
     },
     {
@@ -3998,12 +3530,6 @@
         "translate": [-61.5594986330423, 3.0535128331174013, -4.121645787576225]
       },
       "material": "mat-26",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "4.154 - 1.1 * smoothstep(179.47, 179.92, t)"
-        }
-      ],
       "collection": "station-17"
     },
     {
@@ -4018,12 +3544,6 @@
         "translate": [-60.551251890578605, 1.4770305268093469, -2.2439479164134744]
       },
       "material": "mat-26",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "2.577 - 1.1 * smoothstep(179.61, 180.06, t)"
-        }
-      ],
       "collection": "station-17"
     },
     {
@@ -4038,12 +3558,6 @@
         "translate": [-58.932525422374646, 0.6000000000000001, -4.615136752840582]
       },
       "material": "mat-26",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "1.700 - 1.1 * smoothstep(179.75, 180.20, t)"
-        }
-      ],
       "collection": "station-17"
     },
     {
@@ -4058,12 +3572,6 @@
         "translate": [-56.77554925003693, 2.3752519777557772, -5.490334895955035]
       },
       "material": "mat-26",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "3.475 - 1.1 * smoothstep(179.89, 180.34, t)"
-        }
-      ],
       "collection": "station-17"
     },
     {
@@ -4077,12 +3585,6 @@
         "rotate": [0, 0, 0]
       },
       "material": "mat-27",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "4.405 - 0.000 * smoothstep(177.50, 178.50, t) + 0.05 * sin(0.30 * t + -53.25)"
-        }
-      ],
       "collection": "station-17"
     },
     {
@@ -4096,12 +3598,6 @@
         "rotate": [0, 0.9, 0]
       },
       "material": "mat-27",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "4.400 - 0.000 * smoothstep(177.50, 178.50, t) + 0.07 * sin(0.35 * t + -60.82)"
-        }
-      ],
       "collection": "station-17"
     },
     {
@@ -4115,12 +3611,6 @@
         "rotate": [0, 1.8, 0]
       },
       "material": "mat-27",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "3.630 - 0.000 * smoothstep(177.50, 178.50, t) + 0.09 * sin(0.40 * t + -68.40)"
-        }
-      ],
       "collection": "station-17"
     },
     {
@@ -4134,12 +3624,6 @@
         "rotate": [0, 2.7, 0]
       },
       "material": "mat-27",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "4.223 - 0.000 * smoothstep(177.50, 178.50, t) + 0.05 * sin(0.45 * t + -75.97)"
-        }
-      ],
       "collection": "station-17"
     },
     {
@@ -4153,12 +3637,6 @@
         "rotate": [0, 0.5, 0]
       },
       "material": "mat-27",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "3.084 - 0.000 * smoothstep(177.50, 178.50, t) + 0.07 * sin(0.50 * t + -83.55)"
-        }
-      ],
       "collection": "station-17"
     },
     {
@@ -4172,12 +3650,6 @@
         "rotate": [0, 1.4, 0]
       },
       "material": "mat-27",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "3.818 - 0.000 * smoothstep(177.50, 178.50, t) + 0.09 * sin(0.30 * t + -53.03)"
-        }
-      ],
       "collection": "station-17"
     },
     {
@@ -4191,12 +3663,6 @@
         "rotate": [0, 2.3000000000000003, 0]
       },
       "material": "mat-27",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "2.743 - 0.000 * smoothstep(177.50, 178.50, t) + 0.05 * sin(0.35 * t + -60.60)"
-        }
-      ],
       "collection": "station-17"
     },
     {
@@ -4210,12 +3676,6 @@
         "rotate": [0, 0.09999999999999964, 0]
       },
       "material": "mat-27",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "3.248 - 0.000 * smoothstep(177.50, 178.50, t) + 0.07 * sin(0.40 * t + -68.18)"
-        }
-      ],
       "collection": "station-17"
     },
     {
@@ -4229,12 +3689,6 @@
         "rotate": [0, 1, 0]
       },
       "material": "mat-27",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "2.515 - 0.000 * smoothstep(177.50, 178.50, t) + 0.09 * sin(0.45 * t + -75.75)"
-        }
-      ],
       "collection": "station-17"
     },
     {
@@ -4248,12 +3702,6 @@
         "rotate": [0, 1.8999999999999995, 0]
       },
       "material": "mat-27",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "2.626 - 0.000 * smoothstep(177.50, 178.50, t) + 0.05 * sin(0.50 * t + -83.33)"
-        }
-      ],
       "collection": "station-17"
     },
     {
@@ -4267,12 +3715,6 @@
         "rotate": [0, 2.8, 0]
       },
       "material": "mat-27",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "2.275 - 0.000 * smoothstep(177.50, 178.50, t) + 0.07 * sin(0.30 * t + -52.81)"
-        }
-      ],
       "collection": "station-17"
     },
     {
@@ -4286,12 +3728,6 @@
         "rotate": [0, 0.6000000000000001, 0]
       },
       "material": "mat-27",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "2.074 - 0.000 * smoothstep(177.50, 178.50, t) + 0.09 * sin(0.35 * t + -60.38)"
-        }
-      ],
       "collection": "station-17"
     },
     {
@@ -4305,12 +3741,6 @@
         "rotate": [0, 1.5000000000000004, 0]
       },
       "material": "mat-27",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "1.917 - 0.000 * smoothstep(177.50, 178.50, t) + 0.05 * sin(0.40 * t + -67.96)"
-        }
-      ],
       "collection": "station-17"
     },
     {
@@ -4324,12 +3754,6 @@
         "rotate": [0, 2.400000000000001, 0]
       },
       "material": "mat-27",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "1.675 - 0.000 * smoothstep(177.50, 178.50, t) + 0.07 * sin(0.45 * t + -75.53)"
-        }
-      ],
       "collection": "station-17"
     },
     {
@@ -4343,12 +3767,6 @@
         "rotate": [0, 0.1999999999999993, 0]
       },
       "material": "mat-27",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "1.390 - 0.000 * smoothstep(177.50, 178.50, t) + 0.09 * sin(0.50 * t + -83.11)"
-        }
-      ],
       "collection": "station-17"
     },
     {
@@ -4362,12 +3780,6 @@
         "rotate": [0, 1.0999999999999996, 0]
       },
       "material": "mat-27",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "1.443 - 0.000 * smoothstep(177.50, 178.50, t) + 0.05 * sin(0.30 * t + -52.59)"
-        }
-      ],
       "collection": "station-17"
     },
     {
@@ -4381,12 +3793,6 @@
         "rotate": [0, 2, 0]
       },
       "material": "mat-27",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "0.717 - 0.000 * smoothstep(177.50, 178.50, t) + 0.07 * sin(0.35 * t + -60.16)"
-        }
-      ],
       "collection": "station-17"
     },
     {
@@ -4400,12 +3806,6 @@
         "rotate": [0, 2.9000000000000004, 0]
       },
       "material": "mat-27",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "1.316 - 0.000 * smoothstep(177.50, 178.50, t) + 0.09 * sin(0.40 * t + -67.74)"
-        }
-      ],
       "collection": "station-17"
     },
     {
@@ -4419,12 +3819,6 @@
         "rotate": [0, 0.6999999999999988, 0]
       },
       "material": "mat-27",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "-0.006 - 0.000 * smoothstep(177.50, 178.50, t) + 0.05 * sin(0.45 * t + -75.31)"
-        }
-      ],
       "collection": "station-17"
     },
     {
@@ -4438,12 +3832,6 @@
         "rotate": [0, 1.600000000000001, 0]
       },
       "material": "mat-27",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "1.174 - 0.000 * smoothstep(177.50, 178.50, t) + 0.07 * sin(0.50 * t + -82.89)"
-        }
-      ],
       "collection": "station-17"
     },
     {
@@ -4457,12 +3845,6 @@
         "rotate": [0, 2.4999999999999996, 0]
       },
       "material": "mat-27",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "-0.644 - 0.000 * smoothstep(177.50, 178.50, t) + 0.09 * sin(0.30 * t + -52.37)"
-        }
-      ],
       "collection": "station-17"
     },
     {
@@ -4476,12 +3858,6 @@
         "rotate": [0, 0.3000000000000016, 0]
       },
       "material": "mat-27",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "0.879 - 0.000 * smoothstep(177.50, 178.50, t) + 0.05 * sin(0.35 * t + -59.94)"
-        }
-      ],
       "collection": "station-17"
     },
     {
@@ -4613,12 +3989,6 @@
         "translate": [-42.804345519943865, 3.15, 39.97646805314659]
       },
       "material": "mat-28",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "4.150 - 1 * smoothstep(205.55, 206.10, t)"
-        }
-      ],
       "collection": "station-20"
     },
     {
@@ -4652,12 +4022,6 @@
         "translate": [-42.804345519943865, 2, 38.07646805314659]
       },
       "material": "mat-29",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "3.000 - 1 * smoothstep(207.05, 207.60, t)"
-        }
-      ],
       "collection": "station-20"
     },
     {
@@ -4691,12 +4055,6 @@
         "translate": [-41.158897252753434, 2, 40.92646805314659]
       },
       "material": "mat-29",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "3.000 - 1 * smoothstep(207.05, 207.60, t)"
-        }
-      ],
       "collection": "station-20"
     },
     {
@@ -4730,12 +4088,6 @@
         "translate": [-44.4497937871343, 2, 40.92646805314659]
       },
       "material": "mat-29",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "3.000 - 1 * smoothstep(207.05, 207.60, t)"
-        }
-      ],
       "collection": "station-20"
     },
     {
@@ -4769,12 +4121,6 @@
         "translate": [-41.661453643463496, 0.8500000000000001, 41.61817758333717]
       },
       "material": "mat-30",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "1.850 - 1 * smoothstep(208.55, 209.10, t)"
-        }
-      ],
       "collection": "station-20"
     },
     {
@@ -4873,12 +4219,6 @@
         "translate": [-29.521522271761395, 3.2199999999999998, 50.38250638825236]
       },
       "material": "mat-33",
-      "animation": [
-        {
-          "channel": "transform.translate.z",
-          "expr": "52.443 - 2.060 * smoothstep(216.45, 216.90, t)"
-        }
-      ],
       "collection": "station-21"
     },
     {
@@ -4892,12 +4232,6 @@
         "translate": [-29.521522271761395, 1.7999999999999998, 50.38250638825236]
       },
       "material": "mat-33",
-      "animation": [
-        {
-          "channel": "transform.translate.z",
-          "expr": "52.443 - 2.060 * smoothstep(217.35, 217.80, t)"
-        }
-      ],
       "collection": "station-21"
     },
     {
@@ -4911,12 +4245,6 @@
         "translate": [-31.341522271761395, 3.2199999999999998, 50.38250638825236]
       },
       "material": "mat-33",
-      "animation": [
-        {
-          "channel": "transform.translate.z",
-          "expr": "52.443 - 2.060 * smoothstep(218.25, 218.70, t)"
-        }
-      ],
       "collection": "station-21"
     },
     {
@@ -4930,12 +4258,6 @@
         "translate": [-31.341522271761395, 1.7999999999999998, 50.38250638825236]
       },
       "material": "mat-4",
-      "animation": [
-        {
-          "channel": "transform.translate.z",
-          "expr": "52.443 - 2.060 * smoothstep(219.15, 219.60, t)"
-        }
-      ],
       "collection": "station-21"
     },
     {
@@ -4949,12 +4271,6 @@
         "rotate": [0, -0.9, 0]
       },
       "material": "mat-12",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "3.310 - 0.000 * smoothstep(215.20, 216.20, t) + 0.06 * sin(0.30 * t + -64.56)"
-        }
-      ],
       "collection": "station-21"
     },
     {
@@ -4968,12 +4284,6 @@
         "rotate": [0, -0.4, 0]
       },
       "material": "mat-12",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "2.110 - 0.000 * smoothstep(215.20, 216.20, t) + 0.08 * sin(0.37 * t + -77.42)"
-        }
-      ],
       "collection": "station-21"
     },
     {
@@ -4987,12 +4297,6 @@
         "rotate": [0, 0.09999999999999998, 0]
       },
       "material": "mat-12",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "4.710 - 0.000 * smoothstep(215.20, 216.20, t) + 0.10 * sin(0.44 * t + -90.29)"
-        }
-      ],
       "collection": "station-21"
     },
     {
@@ -5006,12 +4310,6 @@
         "rotate": [0, 0.6, 0]
       },
       "material": "mat-12",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "4.110 - 0.000 * smoothstep(215.20, 216.20, t) + 0.12 * sin(0.51 * t + -109.43)"
-        }
-      ],
       "collection": "station-21"
     },
     {
@@ -5057,12 +4355,6 @@
         "translate": [-14.531732231633432, 0.24, 56.39712095377516]
       },
       "material": "mat-6",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "-0.540 + 0.780 * smoothstep(226.35, 226.95, t)"
-        }
-      ],
       "pattern": "cracked",
       "collection": "station-22"
     },
@@ -5089,12 +4381,6 @@
         "translate": [-15.801732231633432, 1.2, 56.39712095377516]
       },
       "material": "mat-20",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "-1.500 + 2.700 * smoothstep(227.45, 228.05, t)"
-        }
-      ],
       "pattern": "cracked",
       "collection": "station-22"
     },
@@ -5121,12 +4407,6 @@
         "translate": [-17.071732231633433, 2.4, 56.39712095377516]
       },
       "material": "mat-11",
-      "animation": [
-        {
-          "channel": "transform.translate.y",
-          "expr": "-2.700 + 5.100 * smoothstep(228.55, 229.15, t)"
-        }
-      ],
       "collection": "station-22"
     },
     {
@@ -5667,6 +4947,7 @@
       "text": "① 即将爆发的个性化数字媒体市场",
       "anchor": [15.498579321292716, 6.717749959911059, 55.197120953775176],
       "role": "screen",
+      "side": "right",
       "revealAt": 10.05,
       "hideAt": 18.6
     },
@@ -5681,6 +4962,7 @@
       "text": "② 独创的个性化资讯发现引擎",
       "anchor": [14.135932496115032, 5.888298781822307, 55.197120953775176],
       "role": "screen",
+      "side": "right",
       "revealAt": 11.05,
       "hideAt": 18.6
     },
@@ -5695,6 +4977,7 @@
       "text": "③ 领先于世界同类产品的功能和技术",
       "anchor": [13.354388947188697, 4.497620778785201, 55.197120953775176],
       "role": "screen",
+      "side": "right",
       "revealAt": 12.05,
       "hideAt": 18.6
     },
@@ -5709,6 +4992,7 @@
       "text": "④ 行业领先的用户粘度和自然增长",
       "anchor": [13.354388947188697, 2.902379221214799, 55.197120953775176],
       "role": "screen",
+      "side": "right",
       "revealAt": 13.05,
       "hideAt": 18.6
     },
@@ -5723,6 +5007,7 @@
       "text": "⑤ 完善的多产品布局,覆盖移动终端和 PC 端",
       "anchor": [14.135932496115032, 1.5117012181776928, 55.197120953775176],
       "role": "screen",
+      "side": "right",
       "revealAt": 14.05,
       "hideAt": 18.6
     },
@@ -5737,6 +5022,7 @@
       "text": "⑥ 具有丰富创业经验和技术功底的团队",
       "anchor": [15.498579321292716, 0.6822500400889417, 55.197120953775176],
       "role": "screen",
+      "side": "right",
       "revealAt": 15.05,
       "hideAt": 18.6
     },
@@ -6222,6 +5508,7 @@
       "text": "编辑挑选·连续阅读",
       "anchor": [62.03248115611, 0.19999999999999996, -3.496891208906867],
       "role": "screen",
+      "side": "left",
       "revealAt": 73.40000000000002,
       "hideAt": 82.40000000000002
     },
@@ -6229,6 +5516,7 @@
       "text": "浏览/搜索/媒体转载",
       "anchor": [58.43248115611, 0.19999999999999996, -3.496891208906867],
       "role": "screen",
+      "side": "left",
       "revealAt": 73.60000000000001,
       "hideAt": 82.40000000000002
     },
@@ -6236,6 +5524,7 @@
       "text": "PC",
       "anchor": [54.83248115611, 0.19999999999999996, -3.496891208906867],
       "role": "screen",
+      "side": "left",
       "revealAt": 73.80000000000001,
       "hideAt": 82.40000000000002
     },
@@ -6243,6 +5532,7 @@
       "text": "个性化·社交化·碎片阅读",
       "anchor": [62.03248115611, 5.3, -3.596891208906867],
       "role": "screen",
+      "side": "right",
       "revealAt": 76.75000000000001,
       "hideAt": 82.40000000000002
     },
@@ -6250,6 +5540,7 @@
       "text": "关注/推荐/转发",
       "anchor": [58.43248115611, 5.3, -3.596891208906867],
       "role": "screen",
+      "side": "right",
       "revealAt": 77.85000000000001,
       "hideAt": 82.40000000000002
     },
@@ -6257,6 +5548,7 @@
       "text": "移动终端",
       "anchor": [54.83248115611, 5.3, -3.596891208906867],
       "role": "screen",
+      "side": "right",
       "revealAt": 78.95000000000002,
       "hideAt": 82.40000000000002
     },
@@ -6629,6 +5921,7 @@
       "text": "① 独创的数据处理和推荐技术底框架",
       "anchor": [-55.49045081535453, 6.717749959911059, -20.81357038731703],
       "role": "screen",
+      "side": "right",
       "revealAt": 169.74999999999997,
       "hideAt": 176.29999999999998
     },
@@ -6643,6 +5936,7 @@
       "text": "② 自然语言、多媒体信息处理",
       "anchor": [-57.45490124492356, 5.003591609722465, -20.81357038731703],
       "role": "screen",
+      "side": "right",
       "revealAt": 170.74999999999997,
       "hideAt": 176.29999999999998
     },
@@ -6657,6 +5951,7 @@
       "text": "③ 高维度用户兴趣建模",
       "anchor": [-57.45490124492356, 2.3964083902775357, -20.81357038731703],
       "role": "screen",
+      "side": "right",
       "revealAt": 171.74999999999997,
       "hideAt": 176.29999999999998
     },
@@ -6671,6 +5966,7 @@
       "text": "④ 高性能的实时大规模数据运算",
       "anchor": [-55.49045081535453, 0.6822500400889417, -20.81357038731703],
       "role": "screen",
+      "side": "right",
       "revealAt": 172.74999999999997,
       "hideAt": 176.29999999999998
     },
@@ -6883,6 +6179,7 @@
       "text": "扩充信息类型和来源",
       "anchor": [-29.521522271761395, 2.88, 50.24250638825236],
       "role": "screen",
+      "side": "left",
       "align": "center",
       "revealAt": 216.94999999999996,
       "hideAt": 223.49999999999997
@@ -6891,6 +6188,7 @@
       "text": "深挖用户特征·升级推荐系统",
       "anchor": [-29.521522271761395, 1.4599999999999997, 50.24250638825236],
       "role": "screen",
+      "side": "left",
       "align": "center",
       "revealAt": 217.84999999999997,
       "hideAt": 223.49999999999997
@@ -6899,6 +6197,7 @@
       "text": "强化社区互动",
       "anchor": [-31.341522271761395, 2.88, 50.24250638825236],
       "role": "screen",
+      "side": "right",
       "align": "center",
       "revealAt": 218.74999999999997,
       "hideAt": 223.49999999999997
@@ -6907,6 +6206,7 @@
       "text": "国际化与商业化尝试",
       "anchor": [-31.341522271761395, 1.4599999999999997, 50.24250638825236],
       "role": "screen",
+      "side": "right",
       "align": "center",
       "revealAt": 219.64999999999995,
       "hideAt": 223.49999999999997

--- a/sdf-js/scenes/ir/bytedance-bp-2015.json
+++ b/sdf-js/scenes/ir/bytedance-bp-2015.json
@@ -42,9 +42,9 @@
       "structure": "proportion",
       "title": "资讯的移动化远高于搜索",
       "groups": [
-        { "label": "社交/聊天", "values": [76.9, 23.1], "sliceLabels": ["移动", "电脑"] },
-        { "label": "新闻/资讯", "values": [68.6, 31.4], "sliceLabels": ["移动", "电脑"] },
-        { "label": "使用搜索引擎", "values": [42.4, 57.6], "sliceLabels": ["移动", "电脑"] }
+        { "label": "社交/聊天", "values": [23.1, 76.9], "sliceLabels": ["电脑", "移动"] },
+        { "label": "新闻/资讯", "values": [31.4, 68.6], "sliceLabels": ["电脑", "移动"] },
+        { "label": "使用搜索引擎", "values": [57.6, 42.4], "sliceLabels": ["电脑", "移动"] }
       ],
       "emphasis": 2,
       "callout": {
@@ -161,6 +161,7 @@
     {
       "structure": "roadmap",
       "title": "产品演化：推荐内容 → 推荐商品 → 推荐服务",
+      "climb": false,
       "milestones": [
         { "date": "2012", "label": "新闻·时政社会" },
         { "date": "2013", "label": "泛资讯·段子小说" },

--- a/sdf-js/scripts/test-assemble-deck.mjs
+++ b/sdf-js/scripts/test-assemble-deck.mjs
@@ -92,16 +92,13 @@ const deck = JSON.parse(
   );
   ok(transits.length === 2, 'two transit shots (stage transitions)');
 
-  // time: station k's build-ins start after station k-1's camera time has elapsed
-  const t0Of = (pfx) =>
-    Math.min(
-      ...scene.subjects
-        .filter((s) => s.id.startsWith(pfx) && s.animation)
-        .map((s) => Number(s.animation[0].expr.match(/smoothstep\((-?[\d.]+)/)[1])),
-    );
-  const dur0 = stations[0].cameraSequence.shots.reduce((s, sh) => s + sh.duration, 0);
-  ok(t0Of('s1-') >= dur0, 'station 2 build-ins wait for station 1 to play out');
-  ok(t0Of('s2-') > t0Of('s1-'), 'stations reveal in deck order');
+  // STATIC GEOMETRY (user-locked 2026-07-15): only the CAMERA animates, so the
+  // deck carries no geometry build-ins at all — the pacing now lives entirely
+  // in the camera timeline and the overlay reveals (checked just below).
+  ok(
+    scene.subjects.every((s) => !s.animation),
+    'assembled deck has ZERO geometry build-ins (camera owns all motion)',
+  );
 
   // overlay: anchors moved with stations; titles reveal with their slide
   const titles = scene.overlay.filter((o) => o.role === 'title');

--- a/sdf-js/scripts/test-render-hierarchy.mjs
+++ b/sdf-js/scripts/test-render-hierarchy.mjs
@@ -49,21 +49,15 @@ ok(
   const scene = renderHierarchy(ir);
   const nodeSubjects = scene.subjects.filter((s) => s.id.startsWith('node-'));
   ok(nodeSubjects.length === 9, 'one subject per node');
+  // STATIC GEOMETRY (user-locked 2026-07-15): only the CAMERA animates — the
+  // whole tree stands from frame one, matching the source org chart.
   ok(
-    nodeSubjects.every(
-      (s) => Array.isArray(s.animation) && s.animation[0].channel === 'transform.translate.y',
-    ),
-    'every node has a translate.y build-in',
+    nodeSubjects.every((s) => !s.animation),
+    'nodes carry NO build-in animation (camera owns all motion)',
   );
   // edges ride with the CHILD subject (union: ball + up-link capsule)
   const withLink = nodeSubjects.filter((s) => s.children.some((c) => c.type === 'capsule'));
   ok(withLink.length === 8, 'every non-root node carries its up-link capsule');
-  // root reveals first, deeper levels later
-  const t0 = (s) => Number(s.animation[0].expr.match(/smoothstep\(([\d.]+)/)[1]);
-  ok(
-    t0(nodeSubjects[0]) < t0(nodeSubjects[4]),
-    'root lands before grandchildren (per-level cascade)',
-  );
 
   // fighting-game grammar: rises to a crane peak, descends, has the super, ends wide
   const shots = scene.cameraSequence.shots;

--- a/sdf-js/scripts/test-render-hold.mjs
+++ b/sdf-js/scripts/test-render-hold.mjs
@@ -15,7 +15,10 @@ const ok = (c, n) => (c ? (pass++, console.log(`  ✓ ${n}`)) : (fail++, console
 console.log('=== render-hold (title-card interlude) ===\n');
 
 // ---- IR validation --------------------------------------------------------------
-ok(validateIR({ structure: 'hold', title: '封面', nodes: [] }).ok, 'bare cover (empty nodes) is valid');
+ok(
+  validateIR({ structure: 'hold', title: '封面', nodes: [] }).ok,
+  'bare cover (empty nodes) is valid',
+);
 ok(
   validateIR({ structure: 'hold', title: 't', nodes: ['a', 'b'] }).ok,
   'hold with bullets is valid',
@@ -73,19 +76,22 @@ const IR = {
     JSON.stringify(orbs[5].material) !== JSON.stringify(orbs[0].material),
     'emphasized bullet orb is gold among the red',
   );
-  // deck-transplant safety: every build-in expr (drop + idle bob tails on the
-  // floaters) must parse under the STRICT shifter
+  // STATIC GEOMETRY (user-locked 2026-07-15): only the CAMERA animates — the
+  // arc of balls is fully drawn from frame one, matching the source page.
+  ok(
+    s.subjects.every((x) => !x.animation),
+    'no build-in animation anywhere (camera owns all motion)',
+  );
+  // whatever exprs DO survive here must still parse under the STRICT shifter
   let allShift = true;
-  const animated = s.subjects.filter((x) => x.animation);
-  ok(animated.length >= 6, 'orbs drop in on their beats (animated bodies)');
-  for (const p of animated) {
+  for (const p of s.subjects.filter((x) => x.animation)) {
     try {
       shiftBuildInExpr(p.animation[0].expr, 2.5, 10);
-    } catch (e) {
+    } catch {
       allShift = false;
     }
   }
-  ok(allShift, 'all build-in exprs survive assembleDeck expr shifting');
+  ok(allShift, 'any surviving build-in expr still shifts under assembleDeck');
 }
 
 // ---- renderIR seam -----------------------------------------------------------------

--- a/sdf-js/scripts/test-render-magnitude.mjs
+++ b/sdf-js/scripts/test-render-magnitude.mjs
@@ -40,12 +40,17 @@ ok(
     monos.every((s) => s.args.dims[0] === monos[0].args.dims[0]),
     'equal footprints',
   );
-  // rise-not-drop: animated y starts BELOW the final position
-  const startsBelow = monos.every((s) => {
-    const m = s.animation[0].expr.match(/^(-?[\d.]+) \+ ([\d.]+) \* smoothstep/);
-    return m && Number(m[1]) < s.transform.translate[1];
-  });
-  ok(startsBelow, 'monoliths ERUPT from underground (rise, not drop)');
+  // STATIC GEOMETRY (user-locked 2026-07-15): only the CAMERA animates — an
+  // erupting monolith is the wrong HEIGHT at every frame but the last, so the
+  // chart never matches its source page while it plays.
+  ok(
+    monos.every((s) => !s.animation),
+    'monoliths carry NO build-in animation (camera owns all motion)',
+  );
+  ok(
+    monos.every((s) => Math.abs(s.transform.translate[1] - s.args.dims[1] / 2) < 1e-9),
+    'every monolith stands ON the floor from frame one (height = the encoding)',
+  );
 
   // fighting-game grammar: hero low at the champion → crane → tracking beats → super → wide
   const shots = scene.cameraSequence.shots;

--- a/sdf-js/scripts/test-render-matrix.mjs
+++ b/sdf-js/scripts/test-render-matrix.mjs
@@ -5,15 +5,24 @@ import { assembleDeck } from '../src/scene/assemble-deck.js';
 import { compile } from '../src/scene/index.js';
 import { expandStage } from '../src/scene/stage.js';
 
-let pass = 0, fail = 0;
+let pass = 0,
+  fail = 0;
 const ok = (c, n) => (c ? (pass++, console.log(`  ✓ ${n}`)) : (fail++, console.log(`  ✗ ${n}`)));
 console.log('=== render-matrix (quadrant wall) ===\n');
 
 const swot = {
   structure: 'matrix',
   nodes: ['Strong team', 'High burn', 'AI wave', 'Incumbents'],
-  axes: [['Internal', 'External'], ['Helpful', 'Harmful']],
-  cells: [[0, 0], [0, 1], [1, 0], [1, 1]],
+  axes: [
+    ['Internal', 'External'],
+    ['Helpful', 'Harmful'],
+  ],
+  cells: [
+    [0, 0],
+    [0, 1],
+    [1, 0],
+    [1, 1],
+  ],
   emphasis: [2],
   title: 'SWOT',
 };
@@ -37,16 +46,31 @@ ok(
   'items land exactly on their cells',
 );
 
-// build-in: items slam in along z with a smoothstep window, staggered
-ok(items.every((s) => s.animation && s.animation[0].channel === 'transform.translate.z'), 'items animate along z');
-ok(items.every((s) => /smoothstep\(/.test(s.animation[0].expr)), 'slam uses smoothstep');
+// STATIC GEOMETRY (user-locked 2026-07-15): only the CAMERA animates — the
+// board is fully filled from frame one, exactly like the source page.
+ok(
+  items.every((s) => !s.animation),
+  'items carry NO build-in animation (camera owns all motion)',
+);
 
 // emphasis item gets the gold treatment + a value label; camera has cut super + payoff
 ok(items.find((s) => s.id === 'item-2').material.glow > 0, 'emphasis item glows (gold)');
-ok(scene.cameraSequence.shots.some((s) => s.transition === 'cut'), 'has the punch-in super');
-ok(scene.overlay.filter((o) => o.role === 'card').length >= 2 + 2, 'axis labels stay ANCHORED (they define the space)');
-ok(scene.overlay.filter((o) => o.role === 'screen').length >= 3, 'cell texts ride the subtitle column');
-ok(scene.subjects.every((s) => !/text/.test(s.type)), 'no baked SDF text');
+ok(
+  scene.cameraSequence.shots.some((s) => s.transition === 'cut'),
+  'has the punch-in super',
+);
+ok(
+  scene.overlay.filter((o) => o.role === 'card').length >= 2 + 2,
+  'axis labels stay ANCHORED (they define the space)',
+);
+ok(
+  scene.overlay.filter((o) => o.role === 'screen').length >= 3,
+  'cell texts ride the subtitle column',
+);
+ok(
+  scene.subjects.every((s) => !/text/.test(s.type)),
+  'no baked SDF text',
+);
 
 // compiles; renderIR dispatch reaches it; staged deck with a matrix slide assembles
 try {
@@ -58,7 +82,10 @@ try {
 ok(renderIR(swot).subjects.length === scene.subjects.length, 'renderIR dispatches matrix');
 {
   const deck = assembleDeck({ title: 't', slides: [swot] }, { stage: true });
-  ok(deck.subjects.some((s) => s.id.includes('stage-platform')), 'staged deck with matrix slide assembles');
+  ok(
+    deck.subjects.some((s) => s.id.includes('stage-platform')),
+    'staged deck with matrix slide assembles',
+  );
 }
 
 console.log(`\n${pass} passed, ${fail} failed`);

--- a/sdf-js/scripts/test-render-network.mjs
+++ b/sdf-js/scripts/test-render-network.mjs
@@ -51,18 +51,11 @@ ok(
   const edgesS = scene.subjects.filter((s) => s.id.startsWith('net-edge-'));
   ok(nodesS.length === 10, 'one subject per node');
   ok(edgesS.length === 14, 'one subject per edge');
+  // STATIC GEOMETRY (user-locked 2026-07-15): only the CAMERA animates — the
+  // graph is fully wired from frame one, matching the source diagram.
   ok(
-    [...nodesS, ...edgesS].every(
-      (s) => Array.isArray(s.animation) && s.animation[0].channel === 'transform.translate.y',
-    ),
-    'every node AND edge has a build-in',
-  );
-  // wiring order: all nodes land before the first edge starts
-  const t0 = (s) => Number(s.animation[0].expr.match(/smoothstep\(([\d.]+)/)[1]);
-  ok(Math.max(...nodesS.map(t0)) < Math.min(...edgesS.map(t0)), 'edges wire AFTER nodes land');
-  ok(
-    nodesS.every((s) => /sin\(/.test(s.animation[0].expr)),
-    'nodes idle-breathe after landing',
+    [...nodesS, ...edgesS].every((s) => !s.animation),
+    'nodes and edges carry NO build-in animation (camera owns all motion)',
   );
 
   // fighting-game grammar

--- a/sdf-js/scripts/test-render-sequence.mjs
+++ b/sdf-js/scripts/test-render-sequence.mjs
@@ -38,19 +38,14 @@ ok(
   'top stage wider than bottom (radii from magnitude)',
 );
 
-// build-in: each stage animates transform.translate.y with a staggered smoothstep reveal
+// STATIC GEOMETRY (user-locked 2026-07-15): only the CAMERA animates. A stage
+// that drops in is at the wrong height every frame but the last, so the funnel
+// never matches its source page while it plays; and geometry moving under a
+// moving camera splits the viewer's attention.
 ok(
-  stages.every(
-    (s) => Array.isArray(s.animation) && s.animation[0].channel === 'transform.translate.y',
-  ),
-  'each stage has a translate.y build-in channel',
+  stages.every((s) => !s.animation),
+  'stages carry NO build-in animation (camera owns all motion)',
 );
-ok(
-  stages.every((s) => /smoothstep\(/.test(s.animation[0].expr)),
-  'build-in uses smoothstep (one-shot reveal)',
-);
-const starts = stages.map((s) => Number(s.animation[0].expr.match(/smoothstep\(([\d.]+)/)[1]));
-ok(starts[0] < starts[3], 'reveal windows staggered by order (top reveals first)');
 
 ok(scene.cameraSequence && scene.cameraSequence.shots.length >= 4, 'has a multi-shot fly-through');
 // fighting-game grammar: low hero opening → crane peak → spiral descent →

--- a/sdf-js/src/scene/render-hierarchy.js
+++ b/sdf-js/src/scene/render-hierarchy.js
@@ -150,12 +150,7 @@ export function renderHierarchy(ir, opts = {}) {
       children,
       transform: { translate: p },
       material: nodeMat(level[i], maxLevel, emphasis.has(i)),
-      animation: [
-        {
-          channel: 'transform.translate.y',
-          expr: `${(p[1] + drop).toFixed(3)} - ${drop} * smoothstep(${t0.toFixed(2)}, ${t1.toFixed(2)}, t)`,
-        },
-      ],
+      // STATIC (user-locked 2026-07-15): only the CAMERA animates.
     });
   }
 

--- a/sdf-js/src/scene/render-hold.js
+++ b/sdf-js/src/scene/render-hold.js
@@ -124,36 +124,21 @@ export function renderHold(ir, opts = {}) {
       args: { radius: HR, h: 0 },
       transform: { translate: [0.6, HCY, -1.2], rotate: [0, 0, Math.PI / 2] },
       material: { ...ROCK_MAT, roughness: 0.4 },
-      animation: [
-        {
-          // the float: a slow breath — 悬空 must read as suspension, not parking
-          channel: 'transform.translate.y',
-          expr: `${HCY.toFixed(3)} - 0.000 * smoothstep(0.00, 1.00, t) + 0.07 * sin(0.35 * t + 1.10)`,
-        },
-      ],
     });
-    // balls on the curved rim, top → bottom down the screen-right side
+    // balls on the curved rim, top → bottom down the screen-right side.
+    // STATIC (user-locked 2026-07-15): only the CAMERA animates.
     const R = HR + 0.75;
     const E0 = 1.28; // rad above horizontal for ball ①  (~73°)
     bullets.forEach((_, k) => {
       const e = E0 - (k * (2 * E0)) / Math.max(1, N - 1); // ① top … ⑥ bottom
       const x = 0.6 - Math.cos(e) * R; // -x renders screen-RIGHT (the curved side)
       const y = HCY + Math.sin(e) * R;
-      const drop = 1.3;
-      const t0 = introLead + k * holdEach - 0.35;
-      const t1 = t0 + 0.55;
       subjects.push({
         id: `orb-${k}`,
         type: 'sphere',
         args: { radius: 0.42 },
         transform: { translate: [x, y, -1.2] },
         material: emphasis.has(k) ? GOLD_MAT : RED_MAT,
-        animation: [
-          {
-            channel: 'transform.translate.y',
-            expr: `${(y + drop).toFixed(3)} - ${drop.toFixed(3)} * smoothstep(${t0.toFixed(2)}, ${t1.toFixed(2)}, t) + 0.04 * sin(0.6 * t + ${((k * 1.7) % 6.28).toFixed(2)})`,
-          },
-        ],
       });
     });
   }
@@ -173,17 +158,10 @@ export function renderHold(ir, opts = {}) {
     [6.8, 2.0, -13, 1.1, 0.6],
   ];
   if (N > 0) FLOATERS.length = 0; // contents page: the dome owns the stage
+  // STATIC (user-locked 2026-07-15): only the CAMERA animates.
   FLOATERS.forEach(([x, y, z, w, h], i) => {
     subjects.push(
-      rock(`floater-${i}`, [x, y, z], [w, h, w * 0.55], ROCK_MAT, {
-        rotate: [0, 0.5 * i - 1, 0],
-        animation: [
-          {
-            channel: 'transform.translate.y',
-            expr: `${y.toFixed(3)} - 0.000 * smoothstep(0.00, 1.00, t) + ${(0.07 + 0.02 * i).toFixed(2)} * sin(${(0.35 + 0.08 * i).toFixed(2)} * t + ${((i * 2.1) % 6.28).toFixed(2)})`,
-          },
-        ],
-      }),
+      rock(`floater-${i}`, [x, y, z], [w, h, w * 0.55], ROCK_MAT, { rotate: [0, 0.5 * i - 1, 0] }),
     );
   });
 
@@ -277,9 +255,13 @@ export function renderHold(ir, opts = {}) {
     const x = 0.6 - Math.cos(e) * 3.15;
     const y = 3.7 + Math.sin(e) * 3.15;
     overlay.push({
+      // The source page-2 lists its numbered items to the RIGHT of the
+      // semicircle, beside their balls — the left column put the words on the
+      // OPPOSITE side from the geometry they name (user-locked 2026-07-15).
       text: b,
       anchor: [x, y, -1.2],
       role: 'screen',
+      side: 'right',
       revealAt: introLead + k * holdEach + 0.25,
     });
     // the source page numbers its balls — the digit rides ITS orb (anchor

--- a/sdf-js/src/scene/render-magnitude.js
+++ b/sdf-js/src/scene/render-magnitude.js
@@ -92,22 +92,15 @@ function renderHorizontalBars(ir, opts, env) {
     const L = lenOf(i);
     const y = yOf(k);
     const xc = -L / 2; // grows screen-right (-x)
-    const t0 = Math.max(0.2, introLead + k * holdEach - 0.45);
-    const t1 = t0 + 0.55;
-    // rail the bar rides in on (a thin baseline groove at x=0)
+    // STATIC (user-locked 2026-07-15): only the CAMERA animates. A bar that
+    // slides in is the wrong length at every frame but the last — the chart
+    // must match the source page's geometry the moment it is on screen.
     subjects.push({
       id: `hbar-${i}`,
       type: 'rounded_box',
       args: { dims: [L, BAR_H, DEPTH], cornerR: 0.05 },
       transform: { translate: [xc, y, 0] },
       material: monoMat(k, N, emphasis.has(i), opts.accent),
-      animation: [
-        {
-          // slide in from screen-right (off its final centre by the bar length)
-          channel: 'transform.translate.x',
-          expr: `${(xc - L - 1.5).toFixed(3)} + ${(L + 1.5).toFixed(3)} * smoothstep(${t0.toFixed(2)}, ${t1.toFixed(2)}, t)`,
-        },
-      ],
     });
   });
   // a baseline spine at x=0 (where every bar starts) + a back wall of guards
@@ -282,11 +275,8 @@ export function renderMagnitude(ir, opts = {}) {
   order.forEach((i, k) => {
     const H = height(i);
     const yFinal = H / 2; // box centre when standing on the floor
-    const buried = H + 0.3; // start fully underground, then erupt
-    const t0 = Math.max(0.2, riseStart(k));
-    const t1 = t0 + 0.6;
-    // Plinth first: a static base slab each monolith erupts THROUGH — turns a
-    // floating box into a mounted monument (and grounds the eruption).
+    // Plinth: a base slab each monolith stands ON — turns a floating box into
+    // a mounted monument.
     subjects.push({
       id: `plinth-${i}`,
       type: 'box',
@@ -301,18 +291,14 @@ export function renderMagnitude(ir, opts = {}) {
         clearcoat: 0.1,
       },
     });
+    // STATIC (user-locked 2026-07-15): only the CAMERA animates — an erupting
+    // monolith is the wrong height at every frame but the last.
     const craft = {
       id: `mono-${i}`,
       type: 'rounded_box', // beveled edges — a hewn stone, not a raw prim
       args: { dims: [W, H, W], cornerR: 0.045 },
       transform: { translate: [xOf(i), yFinal, 0] },
       material: monoMat(i, N, emphasis.has(i), opts.accent),
-      animation: [
-        {
-          channel: 'transform.translate.y',
-          expr: `${(yFinal - buried).toFixed(3)} + ${buried.toFixed(3)} * smoothstep(${t0.toFixed(2)}, ${t1.toFixed(2)}, t)`,
-        },
-      ],
     };
     if (!emphasis.has(i)) craft.pattern = 'cracked'; // stone grain; the gold champion stays polished
     subjects.push(craft);

--- a/sdf-js/src/scene/render-matrix.js
+++ b/sdf-js/src/scene/render-matrix.js
@@ -131,32 +131,32 @@ function renderEvolutionForm(ir, env) {
         material: EVO_ROCK,
       });
       overlay.push({
+        // the PAST stratum reads down the LEFT column; the PRESENT down the
+        // RIGHT (a two-stratum comparison needs its text in two places)
         text: nodes[i],
         anchor: [x, PAST_Y - 0.75, 0.5],
         role: 'screen',
+        side: 'left',
         revealAt: 0.4 + yi * 0.2,
       });
     } else {
-      // the PRESENT: a red orb that RISES out of its past tablet
-      const t0 = riseStart + k * holdEach;
-      const t1 = t0 + 0.75;
+      // the PRESENT: a red orb at the upper stratum. STATIC (user-locked
+      // 2026-07-15): only the CAMERA animates — a rising orb is at the wrong
+      // height at every frame but the last, so the page never matches its
+      // source diagram while it plays.
+      const t1 = riseStart + k * holdEach + 0.75;
       subjects.push({
         id: `now-${i}`,
         type: 'sphere',
         args: { radius: emphasis.has(i) ? 0.85 : 0.7 },
         transform: { translate: [x, NOW_Y, 0] },
         material: emphasis.has(i) ? { ...EVO_RED, glow: 0.24 } : EVO_RED,
-        animation: [
-          {
-            channel: 'transform.translate.y',
-            expr: `${PAST_Y.toFixed(3)} + ${(NOW_Y - PAST_Y).toFixed(3)} * smoothstep(${t0.toFixed(2)}, ${t1.toFixed(2)}, t) + 0.05 * sin(0.5 * t + ${((k * 2.1) % 6.28).toFixed(2)})`,
-          },
-        ],
       });
       overlay.push({
         text: nodes[i],
         anchor: [x, NOW_Y + 1.0, 0.4],
         role: 'screen',
+        side: 'right',
         revealAt: t1 + 0.1,
       });
       k++;
@@ -166,16 +166,9 @@ function renderEvolutionForm(ir, env) {
   // THE BIG UPWARD ARROW — far screen-left, foot at the past stratum, tip at
   // the present stratum (the source page's red rising arrow). Vertical shaft
   // + a stepped head narrowing upward (analytic tier: no z-rotation, so the
-  // wedge is stacked slabs). It RISES into place before the first orb flies.
+  // wedge is stacked slabs). STATIC (user-locked 2026-07-15): only the CAMERA
+  // animates — the arrow stands drawn from frame one, like the source page.
   const arrowMat = { ...EVO_RED, glow: 0.16 };
-  const arrT0 = introLead + 0.2;
-  const arrT1 = arrT0 + 0.7;
-  const rise = (fy) => [
-    {
-      channel: 'transform.translate.y',
-      expr: `${(fy - 2.0).toFixed(3)} + 2.000 * smoothstep(${arrT0.toFixed(2)}, ${arrT1.toFixed(2)}, t)`,
-    },
-  ];
   const shaftH = NOW_Y - PAST_Y - 0.9;
   const shaftY = PAST_Y + shaftH / 2;
   subjects.push({
@@ -184,7 +177,6 @@ function renderEvolutionForm(ir, env) {
     args: { dims: [0.34, shaftH, 0.3], cornerR: 0.06 },
     transform: { translate: [AX, shaftY, 0] },
     material: arrowMat,
-    animation: rise(shaftY),
   });
   for (let j = 0; j < 4; j++) {
     const hy = PAST_Y + shaftH + 0.1 + j * 0.22;
@@ -194,7 +186,6 @@ function renderEvolutionForm(ir, env) {
       args: { dims: [1.15 - j * 0.27, 0.22, 0.3] },
       transform: { translate: [AX, hy, 0] },
       material: arrowMat,
-      animation: rise(hy),
     });
   }
 
@@ -324,29 +315,23 @@ export function renderMatrix(ir, opts = {}) {
   const introLead = 1.6;
   const holdEach = 0.9;
   const zStart = 2.4; // launched from the camera side
-  order.forEach((i, k) => {
+  // STATIC (user-locked 2026-07-15): only the CAMERA animates — the board is
+  // fully filled from frame one, exactly like the source page.
+  order.forEach((i) => {
     const [xi, yi] = ir.cells[i];
     const size = mag ? 0.24 + 0.32 * Math.sqrt((Number(mag[i]) || 0) / mMax) : 0.34;
     const zFinal = 0.15 + size / 2 + 0.02; // clear the thick cell face
-    const t0 = introLead + k * holdEach - 0.35;
-    const t1 = t0 + 0.45;
     subjects.push({
       id: `item-${i}`,
       type: 'rounded_box',
       args: { dims: [size, size, size], cornerR: 0.06 },
       transform: { translate: [cellX(xi), cellY(yi), zFinal] },
       material: itemMat(emphasis.has(i), opts.accent),
-      animation: [
-        {
-          channel: 'transform.translate.z',
-          expr: `${zStart.toFixed(3)} - ${(zStart - zFinal).toFixed(3)} * smoothstep(${Math.max(0.2, t0).toFixed(2)}, ${t1.toFixed(2)}, t)`,
-        },
-      ],
     });
   });
 
-  // Floating flank rocks: the black-stone motif hovers beside the board —
-  // depth layers behind the flat wall, slow idle bob (transplant-safe tail).
+  // Flank rocks: the black-stone motif beside the board — depth layers behind
+  // the flat wall (static, like everything else).
   [
     [-(boardW / 2 + 2.4), cy + 0.8, -2.2, 1.5, 0.9],
     [boardW / 2 + 2.7, cy - 0.4, -3.0, 1.9, 1.1],
@@ -366,12 +351,6 @@ export function renderMatrix(ir, opts = {}) {
         roughness: 0.5,
         clearcoat: 0.35,
       },
-      animation: [
-        {
-          channel: 'transform.translate.y',
-          expr: `${fy.toFixed(3)} - 0.000 * smoothstep(0.00, 1.00, t) + ${(0.06 + 0.02 * fi).toFixed(2)} * sin(${(0.3 + 0.07 * fi).toFixed(2)} * t + ${((fi * 2.2) % 6.28).toFixed(2)})`,
-        },
-      ],
     });
   });
 
@@ -458,12 +437,15 @@ export function renderMatrix(ir, opts = {}) {
   order.forEach((i, k) => {
     const [xi, yi] = ir.cells[i];
     overlay.push({
-      // cell texts are SPOKEN — the subtitle column lights each entry as its
-      // cube slams onto the board. Axis labels above stay ANCHORED: they
-      // define the space and are unreadable anywhere else.
+      // Cell texts ride the narration column — but a 2-column matrix is a
+      // COMPARISON, so each side gets its OWN column: axes[0][0]'s entries read
+      // down the LEFT, axes[0][1]'s down the RIGHT. Stacking both sides in one
+      // column destroys the contrast the page exists to make (user-locked
+      // 2026-07-15: 对比必须把文本放在两个地方). Axis labels stay ANCHORED.
       text: nodes[i],
       anchor: [cellX(xi), cellY(yi) - 0.34, 0.2],
       role: 'screen',
+      ...(X === 2 ? { side: xi === 0 ? 'left' : 'right' } : {}),
       align: 'center',
       revealAt: introLead + k * holdEach + 0.15,
     });

--- a/sdf-js/src/scene/render-network.js
+++ b/sdf-js/src/scene/render-network.js
@@ -158,32 +158,26 @@ export function renderNetwork(ir, opts = {}) {
 
   const nodeR = (i) => 0.24 + 0.26 * Math.sqrt((Number(mag[i]) || 1) / mMax);
 
-  // Assembly: nodes cascade in a quick wave, then edges land in waves — the
-  // network wires itself while the camera orbits.
-  const drop = 1.1;
+  // STATIC (user-locked 2026-07-15): only the CAMERA animates — the graph is
+  // fully wired from frame one, so it matches its source diagram at every
+  // moment and the camera owns all the motion. The beat CLOCK survives: label
+  // reveals and camera timing still ride these (text syncs to the camera; only
+  // GEOMETRY stopped moving).
   const nodeT0 = (i) => 0.25 + i * 0.12;
   const edgesStart = 0.25 + N * 0.12 + 0.2;
   const subjects = [];
   for (let i = 0; i < N; i++) {
     const p = pos[i];
-    const t0 = nodeT0(i);
     subjects.push({
       id: `net-node-${i}`,
       type: 'sphere',
       args: { radius: nodeR(i) },
       transform: { translate: p },
       material: nodeMatN(degree[i], maxDeg, emphasis.has(i), opts.accent),
-      animation: [
-        {
-          channel: 'transform.translate.y',
-          expr: `${(p[1] + drop).toFixed(3)} - ${drop} * smoothstep(${t0.toFixed(2)}, ${(t0 + 0.5).toFixed(2)}, t) + 0.018 * sin(1.3 * t + ${(i * 2.1).toFixed(2)})`, // + idle breathing: a living constellation, not statues
-        },
-      ],
     });
   }
   ir.relations.forEach(([a, b], e) => {
     const pa = pos[a];
-    const t0 = edgesStart + e * 0.14;
     subjects.push({
       id: `net-edge-${e}`,
       type: 'capsule',
@@ -194,12 +188,6 @@ export function renderNetwork(ir, opts = {}) {
       },
       transform: { translate: pa },
       material: EDGE_MAT,
-      animation: [
-        {
-          channel: 'transform.translate.y',
-          expr: `${(pa[1] + drop).toFixed(3)} - ${drop} * smoothstep(${t0.toFixed(2)}, ${(t0 + 0.45).toFixed(2)}, t)`,
-        },
-      ],
     });
   });
 
@@ -225,12 +213,6 @@ export function renderNetwork(ir, opts = {}) {
           rotate: [0, (d * 0.9) % 3.1, 0],
         },
         material: { hue: 0.62, sat: 0.2, value: 0.18, kind: 'normal', roughness: 0.5 }, // R1: near-black dust, not floating bricks
-        animation: [
-          {
-            channel: 'transform.translate.y',
-            expr: `${(2.2 + y * shell * 0.55).toFixed(3)} - 0.000 * smoothstep(0.00, 1.00, t) + ${(0.05 + 0.02 * (d % 3)).toFixed(2)} * sin(${(0.3 + 0.05 * (d % 5)).toFixed(2)} * t + ${((d * 1.3) % 6.28).toFixed(2)})`,
-          },
-        ],
       });
     }
   }

--- a/sdf-js/src/scene/render-proportion.js
+++ b/sdf-js/src/scene/render-proportion.js
@@ -76,20 +76,15 @@ export function renderProportion(ir, opts = {}) {
     const values = (grp.values || []).map((x) => Number(x) || 0);
     const slices = buildSlices(values);
     const x = xOf(g);
-    // the pie floats and bobs — a proportion standing in the room
+    // STATIC (user-locked 2026-07-15): only the CAMERA animates. A bobbing pie
+    // never matches the source page's geometry at any given frame, and motion
+    // under a moving camera splits the viewer's attention.
     subjects.push({
       id: `pie-${g}`,
       type: 'pie-chart',
       args: { radius: R, thickness: THICK, startAngle: Math.PI / 2, slices },
       transform: { translate: [x, CY, 0] },
       material: { hue: 0.58, sat: 0.2, value: 0.7, kind: 'normal', roughness: 0.4, clearcoat: 0.4 },
-      animation: [
-        {
-          // gentle bob — the coin floats, it does not sit parked
-          channel: 'transform.translate.y',
-          expr: `${CY.toFixed(3)} - 0.000 * smoothstep(0.00, 1.00, t) + 0.05 * sin(0.4 * t + ${((g * 1.7) % 6.28).toFixed(2)})`,
-        },
-      ],
     });
     // a slim pedestal so the pie reads as STANDING in the room
     subjects.push({
@@ -100,10 +95,11 @@ export function renderProportion(ir, opts = {}) {
       material: { hue: 0.6, sat: 0.05, value: 0.5, kind: 'normal', roughness: 0.6 },
     });
 
-    // group label under the pie
+    // group label ABOVE the pie — the source page captions each pie on top
+    // (2D-fidelity round 2: up/down must match the original)
     overlay.push({
       text: String(grp.label || ''),
-      anchor: [x, CY - R - 0.55, 0],
+      anchor: [x, CY + R + 0.5, 0],
       role: 'card',
       align: 'center',
       revealAt: introLead + g * holdEach + 0.2,

--- a/sdf-js/src/scene/render-roadmap.js
+++ b/sdf-js/src/scene/render-roadmap.js
@@ -13,6 +13,10 @@
 //   { structure:'roadmap',
 //     title,
 //     milestones: [ { date, label, detail? }, … ],
+//     climb?: boolean,   // true (default) = a RISING milestone curve (a growth
+//                        // timeline, source p9); false = a FLAT staged timeline
+//                        // (source p10: years above the line, stages below).
+//                        // 2D-fidelity: the source page's shape decides.
 //     emphasis?: <index>,  callout? }
 import { validateIR } from './ir.js';
 import { getEnvironment } from './environments.js';
@@ -58,12 +62,15 @@ export function renderRoadmap(ir, opts = {}) {
   const stride = 2.9;
   // +x renders screen-LEFT → i=0 sits screen-left (time reads L→R)
   const xOf = (i) => ((N - 1) / 2 - i) * stride;
-  const yOf = (i) => RAIL_Y + 0.5 + i * CLIMB; // the line climbs over time
+  // climb (default): a RISING milestone curve. climb:false: a FLAT staged
+  // timeline — the source page's own shape decides (2D-fidelity round 2).
+  const climbing = ir.climb !== false;
+  const step = climbing ? CLIMB : 0;
+  const yOf = (i) => RAIL_Y + 0.5 + i * step;
   const span = (N - 1) * stride;
 
   const introLead = 1.6;
   const holdEach = 1.05;
-  const riseAt = (i) => introLead + i * holdEach - 0.4;
 
   const subjects = [];
 
@@ -76,31 +83,24 @@ export function renderRoadmap(ir, opts = {}) {
     material: RAIL_MAT,
   });
 
-  // connector segments (node i → node i+1) — the rising line. Each is a capsule
-  // between two node points; it rises with the LATER node's beat.
+  // connector segments (node i → node i+1) — the rising line, drawn STATIC:
+  // only the camera animates (user-locked 2026-07-15). A line that assembles
+  // itself never matches the source diagram at any frame.
   for (let i = 0; i < N - 1; i++) {
     const a = [xOf(i), yOf(i), 0];
     const b = [xOf(i + 1), yOf(i + 1), 0];
-    const t0 = riseAt(i + 1);
     subjects.push({
       id: `seg-${i}`,
       type: 'capsule',
       args: { a: [0, 0, 0], b: [b[0] - a[0], b[1] - a[1], b[2] - a[2]], radius: 0.06 },
       transform: { translate: a },
       material: SEG_MAT,
-      animation: [
-        {
-          channel: 'transform.translate.y',
-          expr: `${(a[1] - 1.1).toFixed(3)} + 1.100 * smoothstep(${t0.toFixed(2)}, ${(t0 + 0.5).toFixed(2)}, t)`,
-        },
-      ],
     });
   }
 
   ms.forEach((m, i) => {
     const x = xOf(i);
     const y = yOf(i);
-    const t0 = riseAt(i);
     const emph = i === emphasisIdx;
     // post from the rail up to the node — the milestone stands on the timeline
     const postH = y - RAIL_Y;
@@ -110,12 +110,6 @@ export function renderRoadmap(ir, opts = {}) {
       args: { dims: [0.1, postH, 0.1] },
       transform: { translate: [x, RAIL_Y + postH / 2, 0] },
       material: RAIL_MAT,
-      animation: [
-        {
-          channel: 'transform.translate.y',
-          expr: `${(RAIL_Y + postH / 2 - 1.1).toFixed(3)} + 1.100 * smoothstep(${t0.toFixed(2)}, ${(t0 + 0.5).toFixed(2)}, t)`,
-        },
-      ],
     });
     // the milestone node
     subjects.push({
@@ -124,12 +118,6 @@ export function renderRoadmap(ir, opts = {}) {
       args: { radius: emph ? NODE_R * 1.35 : NODE_R },
       transform: { translate: [x, y, 0] },
       material: NODE_MAT(emph, opts.accent),
-      animation: [
-        {
-          channel: 'transform.translate.y',
-          expr: `${(y - 1.1).toFixed(3)} + 1.100 * smoothstep(${t0.toFixed(2)}, ${(t0 + 0.5).toFixed(2)}, t) + 0.02 * sin(1.1 * t + ${((i * 1.7) % 6.28).toFixed(2)})`,
-        },
-      ],
     });
   });
 
@@ -141,6 +129,11 @@ export function renderRoadmap(ir, opts = {}) {
       role: 'title',
     },
   ];
+  // Label geometry follows the source page's own shape (2D-fidelity round 2):
+  //   climb  (p9 growth curve): date BELOW the rail, milestone ABOVE its node —
+  //          the diagonal climb spreads neighbours so they don't stack.
+  //   stages (p10 flat timeline): year ABOVE the line, stage content BELOW it —
+  //          exactly the source's tick-above / box-below arrangement.
   ms.forEach((m, i) => {
     const x = xOf(i);
     const y = yOf(i);
@@ -148,16 +141,14 @@ export function renderRoadmap(ir, opts = {}) {
     if (m.date)
       overlay.push({
         text: String(m.date),
-        anchor: [x, RAIL_Y - 0.35, 0.25],
+        anchor: climbing ? [x, RAIL_Y - 0.35, 0.25] : [x, y + 0.6, 0.2],
         role: 'card',
         align: 'center',
         revealAt,
       });
-    // milestone label sits ABOVE its node (a diagram, not narration); the
-    // diagonal climb spreads neighbours so they don't stack
     overlay.push({
       text: String(m.label || ''),
-      anchor: [x, y + 0.6, 0.2],
+      anchor: climbing ? [x, y + 0.6, 0.2] : [x, RAIL_Y - 0.5, 0.25],
       role: 'card',
       align: 'center',
       revealAt,

--- a/sdf-js/src/scene/render-sequence.js
+++ b/sdf-js/src/scene/render-sequence.js
@@ -97,12 +97,7 @@ export function renderSequence(ir, opts = {}) {
       args: { stages: 1, radii: [radii[i], radii[i + 1]], stageHeight, gap: 0 },
       transform: { translate: [0, yc, 0] },
       material: stageMat(i, N, emphasis.has(i), opts.accent),
-      animation: [
-        {
-          channel: 'transform.translate.y',
-          expr: `${yFull} - ${drop} * smoothstep(${revealStart.toFixed(2)}, ${revealEnd.toFixed(2)}, t)`,
-        },
-      ],
+      // STATIC (user-locked 2026-07-15): only the CAMERA animates.
     });
   });
 


### PR DESCRIPTION
## R1 — 组件动画全部取消,只保留镜头动画

8 个渲染器的 build-in 动画**全删**。理由是你说的两条:组件在飞时**除最后一帧外每帧形状都跟原 2D 对不上**;镜头动+物体动=观众分心。镜头保留全套格斗语法,现在**独占 100% 运动**。节拍时钟保留(标签 reveal 跟镜头同步)。测试**反向钉死**:每个渲染器断言"无 build-in 动画"。

## R2 — 几何跟原图对上(上下高低左右)

- **饼图**:切片顺序+配色对齐 p3(12点顺时针先蓝=电脑,珊瑚=移动占余),类目标题移到饼**上方**。
  - ⚠️ **像素验证时抓到一个真 bug**:整个饼是**水平镜像**的。根因——引擎 +x 渲染为屏幕左,局部坐标里的"顺时针"在屏幕上是逆时针。改为读**屏幕角**(atan2 negate x),百分比标签锚点同步翻转(否则标签会指错扇区)。修完逐扇区跟原图对上。
- **roadmap** 新增 `climb` 选项:p9 = **上升里程碑曲线**(默认);p10 = **平的阶段时间轴**,且平模式下**年份在线上、阶段框在线下**——正是原图排布。

## R3 — 文本不再全堆左边

新增 overlay `side:'right'` 右侧叙述列(`.stage-bullet.side-right` + 两个独立 slot 计数器)。**两列 matrix 对比页**两侧文本各走相对一列;evolution 过去左/现在右;目录页文字移到右列贴着球。

## 两个新的可复用形态(你点名的页)

- **p22 飞轮 `network form:'cycle'`**:你说"球没做好"其实是**三个错叠一起**——通用图布局(黄金角+弹簧)把环打散成随机 3D 散点、按度数缩放让同级节点大小不一(环读成了排名)、绕飞机位把轮子看成侧面。现在:hub 居中、同级等大成环(12点起顺时针)、**正面机位**(平面图必须正对,不能绕飞)。通用星云保留绕飞。
- **p7 概念圆 `hold form:'circles'`**:原图是三个并排标注圆(技术/世界/人),之前渲成了目录页的穹顶+弧。现在 N 个等大同级球一行,**每球下方贴自己的文本**(你说的"外围三块文本"),不进左列。取景按**宽画幅**算(按竖直 fov 算会把镜头停到两倍远、圆变纽扣)。

全部 analytic、全部静止、全部可复用(任何 deck 发 `form:'cycle'`/`form:'circles'` 就有)。

## 验证

**逐页像素验证**(截图存 `manual-tests/static-geometry/`):p3 饼图逐扇区对上原图 · p10 平轴年份在上框在下 · p5 头条读左列/Google 读右列 · p22 飞轮正面对称 · p7 三圆填满画面(人=金色,原页的论点)。套件 **163/163**,goldens 重生成。

## 未做(留给下一轮)

- **p27** 饼+柱同页:需要拆站+重编号,比较侵入,单独一轮做。
- **p4** 演进改 column:现有 evolution 已对齐原图,优先级低。

🤖 Generated with [Claude Code](https://claude.com/claude-code)