### PR TITLE
C-lite:飞轮环 + 对比夹道 — 旗舰缺的两个原生 3D 形态

### DIFF
--- a/sdf-js/fixtures/golden/assemble-deck-2015-theater.json
+++ b/sdf-js/fixtures/golden/assemble-deck-2015-theater.json
@@ -888,6 +888,47 @@
       "clearcoat": 0.5
     },
     "mat-12": {
+      "hue": 0.995,
+      "sat": 0.8,
+      "value": 0.75,
+      "glow": 0.1,
+      "kind": "normal",
+      "roughness": 0.3,
+      "clearcoat": 0.5
+    },
+    "mat-13": {
+      "hue": 0.6,
+      "sat": 0.25,
+      "value": 0.35,
+      "kind": "normal",
+      "roughness": 0.45,
+      "clearcoat": 0.3
+    },
+    "mat-14": {
+      "hue": 0.07,
+      "sat": 0.42,
+      "value": 0.78,
+      "kind": "normal",
+      "roughness": 0.35,
+      "clearcoat": 0.4
+    },
+    "mat-15": {
+      "hue": 0.6,
+      "sat": 0.28,
+      "value": 0.45,
+      "kind": "normal",
+      "roughness": 0.45,
+      "clearcoat": 0.3
+    },
+    "mat-16": {
+      "hue": 0.6,
+      "sat": 0.2,
+      "value": 0.4,
+      "glow": 0.06,
+      "kind": "normal",
+      "roughness": 0.6
+    },
+    "mat-17": {
       "hue": 0.62,
       "sat": 0.3,
       "value": 0.22,
@@ -895,7 +936,7 @@
       "roughness": 0.4,
       "clearcoat": 0.3
     },
-    "mat-13": {
+    "mat-18": {
       "hue": 0.6,
       "sat": 0.1,
       "value": 0.3,
@@ -903,7 +944,7 @@
       "roughness": 0.7,
       "clearcoat": 0.1
     },
-    "mat-14": {
+    "mat-19": {
       "hue": 0.57,
       "sat": 0.55,
       "value": 0.72,
@@ -911,14 +952,14 @@
       "roughness": 0.3,
       "clearcoat": 0.45
     },
-    "mat-15": {
+    "mat-20": {
       "hue": 0.6,
       "sat": 0.08,
       "value": 0.5,
       "kind": "normal",
       "roughness": 0.6
     },
-    "mat-16": {
+    "mat-21": {
       "hue": 0.57,
       "sat": 0.35,
       "value": 0.7,
@@ -926,7 +967,7 @@
       "kind": "normal",
       "roughness": 0.4
     },
-    "mat-17": {
+    "mat-22": {
       "hue": 0.57,
       "sat": 0.6,
       "value": 0.78,
@@ -934,7 +975,7 @@
       "roughness": 0.3,
       "clearcoat": 0.45
     },
-    "mat-18": {
+    "mat-23": {
       "hue": 0.11,
       "sat": 0.78,
       "value": 0.95,
@@ -943,7 +984,7 @@
       "roughness": 0.24,
       "clearcoat": 0.6
     },
-    "mat-19": {
+    "mat-24": {
       "hue": 0.11,
       "sat": 0.78,
       "value": 0.95,
@@ -953,7 +994,7 @@
       "roughness": 0.22,
       "clearcoat": 0.6
     },
-    "mat-20": {
+    "mat-25": {
       "hue": 0.625,
       "sat": 0.7533333333333334,
       "value": 0.6000000000000001,
@@ -961,7 +1002,7 @@
       "roughness": 0.55,
       "clearcoat": 0.2
     },
-    "mat-21": {
+    "mat-26": {
       "hue": 0.61,
       "sat": 0.7266666666666667,
       "value": 0.65,
@@ -969,7 +1010,7 @@
       "roughness": 0.55,
       "clearcoat": 0.2
     },
-    "mat-22": {
+    "mat-27": {
       "hue": 0.58,
       "sat": 0.25,
       "value": 0.55,
@@ -978,14 +1019,14 @@
       "roughness": 0.6,
       "clearcoat": 0.15
     },
-    "mat-23": {
+    "mat-28": {
       "hue": 0.62,
       "sat": 0.2,
       "value": 0.18,
       "kind": "normal",
       "roughness": 0.5
     },
-    "mat-24": {
+    "mat-29": {
       "hue": 0.6,
       "sat": 0.03,
       "value": 0.92,
@@ -993,7 +1034,7 @@
       "roughness": 0.35,
       "clearcoat": 0.4
     },
-    "mat-25": {
+    "mat-30": {
       "hue": 0.5800000000000001,
       "sat": 0.6733333333333333,
       "value": 0.75,
@@ -1001,7 +1042,7 @@
       "roughness": 0.55,
       "clearcoat": 0.2
     },
-    "mat-26": {
+    "mat-31": {
       "hue": 0.55,
       "sat": 0.62,
       "value": 0.8500000000000001,
@@ -1009,7 +1050,7 @@
       "roughness": 0.55,
       "clearcoat": 0.2
     },
-    "mat-27": {
+    "mat-32": {
       "hue": 0.57,
       "sat": 0.45,
       "value": 0.72,
@@ -1017,7 +1058,7 @@
       "kind": "normal",
       "roughness": 0.35
     },
-    "mat-28": {
+    "mat-33": {
       "hue": 0.5680000000000001,
       "sat": 0.648,
       "value": 0.7759999999999999,
@@ -1025,7 +1066,7 @@
       "roughness": 0.3,
       "clearcoat": 0.45
     },
-    "mat-29": {
+    "mat-34": {
       "hue": 0.5860000000000001,
       "sat": 0.676,
       "value": 0.732,
@@ -1033,7 +1074,7 @@
       "roughness": 0.3,
       "clearcoat": 0.45
     },
-    "mat-30": {
+    "mat-35": {
       "hue": 0.6040000000000001,
       "sat": 0.704,
       "value": 0.688,
@@ -1041,7 +1082,7 @@
       "roughness": 0.3,
       "clearcoat": 0.45
     },
-    "mat-31": {
+    "mat-36": {
       "hue": 0.622,
       "sat": 0.732,
       "value": 0.6439999999999999,
@@ -1049,7 +1090,7 @@
       "roughness": 0.3,
       "clearcoat": 0.45
     },
-    "mat-32": {
+    "mat-37": {
       "hue": 0.64,
       "sat": 0.76,
       "value": 0.6,
@@ -1057,7 +1098,7 @@
       "roughness": 0.3,
       "clearcoat": 0.45
     },
-    "mat-33": {
+    "mat-38": {
       "hue": 0.58,
       "sat": 0.1,
       "value": 0.55,
@@ -1065,7 +1106,7 @@
       "roughness": 0.6,
       "clearcoat": 0.1
     },
-    "mat-34": {
+    "mat-39": {
       "hue": 0.55,
       "sat": 0.62,
       "value": 0.82,
@@ -1073,7 +1114,7 @@
       "roughness": 0.3,
       "clearcoat": 0.45
     },
-    "mat-35": {
+    "mat-40": {
       "hue": 0.5725,
       "sat": 0.655,
       "value": 0.7649999999999999,
@@ -1081,7 +1122,7 @@
       "roughness": 0.3,
       "clearcoat": 0.45
     },
-    "mat-36": {
+    "mat-41": {
       "hue": 0.5950000000000001,
       "sat": 0.69,
       "value": 0.71,
@@ -1089,7 +1130,7 @@
       "roughness": 0.3,
       "clearcoat": 0.45
     },
-    "mat-37": {
+    "mat-42": {
       "hue": 0.6175,
       "sat": 0.725,
       "value": 0.6549999999999999,
@@ -1097,7 +1138,7 @@
       "roughness": 0.3,
       "clearcoat": 0.45
     },
-    "mat-38": {
+    "mat-43": {
       "hue": 0.562857142857143,
       "sat": 0.64,
       "value": 0.7885714285714285,
@@ -1105,7 +1146,7 @@
       "roughness": 0.3,
       "clearcoat": 0.45
     },
-    "mat-39": {
+    "mat-44": {
       "hue": 0.5757142857142857,
       "sat": 0.66,
       "value": 0.7571428571428571,
@@ -1113,7 +1154,7 @@
       "roughness": 0.3,
       "clearcoat": 0.45
     },
-    "mat-40": {
+    "mat-45": {
       "hue": 0.5885714285714286,
       "sat": 0.68,
       "value": 0.7257142857142856,
@@ -1121,7 +1162,7 @@
       "roughness": 0.3,
       "clearcoat": 0.45
     },
-    "mat-41": {
+    "mat-46": {
       "hue": 0.6014285714285714,
       "sat": 0.7,
       "value": 0.6942857142857143,
@@ -1129,7 +1170,7 @@
       "roughness": 0.3,
       "clearcoat": 0.45
     },
-    "mat-42": {
+    "mat-47": {
       "hue": 0.6142857142857143,
       "sat": 0.72,
       "value": 0.6628571428571428,
@@ -1137,7 +1178,7 @@
       "roughness": 0.3,
       "clearcoat": 0.45
     },
-    "mat-43": {
+    "mat-48": {
       "hue": 0.6271428571428572,
       "sat": 0.74,
       "value": 0.6314285714285715,
@@ -1145,7 +1186,7 @@
       "roughness": 0.3,
       "clearcoat": 0.45
     },
-    "mat-44": {
+    "mat-49": {
       "hue": 0.55,
       "sat": 0.62,
       "value": 0.85,
@@ -1153,7 +1194,7 @@
       "roughness": 0.3,
       "clearcoat": 0.45
     },
-    "mat-45": {
+    "mat-50": {
       "hue": 0.11,
       "sat": 0.78,
       "value": 0.95,
@@ -1163,7 +1204,7 @@
       "roughness": 0.22,
       "clearcoat": 0.6
     },
-    "mat-46": {
+    "mat-51": {
       "hue": 0.5950000000000001,
       "sat": 0.7,
       "value": 0.71,
@@ -1171,7 +1212,7 @@
       "roughness": 0.3,
       "clearcoat": 0.45
     },
-    "mat-47": {
+    "mat-52": {
       "hue": 0.64,
       "sat": 0.78,
       "value": 0.57,
@@ -1179,7 +1220,7 @@
       "roughness": 0.3,
       "clearcoat": 0.45
     },
-    "mat-48": {
+    "mat-53": {
       "hue": 0.62,
       "sat": 0.22,
       "value": 0.2,
@@ -1188,7 +1229,7 @@
       "kind": "normal",
       "roughness": 0.6
     },
-    "mat-49": {
+    "mat-54": {
       "hue": 0.62,
       "sat": 0.25,
       "value": 0.14,
@@ -2156,380 +2197,263 @@
       "material": "mat-1"
     },
     {
-      "id": "s5-backboard",
+      "id": "s5-vs-stele-0",
       "type": "rounded_box",
       "args": {
-        "dims": [4.02, 5, 0.28],
+        "dims": [0.5, 2.6, 0.5],
         "cornerR": 0.08
       },
       "transform": {
-        "translate": [-160, 3.4, -0.34]
+        "translate": [-157.65, 1.4, 1.8399999999999999]
       },
       "material": "mat-12",
       "collection": "station-5"
     },
     {
-      "id": "s5-cell-0-0",
+      "id": "s5-vs-stele-1",
       "type": "rounded_box",
       "args": {
-        "dims": [1.7, 0.65, 0.3],
-        "cornerR": 0.06
+        "dims": [0.5, 2.6, 0.5],
+        "cornerR": 0.08
       },
       "transform": {
-        "translate": [-159.09, 5.325, 0]
+        "translate": [-162.35, 1.4, 1.8399999999999999]
       },
       "material": "mat-13",
       "collection": "station-5"
     },
     {
-      "id": "s5-cell-1-0",
+      "id": "s5-vs-panel-0-0",
       "type": "rounded_box",
       "args": {
-        "dims": [1.7, 0.65, 0.3],
-        "cornerR": 0.06
+        "dims": [0.36, 1.25, 1.65],
+        "cornerR": 0.07
       },
       "transform": {
-        "translate": [-160.91, 5.325, 0]
-      },
-      "material": "mat-13",
-      "collection": "station-5"
-    },
-    {
-      "id": "s5-cell-0-1",
-      "type": "rounded_box",
-      "args": {
-        "dims": [1.7, 0.65, 0.3],
-        "cornerR": 0.06
-      },
-      "transform": {
-        "translate": [-159.09, 4.555, 0]
-      },
-      "material": "mat-13",
-      "collection": "station-5"
-    },
-    {
-      "id": "s5-cell-1-1",
-      "type": "rounded_box",
-      "args": {
-        "dims": [1.7, 0.65, 0.3],
-        "cornerR": 0.06
-      },
-      "transform": {
-        "translate": [-160.91, 4.555, 0]
-      },
-      "material": "mat-13",
-      "collection": "station-5"
-    },
-    {
-      "id": "s5-cell-0-2",
-      "type": "rounded_box",
-      "args": {
-        "dims": [1.7, 0.65, 0.3],
-        "cornerR": 0.06
-      },
-      "transform": {
-        "translate": [-159.09, 3.785, 0]
-      },
-      "material": "mat-13",
-      "collection": "station-5"
-    },
-    {
-      "id": "s5-cell-1-2",
-      "type": "rounded_box",
-      "args": {
-        "dims": [1.7, 0.65, 0.3],
-        "cornerR": 0.06
-      },
-      "transform": {
-        "translate": [-160.91, 3.785, 0]
-      },
-      "material": "mat-13",
-      "collection": "station-5"
-    },
-    {
-      "id": "s5-cell-0-3",
-      "type": "rounded_box",
-      "args": {
-        "dims": [1.7, 0.65, 0.3],
-        "cornerR": 0.06
-      },
-      "transform": {
-        "translate": [-159.09, 3.0149999999999997, 0]
-      },
-      "material": "mat-13",
-      "collection": "station-5"
-    },
-    {
-      "id": "s5-cell-1-3",
-      "type": "rounded_box",
-      "args": {
-        "dims": [1.7, 0.65, 0.3],
-        "cornerR": 0.06
-      },
-      "transform": {
-        "translate": [-160.91, 3.0149999999999997, 0]
-      },
-      "material": "mat-13",
-      "collection": "station-5"
-    },
-    {
-      "id": "s5-cell-0-4",
-      "type": "rounded_box",
-      "args": {
-        "dims": [1.7, 0.65, 0.3],
-        "cornerR": 0.06
-      },
-      "transform": {
-        "translate": [-159.09, 2.245, 0]
-      },
-      "material": "mat-13",
-      "collection": "station-5"
-    },
-    {
-      "id": "s5-cell-1-4",
-      "type": "rounded_box",
-      "args": {
-        "dims": [1.7, 0.65, 0.3],
-        "cornerR": 0.06
-      },
-      "transform": {
-        "translate": [-160.91, 2.245, 0]
-      },
-      "material": "mat-13",
-      "collection": "station-5"
-    },
-    {
-      "id": "s5-cell-0-5",
-      "type": "rounded_box",
-      "args": {
-        "dims": [1.7, 0.65, 0.3],
-        "cornerR": 0.06
-      },
-      "transform": {
-        "translate": [-159.09, 1.4749999999999999, 0]
-      },
-      "material": "mat-13",
-      "collection": "station-5"
-    },
-    {
-      "id": "s5-cell-1-5",
-      "type": "rounded_box",
-      "args": {
-        "dims": [1.7, 0.65, 0.3],
-        "cornerR": 0.06
-      },
-      "transform": {
-        "translate": [-160.91, 1.4749999999999999, 0]
-      },
-      "material": "mat-13",
-      "collection": "station-5"
-    },
-    {
-      "id": "s5-item-0",
-      "type": "rounded_box",
-      "args": {
-        "dims": [0.34, 0.34, 0.34],
-        "cornerR": 0.06
-      },
-      "transform": {
-        "translate": [-159.09, 5.325, 0.34]
+        "translate": [-157.65, 1.75, 0]
       },
       "material": "mat-3",
       "collection": "station-5"
     },
     {
-      "id": "s5-item-1",
+      "id": "s5-vs-panel-0-1",
       "type": "rounded_box",
       "args": {
-        "dims": [0.34, 0.34, 0.34],
-        "cornerR": 0.06
+        "dims": [0.36, 1.25, 1.65],
+        "cornerR": 0.07
       },
       "transform": {
-        "translate": [-159.09, 4.555, 0.34]
+        "translate": [-157.65, 1.75, -2.3]
       },
       "material": "mat-14",
       "collection": "station-5"
     },
     {
-      "id": "s5-item-2",
+      "id": "s5-vs-panel-0-2",
       "type": "rounded_box",
       "args": {
-        "dims": [0.34, 0.34, 0.34],
-        "cornerR": 0.06
+        "dims": [0.36, 1.25, 1.65],
+        "cornerR": 0.07
       },
       "transform": {
-        "translate": [-159.09, 3.785, 0.34]
+        "translate": [-157.65, 1.75, -4.6]
       },
       "material": "mat-14",
       "collection": "station-5"
     },
     {
-      "id": "s5-item-3",
+      "id": "s5-vs-panel-0-3",
       "type": "rounded_box",
       "args": {
-        "dims": [0.34, 0.34, 0.34],
-        "cornerR": 0.06
+        "dims": [0.36, 1.25, 1.65],
+        "cornerR": 0.07
       },
       "transform": {
-        "translate": [-159.09, 3.0149999999999997, 0.34]
+        "translate": [-157.65, 1.75, -6.8999999999999995]
       },
       "material": "mat-14",
       "collection": "station-5"
     },
     {
-      "id": "s5-item-4",
+      "id": "s5-vs-panel-0-4",
       "type": "rounded_box",
       "args": {
-        "dims": [0.34, 0.34, 0.34],
-        "cornerR": 0.06
+        "dims": [0.36, 1.25, 1.65],
+        "cornerR": 0.07
       },
       "transform": {
-        "translate": [-159.09, 2.245, 0.34]
+        "translate": [-157.65, 1.75, -9.2]
       },
       "material": "mat-14",
       "collection": "station-5"
     },
     {
-      "id": "s5-item-5",
+      "id": "s5-vs-panel-0-5",
       "type": "rounded_box",
       "args": {
-        "dims": [0.34, 0.34, 0.34],
-        "cornerR": 0.06
+        "dims": [0.36, 1.25, 1.65],
+        "cornerR": 0.07
       },
       "transform": {
-        "translate": [-159.09, 1.4749999999999999, 0.34]
+        "translate": [-157.65, 1.75, -11.5]
       },
       "material": "mat-14",
       "collection": "station-5"
     },
     {
-      "id": "s5-item-6",
+      "id": "s5-vs-panel-1-0",
       "type": "rounded_box",
       "args": {
-        "dims": [0.34, 0.34, 0.34],
-        "cornerR": 0.06
+        "dims": [0.36, 1.25, 1.65],
+        "cornerR": 0.07
       },
       "transform": {
-        "translate": [-160.91, 5.325, 0.34]
+        "translate": [-162.35, 1.75, 0]
       },
-      "material": "mat-14",
+      "material": "mat-15",
       "collection": "station-5"
     },
     {
-      "id": "s5-item-7",
+      "id": "s5-vs-panel-1-1",
       "type": "rounded_box",
       "args": {
-        "dims": [0.34, 0.34, 0.34],
-        "cornerR": 0.06
+        "dims": [0.36, 1.25, 1.65],
+        "cornerR": 0.07
       },
       "transform": {
-        "translate": [-160.91, 4.555, 0.34]
+        "translate": [-162.35, 1.75, -2.3]
       },
-      "material": "mat-14",
+      "material": "mat-15",
       "collection": "station-5"
     },
     {
-      "id": "s5-item-8",
+      "id": "s5-vs-panel-1-2",
       "type": "rounded_box",
       "args": {
-        "dims": [0.34, 0.34, 0.34],
-        "cornerR": 0.06
+        "dims": [0.36, 1.25, 1.65],
+        "cornerR": 0.07
       },
       "transform": {
-        "translate": [-160.91, 3.785, 0.34]
+        "translate": [-162.35, 1.75, -4.6]
       },
-      "material": "mat-14",
+      "material": "mat-15",
       "collection": "station-5"
     },
     {
-      "id": "s5-item-9",
+      "id": "s5-vs-panel-1-3",
       "type": "rounded_box",
       "args": {
-        "dims": [0.34, 0.34, 0.34],
-        "cornerR": 0.06
+        "dims": [0.36, 1.25, 1.65],
+        "cornerR": 0.07
       },
       "transform": {
-        "translate": [-160.91, 3.0149999999999997, 0.34]
+        "translate": [-162.35, 1.75, -6.8999999999999995]
       },
-      "material": "mat-14",
+      "material": "mat-15",
       "collection": "station-5"
     },
     {
-      "id": "s5-item-10",
+      "id": "s5-vs-panel-1-4",
       "type": "rounded_box",
       "args": {
-        "dims": [0.34, 0.34, 0.34],
-        "cornerR": 0.06
+        "dims": [0.36, 1.25, 1.65],
+        "cornerR": 0.07
       },
       "transform": {
-        "translate": [-160.91, 2.245, 0.34]
+        "translate": [-162.35, 1.75, -9.2]
       },
-      "material": "mat-14",
+      "material": "mat-15",
       "collection": "station-5"
     },
     {
-      "id": "s5-item-11",
+      "id": "s5-vs-panel-1-5",
       "type": "rounded_box",
       "args": {
-        "dims": [0.34, 0.34, 0.34],
-        "cornerR": 0.06
+        "dims": [0.36, 1.25, 1.65],
+        "cornerR": 0.07
       },
       "transform": {
-        "translate": [-160.91, 1.4749999999999999, 0.34]
+        "translate": [-162.35, 1.75, -11.5]
       },
-      "material": "mat-14",
+      "material": "mat-15",
       "collection": "station-5"
     },
     {
-      "id": "s5-flank-0",
-      "type": "box",
+      "id": "s5-vs-spine-0",
+      "type": "rounded_box",
       "args": {
-        "dims": [1.5, 0.9, 0.75]
+        "dims": [0.28, 0.14, 0.28],
+        "cornerR": 0.05
       },
       "transform": {
-        "translate": [-164.16, 4.2, -2.2],
-        "rotate": [0, -0.9, 0]
+        "translate": [-160, 0.12, 0]
       },
-      "material": "mat-9",
+      "material": "mat-16",
       "collection": "station-5"
     },
     {
-      "id": "s5-flank-1",
-      "type": "box",
+      "id": "s5-vs-spine-1",
+      "type": "rounded_box",
       "args": {
-        "dims": [1.9, 1.1, 0.95]
+        "dims": [0.28, 0.14, 0.28],
+        "cornerR": 0.05
       },
       "transform": {
-        "translate": [-155.54, 3, -3],
-        "rotate": [0, -0.4, 0]
+        "translate": [-160, 0.12, -2.3]
       },
-      "material": "mat-9",
+      "material": "mat-16",
       "collection": "station-5"
     },
     {
-      "id": "s5-flank-2",
-      "type": "box",
+      "id": "s5-vs-spine-2",
+      "type": "rounded_box",
       "args": {
-        "dims": [2.6, 1.4, 1.3]
+        "dims": [0.28, 0.14, 0.28],
+        "cornerR": 0.05
       },
       "transform": {
-        "translate": [-165.96, 5.6, -5.5],
-        "rotate": [0, 0.09999999999999998, 0]
+        "translate": [-160, 0.12, -4.6]
       },
-      "material": "mat-9",
+      "material": "mat-16",
       "collection": "station-5"
     },
     {
-      "id": "s5-flank-3",
-      "type": "box",
+      "id": "s5-vs-spine-3",
+      "type": "rounded_box",
       "args": {
-        "dims": [2.2, 1.2, 1.1]
+        "dims": [0.28, 0.14, 0.28],
+        "cornerR": 0.05
       },
       "transform": {
-        "translate": [-153.44, 5, -6.5],
-        "rotate": [0, 0.6, 0]
+        "translate": [-160, 0.12, -6.8999999999999995]
       },
-      "material": "mat-9",
+      "material": "mat-16",
+      "collection": "station-5"
+    },
+    {
+      "id": "s5-vs-spine-4",
+      "type": "rounded_box",
+      "args": {
+        "dims": [0.28, 0.14, 0.28],
+        "cornerR": 0.05
+      },
+      "transform": {
+        "translate": [-160, 0.12, -9.2]
+      },
+      "material": "mat-16",
+      "collection": "station-5"
+    },
+    {
+      "id": "s5-vs-spine-5",
+      "type": "rounded_box",
+      "args": {
+        "dims": [0.28, 0.14, 0.28],
+        "cornerR": 0.05
+      },
+      "transform": {
+        "translate": [-160, 0.12, -11.5]
+      },
+      "material": "mat-16",
       "collection": "station-5"
     },
     {
@@ -2562,7 +2486,7 @@
       "transform": {
         "translate": [-144, 3.28, -0.34]
       },
-      "material": "mat-12",
+      "material": "mat-17",
       "collection": "station-6"
     },
     {
@@ -2575,7 +2499,7 @@
       "transform": {
         "translate": [-142.18, 4.922499999999999, 0]
       },
-      "material": "mat-13",
+      "material": "mat-18",
       "collection": "station-6"
     },
     {
@@ -2588,7 +2512,7 @@
       "transform": {
         "translate": [-144, 4.922499999999999, 0]
       },
-      "material": "mat-13",
+      "material": "mat-18",
       "collection": "station-6"
     },
     {
@@ -2601,7 +2525,7 @@
       "transform": {
         "translate": [-145.82, 4.922499999999999, 0]
       },
-      "material": "mat-13",
+      "material": "mat-18",
       "collection": "station-6"
     },
     {
@@ -2614,7 +2538,7 @@
       "transform": {
         "translate": [-142.18, 3.8274999999999997, 0]
       },
-      "material": "mat-13",
+      "material": "mat-18",
       "collection": "station-6"
     },
     {
@@ -2627,7 +2551,7 @@
       "transform": {
         "translate": [-144, 3.8274999999999997, 0]
       },
-      "material": "mat-13",
+      "material": "mat-18",
       "collection": "station-6"
     },
     {
@@ -2640,7 +2564,7 @@
       "transform": {
         "translate": [-145.82, 3.8274999999999997, 0]
       },
-      "material": "mat-13",
+      "material": "mat-18",
       "collection": "station-6"
     },
     {
@@ -2653,7 +2577,7 @@
       "transform": {
         "translate": [-142.18, 2.7325, 0]
       },
-      "material": "mat-13",
+      "material": "mat-18",
       "collection": "station-6"
     },
     {
@@ -2666,7 +2590,7 @@
       "transform": {
         "translate": [-144, 2.7325, 0]
       },
-      "material": "mat-13",
+      "material": "mat-18",
       "collection": "station-6"
     },
     {
@@ -2679,7 +2603,7 @@
       "transform": {
         "translate": [-145.82, 2.7325, 0]
       },
-      "material": "mat-13",
+      "material": "mat-18",
       "collection": "station-6"
     },
     {
@@ -2692,7 +2616,7 @@
       "transform": {
         "translate": [-142.18, 1.6374999999999997, 0]
       },
-      "material": "mat-13",
+      "material": "mat-18",
       "collection": "station-6"
     },
     {
@@ -2705,7 +2629,7 @@
       "transform": {
         "translate": [-144, 1.6374999999999997, 0]
       },
-      "material": "mat-13",
+      "material": "mat-18",
       "collection": "station-6"
     },
     {
@@ -2718,7 +2642,7 @@
       "transform": {
         "translate": [-145.82, 1.6374999999999997, 0]
       },
-      "material": "mat-13",
+      "material": "mat-18",
       "collection": "station-6"
     },
     {
@@ -2731,7 +2655,7 @@
       "transform": {
         "translate": [-142.18, 4.922499999999999, 0.34]
       },
-      "material": "mat-14",
+      "material": "mat-19",
       "collection": "station-6"
     },
     {
@@ -2744,7 +2668,7 @@
       "transform": {
         "translate": [-142.18, 3.8274999999999997, 0.34]
       },
-      "material": "mat-14",
+      "material": "mat-19",
       "collection": "station-6"
     },
     {
@@ -2757,7 +2681,7 @@
       "transform": {
         "translate": [-142.18, 2.7325, 0.34]
       },
-      "material": "mat-14",
+      "material": "mat-19",
       "collection": "station-6"
     },
     {
@@ -2770,7 +2694,7 @@
       "transform": {
         "translate": [-142.18, 1.6374999999999997, 0.34]
       },
-      "material": "mat-14",
+      "material": "mat-19",
       "collection": "station-6"
     },
     {
@@ -2783,7 +2707,7 @@
       "transform": {
         "translate": [-145.82, 4.922499999999999, 0.34]
       },
-      "material": "mat-14",
+      "material": "mat-19",
       "collection": "station-6"
     },
     {
@@ -2796,7 +2720,7 @@
       "transform": {
         "translate": [-145.82, 3.8274999999999997, 0.34]
       },
-      "material": "mat-14",
+      "material": "mat-19",
       "collection": "station-6"
     },
     {
@@ -2809,7 +2733,7 @@
       "transform": {
         "translate": [-145.82, 2.7325, 0.34]
       },
-      "material": "mat-14",
+      "material": "mat-19",
       "collection": "station-6"
     },
     {
@@ -2822,7 +2746,7 @@
       "transform": {
         "translate": [-145.82, 1.6374999999999997, 0.34]
       },
-      "material": "mat-14",
+      "material": "mat-19",
       "collection": "station-6"
     },
     {
@@ -2835,7 +2759,7 @@
       "transform": {
         "translate": [-144, 4.922499999999999, 0.34]
       },
-      "material": "mat-14",
+      "material": "mat-19",
       "collection": "station-6"
     },
     {
@@ -2848,7 +2772,7 @@
       "transform": {
         "translate": [-144, 3.8274999999999997, 0.34]
       },
-      "material": "mat-14",
+      "material": "mat-19",
       "collection": "station-6"
     },
     {
@@ -2874,7 +2798,7 @@
       "transform": {
         "translate": [-144, 1.6374999999999997, 0.34]
       },
-      "material": "mat-14",
+      "material": "mat-19",
       "collection": "station-6"
     },
     {
@@ -3108,7 +3032,7 @@
       "transform": {
         "translate": [-96, 1.2, 0]
       },
-      "material": "mat-15",
+      "material": "mat-20",
       "collection": "station-9"
     },
     {
@@ -3122,7 +3046,7 @@
       "transform": {
         "translate": [-87.3, 1.7, 0]
       },
-      "material": "mat-16",
+      "material": "mat-21",
       "collection": "station-9"
     },
     {
@@ -3136,7 +3060,7 @@
       "transform": {
         "translate": [-90.2, 2.32, 0]
       },
-      "material": "mat-16",
+      "material": "mat-21",
       "collection": "station-9"
     },
     {
@@ -3150,7 +3074,7 @@
       "transform": {
         "translate": [-93.1, 2.94, 0]
       },
-      "material": "mat-16",
+      "material": "mat-21",
       "collection": "station-9"
     },
     {
@@ -3164,7 +3088,7 @@
       "transform": {
         "translate": [-96, 3.5599999999999996, 0]
       },
-      "material": "mat-16",
+      "material": "mat-21",
       "collection": "station-9"
     },
     {
@@ -3178,7 +3102,7 @@
       "transform": {
         "translate": [-98.9, 4.18, 0]
       },
-      "material": "mat-16",
+      "material": "mat-21",
       "collection": "station-9"
     },
     {
@@ -3192,7 +3116,7 @@
       "transform": {
         "translate": [-101.8, 4.8, 0]
       },
-      "material": "mat-16",
+      "material": "mat-21",
       "collection": "station-9"
     },
     {
@@ -3204,7 +3128,7 @@
       "transform": {
         "translate": [-87.3, 1.45, 0]
       },
-      "material": "mat-15",
+      "material": "mat-20",
       "collection": "station-9"
     },
     {
@@ -3216,7 +3140,7 @@
       "transform": {
         "translate": [-87.3, 1.7, 0]
       },
-      "material": "mat-17",
+      "material": "mat-22",
       "collection": "station-9"
     },
     {
@@ -3228,7 +3152,7 @@
       "transform": {
         "translate": [-90.2, 1.7599999999999998, 0]
       },
-      "material": "mat-15",
+      "material": "mat-20",
       "collection": "station-9"
     },
     {
@@ -3240,7 +3164,7 @@
       "transform": {
         "translate": [-90.2, 2.32, 0]
       },
-      "material": "mat-17",
+      "material": "mat-22",
       "collection": "station-9"
     },
     {
@@ -3252,7 +3176,7 @@
       "transform": {
         "translate": [-93.1, 2.07, 0]
       },
-      "material": "mat-15",
+      "material": "mat-20",
       "collection": "station-9"
     },
     {
@@ -3264,7 +3188,7 @@
       "transform": {
         "translate": [-93.1, 2.94, 0]
       },
-      "material": "mat-17",
+      "material": "mat-22",
       "collection": "station-9"
     },
     {
@@ -3276,7 +3200,7 @@
       "transform": {
         "translate": [-96, 2.38, 0]
       },
-      "material": "mat-15",
+      "material": "mat-20",
       "collection": "station-9"
     },
     {
@@ -3288,7 +3212,7 @@
       "transform": {
         "translate": [-96, 3.5599999999999996, 0]
       },
-      "material": "mat-17",
+      "material": "mat-22",
       "collection": "station-9"
     },
     {
@@ -3300,7 +3224,7 @@
       "transform": {
         "translate": [-98.9, 2.6899999999999995, 0]
       },
-      "material": "mat-15",
+      "material": "mat-20",
       "collection": "station-9"
     },
     {
@@ -3312,7 +3236,7 @@
       "transform": {
         "translate": [-98.9, 4.18, 0]
       },
-      "material": "mat-17",
+      "material": "mat-22",
       "collection": "station-9"
     },
     {
@@ -3324,7 +3248,7 @@
       "transform": {
         "translate": [-101.8, 3, 0]
       },
-      "material": "mat-15",
+      "material": "mat-20",
       "collection": "station-9"
     },
     {
@@ -3336,7 +3260,7 @@
       "transform": {
         "translate": [-101.8, 4.8, 0]
       },
-      "material": "mat-17",
+      "material": "mat-22",
       "collection": "station-9"
     },
     {
@@ -3348,7 +3272,7 @@
       "transform": {
         "translate": [-104.7, 3.3099999999999996, 0]
       },
-      "material": "mat-15",
+      "material": "mat-20",
       "collection": "station-9"
     },
     {
@@ -3360,7 +3284,7 @@
       "transform": {
         "translate": [-104.7, 5.42, 0]
       },
-      "material": "mat-18",
+      "material": "mat-23",
       "collection": "station-9"
     },
     {
@@ -3392,7 +3316,7 @@
       "transform": {
         "translate": [-80, 1.2, 0]
       },
-      "material": "mat-15",
+      "material": "mat-20",
       "collection": "station-10"
     },
     {
@@ -3406,7 +3330,7 @@
       "transform": {
         "translate": [-74.2, 1.7, 0]
       },
-      "material": "mat-16",
+      "material": "mat-21",
       "collection": "station-10"
     },
     {
@@ -3420,7 +3344,7 @@
       "transform": {
         "translate": [-77.1, 1.7, 0]
       },
-      "material": "mat-16",
+      "material": "mat-21",
       "collection": "station-10"
     },
     {
@@ -3434,7 +3358,7 @@
       "transform": {
         "translate": [-80, 1.7, 0]
       },
-      "material": "mat-16",
+      "material": "mat-21",
       "collection": "station-10"
     },
     {
@@ -3448,7 +3372,7 @@
       "transform": {
         "translate": [-82.9, 1.7, 0]
       },
-      "material": "mat-16",
+      "material": "mat-21",
       "collection": "station-10"
     },
     {
@@ -3460,7 +3384,7 @@
       "transform": {
         "translate": [-74.2, 1.45, 0]
       },
-      "material": "mat-15",
+      "material": "mat-20",
       "collection": "station-10"
     },
     {
@@ -3472,7 +3396,7 @@
       "transform": {
         "translate": [-74.2, 1.7, 0]
       },
-      "material": "mat-17",
+      "material": "mat-22",
       "collection": "station-10"
     },
     {
@@ -3484,7 +3408,7 @@
       "transform": {
         "translate": [-77.1, 1.45, 0]
       },
-      "material": "mat-15",
+      "material": "mat-20",
       "collection": "station-10"
     },
     {
@@ -3496,7 +3420,7 @@
       "transform": {
         "translate": [-77.1, 1.7, 0]
       },
-      "material": "mat-17",
+      "material": "mat-22",
       "collection": "station-10"
     },
     {
@@ -3508,7 +3432,7 @@
       "transform": {
         "translate": [-80, 1.45, 0]
       },
-      "material": "mat-15",
+      "material": "mat-20",
       "collection": "station-10"
     },
     {
@@ -3520,7 +3444,7 @@
       "transform": {
         "translate": [-80, 1.7, 0]
       },
-      "material": "mat-17",
+      "material": "mat-22",
       "collection": "station-10"
     },
     {
@@ -3532,7 +3456,7 @@
       "transform": {
         "translate": [-82.9, 1.45, 0]
       },
-      "material": "mat-15",
+      "material": "mat-20",
       "collection": "station-10"
     },
     {
@@ -3544,7 +3468,7 @@
       "transform": {
         "translate": [-82.9, 1.7, 0]
       },
-      "material": "mat-18",
+      "material": "mat-23",
       "collection": "station-10"
     },
     {
@@ -3556,7 +3480,7 @@
       "transform": {
         "translate": [-85.8, 1.45, 0]
       },
-      "material": "mat-15",
+      "material": "mat-20",
       "collection": "station-10"
     },
     {
@@ -3568,7 +3492,7 @@
       "transform": {
         "translate": [-85.8, 1.7, 0]
       },
-      "material": "mat-17",
+      "material": "mat-22",
       "collection": "station-10"
     },
     {
@@ -3600,7 +3524,7 @@
       "transform": {
         "translate": [-64, 3.4717563084888248, 0]
       },
-      "material": "mat-19",
+      "material": "mat-24",
       "collection": "station-11"
     },
     {
@@ -3612,7 +3536,7 @@
       "transform": {
         "translate": [-65.73457957428285, 5.285994954247422, 1.892199788528165]
       },
-      "material": "mat-20",
+      "material": "mat-25",
       "collection": "station-11"
     },
     {
@@ -3624,7 +3548,7 @@
       "transform": {
         "translate": [-63.75583992848334, 4.526536653867332, -3.0032967145799265]
       },
-      "material": "mat-20",
+      "material": "mat-25",
       "collection": "station-11"
     },
     {
@@ -3636,7 +3560,7 @@
       "transform": {
         "translate": [-62.0287792372525, 3.5773527923138766, 2.522881994877872]
       },
-      "material": "mat-20",
+      "material": "mat-25",
       "collection": "station-11"
     },
     {
@@ -3648,7 +3572,7 @@
       "transform": {
         "translate": [-66.93735084415512, 2.6354304844164727, -0.6193500111537166]
       },
-      "material": "mat-20",
+      "material": "mat-25",
       "collection": "station-11"
     },
     {
@@ -3660,7 +3584,7 @@
       "transform": {
         "translate": [-61.859595464411235, 1.697230350651346, -1.0927212847978929]
       },
-      "material": "mat-21",
+      "material": "mat-26",
       "collection": "station-11"
     },
     {
@@ -3672,7 +3596,7 @@
       "transform": {
         "translate": [-63.810719507758925, 0.6000000000000001, 0.2073612061185931]
       },
-      "material": "mat-21",
+      "material": "mat-26",
       "collection": "station-11"
     },
     {
@@ -3686,7 +3610,7 @@
       "transform": {
         "translate": [-65.73457957428285, 5.285994954247422, 1.892199788528165]
       },
-      "material": "mat-22",
+      "material": "mat-27",
       "collection": "station-11"
     },
     {
@@ -3700,7 +3624,7 @@
       "transform": {
         "translate": [-63.75583992848334, 4.526536653867332, -3.0032967145799265]
       },
-      "material": "mat-22",
+      "material": "mat-27",
       "collection": "station-11"
     },
     {
@@ -3714,7 +3638,7 @@
       "transform": {
         "translate": [-62.0287792372525, 3.5773527923138766, 2.522881994877872]
       },
-      "material": "mat-22",
+      "material": "mat-27",
       "collection": "station-11"
     },
     {
@@ -3728,7 +3652,7 @@
       "transform": {
         "translate": [-66.93735084415512, 2.6354304844164727, -0.6193500111537166]
       },
-      "material": "mat-22",
+      "material": "mat-27",
       "collection": "station-11"
     },
     {
@@ -3742,7 +3666,7 @@
       "transform": {
         "translate": [-64, 3.4717563084888248, 0]
       },
-      "material": "mat-22",
+      "material": "mat-27",
       "collection": "station-11"
     },
     {
@@ -3756,7 +3680,7 @@
       "transform": {
         "translate": [-61.859595464411235, 1.697230350651346, -1.0927212847978929]
       },
-      "material": "mat-22",
+      "material": "mat-27",
       "collection": "station-11"
     },
     {
@@ -3770,7 +3694,7 @@
       "transform": {
         "translate": [-63.810719507758925, 0.6000000000000001, 0.2073612061185931]
       },
-      "material": "mat-22",
+      "material": "mat-27",
       "collection": "station-11"
     },
     {
@@ -3783,7 +3707,7 @@
         "translate": [-62.748125372633254, 4.405000000000001, 0],
         "rotate": [0, 0, 0]
       },
-      "material": "mat-23",
+      "material": "mat-28",
       "collection": "station-11"
     },
     {
@@ -3796,7 +3720,7 @@
         "translate": [-63.442907851507975, 4.399558176477956, -2.2669323891550555],
         "rotate": [0, 0.9, 0]
       },
-      "material": "mat-23",
+      "material": "mat-28",
       "collection": "station-11"
     },
     {
@@ -3809,7 +3733,7 @@
         "translate": [-65.89188406263898, 3.629579332748476, -0.989614658959953],
         "rotate": [0, 1.8, 0]
       },
-      "material": "mat-23",
+      "material": "mat-28",
       "collection": "station-11"
     },
     {
@@ -3822,7 +3746,7 @@
         "translate": [-66.61014035322316, 4.222504230305474, 2.958537169853774],
         "rotate": [0, 2.7, 0]
       },
-      "material": "mat-23",
+      "material": "mat-28",
       "collection": "station-11"
     },
     {
@@ -3835,7 +3759,7 @@
         "translate": [-62.74900969703649, 3.0836452719433054, 1.8017308536587748],
         "rotate": [0, 0.5, 0]
       },
-      "material": "mat-23",
+      "material": "mat-28",
       "collection": "station-11"
     },
     {
@@ -3848,7 +3772,7 @@
         "translate": [-59.24265842696182, 3.8177730524847187, -1.822992316403063],
         "rotate": [0, 1.4, 0]
       },
-      "material": "mat-23",
+      "material": "mat-28",
       "collection": "station-11"
     },
     {
@@ -3861,7 +3785,7 @@
         "translate": [-64.27446124056053, 2.742972950909394, -2.1848703015536812],
         "rotate": [0, 2.3000000000000003, 0]
       },
-      "material": "mat-23",
+      "material": "mat-28",
       "collection": "station-11"
     },
     {
@@ -3874,7 +3798,7 @@
         "translate": [-69.63768529414762, 3.247721417838311, -0.6569637863396396],
         "rotate": [0, 0.09999999999999964, 0]
       },
-      "material": "mat-23",
+      "material": "mat-28",
       "collection": "station-11"
     },
     {
@@ -3887,7 +3811,7 @@
         "translate": [-64.85640951118563, 2.514577769081229, 2.2962604484326103],
         "rotate": [0, 1, 0]
       },
-      "material": "mat-23",
+      "material": "mat-28",
       "collection": "station-11"
     },
     {
@@ -3900,7 +3824,7 @@
         "translate": [-59.34774836537981, 2.626149955099641, 3.1688055851540176],
         "rotate": [0, 1.8999999999999995, 0]
       },
-      "material": "mat-23",
+      "material": "mat-28",
       "collection": "station-11"
     },
     {
@@ -3913,7 +3837,7 @@
         "translate": [-61.7664773648173, 2.2751364752104166, -2.006364302126396],
         "rotate": [0, 2.8, 0]
       },
-      "material": "mat-23",
+      "material": "mat-28",
       "collection": "station-11"
     },
     {
@@ -3926,7 +3850,7 @@
         "translate": [-66.37242027968962, 2.074057518564027, -4.438197954760972],
         "rotate": [0, 0.6000000000000001, 0]
       },
-      "material": "mat-23",
+      "material": "mat-28",
       "collection": "station-11"
     },
     {
@@ -3939,7 +3863,7 @@
         "translate": [-67.61663162490252, 1.9174150657237594, 0.9232036344772824],
         "rotate": [0, 1.5000000000000004, 0]
       },
-      "material": "mat-23",
+      "material": "mat-28",
       "collection": "station-11"
     },
     {
@@ -3952,7 +3876,7 @@
         "translate": [-63.963352076394905, 1.6748001647187152, 4.091483547131837],
         "rotate": [0, 2.400000000000001, 0]
       },
-      "material": "mat-23",
+      "material": "mat-28",
       "collection": "station-11"
     },
     {
@@ -3965,7 +3889,7 @@
         "translate": [-59.729069436164245, 1.3899081353990992, 1.0090925115755864],
         "rotate": [0, 0.1999999999999993, 0]
       },
-      "material": "mat-23",
+      "material": "mat-28",
       "collection": "station-11"
     },
     {
@@ -3978,7 +3902,7 @@
         "translate": [-62.60116795355002, 1.44284528397345, -2.7335382705725464],
         "rotate": [0, 1.0999999999999996, 0]
       },
-      "material": "mat-23",
+      "material": "mat-28",
       "collection": "station-11"
     },
     {
@@ -3991,7 +3915,7 @@
         "translate": [-67.52927148000065, 0.7171594937718098, -3.057888513618657],
         "rotate": [0, 2, 0]
       },
-      "material": "mat-23",
+      "material": "mat-28",
       "collection": "station-11"
     },
     {
@@ -4004,7 +3928,7 @@
         "translate": [-65.79105241534354, 1.3160592709780925, 1.2675014631709414],
         "rotate": [0, 2.9000000000000004, 0]
       },
-      "material": "mat-23",
+      "material": "mat-28",
       "collection": "station-11"
     },
     {
@@ -4017,7 +3941,7 @@
         "translate": [-62.42436082893799, -0.005841134412181592, 4.004131549320719],
         "rotate": [0, 0.6999999999999988, 0]
       },
-      "material": "mat-23",
+      "material": "mat-28",
       "collection": "station-11"
     },
     {
@@ -4030,7 +3954,7 @@
         "translate": [-62.48183488420136, 1.1743019526359513, -0.20453893292798464],
         "rotate": [0, 1.600000000000001, 0]
       },
-      "material": "mat-23",
+      "material": "mat-28",
       "collection": "station-11"
     },
     {
@@ -4043,7 +3967,7 @@
         "translate": [-63.67751383932654, -0.6439061141122786, -3.000946679549864],
         "rotate": [0, 2.4999999999999996, 0]
       },
-      "material": "mat-23",
+      "material": "mat-28",
       "collection": "station-11"
     },
     {
@@ -4056,7 +3980,7 @@
         "translate": [-64.70498913645673, 0.879070215106386, -0.2557625023629266],
         "rotate": [0, 0.3000000000000016, 0]
       },
-      "material": "mat-23",
+      "material": "mat-28",
       "collection": "station-11"
     },
     {
@@ -4089,7 +4013,7 @@
       "transform": {
         "translate": [-48, 3.4875, -0.22]
       },
-      "material": "mat-24",
+      "material": "mat-29",
       "collection": "station-12"
     },
     {
@@ -4133,7 +4057,7 @@
       "transform": {
         "translate": [-32.65726783391228, 8.240083449326644, -0.21027246340471484]
       },
-      "material": "mat-21",
+      "material": "mat-26",
       "collection": "station-13"
     },
     {
@@ -4145,7 +4069,7 @@
       "transform": {
         "translate": [-34.563908261614586, 6.556638433341682, 0.4029354422531373]
       },
-      "material": "mat-25",
+      "material": "mat-30",
       "collection": "station-13"
     },
     {
@@ -4157,7 +4081,7 @@
       "transform": {
         "translate": [-33.20972975387931, 5.410462203579505, -2.0769912532305064]
       },
-      "material": "mat-25",
+      "material": "mat-30",
       "collection": "station-13"
     },
     {
@@ -4169,7 +4093,7 @@
       "transform": {
         "translate": [-32, 4.034705367679379, 0]
       },
-      "material": "mat-26",
+      "material": "mat-31",
       "collection": "station-13"
     },
     {
@@ -4181,7 +4105,7 @@
       "transform": {
         "translate": [-35.127017476932295, 3.0535128331174013, -0.12475457866938144]
       },
-      "material": "mat-19",
+      "material": "mat-24",
       "collection": "station-13"
     },
     {
@@ -4193,7 +4117,7 @@
       "transform": {
         "translate": [-30.343068093926924, 2.3752519777557772, -1.493443687048192]
       },
-      "material": "mat-25",
+      "material": "mat-30",
       "collection": "station-13"
     },
     {
@@ -4205,7 +4129,7 @@
       "transform": {
         "translate": [-34.1187707344686, 1.4770305268093469, 1.7529432924933686]
       },
-      "material": "mat-25",
+      "material": "mat-30",
       "collection": "station-13"
     },
     {
@@ -4217,7 +4141,7 @@
       "transform": {
         "translate": [-32.50004426626464, 0.6000000000000001, -0.6182455439337382]
       },
-      "material": "mat-25",
+      "material": "mat-30",
       "collection": "station-13"
     },
     {
@@ -4231,7 +4155,7 @@
       "transform": {
         "translate": [-32.65726783391228, 8.240083449326644, -0.21027246340471484]
       },
-      "material": "mat-22",
+      "material": "mat-27",
       "collection": "station-13"
     },
     {
@@ -4245,7 +4169,7 @@
       "transform": {
         "translate": [-34.563908261614586, 6.556638433341682, 0.4029354422531373]
       },
-      "material": "mat-22",
+      "material": "mat-27",
       "collection": "station-13"
     },
     {
@@ -4259,7 +4183,7 @@
       "transform": {
         "translate": [-33.20972975387931, 5.410462203579505, -2.0769912532305064]
       },
-      "material": "mat-22",
+      "material": "mat-27",
       "collection": "station-13"
     },
     {
@@ -4273,7 +4197,7 @@
       "transform": {
         "translate": [-32, 4.034705367679379, 0]
       },
-      "material": "mat-22",
+      "material": "mat-27",
       "collection": "station-13"
     },
     {
@@ -4287,7 +4211,7 @@
       "transform": {
         "translate": [-35.127017476932295, 3.0535128331174013, -0.12475457866938144]
       },
-      "material": "mat-22",
+      "material": "mat-27",
       "collection": "station-13"
     },
     {
@@ -4301,7 +4225,7 @@
       "transform": {
         "translate": [-34.1187707344686, 1.4770305268093469, 1.7529432924933686]
       },
-      "material": "mat-22",
+      "material": "mat-27",
       "collection": "station-13"
     },
     {
@@ -4315,7 +4239,7 @@
       "transform": {
         "translate": [-32.50004426626464, 0.6000000000000001, -0.6182455439337382]
       },
-      "material": "mat-22",
+      "material": "mat-27",
       "collection": "station-13"
     },
     {
@@ -4329,7 +4253,7 @@
       "transform": {
         "translate": [-30.343068093926924, 2.3752519777557772, -1.493443687048192]
       },
-      "material": "mat-22",
+      "material": "mat-27",
       "collection": "station-13"
     },
     {
@@ -4342,7 +4266,7 @@
         "translate": [-30.748125372633254, 4.405000000000001, 0],
         "rotate": [0, 0, 0]
       },
-      "material": "mat-23",
+      "material": "mat-28",
       "collection": "station-13"
     },
     {
@@ -4355,7 +4279,7 @@
         "translate": [-31.44290785150797, 4.399558176477956, -2.2669323891550555],
         "rotate": [0, 0.9, 0]
       },
-      "material": "mat-23",
+      "material": "mat-28",
       "collection": "station-13"
     },
     {
@@ -4368,7 +4292,7 @@
         "translate": [-33.89188406263899, 3.629579332748476, -0.989614658959953],
         "rotate": [0, 1.8, 0]
       },
-      "material": "mat-23",
+      "material": "mat-28",
       "collection": "station-13"
     },
     {
@@ -4381,7 +4305,7 @@
         "translate": [-34.61014035322315, 4.222504230305474, 2.958537169853774],
         "rotate": [0, 2.7, 0]
       },
-      "material": "mat-23",
+      "material": "mat-28",
       "collection": "station-13"
     },
     {
@@ -4394,7 +4318,7 @@
         "translate": [-30.749009697036495, 3.0836452719433054, 1.8017308536587748],
         "rotate": [0, 0.5, 0]
       },
-      "material": "mat-23",
+      "material": "mat-28",
       "collection": "station-13"
     },
     {
@@ -4407,7 +4331,7 @@
         "translate": [-27.242658426961814, 3.8177730524847187, -1.822992316403063],
         "rotate": [0, 1.4, 0]
       },
-      "material": "mat-23",
+      "material": "mat-28",
       "collection": "station-13"
     },
     {
@@ -4420,7 +4344,7 @@
         "translate": [-32.27446124056053, 2.742972950909394, -2.1848703015536812],
         "rotate": [0, 2.3000000000000003, 0]
       },
-      "material": "mat-23",
+      "material": "mat-28",
       "collection": "station-13"
     },
     {
@@ -4433,7 +4357,7 @@
         "translate": [-37.637685294147616, 3.247721417838311, -0.6569637863396396],
         "rotate": [0, 0.09999999999999964, 0]
       },
-      "material": "mat-23",
+      "material": "mat-28",
       "collection": "station-13"
     },
     {
@@ -4446,7 +4370,7 @@
         "translate": [-32.85640951118563, 2.514577769081229, 2.2962604484326103],
         "rotate": [0, 1, 0]
       },
-      "material": "mat-23",
+      "material": "mat-28",
       "collection": "station-13"
     },
     {
@@ -4459,7 +4383,7 @@
         "translate": [-27.347748365379807, 2.626149955099641, 3.1688055851540176],
         "rotate": [0, 1.8999999999999995, 0]
       },
-      "material": "mat-23",
+      "material": "mat-28",
       "collection": "station-13"
     },
     {
@@ -4472,7 +4396,7 @@
         "translate": [-29.766477364817298, 2.2751364752104166, -2.006364302126396],
         "rotate": [0, 2.8, 0]
       },
-      "material": "mat-23",
+      "material": "mat-28",
       "collection": "station-13"
     },
     {
@@ -4485,7 +4409,7 @@
         "translate": [-34.37242027968963, 2.074057518564027, -4.438197954760972],
         "rotate": [0, 0.6000000000000001, 0]
       },
-      "material": "mat-23",
+      "material": "mat-28",
       "collection": "station-13"
     },
     {
@@ -4498,7 +4422,7 @@
         "translate": [-35.61663162490253, 1.9174150657237594, 0.9232036344772824],
         "rotate": [0, 1.5000000000000004, 0]
       },
-      "material": "mat-23",
+      "material": "mat-28",
       "collection": "station-13"
     },
     {
@@ -4511,7 +4435,7 @@
         "translate": [-31.96335207639491, 1.6748001647187152, 4.091483547131837],
         "rotate": [0, 2.400000000000001, 0]
       },
-      "material": "mat-23",
+      "material": "mat-28",
       "collection": "station-13"
     },
     {
@@ -4524,7 +4448,7 @@
         "translate": [-27.729069436164245, 1.3899081353990992, 1.0090925115755864],
         "rotate": [0, 0.1999999999999993, 0]
       },
-      "material": "mat-23",
+      "material": "mat-28",
       "collection": "station-13"
     },
     {
@@ -4537,7 +4461,7 @@
         "translate": [-30.601167953550018, 1.44284528397345, -2.7335382705725464],
         "rotate": [0, 1.0999999999999996, 0]
       },
-      "material": "mat-23",
+      "material": "mat-28",
       "collection": "station-13"
     },
     {
@@ -4550,7 +4474,7 @@
         "translate": [-35.529271480000645, 0.7171594937718098, -3.057888513618657],
         "rotate": [0, 2, 0]
       },
-      "material": "mat-23",
+      "material": "mat-28",
       "collection": "station-13"
     },
     {
@@ -4563,7 +4487,7 @@
         "translate": [-33.79105241534354, 1.3160592709780925, 1.2675014631709414],
         "rotate": [0, 2.9000000000000004, 0]
       },
-      "material": "mat-23",
+      "material": "mat-28",
       "collection": "station-13"
     },
     {
@@ -4576,7 +4500,7 @@
         "translate": [-30.424360828937992, -0.005841134412181592, 4.004131549320719],
         "rotate": [0, 0.6999999999999988, 0]
       },
-      "material": "mat-23",
+      "material": "mat-28",
       "collection": "station-13"
     },
     {
@@ -4589,7 +4513,7 @@
         "translate": [-30.481834884201362, 1.1743019526359513, -0.20453893292798464],
         "rotate": [0, 1.600000000000001, 0]
       },
-      "material": "mat-23",
+      "material": "mat-28",
       "collection": "station-13"
     },
     {
@@ -4602,7 +4526,7 @@
         "translate": [-31.677513839326537, -0.6439061141122786, -3.000946679549864],
         "rotate": [0, 2.4999999999999996, 0]
       },
-      "material": "mat-23",
+      "material": "mat-28",
       "collection": "station-13"
     },
     {
@@ -4615,7 +4539,7 @@
         "translate": [-32.70498913645673, 0.879070215106386, -0.2557625023629266],
         "rotate": [0, 0.3000000000000016, 0]
       },
-      "material": "mat-23",
+      "material": "mat-28",
       "collection": "station-13"
     },
     {
@@ -4717,7 +4641,7 @@
       "transform": {
         "translate": [0, 5.612500937596058, 0]
       },
-      "material": "mat-19",
+      "material": "mat-24",
       "collection": "station-15"
     },
     {
@@ -4729,7 +4653,7 @@
       "transform": {
         "translate": [-2.6835432944046884, 5.49864412879805, 1.1629569665620196]
       },
-      "material": "mat-25",
+      "material": "mat-30",
       "collection": "station-15"
     },
     {
@@ -4741,7 +4665,7 @@
       "transform": {
         "translate": [0.37147609348763844, 4.590746278141184, -2.802856657474514]
       },
-      "material": "mat-25",
+      "material": "mat-30",
       "collection": "station-15"
     },
     {
@@ -4753,7 +4677,7 @@
       "transform": {
         "translate": [0.8412441957476138, 3.105491684795802, 1.6520818433789586]
       },
-      "material": "mat-26",
+      "material": "mat-31",
       "collection": "station-15"
     },
     {
@@ -4765,7 +4689,7 @@
       "transform": {
         "translate": [-4.12621613010385, 3.58204078644558, -0.4206778022965862]
       },
-      "material": "mat-21",
+      "material": "mat-26",
       "collection": "station-15"
     },
     {
@@ -4777,7 +4701,7 @@
       "transform": {
         "translate": [2.504557739284042, 2.781869848336224, -2.4544657155219785]
       },
-      "material": "mat-21",
+      "material": "mat-26",
       "collection": "station-15"
     },
     {
@@ -4789,7 +4713,7 @@
       "transform": {
         "translate": [-0.838529938694067, 1.6135346703341025, 3.353054107778977]
       },
-      "material": "mat-21",
+      "material": "mat-26",
       "collection": "station-15"
     },
     {
@@ -4801,7 +4725,7 @@
       "transform": {
         "translate": [0.09760867072010704, 0.5999999999999996, 0.09126848823651082]
       },
-      "material": "mat-21",
+      "material": "mat-26",
       "collection": "station-15"
     },
     {
@@ -4815,7 +4739,7 @@
       "transform": {
         "translate": [0, 5.612500937596058, 0]
       },
-      "material": "mat-22",
+      "material": "mat-27",
       "collection": "station-15"
     },
     {
@@ -4829,7 +4753,7 @@
       "transform": {
         "translate": [0, 5.612500937596058, 0]
       },
-      "material": "mat-22",
+      "material": "mat-27",
       "collection": "station-15"
     },
     {
@@ -4843,7 +4767,7 @@
       "transform": {
         "translate": [0, 5.612500937596058, 0]
       },
-      "material": "mat-22",
+      "material": "mat-27",
       "collection": "station-15"
     },
     {
@@ -4857,7 +4781,7 @@
       "transform": {
         "translate": [-2.6835432944046884, 5.49864412879805, 1.1629569665620196]
       },
-      "material": "mat-22",
+      "material": "mat-27",
       "collection": "station-15"
     },
     {
@@ -4871,7 +4795,7 @@
       "transform": {
         "translate": [0.37147609348763844, 4.590746278141184, -2.802856657474514]
       },
-      "material": "mat-22",
+      "material": "mat-27",
       "collection": "station-15"
     },
     {
@@ -4885,7 +4809,7 @@
       "transform": {
         "translate": [0.8412441957476138, 3.105491684795802, 1.6520818433789586]
       },
-      "material": "mat-22",
+      "material": "mat-27",
       "collection": "station-15"
     },
     {
@@ -4899,7 +4823,7 @@
       "transform": {
         "translate": [0.8412441957476138, 3.105491684795802, 1.6520818433789586]
       },
-      "material": "mat-22",
+      "material": "mat-27",
       "collection": "station-15"
     },
     {
@@ -4912,7 +4836,7 @@
         "translate": [1.2518746273667447, 4.405000000000001, 0],
         "rotate": [0, 0, 0]
       },
-      "material": "mat-23",
+      "material": "mat-28",
       "collection": "station-15"
     },
     {
@@ -4925,7 +4849,7 @@
         "translate": [0.5570921484920283, 4.399558176477956, -2.2669323891550555],
         "rotate": [0, 0.9, 0]
       },
-      "material": "mat-23",
+      "material": "mat-28",
       "collection": "station-15"
     },
     {
@@ -4938,7 +4862,7 @@
         "translate": [-1.8918840626389857, 3.629579332748476, -0.989614658959953],
         "rotate": [0, 1.8, 0]
       },
-      "material": "mat-23",
+      "material": "mat-28",
       "collection": "station-15"
     },
     {
@@ -4951,7 +4875,7 @@
         "translate": [-2.610140353223152, 4.222504230305474, 2.958537169853774],
         "rotate": [0, 2.7, 0]
       },
-      "material": "mat-23",
+      "material": "mat-28",
       "collection": "station-15"
     },
     {
@@ -4964,7 +4888,7 @@
         "translate": [1.250990302963506, 3.0836452719433054, 1.8017308536587748],
         "rotate": [0, 0.5, 0]
       },
-      "material": "mat-23",
+      "material": "mat-28",
       "collection": "station-15"
     },
     {
@@ -4977,7 +4901,7 @@
         "translate": [4.757341573038185, 3.8177730524847187, -1.822992316403063],
         "rotate": [0, 1.4, 0]
       },
-      "material": "mat-23",
+      "material": "mat-28",
       "collection": "station-15"
     },
     {
@@ -4990,7 +4914,7 @@
         "translate": [-0.27446124056052357, 2.742972950909394, -2.1848703015536812],
         "rotate": [0, 2.3000000000000003, 0]
       },
-      "material": "mat-23",
+      "material": "mat-28",
       "collection": "station-15"
     },
     {
@@ -5003,7 +4927,7 @@
         "translate": [-5.637685294147616, 3.247721417838311, -0.6569637863396396],
         "rotate": [0, 0.09999999999999964, 0]
       },
-      "material": "mat-23",
+      "material": "mat-28",
       "collection": "station-15"
     },
     {
@@ -5016,7 +4940,7 @@
         "translate": [-0.8564095111856325, 2.514577769081229, 2.2962604484326103],
         "rotate": [0, 1, 0]
       },
-      "material": "mat-23",
+      "material": "mat-28",
       "collection": "station-15"
     },
     {
@@ -5029,7 +4953,7 @@
         "translate": [4.652251634620194, 2.626149955099641, 3.1688055851540176],
         "rotate": [0, 1.8999999999999995, 0]
       },
-      "material": "mat-23",
+      "material": "mat-28",
       "collection": "station-15"
     },
     {
@@ -5042,7 +4966,7 @@
         "translate": [2.2335226351827036, 2.2751364752104166, -2.006364302126396],
         "rotate": [0, 2.8, 0]
       },
-      "material": "mat-23",
+      "material": "mat-28",
       "collection": "station-15"
     },
     {
@@ -5055,7 +4979,7 @@
         "translate": [-2.372420279689627, 2.074057518564027, -4.438197954760972],
         "rotate": [0, 0.6000000000000001, 0]
       },
-      "material": "mat-23",
+      "material": "mat-28",
       "collection": "station-15"
     },
     {
@@ -5068,7 +4992,7 @@
         "translate": [-3.6166316249025288, 1.9174150657237594, 0.9232036344772824],
         "rotate": [0, 1.5000000000000004, 0]
       },
-      "material": "mat-23",
+      "material": "mat-28",
       "collection": "station-15"
     },
     {
@@ -5081,7 +5005,7 @@
         "translate": [0.03664792360509252, 1.6748001647187152, 4.091483547131837],
         "rotate": [0, 2.400000000000001, 0]
       },
-      "material": "mat-23",
+      "material": "mat-28",
       "collection": "station-15"
     },
     {
@@ -5094,7 +5018,7 @@
         "translate": [4.270930563835756, 1.3899081353990992, 1.0090925115755864],
         "rotate": [0, 0.1999999999999993, 0]
       },
-      "material": "mat-23",
+      "material": "mat-28",
       "collection": "station-15"
     },
     {
@@ -5107,7 +5031,7 @@
         "translate": [1.3988320464499837, 1.44284528397345, -2.7335382705725464],
         "rotate": [0, 1.0999999999999996, 0]
       },
-      "material": "mat-23",
+      "material": "mat-28",
       "collection": "station-15"
     },
     {
@@ -5120,7 +5044,7 @@
         "translate": [-3.529271480000645, 0.7171594937718098, -3.057888513618657],
         "rotate": [0, 2, 0]
       },
-      "material": "mat-23",
+      "material": "mat-28",
       "collection": "station-15"
     },
     {
@@ -5133,7 +5057,7 @@
         "translate": [-1.7910524153435434, 1.3160592709780925, 1.2675014631709414],
         "rotate": [0, 2.9000000000000004, 0]
       },
-      "material": "mat-23",
+      "material": "mat-28",
       "collection": "station-15"
     },
     {
@@ -5146,7 +5070,7 @@
         "translate": [1.5756391710620083, -0.005841134412181592, 4.004131549320719],
         "rotate": [0, 0.6999999999999988, 0]
       },
-      "material": "mat-23",
+      "material": "mat-28",
       "collection": "station-15"
     },
     {
@@ -5159,7 +5083,7 @@
         "translate": [1.5181651157986369, 1.1743019526359513, -0.20453893292798464],
         "rotate": [0, 1.600000000000001, 0]
       },
-      "material": "mat-23",
+      "material": "mat-28",
       "collection": "station-15"
     },
     {
@@ -5172,7 +5096,7 @@
         "translate": [0.3224861606734646, -0.6439061141122786, -3.000946679549864],
         "rotate": [0, 2.4999999999999996, 0]
       },
-      "material": "mat-23",
+      "material": "mat-28",
       "collection": "station-15"
     },
     {
@@ -5185,7 +5109,7 @@
         "translate": [-0.7049891364567351, 0.879070215106386, -0.2557625023629266],
         "rotate": [0, 0.3000000000000016, 0]
       },
-      "material": "mat-23",
+      "material": "mat-28",
       "collection": "station-15"
     },
     {
@@ -5217,7 +5141,7 @@
       "transform": {
         "translate": [16, 1, 0]
       },
-      "material": "mat-15",
+      "material": "mat-20",
       "collection": "station-16"
     },
     {
@@ -5231,7 +5155,7 @@
       "transform": {
         "translate": [21, 1.8852071005917161, 0]
       },
-      "material": "mat-27",
+      "material": "mat-32",
       "collection": "station-16"
     },
     {
@@ -5245,7 +5169,7 @@
       "transform": {
         "translate": [19, 2.366863905325444, 0]
       },
-      "material": "mat-27",
+      "material": "mat-32",
       "collection": "station-16"
     },
     {
@@ -5259,7 +5183,7 @@
       "transform": {
         "translate": [17, 3.2, 0]
       },
-      "material": "mat-27",
+      "material": "mat-32",
       "collection": "station-16"
     },
     {
@@ -5273,7 +5197,7 @@
       "transform": {
         "translate": [15, 3.8639053254437874, 0]
       },
-      "material": "mat-27",
+      "material": "mat-32",
       "collection": "station-16"
     },
     {
@@ -5287,7 +5211,7 @@
       "transform": {
         "translate": [13, 4.5668639053254445, 0]
       },
-      "material": "mat-27",
+      "material": "mat-32",
       "collection": "station-16"
     },
     {
@@ -5391,7 +5315,7 @@
       "transform": {
         "translate": [32, 1, 0]
       },
-      "material": "mat-15",
+      "material": "mat-20",
       "collection": "station-17"
     },
     {
@@ -5405,7 +5329,7 @@
       "transform": {
         "translate": [37, 3.820512820512821, 0]
       },
-      "material": "mat-27",
+      "material": "mat-32",
       "collection": "station-17"
     },
     {
@@ -5419,7 +5343,7 @@
       "transform": {
         "translate": [35, 4.102564102564103, 0]
       },
-      "material": "mat-27",
+      "material": "mat-32",
       "collection": "station-17"
     },
     {
@@ -5433,7 +5357,7 @@
       "transform": {
         "translate": [33, 4.8358974358974365, 0]
       },
-      "material": "mat-27",
+      "material": "mat-32",
       "collection": "station-17"
     },
     {
@@ -5447,7 +5371,7 @@
       "transform": {
         "translate": [31, 4.8358974358974365, 0]
       },
-      "material": "mat-27",
+      "material": "mat-32",
       "collection": "station-17"
     },
     {
@@ -5461,7 +5385,7 @@
       "transform": {
         "translate": [29, 5.117948717948718, 0]
       },
-      "material": "mat-27",
+      "material": "mat-32",
       "collection": "station-17"
     },
     {
@@ -5566,7 +5490,7 @@
       "transform": {
         "translate": [43.75, 7.109999999999999, 0]
       },
-      "material": "mat-19",
+      "material": "mat-24",
       "collection": "station-18"
     },
     {
@@ -5579,7 +5503,7 @@
       "transform": {
         "translate": [44.5328947368421, 5.93, 0]
       },
-      "material": "mat-28",
+      "material": "mat-33",
       "collection": "station-18"
     },
     {
@@ -5592,7 +5516,7 @@
       "transform": {
         "translate": [44.64473684210526, 4.75, 0]
       },
-      "material": "mat-29",
+      "material": "mat-34",
       "collection": "station-18"
     },
     {
@@ -5605,7 +5529,7 @@
       "transform": {
         "translate": [44.86842105263158, 3.5699999999999994, 0]
       },
-      "material": "mat-30",
+      "material": "mat-35",
       "collection": "station-18"
     },
     {
@@ -5618,7 +5542,7 @@
       "transform": {
         "translate": [45.42763157894737, 2.3899999999999997, 0]
       },
-      "material": "mat-31",
+      "material": "mat-36",
       "collection": "station-18"
     },
     {
@@ -5631,7 +5555,7 @@
       "transform": {
         "translate": [45.875, 1.21, 0]
       },
-      "material": "mat-32",
+      "material": "mat-37",
       "collection": "station-18"
     },
     {
@@ -5643,7 +5567,7 @@
       "transform": {
         "translate": [48.06, 4.16, -0.1]
       },
-      "material": "mat-15",
+      "material": "mat-20",
       "collection": "station-18"
     },
     {
@@ -5675,7 +5599,7 @@
       "transform": {
         "translate": [66.54, 0.06, 0]
       },
-      "material": "mat-33",
+      "material": "mat-38",
       "collection": "station-19"
     },
     {
@@ -5688,7 +5612,7 @@
       "transform": {
         "translate": [66.54, 0.13846153846153847, 0]
       },
-      "material": "mat-34",
+      "material": "mat-39",
       "pattern": "cracked",
       "collection": "station-19"
     },
@@ -5701,7 +5625,7 @@
       "transform": {
         "translate": [65.27, 0.06, 0]
       },
-      "material": "mat-33",
+      "material": "mat-38",
       "collection": "station-19"
     },
     {
@@ -5714,7 +5638,7 @@
       "transform": {
         "translate": [65.27, 0.3, 0]
       },
-      "material": "mat-35",
+      "material": "mat-40",
       "pattern": "cracked",
       "collection": "station-19"
     },
@@ -5727,7 +5651,7 @@
       "transform": {
         "translate": [64, 0.06, 0]
       },
-      "material": "mat-33",
+      "material": "mat-38",
       "collection": "station-19"
     },
     {
@@ -5740,7 +5664,7 @@
       "transform": {
         "translate": [64, 0.9692307692307692, 0]
       },
-      "material": "mat-36",
+      "material": "mat-41",
       "pattern": "cracked",
       "collection": "station-19"
     },
@@ -5753,7 +5677,7 @@
       "transform": {
         "translate": [62.73, 0.06, 0]
       },
-      "material": "mat-33",
+      "material": "mat-38",
       "collection": "station-19"
     },
     {
@@ -5766,7 +5690,7 @@
       "transform": {
         "translate": [62.73, 1.776923076923077, 0]
       },
-      "material": "mat-37",
+      "material": "mat-42",
       "pattern": "cracked",
       "collection": "station-19"
     },
@@ -5779,7 +5703,7 @@
       "transform": {
         "translate": [61.46, 0.06, 0]
       },
-      "material": "mat-33",
+      "material": "mat-38",
       "collection": "station-19"
     },
     {
@@ -5792,7 +5716,7 @@
       "transform": {
         "translate": [61.46, 2.4, 0]
       },
-      "material": "mat-19",
+      "material": "mat-24",
       "collection": "station-19"
     },
     {
@@ -5943,7 +5867,7 @@
       "transform": {
         "translate": [91.75, 9.469999999999999, 0]
       },
-      "material": "mat-19",
+      "material": "mat-24",
       "collection": "station-21"
     },
     {
@@ -5956,7 +5880,7 @@
       "transform": {
         "translate": [93.49358974358974, 8.29, 0]
       },
-      "material": "mat-38",
+      "material": "mat-43",
       "collection": "station-21"
     },
     {
@@ -5969,7 +5893,7 @@
       "transform": {
         "translate": [93.6025641025641, 7.109999999999999, 0]
       },
-      "material": "mat-39",
+      "material": "mat-44",
       "collection": "station-21"
     },
     {
@@ -5982,7 +5906,7 @@
       "transform": {
         "translate": [93.82051282051282, 5.929999999999999, 0]
       },
-      "material": "mat-40",
+      "material": "mat-45",
       "collection": "station-21"
     },
     {
@@ -5995,7 +5919,7 @@
       "transform": {
         "translate": [94.36538461538461, 4.749999999999999, 0]
       },
-      "material": "mat-41",
+      "material": "mat-46",
       "collection": "station-21"
     },
     {
@@ -6008,7 +5932,7 @@
       "transform": {
         "translate": [94.3926282051282, 3.5699999999999994, 0]
       },
-      "material": "mat-42",
+      "material": "mat-47",
       "collection": "station-21"
     },
     {
@@ -6021,7 +5945,7 @@
       "transform": {
         "translate": [94.44711538461539, 2.389999999999999, 0]
       },
-      "material": "mat-43",
+      "material": "mat-48",
       "collection": "station-21"
     },
     {
@@ -6034,7 +5958,7 @@
       "transform": {
         "translate": [94.47435897435898, 1.209999999999999, 0]
       },
-      "material": "mat-32",
+      "material": "mat-37",
       "collection": "station-21"
     },
     {
@@ -6046,7 +5970,7 @@
       "transform": {
         "translate": [96.06, 5.34, -0.1]
       },
-      "material": "mat-15",
+      "material": "mat-20",
       "collection": "station-21"
     },
     {
@@ -6078,7 +6002,7 @@
       "transform": {
         "translate": [112, 3.351221146875482, 0]
       },
-      "material": "mat-19",
+      "material": "mat-24",
       "collection": "station-22"
     },
     {
@@ -6090,7 +6014,7 @@
       "transform": {
         "translate": [109.93222711883581, 2.1996652945195647, 0.7629302047216209]
       },
-      "material": "mat-26",
+      "material": "mat-31",
       "collection": "station-22"
     },
     {
@@ -6102,7 +6026,7 @@
       "transform": {
         "translate": [111.15373350564956, 1.7515558523559172, -1.7127710068602287]
       },
-      "material": "mat-26",
+      "material": "mat-31",
       "collection": "station-22"
     },
     {
@@ -6114,7 +6038,7 @@
       "transform": {
         "translate": [111.80638489857787, 0.6000000000000001, 0.39241148989946467]
       },
-      "material": "mat-26",
+      "material": "mat-31",
       "collection": "station-22"
     },
     {
@@ -6128,7 +6052,7 @@
       "transform": {
         "translate": [112, 3.351221146875482, 0]
       },
-      "material": "mat-22",
+      "material": "mat-27",
       "collection": "station-22"
     },
     {
@@ -6142,7 +6066,7 @@
       "transform": {
         "translate": [112, 3.351221146875482, 0]
       },
-      "material": "mat-22",
+      "material": "mat-27",
       "collection": "station-22"
     },
     {
@@ -6156,7 +6080,7 @@
       "transform": {
         "translate": [112, 3.351221146875482, 0]
       },
-      "material": "mat-22",
+      "material": "mat-27",
       "collection": "station-22"
     },
     {
@@ -6170,7 +6094,7 @@
       "transform": {
         "translate": [109.93222711883581, 2.1996652945195647, 0.7629302047216209]
       },
-      "material": "mat-22",
+      "material": "mat-27",
       "collection": "station-22"
     },
     {
@@ -6184,7 +6108,7 @@
       "transform": {
         "translate": [111.15373350564956, 1.7515558523559172, -1.7127710068602287]
       },
-      "material": "mat-22",
+      "material": "mat-27",
       "collection": "station-22"
     },
     {
@@ -6198,7 +6122,7 @@
       "transform": {
         "translate": [111.80638489857787, 0.6000000000000001, 0.39241148989946467]
       },
-      "material": "mat-22",
+      "material": "mat-27",
       "collection": "station-22"
     },
     {
@@ -6211,7 +6135,7 @@
         "translate": [113.25187462736675, 4.405000000000001, 0],
         "rotate": [0, 0, 0]
       },
-      "material": "mat-23",
+      "material": "mat-28",
       "collection": "station-22"
     },
     {
@@ -6224,7 +6148,7 @@
         "translate": [112.55709214849203, 4.399558176477956, -2.2669323891550555],
         "rotate": [0, 0.9, 0]
       },
-      "material": "mat-23",
+      "material": "mat-28",
       "collection": "station-22"
     },
     {
@@ -6237,7 +6161,7 @@
         "translate": [110.10811593736102, 3.629579332748476, -0.989614658959953],
         "rotate": [0, 1.8, 0]
       },
-      "material": "mat-23",
+      "material": "mat-28",
       "collection": "station-22"
     },
     {
@@ -6250,7 +6174,7 @@
         "translate": [109.38985964677684, 4.222504230305474, 2.958537169853774],
         "rotate": [0, 2.7, 0]
       },
-      "material": "mat-23",
+      "material": "mat-28",
       "collection": "station-22"
     },
     {
@@ -6263,7 +6187,7 @@
         "translate": [113.2509903029635, 3.0836452719433054, 1.8017308536587748],
         "rotate": [0, 0.5, 0]
       },
-      "material": "mat-23",
+      "material": "mat-28",
       "collection": "station-22"
     },
     {
@@ -6276,7 +6200,7 @@
         "translate": [116.75734157303819, 3.8177730524847187, -1.822992316403063],
         "rotate": [0, 1.4, 0]
       },
-      "material": "mat-23",
+      "material": "mat-28",
       "collection": "station-22"
     },
     {
@@ -6289,7 +6213,7 @@
         "translate": [111.72553875943947, 2.742972950909394, -2.1848703015536812],
         "rotate": [0, 2.3000000000000003, 0]
       },
-      "material": "mat-23",
+      "material": "mat-28",
       "collection": "station-22"
     },
     {
@@ -6302,7 +6226,7 @@
         "translate": [106.36231470585238, 3.247721417838311, -0.6569637863396396],
         "rotate": [0, 0.09999999999999964, 0]
       },
-      "material": "mat-23",
+      "material": "mat-28",
       "collection": "station-22"
     },
     {
@@ -6315,7 +6239,7 @@
         "translate": [111.14359048881437, 2.514577769081229, 2.2962604484326103],
         "rotate": [0, 1, 0]
       },
-      "material": "mat-23",
+      "material": "mat-28",
       "collection": "station-22"
     },
     {
@@ -6328,7 +6252,7 @@
         "translate": [116.6522516346202, 2.626149955099641, 3.1688055851540176],
         "rotate": [0, 1.8999999999999995, 0]
       },
-      "material": "mat-23",
+      "material": "mat-28",
       "collection": "station-22"
     },
     {
@@ -6341,7 +6265,7 @@
         "translate": [114.23352263518271, 2.2751364752104166, -2.006364302126396],
         "rotate": [0, 2.8, 0]
       },
-      "material": "mat-23",
+      "material": "mat-28",
       "collection": "station-22"
     },
     {
@@ -6354,7 +6278,7 @@
         "translate": [109.62757972031038, 2.074057518564027, -4.438197954760972],
         "rotate": [0, 0.6000000000000001, 0]
       },
-      "material": "mat-23",
+      "material": "mat-28",
       "collection": "station-22"
     },
     {
@@ -6367,7 +6291,7 @@
         "translate": [108.38336837509748, 1.9174150657237594, 0.9232036344772824],
         "rotate": [0, 1.5000000000000004, 0]
       },
-      "material": "mat-23",
+      "material": "mat-28",
       "collection": "station-22"
     },
     {
@@ -6380,7 +6304,7 @@
         "translate": [112.03664792360509, 1.6748001647187152, 4.091483547131837],
         "rotate": [0, 2.400000000000001, 0]
       },
-      "material": "mat-23",
+      "material": "mat-28",
       "collection": "station-22"
     },
     {
@@ -6393,7 +6317,7 @@
         "translate": [116.27093056383576, 1.3899081353990992, 1.0090925115755864],
         "rotate": [0, 0.1999999999999993, 0]
       },
-      "material": "mat-23",
+      "material": "mat-28",
       "collection": "station-22"
     },
     {
@@ -6406,7 +6330,7 @@
         "translate": [113.39883204644998, 1.44284528397345, -2.7335382705725464],
         "rotate": [0, 1.0999999999999996, 0]
       },
-      "material": "mat-23",
+      "material": "mat-28",
       "collection": "station-22"
     },
     {
@@ -6419,7 +6343,7 @@
         "translate": [108.47072851999935, 0.7171594937718098, -3.057888513618657],
         "rotate": [0, 2, 0]
       },
-      "material": "mat-23",
+      "material": "mat-28",
       "collection": "station-22"
     },
     {
@@ -6432,7 +6356,7 @@
         "translate": [110.20894758465646, 1.3160592709780925, 1.2675014631709414],
         "rotate": [0, 2.9000000000000004, 0]
       },
-      "material": "mat-23",
+      "material": "mat-28",
       "collection": "station-22"
     },
     {
@@ -6445,7 +6369,7 @@
         "translate": [113.57563917106201, -0.005841134412181592, 4.004131549320719],
         "rotate": [0, 0.6999999999999988, 0]
       },
-      "material": "mat-23",
+      "material": "mat-28",
       "collection": "station-22"
     },
     {
@@ -6458,7 +6382,7 @@
         "translate": [113.51816511579864, 1.1743019526359513, -0.20453893292798464],
         "rotate": [0, 1.600000000000001, 0]
       },
-      "material": "mat-23",
+      "material": "mat-28",
       "collection": "station-22"
     },
     {
@@ -6471,7 +6395,7 @@
         "translate": [112.32248616067346, -0.6439061141122786, -3.000946679549864],
         "rotate": [0, 2.4999999999999996, 0]
       },
-      "material": "mat-23",
+      "material": "mat-28",
       "collection": "station-22"
     },
     {
@@ -6484,7 +6408,7 @@
         "translate": [111.29501086354327, 0.879070215106386, -0.2557625023629266],
         "rotate": [0, 0.3000000000000016, 0]
       },
-      "material": "mat-23",
+      "material": "mat-28",
       "collection": "station-22"
     },
     {
@@ -6525,7 +6449,7 @@
       "transform": {
         "translate": [128, 3.15, 0]
       },
-      "material": "mat-44",
+      "material": "mat-49",
       "collection": "station-23"
     },
     {
@@ -6558,7 +6482,7 @@
       "transform": {
         "translate": [128, 2, -1.9]
       },
-      "material": "mat-45",
+      "material": "mat-50",
       "collection": "station-23"
     },
     {
@@ -6591,7 +6515,7 @@
       "transform": {
         "translate": [128, 2, 1.9]
       },
-      "material": "mat-46",
+      "material": "mat-51",
       "collection": "station-23"
     },
     {
@@ -6624,7 +6548,7 @@
       "transform": {
         "translate": [128.74045172023568, 0.8500000000000001, -2.3274999999999997]
       },
-      "material": "mat-47",
+      "material": "mat-52",
       "collection": "station-23"
     },
     {
@@ -6657,7 +6581,7 @@
       "transform": {
         "translate": [128, 0.8500000000000001, -1.045]
       },
-      "material": "mat-47",
+      "material": "mat-52",
       "collection": "station-23"
     },
     {
@@ -6690,7 +6614,7 @@
       "transform": {
         "translate": [127.2595482797643, 0.8500000000000001, -2.3274999999999992]
       },
-      "material": "mat-47",
+      "material": "mat-52",
       "collection": "station-23"
     },
     {
@@ -6723,7 +6647,7 @@
       "transform": {
         "translate": [127.04895765539742, 0.8500000000000001, 2.4490845536670394]
       },
-      "material": "mat-47",
+      "material": "mat-52",
       "collection": "station-23"
     },
     {
@@ -6756,7 +6680,7 @@
       "transform": {
         "translate": [127.0489576553974, 0.8500000000000001, 1.3509154463329618]
       },
-      "material": "mat-47",
+      "material": "mat-52",
       "collection": "station-23"
     },
     {
@@ -6789,7 +6713,7 @@
       "transform": {
         "translate": [128, 0.8500000000000001, 0.8018308926659221]
       },
-      "material": "mat-47",
+      "material": "mat-52",
       "collection": "station-23"
     },
     {
@@ -6822,7 +6746,7 @@
       "transform": {
         "translate": [128.9510423446026, 0.8500000000000001, 1.3509154463329605]
       },
-      "material": "mat-47",
+      "material": "mat-52",
       "collection": "station-23"
     },
     {
@@ -6855,7 +6779,7 @@
       "transform": {
         "translate": [128.9510423446026, 0.8500000000000001, 2.449084553667038]
       },
-      "material": "mat-47",
+      "material": "mat-52",
       "collection": "station-23"
     },
     {
@@ -6888,7 +6812,7 @@
       "transform": {
         "translate": [128, 0.8500000000000001, 2.9981691073340775]
       },
-      "material": "mat-47",
+      "material": "mat-52",
       "collection": "station-23"
     },
     {
@@ -6929,7 +6853,7 @@
       "transform": {
         "translate": [144, 2.5749999999999997, 0]
       },
-      "material": "mat-45",
+      "material": "mat-50",
       "collection": "station-24"
     },
     {
@@ -6962,7 +6886,7 @@
       "transform": {
         "translate": [144, 1.4249999999999998, -1.9]
       },
-      "material": "mat-47",
+      "material": "mat-52",
       "collection": "station-24"
     },
     {
@@ -6995,7 +6919,7 @@
       "transform": {
         "translate": [145.48547981668926, 1.4249999999999998, -1.1846306235315935]
       },
-      "material": "mat-47",
+      "material": "mat-52",
       "collection": "station-24"
     },
     {
@@ -7028,7 +6952,7 @@
       "transform": {
         "translate": [145.85236303314545, 1.4249999999999998, 0.42278977451699734]
       },
-      "material": "mat-47",
+      "material": "mat-52",
       "collection": "station-24"
     },
     {
@@ -7061,7 +6985,7 @@
       "transform": {
         "translate": [144.82437910432336, 1.4249999999999998, 1.7118408490145962]
       },
-      "material": "mat-47",
+      "material": "mat-52",
       "collection": "station-24"
     },
     {
@@ -7094,7 +7018,7 @@
       "transform": {
         "translate": [143.17562089567664, 1.4249999999999998, 1.7118408490145962]
       },
-      "material": "mat-47",
+      "material": "mat-52",
       "collection": "station-24"
     },
     {
@@ -7127,7 +7051,7 @@
       "transform": {
         "translate": [142.14763696685455, 1.4249999999999998, 0.42278977451699756]
       },
-      "material": "mat-47",
+      "material": "mat-52",
       "collection": "station-24"
     },
     {
@@ -7160,7 +7084,7 @@
       "transform": {
         "translate": [142.51452018331074, 1.4249999999999998, -1.1846306235315933]
       },
-      "material": "mat-47",
+      "material": "mat-52",
       "collection": "station-24"
     },
     {
@@ -7192,7 +7116,7 @@
       "transform": {
         "translate": [163.175, 0.06, 0]
       },
-      "material": "mat-33",
+      "material": "mat-38",
       "collection": "station-25"
     },
     {
@@ -7205,7 +7129,7 @@
       "transform": {
         "translate": [163.175, 0.06, 0]
       },
-      "material": "mat-34",
+      "material": "mat-39",
       "pattern": "cracked",
       "collection": "station-25"
     },
@@ -7218,7 +7142,7 @@
       "transform": {
         "translate": [161.905, 0.06, 0]
       },
-      "material": "mat-33",
+      "material": "mat-38",
       "collection": "station-25"
     },
     {
@@ -7231,7 +7155,7 @@
       "transform": {
         "translate": [161.905, 0.06, 0]
       },
-      "material": "mat-28",
+      "material": "mat-33",
       "pattern": "cracked",
       "collection": "station-25"
     },
@@ -7244,7 +7168,7 @@
       "transform": {
         "translate": [160.635, 0.06, 0]
       },
-      "material": "mat-33",
+      "material": "mat-38",
       "collection": "station-25"
     },
     {
@@ -7257,7 +7181,7 @@
       "transform": {
         "translate": [160.635, 0.24, 0]
       },
-      "material": "mat-29",
+      "material": "mat-34",
       "pattern": "cracked",
       "collection": "station-25"
     },
@@ -7270,7 +7194,7 @@
       "transform": {
         "translate": [159.365, 0.06, 0]
       },
-      "material": "mat-33",
+      "material": "mat-38",
       "collection": "station-25"
     },
     {
@@ -7283,7 +7207,7 @@
       "transform": {
         "translate": [159.365, 0.576, 0]
       },
-      "material": "mat-30",
+      "material": "mat-35",
       "pattern": "cracked",
       "collection": "station-25"
     },
@@ -7296,7 +7220,7 @@
       "transform": {
         "translate": [158.095, 0.06, 0]
       },
-      "material": "mat-33",
+      "material": "mat-38",
       "collection": "station-25"
     },
     {
@@ -7309,7 +7233,7 @@
       "transform": {
         "translate": [158.095, 1.28, 0]
       },
-      "material": "mat-31",
+      "material": "mat-36",
       "pattern": "cracked",
       "collection": "station-25"
     },
@@ -7322,7 +7246,7 @@
       "transform": {
         "translate": [156.825, 0.06, 0]
       },
-      "material": "mat-33",
+      "material": "mat-38",
       "collection": "station-25"
     },
     {
@@ -7335,7 +7259,7 @@
       "transform": {
         "translate": [156.825, 2.4, 0]
       },
-      "material": "mat-19",
+      "material": "mat-24",
       "collection": "station-25"
     },
     {
@@ -7509,7 +7433,7 @@
       "transform": {
         "translate": [195.175, 0.06, 0]
       },
-      "material": "mat-33",
+      "material": "mat-38",
       "collection": "station-27"
     },
     {
@@ -7522,7 +7446,7 @@
       "transform": {
         "translate": [195.175, 0.14228208943535123, 0]
       },
-      "material": "mat-34",
+      "material": "mat-39",
       "pattern": "cracked",
       "collection": "station-27"
     },
@@ -7535,7 +7459,7 @@
       "transform": {
         "translate": [193.905, 0.06, 0]
       },
-      "material": "mat-33",
+      "material": "mat-38",
       "collection": "station-27"
     },
     {
@@ -7548,7 +7472,7 @@
       "transform": {
         "translate": [193.905, 0.2917064766230715, 0]
       },
-      "material": "mat-28",
+      "material": "mat-33",
       "pattern": "cracked",
       "collection": "station-27"
     },
@@ -7561,7 +7485,7 @@
       "transform": {
         "translate": [192.635, 0.06, 0]
       },
-      "material": "mat-33",
+      "material": "mat-38",
       "collection": "station-27"
     },
     {
@@ -7574,7 +7498,7 @@
       "transform": {
         "translate": [192.635, 0.5133056621505208, 0]
       },
-      "material": "mat-29",
+      "material": "mat-34",
       "pattern": "cracked",
       "collection": "station-27"
     },
@@ -7587,7 +7511,7 @@
       "transform": {
         "translate": [191.365, 0.06, 0]
       },
-      "material": "mat-33",
+      "material": "mat-38",
       "collection": "station-27"
     },
     {
@@ -7600,7 +7524,7 @@
       "transform": {
         "translate": [191.365, 0.9147779779152634, 0]
       },
-      "material": "mat-30",
+      "material": "mat-35",
       "pattern": "cracked",
       "collection": "station-27"
     },
@@ -7613,7 +7537,7 @@
       "transform": {
         "translate": [190.095, 0.06, 0]
       },
-      "material": "mat-33",
+      "material": "mat-38",
       "collection": "station-27"
     },
     {
@@ -7626,7 +7550,7 @@
       "transform": {
         "translate": [190.095, 1.588221473882058, 0]
       },
-      "material": "mat-31",
+      "material": "mat-36",
       "pattern": "cracked",
       "collection": "station-27"
     },
@@ -7639,7 +7563,7 @@
       "transform": {
         "translate": [188.825, 0.06, 0]
       },
-      "material": "mat-33",
+      "material": "mat-38",
       "collection": "station-27"
     },
     {
@@ -7652,7 +7576,7 @@
       "transform": {
         "translate": [188.825, 2.4, 0]
       },
-      "material": "mat-19",
+      "material": "mat-24",
       "collection": "station-27"
     },
     {
@@ -7813,7 +7737,7 @@
       "transform": {
         "translate": [223.69642857142858, 7.109999999999999, 0]
       },
-      "material": "mat-34",
+      "material": "mat-39",
       "collection": "station-29"
     },
     {
@@ -7826,7 +7750,7 @@
       "transform": {
         "translate": [223.39285714285714, 5.93, 0]
       },
-      "material": "mat-28",
+      "material": "mat-33",
       "collection": "station-29"
     },
     {
@@ -7839,7 +7763,7 @@
       "transform": {
         "translate": [222.78571428571428, 4.75, 0]
       },
-      "material": "mat-29",
+      "material": "mat-34",
       "collection": "station-29"
     },
     {
@@ -7852,7 +7776,7 @@
       "transform": {
         "translate": [222.78571428571428, 3.5699999999999994, 0]
       },
-      "material": "mat-30",
+      "material": "mat-35",
       "collection": "station-29"
     },
     {
@@ -7865,7 +7789,7 @@
       "transform": {
         "translate": [222.17857142857142, 2.3899999999999997, 0]
       },
-      "material": "mat-31",
+      "material": "mat-36",
       "collection": "station-29"
     },
     {
@@ -7878,7 +7802,7 @@
       "transform": {
         "translate": [219.75, 1.21, 0]
       },
-      "material": "mat-19",
+      "material": "mat-24",
       "collection": "station-29"
     },
     {
@@ -7890,7 +7814,7 @@
       "transform": {
         "translate": [224.06, 4.16, -0.1]
       },
-      "material": "mat-15",
+      "material": "mat-20",
       "collection": "station-29"
     },
     {
@@ -7973,7 +7897,7 @@
       "transform": {
         "translate": [-239.7875, 9.65, -14.575000000000001]
       },
-      "material": "mat-48"
+      "material": "mat-53"
     },
     {
       "id": "proxy-1",
@@ -7985,7 +7909,7 @@
       "transform": {
         "translate": [-223.985, 3.5688749799555293, -1.1999999999999997]
       },
-      "material": "mat-48"
+      "material": "mat-53"
     },
     {
       "id": "proxy-2",
@@ -7997,7 +7921,7 @@
       "transform": {
         "translate": [-208, 2.3, 0]
       },
-      "material": "mat-48"
+      "material": "mat-53"
     },
     {
       "id": "proxy-3",
@@ -8009,7 +7933,7 @@
       "transform": {
         "translate": [-192, 2.35, 0]
       },
-      "material": "mat-48"
+      "material": "mat-53"
     },
     {
       "id": "proxy-4",
@@ -8021,19 +7945,19 @@
       "transform": {
         "translate": [-174.7125, 2.5749999999999997, 0]
       },
-      "material": "mat-48"
+      "material": "mat-53"
     },
     {
       "id": "proxy-5",
       "collection": "proxy-5",
       "type": "box",
       "args": {
-        "dims": [14.920000000000016, 6.3, 7.56]
+        "dims": [5.199999999999989, 2.7, 14.415]
       },
       "transform": {
-        "translate": [-159.8, 3.15, -3.27]
+        "translate": [-160, 1.35, -5.1175]
       },
-      "material": "mat-48"
+      "material": "mat-53"
     },
     {
       "id": "proxy-6",
@@ -8045,7 +7969,7 @@
       "transform": {
         "translate": [-143.8, 3.0900000000000003, -3.27]
       },
-      "material": "mat-48"
+      "material": "mat-53"
     },
     {
       "id": "proxy-7",
@@ -8057,7 +7981,7 @@
       "transform": {
         "translate": [-128, 2.175, 0]
       },
-      "material": "mat-48"
+      "material": "mat-53"
     },
     {
       "id": "proxy-8",
@@ -8069,7 +7993,7 @@
       "transform": {
         "translate": [-111.985, 3.5688749799555293, -1.1999999999999997]
       },
-      "material": "mat-48"
+      "material": "mat-53"
     },
     {
       "id": "proxy-9",
@@ -8081,7 +8005,7 @@
       "transform": {
         "translate": [-96, 2.953, 0]
       },
-      "material": "mat-48"
+      "material": "mat-53"
     },
     {
       "id": "proxy-10",
@@ -8093,7 +8017,7 @@
       "transform": {
         "translate": [-80, 1.093, 0]
       },
-      "material": "mat-48"
+      "material": "mat-53"
     },
     {
       "id": "proxy-11",
@@ -8105,7 +8029,7 @@
       "transform": {
         "translate": [-64.43174075063118, 2.892997477123711, -0.17351318581199138]
       },
-      "material": "mat-48"
+      "material": "mat-53"
     },
     {
       "id": "proxy-12",
@@ -8117,7 +8041,7 @@
       "transform": {
         "translate": [-48, 3.175, -0.25]
       },
-      "material": "mat-48"
+      "material": "mat-53"
     },
     {
       "id": "proxy-13",
@@ -8129,7 +8053,7 @@
       "transform": {
         "translate": [-32.43174075063118, 4.370041724663322, -0.17351318581199138]
       },
-      "material": "mat-48"
+      "material": "mat-53"
     },
     {
       "id": "proxy-14",
@@ -8141,7 +8065,7 @@
       "transform": {
         "translate": [-15.985000000000001, 3.5688749799555293, -1.1999999999999997]
       },
-      "material": "mat-48"
+      "material": "mat-53"
     },
     {
       "id": "proxy-15",
@@ -8153,7 +8077,7 @@
       "transform": {
         "translate": [-0.43174075063118034, 3.056250468798029, -0.17351318581199138]
       },
-      "material": "mat-48"
+      "material": "mat-53"
     },
     {
       "id": "proxy-16",
@@ -8165,7 +8089,7 @@
       "transform": {
         "translate": [16, 2.85, 0]
       },
-      "material": "mat-48"
+      "material": "mat-53"
     },
     {
       "id": "proxy-17",
@@ -8177,7 +8101,7 @@
       "transform": {
         "translate": [32, 2.85, 0]
       },
-      "material": "mat-48"
+      "material": "mat-53"
     },
     {
       "id": "proxy-18",
@@ -8189,7 +8113,7 @@
       "transform": {
         "translate": [43.8, 3.95, 0]
       },
-      "material": "mat-48"
+      "material": "mat-53"
     },
     {
       "id": "proxy-19",
@@ -8201,7 +8125,7 @@
       "transform": {
         "translate": [66.84, 2.4000000000000004, -2.8000000000000003]
       },
-      "material": "mat-48"
+      "material": "mat-53"
     },
     {
       "id": "proxy-20",
@@ -8213,7 +8137,7 @@
       "transform": {
         "translate": [80, 2.35, 0]
       },
-      "material": "mat-48"
+      "material": "mat-53"
     },
     {
       "id": "proxy-21",
@@ -8225,7 +8149,7 @@
       "transform": {
         "translate": [91.80000000000001, 5.13, 0]
       },
-      "material": "mat-48"
+      "material": "mat-53"
     },
     {
       "id": "proxy-22",
@@ -8237,7 +8161,7 @@
       "transform": {
         "translate": [111.56825924936882, 2.237030074683324, -0.17351318581199138]
       },
-      "material": "mat-48"
+      "material": "mat-53"
     },
     {
       "id": "proxy-23",
@@ -8249,7 +8173,7 @@
       "transform": {
         "translate": [128, 1.975, 0.3353345536670389]
       },
-      "material": "mat-48"
+      "material": "mat-53"
     },
     {
       "id": "proxy-24",
@@ -8261,7 +8185,7 @@
       "transform": {
         "translate": [144, 1.6875, -0.09407957549270196]
       },
-      "material": "mat-48"
+      "material": "mat-53"
     },
     {
       "id": "proxy-25",
@@ -8273,7 +8197,7 @@
       "transform": {
         "translate": [162.83999999999997, 2.4000000000000004, -2.8000000000000003]
       },
-      "material": "mat-48"
+      "material": "mat-53"
     },
     {
       "id": "proxy-26",
@@ -8285,7 +8209,7 @@
       "transform": {
         "translate": [176.15619833004516, 3.5688749799555293, -1.1999999999999997]
       },
-      "material": "mat-48"
+      "material": "mat-53"
     },
     {
       "id": "proxy-27",
@@ -8297,7 +8221,7 @@
       "transform": {
         "translate": [194.83999999999997, 2.4000000000000004, -2.8000000000000003]
       },
-      "material": "mat-48"
+      "material": "mat-53"
     },
     {
       "id": "proxy-28",
@@ -8309,7 +8233,7 @@
       "transform": {
         "translate": [208, 2.35, 0]
       },
-      "material": "mat-48"
+      "material": "mat-53"
     },
     {
       "id": "proxy-29",
@@ -8321,7 +8245,7 @@
       "transform": {
         "translate": [219.8, 3.95, 0]
       },
-      "material": "mat-48"
+      "material": "mat-53"
     },
     {
       "id": "proxy-30",
@@ -8333,7 +8257,7 @@
       "transform": {
         "translate": [240.015, 3.5688749799555293, -1.1999999999999997]
       },
-      "material": "mat-48"
+      "material": "mat-53"
     },
     {
       "id": "horizon-0",
@@ -8345,7 +8269,7 @@
         "translate": [0, 7.016592952333921, 148.44758298167267],
         "rotate": [0, 0, 0]
       },
-      "material": "mat-49",
+      "material": "mat-54",
       "collection": "horizon"
     },
     {
@@ -8358,7 +8282,7 @@
         "translate": [63.3066209152962, 7.62296579657653, 92.85708904982108],
         "rotate": [0, 0.34528374665954953, 0]
       },
-      "material": "mat-49",
+      "material": "mat-54",
       "collection": "horizon"
     },
     {
@@ -8371,7 +8295,7 @@
         "translate": [42.17123438785764, 4.819555072083943, 58.18899581850708],
         "rotate": [0, -0.3486303089654353, 0]
       },
-      "material": "mat-49",
+      "material": "mat-54",
       "collection": "horizon"
     },
     {
@@ -8384,7 +8308,7 @@
         "translate": [133.23992011010677, 4.842001421418689, -15.398862705215285],
         "rotate": [0, 0.006725560193740241, 0]
       },
-      "material": "mat-49",
+      "material": "mat-54",
       "collection": "horizon"
     },
     {
@@ -8397,7 +8321,7 @@
         "translate": [133.43987144268098, 7.640377316314558, 15.945010375042079],
         "rotate": [0, 0.3418395632353122, 0]
       },
-      "material": "mat-49",
+      "material": "mat-54",
       "collection": "horizon"
     },
     {
@@ -8410,7 +8334,7 @@
         "translate": [41.59059376558689, 6.990241111126378, -58.71906850943405],
         "rotate": [0, -0.35187830398866804, 0]
       },
-      "material": "mat-49",
+      "material": "mat-54",
       "collection": "horizon"
     },
     {
@@ -8423,7 +8347,7 @@
         "translate": [64.57684188043537, 4.3376940527581525, -91.58418852702466],
         "rotate": [0, 0.01344921888845539, 0]
       },
-      "material": "mat-49",
+      "material": "mat-54",
       "collection": "horizon"
     },
     {
@@ -8436,7 +8360,7 @@
         "translate": [-2.6216993336706023, 5.582809968766616, -148.54011535108356],
         "rotate": [0, 0.33829873245717335, 0]
       },
-      "material": "mat-49",
+      "material": "mat-54",
       "collection": "horizon"
     },
     {
@@ -8449,7 +8373,7 @@
         "translate": [-46.662129265450154, 7.956071234520032, -70.87525467505033],
         "rotate": [0, -0.35502681343260184, 0]
       },
-      "material": "mat-49",
+      "material": "mat-54",
       "collection": "horizon"
     },
     {
@@ -8462,7 +8386,7 @@
         "translate": [-53.38157647783484, 6.178620822448911, -71.89564197285696],
         "rotate": [0, 0.020169075122725907, 0]
       },
-      "material": "mat-49",
+      "material": "mat-54",
       "collection": "horizon"
     },
     {
@@ -8475,7 +8399,7 @@
         "translate": [-149.30732670480418, 4.204050667126552, 16.540562423767465],
         "rotate": [0, 0.33466225541442246, 0]
       },
-      "material": "mat-49",
+      "material": "mat-54",
       "collection": "horizon"
     },
     {
@@ -8488,7 +8412,7 @@
         "translate": [-105.51113399020367, 6.424407144257572, -12.928144745818537],
         "rotate": [0, -0.35807494712787274, 0]
       },
-      "material": "mat-49",
+      "material": "mat-54",
       "collection": "horizon"
     },
     {
@@ -8501,7 +8425,7 @@
         "translate": [-42.170987072097645, 7.900940120366205, 60.837256078552294],
         "rotate": [0, 0.02688322901019139, 0]
       },
-      "material": "mat-49",
+      "material": "mat-54",
       "collection": "horizon"
     },
     {
@@ -8514,7 +8438,7 @@
         "translate": [-81.72421217765147, 5.34938983448815, 112.20689757324111],
         "rotate": [0, 0.3309311602381515, 0]
       },
-      "material": "mat-49",
+      "material": "mat-54",
       "collection": "horizon"
     }
   ],
@@ -8981,245 +8905,245 @@
     },
     {
       "text": "推荐 VS. 搜索：用户使用习惯差异",
-      "anchor": [-160, 6.45, 0],
+      "anchor": [-160, 4.6, 1.15],
       "role": "title",
       "revealAt": 53.95000000000002,
-      "hideAt": 69.45000000000002
+      "hideAt": 65.65000000000002
     },
     {
       "text": "今日头条",
-      "anchor": [-159.09, 5.970000000000001, 0],
+      "anchor": [-157.65, 3.1, 1.8399999999999999],
       "role": "card",
       "align": "center",
       "revealAt": 53.95000000000002,
-      "hideAt": 69.85000000000002
+      "hideAt": 66.05000000000003
     },
     {
       "text": "Google",
-      "anchor": [-160.91, 5.970000000000001, 0],
+      "anchor": [-162.35, 3.1, 1.8399999999999999],
       "role": "card",
       "align": "center",
       "revealAt": 53.95000000000002,
-      "hideAt": 69.85000000000002
+      "hideAt": 66.05000000000003
     },
     {
       "text": "使用频次",
-      "anchor": [-162.31, 5.325, 0],
+      "anchor": [-160, 2.8, 0],
       "role": "card",
-      "align": "right",
-      "revealAt": 53.95000000000002,
-      "hideAt": 69.85000000000002
+      "align": "center",
+      "revealAt": 55.55000000000002,
+      "hideAt": 66.05000000000003
     },
     {
       "text": "服务方式",
-      "anchor": [-162.31, 4.555, 0],
+      "anchor": [-160, 2.8, -2.3],
       "role": "card",
-      "align": "right",
-      "revealAt": 53.95000000000002,
-      "hideAt": 69.85000000000002
+      "align": "center",
+      "revealAt": 56.70000000000002,
+      "hideAt": 66.05000000000003
     },
     {
       "text": "兴趣表达",
-      "anchor": [-162.31, 3.785, 0],
+      "anchor": [-160, 2.8, -4.6],
       "role": "card",
-      "align": "right",
-      "revealAt": 53.95000000000002,
-      "hideAt": 69.85000000000002
+      "align": "center",
+      "revealAt": 57.850000000000016,
+      "hideAt": 66.05000000000003
     },
     {
       "text": "表达门槛",
-      "anchor": [-162.31, 3.0149999999999997, 0],
+      "anchor": [-160, 2.8, -6.8999999999999995],
       "role": "card",
-      "align": "right",
-      "revealAt": 53.95000000000002,
-      "hideAt": 69.85000000000002
+      "align": "center",
+      "revealAt": 59.000000000000014,
+      "hideAt": 66.05000000000003
     },
     {
       "text": "表达精度",
-      "anchor": [-162.31, 2.245, 0],
+      "anchor": [-160, 2.8, -9.2],
       "role": "card",
-      "align": "right",
-      "revealAt": 53.95000000000002,
-      "hideAt": 69.85000000000002
+      "align": "center",
+      "revealAt": 60.15000000000002,
+      "hideAt": 66.05000000000003
     },
     {
       "text": "表达频次",
-      "anchor": [-162.31, 1.4749999999999999, 0],
+      "anchor": [-160, 2.8, -11.5],
       "role": "card",
-      "align": "right",
-      "revealAt": 53.95000000000002,
-      "hideAt": 69.85000000000002
+      "align": "center",
+      "revealAt": 61.30000000000002,
+      "hideAt": 66.05000000000003
     },
     {
       "text": "高频:6 次/天,3 条/次",
-      "anchor": [-159.09, 4.985, 0.2],
+      "anchor": [-157.65, 0.9, 0],
       "role": "screen",
       "side": "left",
       "align": "center",
       "revealAt": 55.70000000000002,
-      "hideAt": 69.45000000000002
+      "hideAt": 65.65000000000002
     },
     {
       "text": "主动服务用户",
-      "anchor": [-159.09, 4.215, 0.2],
+      "anchor": [-157.65, 0.9, -2.3],
       "role": "screen",
       "side": "left",
       "align": "center",
-      "revealAt": 56.600000000000016,
-      "hideAt": 69.45000000000002
+      "revealAt": 56.850000000000016,
+      "hideAt": 65.65000000000002
     },
     {
       "text": "随时随地,无意识",
-      "anchor": [-159.09, 3.4450000000000003, 0.2],
+      "anchor": [-157.65, 0.9, -4.6],
       "role": "screen",
       "side": "left",
       "align": "center",
-      "revealAt": 57.500000000000014,
-      "hideAt": 69.45000000000002
+      "revealAt": 58.000000000000014,
+      "hideAt": 65.65000000000002
     },
     {
       "text": "低",
-      "anchor": [-159.09, 2.675, 0.2],
+      "anchor": [-157.65, 0.9, -6.8999999999999995],
       "role": "screen",
       "side": "left",
       "align": "center",
-      "revealAt": 58.40000000000002,
-      "hideAt": 69.45000000000002
+      "revealAt": 59.15000000000002,
+      "hideAt": 65.65000000000002
     },
     {
       "text": "目前中等,不断提高",
-      "anchor": [-159.09, 1.905, 0.2],
+      "anchor": [-157.65, 0.9, -9.2],
       "role": "screen",
       "side": "left",
       "align": "center",
-      "revealAt": 59.30000000000002,
-      "hideAt": 69.45000000000002
+      "revealAt": 60.30000000000002,
+      "hideAt": 65.65000000000002
     },
     {
       "text": "高",
-      "anchor": [-159.09, 1.1349999999999998, 0.2],
+      "anchor": [-157.65, 0.9, -11.5],
       "role": "screen",
       "side": "left",
       "align": "center",
-      "revealAt": 60.20000000000002,
-      "hideAt": 69.45000000000002
+      "revealAt": 61.45000000000002,
+      "hideAt": 65.65000000000002
     },
     {
       "text": "低频,并非每天都用",
-      "anchor": [-160.91, 4.985, 0.2],
+      "anchor": [-162.35, 0.9, 0],
       "role": "screen",
       "side": "right",
       "align": "center",
-      "revealAt": 61.100000000000016,
-      "hideAt": 69.45000000000002
+      "revealAt": 55.70000000000002,
+      "hideAt": 65.65000000000002
     },
     {
       "text": "被动响应用户",
-      "anchor": [-160.91, 4.215, 0.2],
+      "anchor": [-162.35, 0.9, -2.3],
       "role": "screen",
       "side": "right",
       "align": "center",
-      "revealAt": 62.000000000000014,
-      "hideAt": 69.45000000000002
+      "revealAt": 56.850000000000016,
+      "hideAt": 65.65000000000002
     },
     {
       "text": "文字/语音/图像的主动输入",
-      "anchor": [-160.91, 3.4450000000000003, 0.2],
+      "anchor": [-162.35, 0.9, -4.6],
       "role": "screen",
       "side": "right",
       "align": "center",
-      "revealAt": 62.90000000000002,
-      "hideAt": 69.45000000000002
+      "revealAt": 58.000000000000014,
+      "hideAt": 65.65000000000002
     },
     {
       "text": "高",
-      "anchor": [-160.91, 2.675, 0.2],
+      "anchor": [-162.35, 0.9, -6.8999999999999995],
       "role": "screen",
       "side": "right",
       "align": "center",
-      "revealAt": 63.80000000000002,
-      "hideAt": 69.45000000000002
+      "revealAt": 59.15000000000002,
+      "hideAt": 65.65000000000002
     },
     {
       "text": "高",
-      "anchor": [-160.91, 1.905, 0.2],
+      "anchor": [-162.35, 0.9, -9.2],
       "role": "screen",
       "side": "right",
       "align": "center",
-      "revealAt": 64.70000000000002,
-      "hideAt": 69.45000000000002
+      "revealAt": 60.30000000000002,
+      "hideAt": 65.65000000000002
     },
     {
       "text": "低",
-      "anchor": [-160.91, 1.1349999999999998, 0.2],
+      "anchor": [-162.35, 0.9, -11.5],
       "role": "screen",
       "side": "right",
       "align": "center",
-      "revealAt": 65.60000000000002,
-      "hideAt": 69.45000000000002
+      "revealAt": 61.45000000000002,
+      "hideAt": 65.65000000000002
     },
     {
       "text": "推荐 VS. 搜索：技术趋势",
       "anchor": [-144, 6.21, 0],
       "role": "title",
-      "revealAt": 70.65000000000002,
-      "hideAt": 86.15000000000002
+      "revealAt": 66.85000000000002,
+      "hideAt": 82.35000000000002
     },
     {
       "text": "今日头条",
       "anchor": [-142.18, 5.73, 0],
       "role": "card",
       "align": "center",
-      "revealAt": 70.65000000000002,
-      "hideAt": 86.55000000000003
+      "revealAt": 66.85000000000002,
+      "hideAt": 82.75000000000003
     },
     {
       "text": "趋势",
       "anchor": [-144, 5.73, 0],
       "role": "card",
       "align": "center",
-      "revealAt": 70.65000000000002,
-      "hideAt": 86.55000000000003
+      "revealAt": 66.85000000000002,
+      "hideAt": 82.75000000000003
     },
     {
       "text": "Google",
       "anchor": [-145.82, 5.73, 0],
       "role": "card",
       "align": "center",
-      "revealAt": 70.65000000000002,
-      "hideAt": 86.55000000000003
+      "revealAt": 66.85000000000002,
+      "hideAt": 82.75000000000003
     },
     {
       "text": "算法技术",
       "anchor": [-147.22, 4.922499999999999, 0],
       "role": "card",
       "align": "right",
-      "revealAt": 70.65000000000002,
-      "hideAt": 86.55000000000003
+      "revealAt": 66.85000000000002,
+      "hideAt": 82.75000000000003
     },
     {
       "text": "兴趣获取",
       "anchor": [-147.22, 3.8274999999999997, 0],
       "role": "card",
       "align": "right",
-      "revealAt": 70.65000000000002,
-      "hideAt": 86.55000000000003
+      "revealAt": 66.85000000000002,
+      "hideAt": 82.75000000000003
     },
     {
       "text": "数据积累",
       "anchor": [-147.22, 2.7325, 0],
       "role": "card",
       "align": "right",
-      "revealAt": 70.65000000000002,
-      "hideAt": 86.55000000000003
+      "revealAt": 66.85000000000002,
+      "hideAt": 82.75000000000003
     },
     {
       "text": "效果",
       "anchor": [-147.22, 1.6374999999999997, 0],
       "role": "card",
       "align": "right",
-      "revealAt": 70.65000000000002,
-      "hideAt": 86.55000000000003
+      "revealAt": 66.85000000000002,
+      "hideAt": 82.75000000000003
     },
     {
       "text": "刚起步·算法更复杂·工程难度更高",
@@ -9227,8 +9151,8 @@
       "role": "screen",
       "side": "left",
       "align": "center",
-      "revealAt": 72.40000000000002,
-      "hideAt": 86.15000000000002
+      "revealAt": 68.60000000000002,
+      "hideAt": 82.35000000000002
     },
     {
       "text": "PC 时代难以获取 → 移动时代容易获取",
@@ -9236,8 +9160,8 @@
       "role": "screen",
       "side": "left",
       "align": "center",
-      "revealAt": 73.30000000000003,
-      "hideAt": 86.15000000000002
+      "revealAt": 69.50000000000003,
+      "hideAt": 82.35000000000002
     },
     {
       "text": "起步晚 —— 迅速积累人的大数据",
@@ -9245,8 +9169,8 @@
       "role": "screen",
       "side": "left",
       "align": "center",
-      "revealAt": 74.20000000000002,
-      "hideAt": 86.15000000000002
+      "revealAt": 70.40000000000002,
+      "hideAt": 82.35000000000002
     },
     {
       "text": "初步",
@@ -9254,8 +9178,8 @@
       "role": "screen",
       "side": "left",
       "align": "center",
-      "revealAt": 75.10000000000002,
-      "hideAt": 86.15000000000002
+      "revealAt": 71.30000000000003,
+      "hideAt": 82.35000000000002
     },
     {
       "text": "发展十余年·技术成熟·已到顶峰",
@@ -9263,8 +9187,8 @@
       "role": "screen",
       "side": "right",
       "align": "center",
-      "revealAt": 76.00000000000001,
-      "hideAt": 86.15000000000002
+      "revealAt": 72.20000000000002,
+      "hideAt": 82.35000000000002
     },
     {
       "text": "用户主动输入,获取能力未变",
@@ -9272,8 +9196,8 @@
       "role": "screen",
       "side": "right",
       "align": "center",
-      "revealAt": 76.90000000000002,
-      "hideAt": 86.15000000000002
+      "revealAt": 73.10000000000002,
+      "hideAt": 82.35000000000002
     },
     {
       "text": "起步早·积累信息大数据,很难积累人的大数据",
@@ -9281,8 +9205,8 @@
       "role": "screen",
       "side": "right",
       "align": "center",
-      "revealAt": 77.80000000000003,
-      "hideAt": 86.15000000000002
+      "revealAt": 74.00000000000003,
+      "hideAt": 82.35000000000002
     },
     {
       "text": "已到顶峰",
@@ -9290,482 +9214,482 @@
       "role": "screen",
       "side": "right",
       "align": "center",
-      "revealAt": 78.70000000000002,
-      "hideAt": 86.15000000000002
+      "revealAt": 74.90000000000002,
+      "hideAt": 82.35000000000002
     },
     {
       "text": "追平",
       "anchor": [-144, 4.5825, 0.2],
       "role": "card",
       "align": "center",
-      "revealAt": 79.60000000000002,
-      "hideAt": 86.55000000000003
+      "revealAt": 75.80000000000003,
+      "hideAt": 82.75000000000003
     },
     {
       "text": "移动、云、可穿戴 —— 科技趋势有利于推荐",
       "anchor": [-144, 3.4875, 0.2],
       "role": "card",
       "align": "center",
-      "revealAt": 80.50000000000001,
-      "hideAt": 86.55000000000003
+      "revealAt": 76.70000000000002,
+      "hideAt": 82.75000000000003
     },
     {
       "text": "推荐 > 搜索",
       "anchor": [-144, 2.3925, 0.2],
       "role": "card",
       "align": "center",
-      "revealAt": 81.40000000000002,
-      "hideAt": 86.55000000000003
+      "revealAt": 77.60000000000002,
+      "hideAt": 82.75000000000003
     },
     {
       "text": "追平",
       "anchor": [-144, 1.2974999999999997, 0.2],
       "role": "card",
       "align": "center",
-      "revealAt": 82.30000000000003,
-      "hideAt": 86.55000000000003
+      "revealAt": 78.50000000000003,
+      "hideAt": 82.75000000000003
     },
     {
       "text": "推荐引擎：顺应趋势,超越搜索",
       "anchor": [-128, 5.949999999999999, 0],
       "role": "title",
-      "revealAt": 87.35000000000002,
-      "hideAt": 95.05000000000003
+      "revealAt": 83.55000000000003,
+      "hideAt": 91.25000000000003
     },
     {
       "text": "技术 越来越进步",
       "anchor": [-123.6, 4.8999999999999995, 0],
       "role": "card",
       "align": "center",
-      "revealAt": 89.40000000000002,
-      "hideAt": 95.45000000000003
+      "revealAt": 85.60000000000002,
+      "hideAt": 91.65000000000003
     },
     {
       "text": "算法/人工智能 · 硬件/可穿戴设备 · 无处不在的云服务",
       "anchor": [-123.6, 1.0499999999999998, -0.4],
       "role": "card",
       "align": "center",
-      "revealAt": 89.60000000000002,
-      "hideAt": 95.45000000000003
+      "revealAt": 85.80000000000003,
+      "hideAt": 91.65000000000003
     },
     {
       "text": "世界 越来越透明",
       "anchor": [-128, 4.8999999999999995, 0],
       "role": "card",
       "align": "center",
-      "revealAt": 90.50000000000003,
-      "hideAt": 95.45000000000003
+      "revealAt": 86.70000000000003,
+      "hideAt": 91.65000000000003
     },
     {
       "text": "行为,皆被传感 · 兴趣,皆可分析 · 万物,皆在云端",
       "anchor": [-128, 1.0499999999999998, -0.4],
       "role": "card",
       "align": "center",
-      "revealAt": 90.70000000000002,
-      "hideAt": 95.45000000000003
+      "revealAt": 86.90000000000002,
+      "hideAt": 91.65000000000003
     },
     {
       "text": "人 越来越懒惰",
       "anchor": [-132.4, 4.8999999999999995, 0],
       "role": "card",
       "align": "center",
-      "revealAt": 91.60000000000002,
-      "hideAt": 95.45000000000003
+      "revealAt": 87.80000000000003,
+      "hideAt": 91.65000000000003
     },
     {
       "text": "交互要简单 · 服务要主动 · 需求满足要精准",
       "anchor": [-132.4, 1.0499999999999998, -0.4],
       "role": "card",
       "align": "center",
-      "revealAt": 91.80000000000003,
-      "hideAt": 95.45000000000003
+      "revealAt": 88.00000000000003,
+      "hideAt": 91.65000000000003
     },
     {
       "text": "搜索引擎是 PC 时代的产物",
       "sub": "在移动时代必将被推荐引擎超越",
       "role": "insight",
-      "revealAt": 93.25000000000003,
-      "hideAt": 95.05000000000003
+      "revealAt": 89.45000000000003,
+      "hideAt": 91.25000000000003
     },
     {
       "text": "推荐 VS. 搜索：总结",
       "anchor": [-112, 7.1, -1.2],
       "role": "title",
-      "revealAt": 96.25000000000003,
-      "hideAt": 106.25000000000003
+      "revealAt": 92.45000000000003,
+      "hideAt": 102.45000000000003
     },
     {
       "text": "① 懒惰是人性:搜索要先输文字,推荐自动出结果 —— 高频侵蚀低频,替代作用",
       "anchor": [-112.30315291034066, 6.717749959911059, -1.2],
       "role": "screen",
       "side": "right",
-      "revealAt": 98.70000000000003,
-      "hideAt": 106.25000000000003
+      "revealAt": 94.90000000000003,
+      "hideAt": 102.45000000000003
     },
     {
       "text": "①",
       "anchor": [-112.30315291034066, 7.377749959911059, -1.2],
       "role": "value",
-      "revealAt": 98.75000000000003,
-      "hideAt": 106.65000000000003
+      "revealAt": 94.95000000000003,
+      "hideAt": 102.85000000000004
     },
     {
       "text": "② 搜索目前仍优于推荐,靠三点:算法技术 · 兴趣获取 · 大数据积累",
       "anchor": [-113.92660163733552, 5.581165640291536, -1.2],
       "role": "screen",
       "side": "right",
-      "revealAt": 99.70000000000003,
-      "hideAt": 106.25000000000003
+      "revealAt": 95.90000000000003,
+      "hideAt": 102.45000000000003
     },
     {
       "text": "②",
       "anchor": [-113.92660163733552, 6.241165640291536, -1.2],
       "role": "value",
-      "revealAt": 99.75000000000003,
-      "hideAt": 106.65000000000003
+      "revealAt": 95.95000000000003,
+      "hideAt": 102.85000000000004
     },
     {
       "text": "③ 搜索算法已到顶峰;推荐更接近人工智能,还需 3~5 年但进化快得多 —— 追上只是时间问题",
       "anchor": [-114.55, 3.7, -1.2],
       "role": "screen",
       "side": "right",
-      "revealAt": 100.70000000000003,
-      "hideAt": 106.25000000000003
+      "revealAt": 96.90000000000003,
+      "hideAt": 102.45000000000003
     },
     {
       "text": "③",
       "anchor": [-114.55, 4.36, -1.2],
       "role": "value",
-      "revealAt": 100.75000000000003,
-      "hideAt": 106.65000000000003
+      "revealAt": 96.95000000000003,
+      "hideAt": 102.85000000000004
     },
     {
       "text": "④ 移动与智能硬件时代,推荐获取用户兴趣的能力将超越搜索",
       "anchor": [-113.92660163733552, 1.8188343597084655, -1.2],
       "role": "screen",
       "side": "right",
-      "revealAt": 101.70000000000003,
-      "hideAt": 106.25000000000003
+      "revealAt": 97.90000000000003,
+      "hideAt": 102.45000000000003
     },
     {
       "text": "④",
       "anchor": [-113.92660163733552, 2.4788343597084657, -1.2],
       "role": "value",
-      "revealAt": 101.75000000000003,
-      "hideAt": 106.65000000000003
+      "revealAt": 97.95000000000003,
+      "hideAt": 102.85000000000004
     },
     {
       "text": "⑤ 信息大数据易抓取;人的大数据靠产品特性 —— 推荐在积累人的大数据上优于搜索",
       "anchor": [-112.30315291034066, 0.6822500400889417, -1.2],
       "role": "screen",
       "side": "right",
-      "revealAt": 102.70000000000003,
-      "hideAt": 106.25000000000003
+      "revealAt": 98.90000000000003,
+      "hideAt": 102.45000000000003
     },
     {
       "text": "⑤",
       "anchor": [-112.30315291034066, 1.3422500400889419, -1.2],
       "role": "value",
-      "revealAt": 102.75000000000003,
-      "hideAt": 106.65000000000003
+      "revealAt": 98.95000000000003,
+      "hideAt": 102.85000000000004
     },
     {
       "text": "第二章 · 产品演进",
       "sub": "推荐内容 → 推荐商品 → 推荐服务",
       "role": "insight",
       "panel": "center",
-      "revealAt": 106.40000000000003,
-      "hideAt": 107.45000000000003
+      "revealAt": 102.60000000000004,
+      "hideAt": 103.65000000000003
     },
     {
       "text": "开创最早、技术最领先、用户规模最大",
       "anchor": [-96, 6.82, 0],
       "role": "title",
-      "revealAt": 107.45000000000003,
-      "hideAt": 119.60000000000002
+      "revealAt": 103.65000000000003,
+      "hideAt": 115.80000000000004
     },
     {
       "text": "2012.3",
       "anchor": [-87.3, 0.85, 0.25],
       "role": "card",
       "align": "center",
-      "revealAt": 109.35000000000004,
-      "hideAt": 120.00000000000003
+      "revealAt": 105.55000000000004,
+      "hideAt": 116.20000000000005
     },
     {
       "text": "字节跳动成立",
       "anchor": [-87.3, 2.3, 0.2],
       "role": "card",
       "align": "center",
-      "revealAt": 109.35000000000004,
-      "hideAt": 120.00000000000003
+      "revealAt": 105.55000000000004,
+      "hideAt": 116.20000000000005
     },
     {
       "text": "2012.8",
       "anchor": [-90.2, 0.85, 0.25],
       "role": "card",
       "align": "center",
-      "revealAt": 110.40000000000003,
-      "hideAt": 120.00000000000003
+      "revealAt": 106.60000000000004,
+      "hideAt": 116.20000000000005
     },
     {
       "text": "今日头条 APP 上线",
       "anchor": [-90.2, 2.92, 0.2],
       "role": "card",
       "align": "center",
-      "revealAt": 110.40000000000003,
-      "hideAt": 120.00000000000003
+      "revealAt": 106.60000000000004,
+      "hideAt": 116.20000000000005
     },
     {
       "text": "2012.10",
       "anchor": [-93.1, 0.85, 0.25],
       "role": "card",
       "align": "center",
-      "revealAt": 111.45000000000003,
-      "hideAt": 120.00000000000003
+      "revealAt": 107.65000000000003,
+      "hideAt": 116.20000000000005
     },
     {
       "text": "用户超 1000 万",
       "anchor": [-93.1, 3.54, 0.2],
       "role": "card",
       "align": "center",
-      "revealAt": 111.45000000000003,
-      "hideAt": 120.00000000000003
+      "revealAt": 107.65000000000003,
+      "hideAt": 116.20000000000005
     },
     {
       "text": "2013.5",
       "anchor": [-96, 0.85, 0.25],
       "role": "card",
       "align": "center",
-      "revealAt": 112.50000000000003,
-      "hideAt": 120.00000000000003
+      "revealAt": 108.70000000000003,
+      "hideAt": 116.20000000000005
     },
     {
       "text": "B 轮融资",
       "anchor": [-96, 4.159999999999999, 0.2],
       "role": "card",
       "align": "center",
-      "revealAt": 112.50000000000003,
-      "hideAt": 120.00000000000003
+      "revealAt": 108.70000000000003,
+      "hideAt": 116.20000000000005
     },
     {
       "text": "2013.7",
       "anchor": [-98.9, 0.85, 0.25],
       "role": "card",
       "align": "center",
-      "revealAt": 113.55000000000003,
-      "hideAt": 120.00000000000003
+      "revealAt": 109.75000000000003,
+      "hideAt": 116.20000000000005
     },
     {
       "text": "用户超 5000 万",
       "anchor": [-98.9, 4.779999999999999, 0.2],
       "role": "card",
       "align": "center",
-      "revealAt": 113.55000000000003,
-      "hideAt": 120.00000000000003
+      "revealAt": 109.75000000000003,
+      "hideAt": 116.20000000000005
     },
     {
       "text": "2014.12",
       "anchor": [-101.8, 0.85, 0.25],
       "role": "card",
       "align": "center",
-      "revealAt": 114.60000000000004,
-      "hideAt": 120.00000000000003
+      "revealAt": 110.80000000000004,
+      "hideAt": 116.20000000000005
     },
     {
       "text": "C 轮融资",
       "anchor": [-101.8, 5.3999999999999995, 0.2],
       "role": "card",
       "align": "center",
-      "revealAt": 114.60000000000004,
-      "hideAt": 120.00000000000003
+      "revealAt": 110.80000000000004,
+      "hideAt": 116.20000000000005
     },
     {
       "text": "2015.3",
       "anchor": [-104.7, 0.85, 0.25],
       "role": "card",
       "align": "center",
-      "revealAt": 115.65000000000003,
-      "hideAt": 120.00000000000003
+      "revealAt": 111.85000000000004,
+      "hideAt": 116.20000000000005
     },
     {
       "text": "用户超 2.4 亿 · 超越所有国外同行",
       "anchor": [-104.7, 6.02, 0.2],
       "role": "card",
       "align": "center",
-      "revealAt": 115.65000000000003,
-      "hideAt": 120.00000000000003
+      "revealAt": 111.85000000000004,
+      "hideAt": 116.20000000000005
     },
     {
       "text": "一直被模仿,从未被超越",
       "sub": "沿途超越新浪、凤凰、百度、Flipboard、网易、搜狐 —— 总日活超 3300 万,已成全球领导者",
       "role": "insight",
-      "revealAt": 116.65000000000003,
-      "hideAt": 119.60000000000002
+      "revealAt": 112.85000000000004,
+      "hideAt": 115.80000000000004
     },
     {
       "text": "产品演化：推荐内容 → 推荐商品 → 推荐服务",
       "anchor": [-80, 3.0999999999999996, 0],
       "role": "title",
-      "revealAt": 120.80000000000003,
-      "hideAt": 130.85000000000002
+      "revealAt": 117.00000000000004,
+      "hideAt": 127.05000000000004
     },
     {
       "text": "2012",
       "anchor": [-74.2, 2.3, 0.2],
       "role": "card",
       "align": "center",
-      "revealAt": 122.70000000000003,
-      "hideAt": 131.25000000000003
+      "revealAt": 118.90000000000005,
+      "hideAt": 127.45000000000005
     },
     {
       "text": "新闻·时政社会",
       "anchor": [-74.2, 0.7, 0.25],
       "role": "card",
       "align": "center",
-      "revealAt": 122.70000000000003,
-      "hideAt": 131.25000000000003
+      "revealAt": 118.90000000000005,
+      "hideAt": 127.45000000000005
     },
     {
       "text": "2013",
       "anchor": [-77.1, 2.3, 0.2],
       "role": "card",
       "align": "center",
-      "revealAt": 123.75000000000003,
-      "hideAt": 131.25000000000003
+      "revealAt": 119.95000000000005,
+      "hideAt": 127.45000000000005
     },
     {
       "text": "泛资讯·段子小说",
       "anchor": [-77.1, 0.7, 0.25],
       "role": "card",
       "align": "center",
-      "revealAt": 123.75000000000003,
-      "hideAt": 131.25000000000003
+      "revealAt": 119.95000000000005,
+      "hideAt": 127.45000000000005
     },
     {
       "text": "2014",
       "anchor": [-80, 2.3, 0.2],
       "role": "card",
       "align": "center",
-      "revealAt": 124.80000000000003,
-      "hideAt": 131.25000000000003
+      "revealAt": 121.00000000000004,
+      "hideAt": 127.45000000000005
     },
     {
       "text": "多媒体·图片视频",
       "anchor": [-80, 0.7, 0.25],
       "role": "card",
       "align": "center",
-      "revealAt": 124.80000000000003,
-      "hideAt": 131.25000000000003
+      "revealAt": 121.00000000000004,
+      "hideAt": 127.45000000000005
     },
     {
       "text": "NOW",
       "anchor": [-82.9, 2.3, 0.2],
       "role": "card",
       "align": "center",
-      "revealAt": 125.85000000000002,
-      "hideAt": 131.25000000000003
+      "revealAt": 122.05000000000004,
+      "hideAt": 127.45000000000005
     },
     {
       "text": "商品·个性化电商",
       "anchor": [-82.9, 0.7, 0.25],
       "role": "card",
       "align": "center",
-      "revealAt": 125.85000000000002,
-      "hideAt": 131.25000000000003
+      "revealAt": 122.05000000000004,
+      "hideAt": 127.45000000000005
     },
     {
       "text": "2016",
       "anchor": [-85.8, 2.3, 0.2],
       "role": "card",
       "align": "center",
-      "revealAt": 126.90000000000002,
-      "hideAt": 131.25000000000003
+      "revealAt": 123.10000000000004,
+      "hideAt": 127.45000000000005
     },
     {
       "text": "服务·电影金融 O2O",
       "anchor": [-85.8, 0.7, 0.25],
       "role": "card",
       "align": "center",
-      "revealAt": 126.90000000000002,
-      "hideAt": 131.25000000000003
+      "revealAt": 123.10000000000004,
+      "hideAt": 127.45000000000005
     },
     {
       "text": "推荐内容 → 推荐商品 → 推荐服务",
       "sub": "推荐引擎将是手机上与微信并列的两大入口之一",
       "role": "insight",
-      "revealAt": 127.90000000000002,
-      "hideAt": 130.85000000000002
+      "revealAt": 124.10000000000004,
+      "hideAt": 127.05000000000004
     },
     {
       "text": "产品介绍：个性推荐,千人千面",
       "anchor": [-64, 6.485994954247422, 0],
       "role": "title",
-      "revealAt": 132.05,
-      "hideAt": 141.35000000000002
+      "revealAt": 128.25000000000003,
+      "hideAt": 137.55000000000004
     },
     {
       "text": "推荐引擎",
       "anchor": [-64, 2.711756308488825, 0],
       "role": "card",
-      "revealAt": 132.9,
-      "hideAt": 141.75000000000003
+      "revealAt": 129.10000000000002,
+      "hideAt": 137.95000000000005
     },
     {
       "text": "头条号 PGC",
       "anchor": [-65.73457957428285, 4.525994954247422, 1.892199788528165],
       "role": "card",
-      "revealAt": 133.02,
-      "hideAt": 141.75000000000003
+      "revealAt": 129.22000000000003,
+      "hideAt": 137.95000000000005
     },
     {
       "text": "门户/微博/博客",
       "anchor": [-63.75583992848334, 3.766536653867332, -3.0032967145799265],
       "role": "card",
-      "revealAt": 133.14000000000001,
-      "hideAt": 141.75000000000003
+      "revealAt": 129.34000000000003,
+      "hideAt": 137.95000000000005
     },
     {
       "text": "社区/视频/垂直信息/专业知识",
       "anchor": [-62.0287792372525, 2.8173527923138764, 2.522881994877872],
       "role": "card",
-      "revealAt": 133.26000000000002,
-      "hideAt": 141.75000000000003
+      "revealAt": 129.46000000000004,
+      "hideAt": 137.95000000000005
     },
     {
       "text": "商品信息",
       "anchor": [-66.93735084415512, 1.8754304844164726, -0.6193500111537166],
       "role": "card",
-      "revealAt": 133.38000000000002,
-      "hideAt": 141.75000000000003
+      "revealAt": 129.58000000000004,
+      "hideAt": 137.95000000000005
     },
     {
       "text": "千人千面 APP",
       "anchor": [-61.859595464411235, 0.937230350651346, -1.0927212847978929],
       "role": "card",
-      "revealAt": 133.5,
-      "hideAt": 141.75000000000003
+      "revealAt": 129.70000000000002,
+      "hideAt": 137.95000000000005
     },
     {
       "text": "用户兴趣回馈",
       "anchor": [-63.810719507758925, -0.15999999999999992, 0.2073612061185931],
       "role": "card",
-      "revealAt": 133.62,
-      "hideAt": 141.75000000000003
+      "revealAt": 129.82000000000002,
+      "hideAt": 137.95000000000005
     },
     {
       "text": "信息聚合提取 · 社交分析 · 用户/资讯建模",
       "sub": "自然语言与多媒体分析 · 海量数据存储与运算 —— 按兴趣推荐,每次动作后立即回馈,不断完善",
       "role": "insight",
-      "revealAt": 138.20000000000002,
-      "hideAt": 141.35000000000002
+      "revealAt": 134.40000000000003,
+      "hideAt": 137.55000000000004
     },
     {
       "text": "产品介绍：基于兴趣,全面包围",
       "anchor": [-48, 7.074999999999999, 0],
       "role": "title",
-      "revealAt": 142.55,
-      "hideAt": 149.35000000000002
+      "revealAt": 138.75000000000003,
+      "hideAt": 145.55000000000004
     },
     {
       "role": "plate",
@@ -9773,1573 +9697,1573 @@
       "anchor": [-48, 3.4875, -0.06],
       "w": 9.2,
       "h": 5.175,
-      "revealAt": 141.55,
-      "hideAt": 149.75000000000003
+      "revealAt": 137.75000000000003,
+      "hideAt": 145.95000000000005
     },
     {
       "text": "技术特点：先进的大数据处理和推荐引擎框架",
       "anchor": [-32, 9.440083449326643, 0],
       "role": "title",
-      "revealAt": 150.55,
-      "hideAt": 159.85000000000002
+      "revealAt": 146.75000000000003,
+      "hideAt": 156.05000000000004
     },
     {
       "text": "Web/Social Data",
       "anchor": [-32.65726783391228, 7.480083449326644, -0.21027246340471484],
       "role": "card",
-      "revealAt": 151.4,
-      "hideAt": 160.25000000000003
+      "revealAt": 147.60000000000002,
+      "hideAt": 156.45000000000005
     },
     {
       "text": "Spider",
       "anchor": [-34.563908261614586, 5.796638433341682, 0.4029354422531373],
       "role": "card",
-      "revealAt": 151.52,
-      "hideAt": 160.25000000000003
+      "revealAt": 147.72000000000003,
+      "hideAt": 156.45000000000005
     },
     {
       "text": "Extractor",
       "anchor": [-33.20972975387931, 4.650462203579505, -2.0769912532305064],
       "role": "card",
-      "revealAt": 151.64000000000001,
-      "hideAt": 160.25000000000003
+      "revealAt": 147.84000000000003,
+      "hideAt": 156.45000000000005
     },
     {
       "text": "Miner",
       "anchor": [-32, 3.2747053676793794, 0],
       "role": "card",
-      "revealAt": 151.76000000000002,
-      "hideAt": 160.25000000000003
+      "revealAt": 147.96000000000004,
+      "hideAt": 156.45000000000005
     },
     {
       "text": "Recommender",
       "anchor": [-35.127017476932295, 2.2935128331174015, -0.12475457866938144],
       "role": "card",
-      "revealAt": 151.88000000000002,
-      "hideAt": 160.25000000000003
+      "revealAt": 148.08000000000004,
+      "hideAt": 156.45000000000005
     },
     {
       "text": "用户数据库",
       "anchor": [-30.343068093926924, 1.6152519777557772, -1.493443687048192],
       "role": "card",
-      "revealAt": 152,
-      "hideAt": 160.25000000000003
+      "revealAt": 148.20000000000002,
+      "hideAt": 156.45000000000005
     },
     {
       "text": "API",
       "anchor": [-34.1187707344686, 0.7170305268093469, 1.7529432924933686],
       "role": "card",
-      "revealAt": 152.12,
-      "hideAt": 160.25000000000003
+      "revealAt": 148.32000000000002,
+      "hideAt": 156.45000000000005
     },
     {
       "text": "Web / App",
       "anchor": [-32.50004426626464, -0.15999999999999992, -0.6182455439337382],
       "role": "card",
-      "revealAt": 152.24,
-      "hideAt": 160.25000000000003
+      "revealAt": 148.44000000000003,
+      "hideAt": 156.45000000000005
     },
     {
       "text": "每条信息,几十到几百个高维特征",
       "sub": "为每一位用户通过多种模型计算上万个维度的兴趣分布,每次动作后立即更新",
       "role": "insight",
-      "revealAt": 156.70000000000002,
-      "hideAt": 159.85000000000002
+      "revealAt": 152.90000000000003,
+      "hideAt": 156.05000000000004
     },
     {
       "text": "信息流精准广告是手机上的最佳广告形式",
       "anchor": [-16, 7.1, -1.2],
       "role": "title",
-      "revealAt": 161.05,
-      "hideAt": 169.05
+      "revealAt": 157.25000000000003,
+      "hideAt": 165.25000000000003
     },
     {
       "text": "① 广告库存充裕,总刷总有 —— 解决手机屏幕小、广告位有限的问题",
       "anchor": [-16.30315291034066, 6.717749959911059, -1.2],
       "role": "screen",
       "side": "right",
-      "revealAt": 163.5,
-      "hideAt": 169.05
+      "revealAt": 159.70000000000002,
+      "hideAt": 165.25000000000003
     },
     {
       "text": "①",
       "anchor": [-16.30315291034066, 7.377749959911059, -1.2],
       "role": "value",
-      "revealAt": 163.55,
-      "hideAt": 169.45000000000002
+      "revealAt": 159.75000000000003,
+      "hideAt": 165.65000000000003
     },
     {
       "text": "② 精准推荐,内容即广告 —— 类似搜索广告,用户接受度高,转化效果好",
       "anchor": [-18.55, 3.7, -1.2],
       "role": "screen",
       "side": "right",
-      "revealAt": 164.5,
-      "hideAt": 169.05
+      "revealAt": 160.70000000000002,
+      "hideAt": 165.25000000000003
     },
     {
       "text": "②",
       "anchor": [-18.55, 4.36, -1.2],
       "role": "value",
-      "revealAt": 164.55,
-      "hideAt": 169.45000000000002
+      "revealAt": 160.75000000000003,
+      "hideAt": 165.65000000000003
     },
     {
       "text": "③ 效果付费 —— 最受广告主欢迎的广告形式",
       "anchor": [-16.30315291034066, 0.6822500400889417, -1.2],
       "role": "screen",
       "side": "right",
-      "revealAt": 165.5,
-      "hideAt": 169.05
+      "revealAt": 161.70000000000002,
+      "hideAt": 165.25000000000003
     },
     {
       "text": "③",
       "anchor": [-16.30315291034066, 1.3422500400889419, -1.2],
       "role": "value",
-      "revealAt": 165.55,
-      "hideAt": 169.45000000000002
+      "revealAt": 161.75000000000003,
+      "hideAt": 165.65000000000003
     },
     {
       "text": "从广告到电商,从电商到 O2O",
       "anchor": [0, 6.812500937596059, 0],
       "role": "title",
-      "revealAt": 170.25,
-      "hideAt": 179.55
+      "revealAt": 166.45000000000002,
+      "hideAt": 175.75000000000003
     },
     {
       "text": "推荐引擎",
       "anchor": [0, 4.852500937596059, 0],
       "role": "card",
-      "revealAt": 171.1,
-      "hideAt": 179.95000000000002
+      "revealAt": 167.3,
+      "hideAt": 176.15000000000003
     },
     {
       "text": "内容",
       "anchor": [-2.6835432944046884, 4.73864412879805, 1.1629569665620196],
       "role": "card",
-      "revealAt": 171.22,
-      "hideAt": 179.95000000000002
+      "revealAt": 167.42000000000002,
+      "hideAt": 176.15000000000003
     },
     {
       "text": "商品",
       "anchor": [0.37147609348763844, 3.8307462781411843, -2.802856657474514],
       "role": "card",
-      "revealAt": 171.34,
-      "hideAt": 179.95000000000002
+      "revealAt": 167.54000000000002,
+      "hideAt": 176.15000000000003
     },
     {
       "text": "服务",
       "anchor": [0.8412441957476138, 2.3454916847958023, 1.6520818433789586],
       "role": "card",
-      "revealAt": 171.46,
-      "hideAt": 179.95000000000002
+      "revealAt": 167.66000000000003,
+      "hideAt": 176.15000000000003
     },
     {
       "text": "精准广告",
       "anchor": [-4.12621613010385, 2.82204078644558, -0.4206778022965862],
       "role": "card",
-      "revealAt": 171.58,
-      "hideAt": 179.95000000000002
+      "revealAt": 167.78000000000003,
+      "hideAt": 176.15000000000003
     },
     {
       "text": "个性化电商",
       "anchor": [2.504557739284042, 2.021869848336224, -2.4544657155219785],
       "role": "card",
-      "revealAt": 171.7,
-      "hideAt": 179.95000000000002
+      "revealAt": 167.9,
+      "hideAt": 176.15000000000003
     },
     {
       "text": "O2O",
       "anchor": [-0.838529938694067, 0.8535346703341025, 3.353054107778977],
       "role": "card",
-      "revealAt": 171.82,
-      "hideAt": 179.95000000000002
+      "revealAt": 168.02,
+      "hideAt": 176.15000000000003
     },
     {
       "text": "金融",
       "anchor": [0.09760867072010704, -0.16000000000000036, 0.09126848823651082],
       "role": "card",
-      "revealAt": 171.94,
-      "hideAt": 179.95000000000002
+      "revealAt": 168.14000000000001,
+      "hideAt": 176.15000000000003
     },
     {
       "text": "一台引擎,三层变现",
       "sub": "内容 → 精准广告;商品 → 个性化电商;服务 → O2O·金融·电影·旅游",
       "role": "insight",
-      "revealAt": 176.4,
-      "hideAt": 179.55
+      "revealAt": 172.60000000000002,
+      "hideAt": 175.75000000000003
     },
     {
       "text": "第三章 · 数据说话",
       "sub": "增长、粘性、领先、商业化 —— 四组硬数据",
       "role": "insight",
       "panel": "center",
-      "revealAt": 179.70000000000002,
-      "hideAt": 180.75
+      "revealAt": 175.90000000000003,
+      "hideAt": 176.95000000000002
     },
     {
       "text": "数据说话：用户量迅猛增长（总日活·万）",
       "anchor": [16, 6.9, 0],
       "role": "title",
-      "revealAt": 180.75,
-      "hideAt": 191.2
+      "revealAt": 176.95000000000002,
+      "hideAt": 187.4
     },
     {
       "text": "14-01",
       "anchor": [21, 0.55, 0.2],
       "role": "card",
       "align": "center",
-      "revealAt": 183.15,
-      "hideAt": 191.6
+      "revealAt": 179.35000000000002,
+      "hideAt": 187.8
     },
     {
       "text": "680",
       "anchor": [21, 2.5052071005917163, 0],
       "role": "value",
       "radius": 0.32,
-      "revealAt": 183.15,
-      "hideAt": 191.6
+      "revealAt": 179.35000000000002,
+      "hideAt": 187.8
     },
     {
       "text": "14-04",
       "anchor": [19, 0.55, 0.2],
       "role": "card",
       "align": "center",
-      "revealAt": 183.975,
-      "hideAt": 191.6
+      "revealAt": 180.175,
+      "hideAt": 187.8
     },
     {
       "text": "1050",
       "anchor": [19, 2.986863905325444, 0],
       "role": "value",
       "radius": 0.32,
-      "revealAt": 183.975,
-      "hideAt": 191.6
+      "revealAt": 180.175,
+      "hideAt": 187.8
     },
     {
       "text": "14-07",
       "anchor": [17, 0.55, 0.2],
       "role": "card",
       "align": "center",
-      "revealAt": 184.8,
-      "hideAt": 191.6
+      "revealAt": 181.00000000000003,
+      "hideAt": 187.8
     },
     {
       "text": "1690",
       "anchor": [17, 3.8200000000000003, 0],
       "role": "value",
       "radius": 0.32,
-      "revealAt": 184.8,
-      "hideAt": 191.6
+      "revealAt": 181.00000000000003,
+      "hideAt": 187.8
     },
     {
       "text": "14-10",
       "anchor": [15, 0.55, 0.2],
       "role": "card",
       "align": "center",
-      "revealAt": 185.625,
-      "hideAt": 191.6
+      "revealAt": 181.82500000000002,
+      "hideAt": 187.8
     },
     {
       "text": "2200",
       "anchor": [15, 4.4839053254437875, 0],
       "role": "value",
       "radius": 0.32,
-      "revealAt": 185.625,
-      "hideAt": 191.6
+      "revealAt": 181.82500000000002,
+      "hideAt": 187.8
     },
     {
       "text": "15-01",
       "anchor": [13, 0.55, 0.2],
       "role": "card",
       "align": "center",
-      "revealAt": 186.45,
-      "hideAt": 191.6
+      "revealAt": 182.65,
+      "hideAt": 187.8
     },
     {
       "text": "2740",
       "anchor": [13, 5.186863905325445, 0],
       "role": "value",
       "radius": 0.32,
-      "revealAt": 186.45,
-      "hideAt": 191.6
+      "revealAt": 182.65,
+      "hideAt": 187.8
     },
     {
       "text": "15-03",
       "anchor": [11, 0.55, 0.2],
       "role": "card",
       "align": "center",
-      "revealAt": 187.275,
-      "hideAt": 191.6
+      "revealAt": 183.47500000000002,
+      "hideAt": 187.8
     },
     {
       "text": "3380",
       "anchor": [11, 6.0200000000000005, 0],
       "role": "value",
       "radius": 0.46,
-      "revealAt": 187.275,
-      "hideAt": 191.6
+      "revealAt": 183.47500000000002,
+      "hideAt": 187.8
     },
     {
       "text": "15-03 最高:3380",
       "sub": "第二位 15-01:2740",
       "role": "insight",
-      "revealAt": 189.2,
-      "hideAt": 191.2
+      "revealAt": 185.4,
+      "hideAt": 187.4
     },
     {
       "text": "14 个月,日活 ×5",
       "sub": "累计激活 2.45 亿(14 个月 ×4)· 2015-03 总日活 3,380 万 —— 源:公司内部监控/友盟/Google Analysis·月度读图近似",
       "role": "insight",
-      "revealAt": 188.05,
-      "hideAt": 189.2
+      "revealAt": 184.25000000000003,
+      "hideAt": 185.4
     },
     {
       "text": "数据说话：产品粘性大幅提升（人均日使用时长·分钟）",
       "anchor": [32, 6.9, 0],
       "role": "title",
-      "revealAt": 192.39999999999998,
-      "hideAt": 202.84999999999997
+      "revealAt": 188.6,
+      "hideAt": 199.04999999999998
     },
     {
       "text": "14-01",
       "anchor": [37, 0.55, 0.2],
       "role": "card",
       "align": "center",
-      "revealAt": 194.79999999999998,
-      "hideAt": 203.24999999999997
+      "revealAt": 191,
+      "hideAt": 199.45
     },
     {
       "text": "25",
       "anchor": [37, 4.440512820512821, 0],
       "role": "value",
       "radius": 0.32,
-      "revealAt": 194.79999999999998,
-      "hideAt": 203.24999999999997
+      "revealAt": 191,
+      "hideAt": 199.45
     },
     {
       "text": "14-03",
       "anchor": [35, 0.55, 0.2],
       "role": "card",
       "align": "center",
-      "revealAt": 195.62499999999997,
-      "hideAt": 203.24999999999997
+      "revealAt": 191.825,
+      "hideAt": 199.45
     },
     {
       "text": "27.5",
       "anchor": [35, 4.722564102564103, 0],
       "role": "value",
       "radius": 0.32,
-      "revealAt": 195.62499999999997,
-      "hideAt": 203.24999999999997
+      "revealAt": 191.825,
+      "hideAt": 199.45
     },
     {
       "text": "14-05",
       "anchor": [33, 0.55, 0.2],
       "role": "card",
       "align": "center",
-      "revealAt": 196.45,
-      "hideAt": 203.24999999999997
+      "revealAt": 192.65,
+      "hideAt": 199.45
     },
     {
       "text": "34",
       "anchor": [33, 5.455897435897437, 0],
       "role": "value",
       "radius": 0.32,
-      "revealAt": 196.45,
-      "hideAt": 203.24999999999997
+      "revealAt": 192.65,
+      "hideAt": 199.45
     },
     {
       "text": "14-07",
       "anchor": [31, 0.55, 0.2],
       "role": "card",
       "align": "center",
-      "revealAt": 197.27499999999998,
-      "hideAt": 203.24999999999997
+      "revealAt": 193.475,
+      "hideAt": 199.45
     },
     {
       "text": "34",
       "anchor": [31, 5.455897435897437, 0],
       "role": "value",
       "radius": 0.32,
-      "revealAt": 197.27499999999998,
-      "hideAt": 203.24999999999997
+      "revealAt": 193.475,
+      "hideAt": 199.45
     },
     {
       "text": "14-09",
       "anchor": [29, 0.55, 0.2],
       "role": "card",
       "align": "center",
-      "revealAt": 198.09999999999997,
-      "hideAt": 203.24999999999997
+      "revealAt": 194.29999999999998,
+      "hideAt": 199.45
     },
     {
       "text": "36.5",
       "anchor": [29, 5.7379487179487185, 0],
       "role": "value",
       "radius": 0.32,
-      "revealAt": 198.09999999999997,
-      "hideAt": 203.24999999999997
+      "revealAt": 194.29999999999998,
+      "hideAt": 199.45
     },
     {
       "text": "14-11",
       "anchor": [27, 0.55, 0.2],
       "role": "card",
       "align": "center",
-      "revealAt": 198.92499999999998,
-      "hideAt": 203.24999999999997
+      "revealAt": 195.125,
+      "hideAt": 199.45
     },
     {
       "text": "39",
       "anchor": [27, 6.0200000000000005, 0],
       "role": "value",
       "radius": 0.46,
-      "revealAt": 198.92499999999998,
-      "hideAt": 203.24999999999997
+      "revealAt": 195.125,
+      "hideAt": 199.45
     },
     {
       "text": "14-11 最高:39",
       "sub": "第二位 14-09:36.5",
       "role": "insight",
-      "revealAt": 200.84999999999997,
-      "hideAt": 202.84999999999997
+      "revealAt": 197.04999999999998,
+      "hideAt": 199.04999999999998
     },
     {
       "text": "使用时长 +55%",
       "sub": "同年人均日阅读数 +90%(2014 全年,月度读图近似)",
       "role": "insight",
-      "revealAt": 199.7,
-      "hideAt": 200.84999999999997
+      "revealAt": 195.9,
+      "hideAt": 197.04999999999998
     },
     {
       "text": "全面领先：资讯类 APP 人均日使用时长（分钟）",
       "anchor": [48, 8.61, 0],
       "role": "title",
-      "revealAt": 204.04999999999995,
-      "hideAt": 216.14999999999995
+      "revealAt": 200.24999999999997,
+      "hideAt": 212.34999999999997
     },
     {
       "text": "今日头条",
       "anchor": [48.3, 7.109999999999999, 0.51],
       "role": "card",
       "align": "left",
-      "revealAt": 206.49999999999994,
-      "hideAt": 216.54999999999995
+      "revealAt": 202.69999999999996,
+      "hideAt": 212.74999999999997
     },
     {
       "text": "38",
       "anchor": [39.2, 7.109999999999999, 0],
       "role": "value",
       "radius": 0.46,
-      "revealAt": 206.49999999999994,
-      "hideAt": 216.54999999999995
+      "revealAt": 202.69999999999996,
+      "hideAt": 212.74999999999997
     },
     {
       "text": "网易新闻",
       "anchor": [48.3, 5.93, 0.51],
       "role": "card",
       "align": "left",
-      "revealAt": 207.59999999999997,
-      "hideAt": 216.54999999999995
+      "revealAt": 203.79999999999998,
+      "hideAt": 212.74999999999997
     },
     {
       "text": "31",
       "anchor": [40.76578947368421, 5.93, 0],
       "role": "value",
       "radius": 0.34,
-      "revealAt": 207.59999999999997,
-      "hideAt": 216.54999999999995
+      "revealAt": 203.79999999999998,
+      "hideAt": 212.74999999999997
     },
     {
       "text": "搜狐新闻",
       "anchor": [48.3, 4.75, 0.51],
       "role": "card",
       "align": "left",
-      "revealAt": 208.69999999999996,
-      "hideAt": 216.54999999999995
+      "revealAt": 204.89999999999998,
+      "hideAt": 212.74999999999997
     },
     {
       "text": "30",
       "anchor": [40.98947368421052, 4.75, 0],
       "role": "value",
       "radius": 0.34,
-      "revealAt": 208.69999999999996,
-      "hideAt": 216.54999999999995
+      "revealAt": 204.89999999999998,
+      "hideAt": 212.74999999999997
     },
     {
       "text": "凤凰新闻",
       "anchor": [48.3, 3.5699999999999994, 0.51],
       "role": "card",
       "align": "left",
-      "revealAt": 209.79999999999995,
-      "hideAt": 216.54999999999995
+      "revealAt": 205.99999999999997,
+      "hideAt": 212.74999999999997
     },
     {
       "text": "28",
       "anchor": [41.43684210526316, 3.5699999999999994, 0],
       "role": "value",
       "radius": 0.34,
-      "revealAt": 209.79999999999995,
-      "hideAt": 216.54999999999995
+      "revealAt": 205.99999999999997,
+      "hideAt": 212.74999999999997
     },
     {
       "text": "腾讯新闻",
       "anchor": [48.3, 2.3899999999999997, 0.51],
       "role": "card",
       "align": "left",
-      "revealAt": 210.89999999999995,
-      "hideAt": 216.54999999999995
+      "revealAt": 207.09999999999997,
+      "hideAt": 212.74999999999997
     },
     {
       "text": "23",
       "anchor": [42.555263157894736, 2.3899999999999997, 0],
       "role": "value",
       "radius": 0.34,
-      "revealAt": 210.89999999999995,
-      "hideAt": 216.54999999999995
+      "revealAt": 207.09999999999997,
+      "hideAt": 212.74999999999997
     },
     {
       "text": "新浪新闻",
       "anchor": [48.3, 1.21, 0.51],
       "role": "card",
       "align": "left",
-      "revealAt": 211.99999999999994,
-      "hideAt": 216.54999999999995
+      "revealAt": 208.19999999999996,
+      "hideAt": 212.74999999999997
     },
     {
       "text": "19",
       "anchor": [43.45, 1.21, 0],
       "role": "value",
       "radius": 0.34,
-      "revealAt": 211.99999999999994,
-      "hideAt": 216.54999999999995
+      "revealAt": 208.19999999999996,
+      "hideAt": 212.74999999999997
     },
     {
       "text": "今日头条 最高:38",
       "sub": "第二位 网易新闻:31",
       "role": "insight",
-      "revealAt": 214.14999999999995,
-      "hideAt": 216.14999999999995
+      "revealAt": 210.34999999999997,
+      "hideAt": 212.34999999999997
     },
     {
       "text": "头条已超手机 QQ(安卓月时长)",
       "sub": "资讯类时长、微博分享数领先;用户覆盖比例仅次于腾讯新闻(其靠微信/手机QQ调起)——源:QuestMobile/新浪微博/TalkingData 2014·读图近似",
       "role": "insight",
-      "revealAt": 212.99999999999994,
-      "hideAt": 214.14999999999995
+      "revealAt": 209.19999999999996,
+      "hideAt": 210.34999999999997
     },
     {
       "text": "数据说话：进展迅猛的商业化（广告收入·万元）",
       "anchor": [64, 6.1, 0],
       "role": "title",
-      "revealAt": 217.34999999999994,
-      "hideAt": 228.34999999999994
+      "revealAt": 213.54999999999995,
+      "hideAt": 224.54999999999995
     },
     {
       "text": "2014Q4 最高:10400",
       "sub": "第二位 2014Q3:7700",
       "role": "insight",
-      "revealAt": 226.34999999999994,
-      "hideAt": 228.34999999999994
+      "revealAt": 222.54999999999995,
+      "hideAt": 224.54999999999995
     },
     {
       "text": "14 年广告收入 2.4 亿,增速与 Google 成立头三年不相上下",
       "sub": "年初预算 5,000 万超额近 5 倍 —— 15 年预计 13~15 亿;阿里系电商合同 15 年至少 1.2 亿——电商潜力有可能超过广告(源:公司内部/SEC·季度读图近似)",
       "role": "insight",
-      "revealAt": 225.19999999999993,
-      "hideAt": 226.34999999999994
+      "revealAt": 221.39999999999995,
+      "hideAt": 222.54999999999995
     },
     {
       "text": "2013Q4",
       "anchor": [66.54, -0.02, 0.96],
       "role": "card",
-      "revealAt": 219.79999999999993,
-      "hideAt": 228.74999999999994
+      "revealAt": 215.99999999999994,
+      "hideAt": 224.94999999999996
     },
     {
       "text": "600",
       "anchor": [66.54, 0.5969230769230769, 0],
       "role": "value",
       "radius": 0.36,
-      "revealAt": 219.79999999999993,
-      "hideAt": 228.74999999999994
+      "revealAt": 215.99999999999994,
+      "hideAt": 224.94999999999996
     },
     {
       "text": "2014Q1",
       "anchor": [65.27, -0.02, 0.96],
       "role": "card",
-      "revealAt": 220.89999999999995,
-      "hideAt": 228.74999999999994
+      "revealAt": 217.09999999999997,
+      "hideAt": 224.94999999999996
     },
     {
       "text": "1300",
       "anchor": [65.27, 0.9199999999999999, 0],
       "role": "value",
       "radius": 0.36,
-      "revealAt": 220.89999999999995,
-      "hideAt": 228.74999999999994
+      "revealAt": 217.09999999999997,
+      "hideAt": 224.94999999999996
     },
     {
       "text": "2014Q2",
       "anchor": [64, -0.02, 0.96],
       "role": "card",
-      "revealAt": 221.99999999999994,
-      "hideAt": 228.74999999999994
+      "revealAt": 218.19999999999996,
+      "hideAt": 224.94999999999996
     },
     {
       "text": "4200",
       "anchor": [64, 2.2584615384615385, 0],
       "role": "value",
       "radius": 0.36,
-      "revealAt": 221.99999999999994,
-      "hideAt": 228.74999999999994
+      "revealAt": 218.19999999999996,
+      "hideAt": 224.94999999999996
     },
     {
       "text": "2014Q3",
       "anchor": [62.73, -0.02, 0.96],
       "role": "card",
-      "revealAt": 223.09999999999994,
-      "hideAt": 228.74999999999994
+      "revealAt": 219.29999999999995,
+      "hideAt": 224.94999999999996
     },
     {
       "text": "7700",
       "anchor": [62.73, 3.873846153846154, 0],
       "role": "value",
       "radius": 0.36,
-      "revealAt": 223.09999999999994,
-      "hideAt": 228.74999999999994
+      "revealAt": 219.29999999999995,
+      "hideAt": 224.94999999999996
     },
     {
       "text": "2014Q4",
       "anchor": [61.46, -0.02, 0.96],
       "role": "card",
-      "revealAt": 224.19999999999993,
-      "hideAt": 228.74999999999994
+      "revealAt": 220.39999999999995,
+      "hideAt": 224.94999999999996
     },
     {
       "text": "10400",
       "anchor": [61.46, 5.12, 0],
       "role": "value",
       "radius": 0.5,
-      "revealAt": 224.19999999999993,
-      "hideAt": 228.74999999999994
+      "revealAt": 220.39999999999995,
+      "hideAt": 224.94999999999996
     },
     {
       "text": "强大的内容获取和生产能力",
       "anchor": [80, 6.1, 0],
       "role": "title",
-      "revealAt": 229.54999999999993,
-      "hideAt": 235.29999999999993
+      "revealAt": 225.74999999999994,
+      "hideAt": 231.49999999999994
     },
     {
       "text": "今日头条内容来源",
       "anchor": [80, 5.2, 0],
       "role": "card",
       "align": "center",
-      "revealAt": 231.34999999999994,
-      "hideAt": 235.69999999999993
+      "revealAt": 227.54999999999995,
+      "hideAt": 231.89999999999995
     },
     {
       "text": "外部媒体 27%",
       "anchor": [79.3474033694215, 3.775341322831577, 0.26],
       "role": "value",
-      "revealAt": 231.59999999999994,
-      "hideAt": 235.69999999999993
+      "revealAt": 227.79999999999995,
+      "hideAt": 231.89999999999995
     },
     {
       "text": "头条号 73%",
       "anchor": [80.6525966305785, 2.6246586771684233, 0.26],
       "role": "value",
-      "revealAt": 231.59999999999994,
-      "hideAt": 235.69999999999993
+      "revealAt": 227.79999999999995,
+      "hideAt": 231.89999999999995
     },
     {
       "text": "每周生产超过 120,000 篇新内容",
       "sub": "13,000 家内容源合作 · 73% 内容来自自身头条号 · 自媒体分发效果远高于微信微博,有些超出上百倍",
       "role": "insight",
-      "revealAt": 232.49999999999991,
-      "hideAt": 235.29999999999993
+      "revealAt": 228.69999999999993,
+      "hideAt": 231.49999999999994
     },
     {
       "text": "「头条号」已成第一大内容分发平台（总阅读数·亿次）",
       "anchor": [96, 10.969999999999999, 0],
       "role": "title",
-      "revealAt": 236.49999999999991,
-      "hideAt": 250.79999999999993
+      "revealAt": 232.69999999999993,
+      "hideAt": 246.99999999999994
     },
     {
       "text": "前瞻网",
       "anchor": [96.3, 9.469999999999999, 0.51],
       "role": "card",
       "align": "left",
-      "revealAt": 238.9499999999999,
-      "hideAt": 251.19999999999993
+      "revealAt": 235.14999999999992,
+      "hideAt": 247.39999999999995
     },
     {
       "text": "7.8",
       "anchor": [87.2, 9.469999999999999, 0],
       "role": "value",
       "radius": 0.46,
-      "revealAt": 238.9499999999999,
-      "hideAt": 251.19999999999993
+      "revealAt": 235.14999999999992,
+      "hideAt": 247.39999999999995
     },
     {
       "text": "微微健康网",
       "anchor": [96.3, 8.29, 0.51],
       "role": "card",
       "align": "left",
-      "revealAt": 240.04999999999993,
-      "hideAt": 251.19999999999993
+      "revealAt": 236.24999999999994,
+      "hideAt": 247.39999999999995
     },
     {
       "text": "4.6",
       "anchor": [90.68717948717949, 8.29, 0],
       "role": "value",
       "radius": 0.34,
-      "revealAt": 240.04999999999993,
-      "hideAt": 251.19999999999993
+      "revealAt": 236.24999999999994,
+      "hideAt": 247.39999999999995
     },
     {
       "text": "青春娱乐网",
       "anchor": [96.3, 7.109999999999999, 0.51],
       "role": "card",
       "align": "left",
-      "revealAt": 241.14999999999992,
-      "hideAt": 251.19999999999993
+      "revealAt": 237.34999999999994,
+      "hideAt": 247.39999999999995
     },
     {
       "text": "4.4",
       "anchor": [90.90512820512821, 7.109999999999999, 0],
       "role": "value",
       "radius": 0.34,
-      "revealAt": 241.14999999999992,
-      "hideAt": 251.19999999999993
+      "revealAt": 237.34999999999994,
+      "hideAt": 247.39999999999995
     },
     {
       "text": "内涵段子",
       "anchor": [96.3, 5.929999999999999, 0.51],
       "role": "card",
       "align": "left",
-      "revealAt": 242.24999999999991,
-      "hideAt": 251.19999999999993
+      "revealAt": 238.44999999999993,
+      "hideAt": 247.39999999999995
     },
     {
       "text": "4",
       "anchor": [91.34102564102564, 5.929999999999999, 0],
       "role": "value",
       "radius": 0.34,
-      "revealAt": 242.24999999999991,
-      "hideAt": 251.19999999999993
+      "revealAt": 238.44999999999993,
+      "hideAt": 247.39999999999995
     },
     {
       "text": "国际在线",
       "anchor": [96.3, 4.749999999999999, 0.51],
       "role": "card",
       "align": "left",
-      "revealAt": 243.3499999999999,
-      "hideAt": 251.19999999999993
+      "revealAt": 239.54999999999993,
+      "hideAt": 247.39999999999995
     },
     {
       "text": "3",
       "anchor": [92.43076923076923, 4.749999999999999, 0],
       "role": "value",
       "radius": 0.34,
-      "revealAt": 243.3499999999999,
-      "hideAt": 251.19999999999993
+      "revealAt": 239.54999999999993,
+      "hideAt": 247.39999999999995
     },
     {
       "text": "中国网",
       "anchor": [96.3, 3.5699999999999994, 0.51],
       "role": "card",
       "align": "left",
-      "revealAt": 244.4499999999999,
-      "hideAt": 251.19999999999993
+      "revealAt": 240.64999999999992,
+      "hideAt": 247.39999999999995
     },
     {
       "text": "2.95",
       "anchor": [92.48525641025641, 3.5699999999999994, 0],
       "role": "value",
       "radius": 0.34,
-      "revealAt": 244.4499999999999,
-      "hideAt": 251.19999999999993
+      "revealAt": 240.64999999999992,
+      "hideAt": 247.39999999999995
     },
     {
       "text": "中金在线",
       "anchor": [96.3, 2.389999999999999, 0.51],
       "role": "card",
       "align": "left",
-      "revealAt": 245.54999999999993,
-      "hideAt": 251.19999999999993
+      "revealAt": 241.74999999999994,
+      "hideAt": 247.39999999999995
     },
     {
       "text": "2.85",
       "anchor": [92.59423076923076, 2.389999999999999, 0],
       "role": "value",
       "radius": 0.34,
-      "revealAt": 245.54999999999993,
-      "hideAt": 251.19999999999993
+      "revealAt": 241.74999999999994,
+      "hideAt": 247.39999999999995
     },
     {
       "text": "Yes娱乐",
       "anchor": [96.3, 1.209999999999999, 0.51],
       "role": "card",
       "align": "left",
-      "revealAt": 246.64999999999992,
-      "hideAt": 251.19999999999993
+      "revealAt": 242.84999999999994,
+      "hideAt": 247.39999999999995
     },
     {
       "text": "2.8",
       "anchor": [92.64871794871794, 1.209999999999999, 0],
       "role": "value",
       "radius": 0.34,
-      "revealAt": 246.64999999999992,
-      "hideAt": 251.19999999999993
+      "revealAt": 242.84999999999994,
+      "hideAt": 247.39999999999995
     },
     {
       "text": "前瞻网 最高:7.8",
       "sub": "第二位 微微健康网:4.6",
       "role": "insight",
-      "revealAt": 248.79999999999993,
-      "hideAt": 250.79999999999993
+      "revealAt": 244.99999999999994,
+      "hideAt": 246.99999999999994
     },
     {
       "text": "全部头条号总阅读数 TOP15",
       "sub": "政务号同样入驻:最高人民检察院总阅读近 700 万 —— 截至 2015-02-26(读图近似)",
       "role": "insight",
-      "revealAt": 247.64999999999992,
-      "hideAt": 248.79999999999993
+      "revealAt": 243.84999999999994,
+      "hideAt": 244.99999999999994
     },
     {
       "text": "推荐引擎加速内容生态效率",
       "anchor": [112, 4.5512211468754815, 0],
       "role": "title",
-      "revealAt": 251.99999999999991,
-      "hideAt": 261.2999999999999
+      "revealAt": 248.19999999999993,
+      "hideAt": 257.49999999999994
     },
     {
       "text": "推荐引擎",
       "anchor": [112, 2.5912211468754816, 0],
       "role": "card",
-      "revealAt": 252.8499999999999,
-      "hideAt": 261.6999999999999
+      "revealAt": 249.04999999999993,
+      "hideAt": 257.8999999999999
     },
     {
       "text": "创作",
       "anchor": [109.93222711883581, 1.4396652945195647, 0.7629302047216209],
       "role": "card",
-      "revealAt": 252.9699999999999,
-      "hideAt": 261.6999999999999
+      "revealAt": 249.16999999999993,
+      "hideAt": 257.8999999999999
     },
     {
       "text": "分发",
       "anchor": [111.15373350564956, 0.9915558523559171, -1.7127710068602287],
       "role": "card",
-      "revealAt": 253.08999999999992,
-      "hideAt": 261.6999999999999
+      "revealAt": 249.28999999999994,
+      "hideAt": 257.8999999999999
     },
     {
       "text": "互动",
       "anchor": [111.80638489857787, -0.15999999999999992, 0.39241148989946467],
       "role": "card",
-      "revealAt": 253.20999999999992,
-      "hideAt": 261.6999999999999
+      "revealAt": 249.40999999999994,
+      "hideAt": 257.8999999999999
     },
     {
       "text": "引擎在中心,飞轮在外圈",
       "sub": "优质内容提升分发效率 · 精准分发刺激互动 · 有效互动刺激创作与再创作",
       "role": "insight",
-      "revealAt": 258.1499999999999,
-      "hideAt": 261.2999999999999
+      "revealAt": 254.34999999999994,
+      "hideAt": 257.49999999999994
     },
     {
       "text": "第四章 · 团队、收入与未来",
       "sub": "下一家千亿美金公司",
       "role": "insight",
       "panel": "center",
-      "revealAt": 261.4499999999999,
-      "hideAt": 262.4999999999999
+      "revealAt": 257.6499999999999,
+      "hideAt": 258.69999999999993
     },
     {
       "text": "产品矩阵：战略级与战术级项目",
       "anchor": [128, 4.45, 0],
       "role": "title",
-      "revealAt": 262.4999999999999,
-      "hideAt": 272.4999999999999
+      "revealAt": 258.69999999999993,
+      "hideAt": 268.69999999999993
     },
     {
       "text": "产品矩阵",
       "anchor": [128, 2.33, 0],
       "role": "card",
-      "revealAt": 264.9499999999999,
-      "hideAt": 272.89999999999986
+      "revealAt": 261.1499999999999,
+      "hideAt": 269.0999999999999
     },
     {
       "text": "战略级项目",
       "anchor": [128, 1.18, -1.9],
       "role": "card",
-      "revealAt": 266.4499999999999,
-      "hideAt": 272.89999999999986
+      "revealAt": 262.6499999999999,
+      "hideAt": 269.0999999999999
     },
     {
       "text": "战术级项目",
       "anchor": [128, 1.18, 1.9],
       "role": "card",
-      "revealAt": 266.4499999999999,
-      "hideAt": 272.89999999999986
+      "revealAt": 262.6499999999999,
+      "hideAt": 269.0999999999999
     },
     {
       "text": "今日头条",
       "anchor": [128.74045172023568, 0.030000000000000027, -2.3274999999999997],
       "role": "card",
-      "revealAt": 267.9499999999999,
-      "hideAt": 272.89999999999986
+      "revealAt": 264.1499999999999,
+      "hideAt": 269.0999999999999
     },
     {
       "text": "Confidential ①",
       "anchor": [128, 0.030000000000000027, -1.045],
       "role": "card",
-      "revealAt": 267.9499999999999,
-      "hideAt": 272.89999999999986
+      "revealAt": 264.1499999999999,
+      "hideAt": 269.0999999999999
     },
     {
       "text": "Confidential ②",
       "anchor": [127.2595482797643, 0.030000000000000027, -2.3274999999999992],
       "role": "card",
-      "revealAt": 267.9499999999999,
-      "hideAt": 272.89999999999986
+      "revealAt": 264.1499999999999,
+      "hideAt": 269.0999999999999
     },
     {
       "text": "内涵段子",
       "anchor": [127.04895765539742, 0.030000000000000027, 2.4490845536670394],
       "role": "card",
-      "revealAt": 267.9499999999999,
-      "hideAt": 272.89999999999986
+      "revealAt": 264.1499999999999,
+      "hideAt": 269.0999999999999
     },
     {
       "text": "有点意思",
       "anchor": [127.0489576553974, 0.030000000000000027, 1.3509154463329618],
       "role": "card",
-      "revealAt": 267.9499999999999,
-      "hideAt": 272.89999999999986
+      "revealAt": 264.1499999999999,
+      "hideAt": 269.0999999999999
     },
     {
       "text": "今日特卖",
       "anchor": [128, 0.030000000000000027, 0.8018308926659221],
       "role": "card",
-      "revealAt": 267.9499999999999,
-      "hideAt": 272.89999999999986
+      "revealAt": 264.1499999999999,
+      "hideAt": 269.0999999999999
     },
     {
       "text": "今日头彩",
       "anchor": [128.9510423446026, 0.030000000000000027, 1.3509154463329605],
       "role": "card",
-      "revealAt": 267.9499999999999,
-      "hideAt": 272.89999999999986
+      "revealAt": 264.1499999999999,
+      "hideAt": 269.0999999999999
     },
     {
       "text": "图虫",
       "anchor": [128.9510423446026, 0.030000000000000027, 2.449084553667038],
       "role": "card",
-      "revealAt": 267.9499999999999,
-      "hideAt": 272.89999999999986
+      "revealAt": 264.1499999999999,
+      "hideAt": 269.0999999999999
     },
     {
       "text": "多说",
       "anchor": [128, 0.030000000000000027, 2.9981691073340775],
       "role": "card",
-      "revealAt": 267.9499999999999,
-      "hideAt": 272.89999999999986
+      "revealAt": 264.1499999999999,
+      "hideAt": 269.0999999999999
     },
     {
       "text": "战略级:头条 + 两个保密项目",
       "sub": "战术级 6 款:内涵段子 / 有点意思 / 今日特卖 / 今日头彩 / 图虫 / 多说",
       "role": "insight",
-      "revealAt": 269.3499999999999,
-      "hideAt": 272.4999999999999
+      "revealAt": 265.54999999999995,
+      "hideAt": 268.69999999999993
     },
     {
       "text": "创业经验丰富的一流团队",
       "anchor": [144, 3.875, 0],
       "role": "title",
-      "revealAt": 273.6999999999999,
-      "hideAt": 282.1999999999999
+      "revealAt": 269.8999999999999,
+      "hideAt": 278.3999999999999
     },
     {
       "text": "张一鸣 创始人/CEO",
       "anchor": [144, 1.7549999999999997, 0],
       "role": "card",
-      "revealAt": 276.14999999999986,
-      "hideAt": 282.59999999999985
+      "revealAt": 272.3499999999999,
+      "hideAt": 278.7999999999999
     },
     {
       "text": "PM Leader 产品",
       "anchor": [144, 0.6049999999999998, -1.9],
       "role": "card",
-      "revealAt": 277.64999999999986,
-      "hideAt": 282.59999999999985
+      "revealAt": 273.8499999999999,
+      "hideAt": 278.7999999999999
     },
     {
       "text": "RD Leader 研发",
       "anchor": [145.48547981668926, 0.6049999999999998, -1.1846306235315935],
       "role": "card",
-      "revealAt": 277.64999999999986,
-      "hideAt": 282.59999999999985
+      "revealAt": 273.8499999999999,
+      "hideAt": 278.7999999999999
     },
     {
       "text": "Sales Leader 销售",
       "anchor": [145.85236303314545, 0.6049999999999998, 0.42278977451699734],
       "role": "card",
-      "revealAt": 277.64999999999986,
-      "hideAt": 282.59999999999985
+      "revealAt": 273.8499999999999,
+      "hideAt": 278.7999999999999
     },
     {
       "text": "HR Leader",
       "anchor": [144.82437910432336, 0.6049999999999998, 1.7118408490145962],
       "role": "card",
-      "revealAt": 277.64999999999986,
-      "hideAt": 282.59999999999985
+      "revealAt": 273.8499999999999,
+      "hideAt": 278.7999999999999
     },
     {
       "text": "PR Leader",
       "anchor": [143.17562089567664, 0.6049999999999998, 1.7118408490145962],
       "role": "card",
-      "revealAt": 277.64999999999986,
-      "hideAt": 282.59999999999985
+      "revealAt": 273.8499999999999,
+      "hideAt": 278.7999999999999
     },
     {
       "text": "GR Leader",
       "anchor": [142.14763696685455, 0.6049999999999998, 0.42278977451699756],
       "role": "card",
-      "revealAt": 277.64999999999986,
-      "hideAt": 282.59999999999985
+      "revealAt": 273.8499999999999,
+      "hideAt": 278.7999999999999
     },
     {
       "text": "M&A Leader",
       "anchor": [142.51452018331074, 0.6049999999999998, -1.1846306235315933],
       "role": "card",
-      "revealAt": 277.64999999999986,
-      "hideAt": 282.59999999999985
+      "revealAt": 273.8499999999999,
+      "hideAt": 278.7999999999999
     },
     {
       "text": "连续创业者带队",
       "sub": "酷讯 → 饭否 → 九九房 → 字节跳动 —— 微软/腾讯/百度/小米系 · 北大/南开/复旦人才汇聚",
       "role": "insight",
-      "revealAt": 279.0499999999999,
-      "hideAt": 282.1999999999999
+      "revealAt": 275.24999999999994,
+      "hideAt": 278.3999999999999
     },
     {
       "text": "收入预期（全年收入·亿元）",
       "anchor": [160, 6.1, 0],
       "role": "title",
-      "revealAt": 283.39999999999986,
-      "hideAt": 295.4999999999999
+      "revealAt": 279.5999999999999,
+      "hideAt": 291.69999999999993
     },
     {
       "text": "2018E 最高:150",
       "sub": "第二位 2017E:80",
       "role": "insight",
-      "revealAt": 293.4999999999999,
-      "hideAt": 295.4999999999999
+      "revealAt": 289.69999999999993,
+      "hideAt": 291.69999999999993
     },
     {
       "text": "2018E 收入 150 亿",
       "sub": "轻资产、高毛利:每月固定开支仅 1,000 多万 —— 2018 年末 DAU 目标 1.7 亿(15E 5,000 万起步);对未来的预估同样可能过于保守",
       "role": "insight",
-      "revealAt": 292.34999999999985,
-      "hideAt": 293.4999999999999
+      "revealAt": 288.5499999999999,
+      "hideAt": 289.69999999999993
     },
     {
       "text": "2013",
       "anchor": [163.175, -0.02, 0.96],
       "role": "card",
-      "revealAt": 285.84999999999985,
-      "hideAt": 295.89999999999986
+      "revealAt": 282.0499999999999,
+      "hideAt": 292.0999999999999
     },
     {
       "text": "0.08",
       "anchor": [163.175, 0.44, 0],
       "role": "value",
       "radius": 0.36,
-      "revealAt": 285.84999999999985,
-      "hideAt": 295.89999999999986
+      "revealAt": 282.0499999999999,
+      "hideAt": 292.0999999999999
     },
     {
       "text": "2014",
       "anchor": [161.905, -0.02, 0.96],
       "role": "card",
-      "revealAt": 286.9499999999999,
-      "hideAt": 295.89999999999986
+      "revealAt": 283.1499999999999,
+      "hideAt": 292.0999999999999
     },
     {
       "text": "2.4",
       "anchor": [161.905, 0.44, 0],
       "role": "value",
       "radius": 0.36,
-      "revealAt": 286.9499999999999,
-      "hideAt": 295.89999999999986
+      "revealAt": 283.1499999999999,
+      "hideAt": 292.0999999999999
     },
     {
       "text": "2015E",
       "anchor": [160.635, -0.02, 0.96],
       "role": "card",
-      "revealAt": 288.04999999999984,
-      "hideAt": 295.89999999999986
+      "revealAt": 284.2499999999999,
+      "hideAt": 292.0999999999999
     },
     {
       "text": "15",
       "anchor": [160.635, 0.8, 0],
       "role": "value",
       "radius": 0.36,
-      "revealAt": 288.04999999999984,
-      "hideAt": 295.89999999999986
+      "revealAt": 284.2499999999999,
+      "hideAt": 292.0999999999999
     },
     {
       "text": "2016E",
       "anchor": [159.365, -0.02, 0.96],
       "role": "card",
-      "revealAt": 289.14999999999986,
-      "hideAt": 295.89999999999986
+      "revealAt": 285.3499999999999,
+      "hideAt": 292.0999999999999
     },
     {
       "text": "36",
       "anchor": [159.365, 1.472, 0],
       "role": "value",
       "radius": 0.36,
-      "revealAt": 289.14999999999986,
-      "hideAt": 295.89999999999986
+      "revealAt": 285.3499999999999,
+      "hideAt": 292.0999999999999
     },
     {
       "text": "2017E",
       "anchor": [158.095, -0.02, 0.96],
       "role": "card",
-      "revealAt": 290.2499999999999,
-      "hideAt": 295.89999999999986
+      "revealAt": 286.44999999999993,
+      "hideAt": 292.0999999999999
     },
     {
       "text": "80",
       "anchor": [158.095, 2.88, 0],
       "role": "value",
       "radius": 0.36,
-      "revealAt": 290.2499999999999,
-      "hideAt": 295.89999999999986
+      "revealAt": 286.44999999999993,
+      "hideAt": 292.0999999999999
     },
     {
       "text": "2018E",
       "anchor": [156.825, -0.02, 0.96],
       "role": "card",
-      "revealAt": 291.34999999999985,
-      "hideAt": 295.89999999999986
+      "revealAt": 287.5499999999999,
+      "hideAt": 292.0999999999999
     },
     {
       "text": "150",
       "anchor": [156.825, 5.12, 0],
       "role": "value",
       "radius": 0.5,
-      "revealAt": 291.34999999999985,
-      "hideAt": 295.89999999999986
+      "revealAt": 287.5499999999999,
+      "hideAt": 292.0999999999999
     },
     {
       "text": "收入增长的推动力",
       "anchor": [176, 7.1, -1.2],
       "role": "title",
-      "revealAt": 296.6999999999999,
-      "hideAt": 305.6999999999999
+      "revealAt": 292.8999999999999,
+      "hideAt": 301.8999999999999
     },
     {
       "text": "① 用户增长有望加速 —— 过往市场投入过于保守,15 年下大决心解决",
       "anchor": [175.69684708965934, 6.717749959911059, -1.2],
       "role": "screen",
       "side": "right",
-      "revealAt": 299.14999999999986,
-      "hideAt": 305.6999999999999
+      "revealAt": 295.3499999999999,
+      "hideAt": 301.8999999999999
     },
     {
       "text": "①",
       "anchor": [175.69684708965934, 7.377749959911059, -1.2],
       "role": "value",
-      "revealAt": 299.1999999999999,
-      "hideAt": 306.09999999999985
+      "revealAt": 295.3999999999999,
+      "hideAt": 302.2999999999999
     },
     {
       "text": "② 移动广告市场迅速膨胀 —— 广告位向头条、微信等超级 APP 聚集;搜索广告也将大量转向推荐引擎",
       "anchor": [173.7323966600903, 5.003591609722465, -1.2],
       "role": "screen",
       "side": "right",
-      "revealAt": 300.14999999999986,
-      "hideAt": 305.6999999999999
+      "revealAt": 296.3499999999999,
+      "hideAt": 301.8999999999999
     },
     {
       "text": "②",
       "anchor": [173.7323966600903, 5.663591609722465, -1.2],
       "role": "value",
-      "revealAt": 300.1999999999999,
-      "hideAt": 306.09999999999985
+      "revealAt": 296.3999999999999,
+      "hideAt": 302.2999999999999
     },
     {
       "text": "③ 精准广告投放系统上线不久 —— 类似百度凤巢,有巨大提升空间",
       "anchor": [173.7323966600903, 2.3964083902775357, -1.2],
       "role": "screen",
       "side": "right",
-      "revealAt": 301.14999999999986,
-      "hideAt": 305.6999999999999
+      "revealAt": 297.3499999999999,
+      "hideAt": 301.8999999999999
     },
     {
       "text": "③",
       "anchor": [173.7323966600903, 3.056408390277536, -1.2],
       "role": "value",
-      "revealAt": 301.1999999999999,
-      "hideAt": 306.09999999999985
+      "revealAt": 297.3999999999999,
+      "hideAt": 302.2999999999999
     },
     {
       "text": "④ 商品和服务推荐潜力巨大 —— 电商与 O2O 市场远大于广告;阿里被微信封杀,阿里系对头条会很依赖",
       "anchor": [175.69684708965934, 0.6822500400889417, -1.2],
       "role": "screen",
       "side": "right",
-      "revealAt": 302.14999999999986,
-      "hideAt": 305.6999999999999
+      "revealAt": 298.3499999999999,
+      "hideAt": 301.8999999999999
     },
     {
       "text": "④",
       "anchor": [175.69684708965934, 1.3422500400889419, -1.2],
       "role": "value",
-      "revealAt": 302.1999999999999,
-      "hideAt": 306.09999999999985
+      "revealAt": 298.3999999999999,
+      "hideAt": 302.2999999999999
     },
     {
       "text": "收入增长前景分析（中国移动广告市场·亿元）",
       "anchor": [192, 6.1, 0],
       "role": "title",
-      "revealAt": 306.89999999999986,
-      "hideAt": 318.9999999999999
+      "revealAt": 303.0999999999999,
+      "hideAt": 315.19999999999993
     },
     {
       "text": "2017E 最高:1276.9",
       "sub": "第二位 2016E:845",
       "role": "insight",
-      "revealAt": 316.9999999999999,
-      "hideAt": 318.9999999999999
+      "revealAt": 313.19999999999993,
+      "hideAt": 315.19999999999993
     },
     {
       "text": "我们预估 2018 年市场 ≥1500 亿",
       "sub": "2012–2017E 市场规模系列源:iResearch;1500 亿为公司预估",
       "role": "insight",
-      "revealAt": 315.84999999999985,
-      "hideAt": 316.9999999999999
+      "revealAt": 312.0499999999999,
+      "hideAt": 313.19999999999993
     },
     {
       "text": "2012",
       "anchor": [195.175, -0.02, 0.96],
       "role": "card",
-      "revealAt": 309.34999999999985,
-      "hideAt": 319.39999999999986
+      "revealAt": 305.5499999999999,
+      "hideAt": 315.5999999999999
     },
     {
       "text": "75.7",
       "anchor": [195.175, 0.6045641788707025, 0],
       "role": "value",
       "radius": 0.36,
-      "revealAt": 309.34999999999985,
-      "hideAt": 319.39999999999986
+      "revealAt": 305.5499999999999,
+      "hideAt": 315.5999999999999
     },
     {
       "text": "2013",
       "anchor": [193.905, -0.02, 0.96],
       "role": "card",
-      "revealAt": 310.4499999999999,
-      "hideAt": 319.39999999999986
+      "revealAt": 306.6499999999999,
+      "hideAt": 315.5999999999999
     },
     {
       "text": "155.2",
       "anchor": [193.905, 0.903412953246143, 0],
       "role": "value",
       "radius": 0.36,
-      "revealAt": 310.4499999999999,
-      "hideAt": 319.39999999999986
+      "revealAt": 306.6499999999999,
+      "hideAt": 315.5999999999999
     },
     {
       "text": "2014E",
       "anchor": [192.635, -0.02, 0.96],
       "role": "card",
-      "revealAt": 311.54999999999984,
-      "hideAt": 319.39999999999986
+      "revealAt": 307.7499999999999,
+      "hideAt": 315.5999999999999
     },
     {
       "text": "273.1",
       "anchor": [192.635, 1.3466113243010416, 0],
       "role": "value",
       "radius": 0.36,
-      "revealAt": 311.54999999999984,
-      "hideAt": 319.39999999999986
+      "revealAt": 307.7499999999999,
+      "hideAt": 315.5999999999999
     },
     {
       "text": "2015E",
       "anchor": [191.365, -0.02, 0.96],
       "role": "card",
-      "revealAt": 312.64999999999986,
-      "hideAt": 319.39999999999986
+      "revealAt": 308.8499999999999,
+      "hideAt": 315.5999999999999
     },
     {
       "text": "486.7",
       "anchor": [191.365, 2.1495559558305266, 0],
       "role": "value",
       "radius": 0.36,
-      "revealAt": 312.64999999999986,
-      "hideAt": 319.39999999999986
+      "revealAt": 308.8499999999999,
+      "hideAt": 315.5999999999999
     },
     {
       "text": "2016E",
       "anchor": [190.095, -0.02, 0.96],
       "role": "card",
-      "revealAt": 313.7499999999999,
-      "hideAt": 319.39999999999986
+      "revealAt": 309.94999999999993,
+      "hideAt": 315.5999999999999
     },
     {
       "text": "845",
       "anchor": [190.095, 3.4964429477641157, 0],
       "role": "value",
       "radius": 0.36,
-      "revealAt": 313.7499999999999,
-      "hideAt": 319.39999999999986
+      "revealAt": 309.94999999999993,
+      "hideAt": 315.5999999999999
     },
     {
       "text": "2017E",
       "anchor": [188.825, -0.02, 0.96],
       "role": "card",
-      "revealAt": 314.84999999999985,
-      "hideAt": 319.39999999999986
+      "revealAt": 311.0499999999999,
+      "hideAt": 315.5999999999999
     },
     {
       "text": "1276.9",
       "anchor": [188.825, 5.12, 0],
       "role": "value",
       "radius": 0.5,
-      "revealAt": 314.84999999999985,
-      "hideAt": 319.39999999999986
+      "revealAt": 311.0499999999999,
+      "hideAt": 315.5999999999999
     },
     {
       "text": "2018 年移动广告市场份额（亿元）",
       "anchor": [208, 6.1, 0],
       "role": "title",
-      "revealAt": 320.1999999999999,
-      "hideAt": 325.9499999999999
+      "revealAt": 316.3999999999999,
+      "hideAt": 322.1499999999999
     },
     {
       "text": "2018E 市场 ≥1500 亿",
       "anchor": [208, 5.2, 0],
       "role": "card",
       "align": "center",
-      "revealAt": 321.9999999999999,
-      "hideAt": 326.34999999999985
+      "revealAt": 318.19999999999993,
+      "hideAt": 322.5499999999999
     },
     {
       "text": "今日头条 10%",
       "anchor": [207.7311552148938, 4.027419169176784, 0.26],
       "role": "value",
-      "revealAt": 322.2499999999999,
-      "hideAt": 326.34999999999985
+      "revealAt": 318.44999999999993,
+      "hideAt": 322.5499999999999
     },
     {
       "text": "百度 WAP+APP 20%",
       "anchor": [207.17258083082322, 3.4688447851062043, 0.26],
       "role": "value",
-      "revealAt": 322.2499999999999,
-      "hideAt": 326.34999999999985
+      "revealAt": 318.44999999999993,
+      "hideAt": 322.5499999999999
     },
     {
       "text": "微信 30%",
       "anchor": [207.7311552148938, 2.3725808308232166, 0.26],
       "role": "value",
-      "revealAt": 322.2499999999999,
-      "hideAt": 326.34999999999985
+      "revealAt": 318.44999999999993,
+      "hideAt": 322.5499999999999
     },
     {
       "text": "其他 40%",
       "anchor": [208.82741916917678, 3.4688447851062043, 0.26],
       "role": "value",
-      "revealAt": 322.2499999999999,
-      "hideAt": 326.34999999999985
+      "revealAt": 318.44999999999993,
+      "hideAt": 322.5499999999999
     },
     {
       "text": "保守估计:份额 ≥10% = 150 亿",
       "sub": "前提:实现 DAU 目标 —— 公司预估,非 iResearch 口径",
       "role": "insight",
-      "revealAt": 323.14999999999986,
-      "hideAt": 325.9499999999999
+      "revealAt": 319.3499999999999,
+      "hideAt": 322.1499999999999
     },
     {
       "text": "业务发展规划（时间轴·月）",
       "anchor": [224, 8.61, 0],
       "role": "title",
-      "revealAt": 327.14999999999986,
-      "hideAt": 339.2499999999999
+      "revealAt": 323.3499999999999,
+      "hideAt": 335.44999999999993
     },
     {
       "text": "兴趣社区·SNS 功能",
       "anchor": [224.3, 7.109999999999999, 0.51],
       "role": "screen",
       "align": "left",
-      "revealAt": 329.59999999999985,
-      "hideAt": 339.2499999999999
+      "revealAt": 325.7999999999999,
+      "hideAt": 335.44999999999993
     },
     {
       "text": "3-6 个月",
       "anchor": [223.09285714285716, 7.109999999999999, 0],
       "role": "value",
       "radius": 0.34,
-      "revealAt": 329.59999999999985,
-      "hideAt": 339.64999999999986
+      "revealAt": 325.7999999999999,
+      "hideAt": 335.8499999999999
     },
     {
       "text": "两个战略级新品",
       "anchor": [224.3, 5.93, 0.51],
       "role": "screen",
       "align": "left",
-      "revealAt": 330.6999999999999,
-      "hideAt": 339.2499999999999
+      "revealAt": 326.8999999999999,
+      "hideAt": 335.44999999999993
     },
     {
       "text": "12 个月",
       "anchor": [222.4857142857143, 5.93, 0],
       "role": "value",
       "radius": 0.34,
-      "revealAt": 330.6999999999999,
-      "hideAt": 339.64999999999986
+      "revealAt": 326.8999999999999,
+      "hideAt": 335.8499999999999
     },
     {
       "text": "进军海外·英文优先",
       "anchor": [224.3, 4.75, 0.51],
       "role": "screen",
       "align": "left",
-      "revealAt": 331.79999999999984,
-      "hideAt": 339.2499999999999
+      "revealAt": 327.9999999999999,
+      "hideAt": 335.44999999999993
     },
     {
       "text": "6-24 个月",
       "anchor": [221.27142857142857, 4.75, 0],
       "role": "value",
       "radius": 0.34,
-      "revealAt": 331.79999999999984,
-      "hideAt": 339.64999999999986
+      "revealAt": 327.9999999999999,
+      "hideAt": 335.8499999999999
     },
     {
       "text": "国内分发用户第一",
       "anchor": [224.3, 3.5699999999999994, 0.51],
       "role": "screen",
       "align": "left",
-      "revealAt": 332.89999999999986,
-      "hideAt": 339.2499999999999
+      "revealAt": 329.0999999999999,
+      "hideAt": 335.44999999999993
     },
     {
       "text": "2 年",
       "anchor": [221.27142857142857, 3.5699999999999994, 0],
       "role": "value",
       "radius": 0.34,
-      "revealAt": 332.89999999999986,
-      "hideAt": 339.64999999999986
+      "revealAt": 329.0999999999999,
+      "hideAt": 335.8499999999999
     },
     {
       "text": "变现逼近并超越搜索·强化电商服务变现",
       "anchor": [224.3, 2.3899999999999997, 0.51],
       "role": "screen",
       "align": "left",
-      "revealAt": 333.9999999999999,
-      "hideAt": 339.2499999999999
+      "revealAt": 330.19999999999993,
+      "hideAt": 335.44999999999993
     },
     {
       "text": "3 年",
       "anchor": [220.05714285714285, 2.3899999999999997, 0],
       "role": "value",
       "radius": 0.34,
-      "revealAt": 333.9999999999999,
-      "hideAt": 339.64999999999986
+      "revealAt": 330.19999999999993,
+      "hideAt": 335.8499999999999
     },
     {
       "text": "千亿美金公司",
       "anchor": [224.3, 1.21, 0.51],
       "role": "screen",
       "align": "left",
-      "revealAt": 335.09999999999985,
-      "hideAt": 339.2499999999999
+      "revealAt": 331.2999999999999,
+      "hideAt": 335.44999999999993
     },
     {
       "text": "5-7 年",
       "anchor": [215.2, 1.21, 0],
       "role": "value",
       "radius": 0.46,
-      "revealAt": 335.09999999999985,
-      "hideAt": 339.64999999999986
+      "revealAt": 331.2999999999999,
+      "hideAt": 335.8499999999999
     },
     {
       "text": "千亿美金公司 最高:5-7 年",
       "sub": "第二位 变现逼近并超越搜索·强化电商服务变现:3 年",
       "role": "insight",
-      "revealAt": 337.2499999999999,
-      "hideAt": 339.2499999999999
+      "revealAt": 333.44999999999993,
+      "hideAt": 335.44999999999993
     },
     {
       "text": "五到七年,千亿美金",
       "sub": "半年做社区 → 一年推两个战略级新品 → 两年国内第一 → 五到七年千亿美金",
       "role": "insight",
-      "revealAt": 336.09999999999985,
-      "hideAt": 337.2499999999999
+      "revealAt": 332.2999999999999,
+      "hideAt": 333.44999999999993
     },
     {
       "text": "愿景与使命",
       "anchor": [240, 7.1, -1.2],
       "role": "title",
-      "revealAt": 340.4499999999999,
-      "hideAt": 348.4499999999999
+      "revealAt": 336.6499999999999,
+      "hideAt": 344.6499999999999
     },
     {
       "text": "① 做从产品、技术到商业模式都完全创新的全球性公司,技术上做全球领导者",
       "anchor": [239.69684708965934, 6.717749959911059, -1.2],
       "role": "screen",
       "side": "right",
-      "revealAt": 342.89999999999986,
-      "hideAt": 348.4499999999999
+      "revealAt": 339.0999999999999,
+      "hideAt": 344.6499999999999
     },
     {
       "text": "①",
       "anchor": [239.69684708965934, 7.377749959911059, -1.2],
       "role": "value",
-      "revealAt": 342.9499999999999,
-      "hideAt": 348.84999999999985
+      "revealAt": 339.1499999999999,
+      "hideAt": 345.0499999999999
     },
     {
       "text": "② 两个战略级产品在路上 —— 同时打造三个亿级创新产品,依靠创新而非垄断达到千亿美元",
       "anchor": [237.45, 3.7, -1.2],
       "role": "screen",
       "side": "right",
-      "revealAt": 343.89999999999986,
-      "hideAt": 348.4499999999999
+      "revealAt": 340.0999999999999,
+      "hideAt": 344.6499999999999
     },
     {
       "text": "②",
       "anchor": [237.45, 4.36, -1.2],
       "role": "value",
-      "revealAt": 343.9499999999999,
-      "hideAt": 348.84999999999985
+      "revealAt": 340.1499999999999,
+      "hideAt": 345.0499999999999
     },
     {
       "text": "③ 本轮计划融资 0.5~1 亿美元,用于 milestone",
       "anchor": [239.69684708965934, 0.6822500400889417, -1.2],
       "role": "screen",
       "side": "right",
-      "revealAt": 344.89999999999986,
-      "hideAt": 348.4499999999999
+      "revealAt": 341.0999999999999,
+      "hideAt": 344.6499999999999
     },
     {
       "text": "③",
       "anchor": [239.69684708965934, 1.3422500400889419, -1.2],
       "role": "value",
-      "revealAt": 344.9499999999999,
-      "hideAt": 348.84999999999985
+      "revealAt": 341.1499999999999,
+      "hideAt": 345.0499999999999
     },
     {
       "text": "你想要的一切,都自动给你!",
       "sub": "Google 帮你找到想要的一切,而我们的愿景是 —— 超越 Google 之路 · 谢谢",
       "role": "insight",
       "panel": "center",
-      "revealAt": 348.9499999999999
+      "revealAt": 345.1499999999999
     }
   ],
   "cameraSequence": {
@@ -11670,8 +11594,8 @@
       },
       {
         "duration": 1.2,
-        "pos": [-167.6832, 5.5, 16.436],
-        "target": [-164.8, 3.4, 0],
+        "pos": [-168, 4.4, 16.436],
+        "target": [-164.8, 1.75, -3.6224999999999996],
         "fov": 50,
         "transition": "blend",
         "aperture": 0,
@@ -11680,165 +11604,106 @@
         "ease": "whip"
       },
       {
-        "duration": 1.6,
-        "pos": [-159.3664, 3.9, 6.496],
-        "target": [-160, 3.4, 0],
-        "fov": 48,
-        "aperture": 0.12,
-        "focalDistance": 5.296,
+        "duration": 1.5,
+        "pos": [-160, 2.6, 4.369999999999999],
+        "target": [-160, 1.75, -5.175],
+        "fov": 52,
+        "aperture": 0.18,
+        "focalDistance": 5.06,
         "ease": "out",
         "transition": "blend"
       },
       {
-        "duration": 0.9,
-        "pos": [-159.4995, 4.07375, 4.13088],
-        "target": [-159.09, 5.325, 0],
-        "fov": 46,
+        "duration": 1.15,
+        "pos": [-160, 2.15, 3.105],
+        "target": [-160, 1.65, -0.9199999999999999],
+        "fov": 50,
         "transition": "blend",
-        "aperture": 0.2,
-        "focalDistance": 4.13088,
+        "aperture": 0.3,
+        "focalDistance": 3.4499999999999997,
         "ease": "smooth"
       },
       {
-        "duration": 0.9,
-        "pos": [-159.4995, 3.8042499999999997, 4.13088],
-        "target": [-159.09, 4.555, 0],
-        "fov": 46,
+        "duration": 1.15,
+        "pos": [-160, 2.15, 0.8050000000000002],
+        "target": [-160, 1.65, -3.2199999999999998],
+        "fov": 50,
         "transition": "blend",
-        "aperture": 0.2,
-        "focalDistance": 4.13088,
+        "aperture": 0.3,
+        "focalDistance": 3.4499999999999997,
         "ease": "smooth"
       },
       {
-        "duration": 0.9,
-        "pos": [-159.4995, 3.53475, 4.13088],
-        "target": [-159.09, 3.785, 0],
-        "fov": 46,
+        "duration": 1.15,
+        "pos": [-160, 2.15, -1.4949999999999997],
+        "target": [-160, 1.65, -5.52],
+        "fov": 50,
         "transition": "blend",
-        "aperture": 0.2,
-        "focalDistance": 4.13088,
+        "aperture": 0.3,
+        "focalDistance": 3.4499999999999997,
         "ease": "smooth"
       },
       {
-        "duration": 0.9,
-        "pos": [-159.4995, 3.26525, 4.13088],
-        "target": [-159.09, 3.0149999999999997, 0],
-        "fov": 46,
+        "duration": 1.15,
+        "pos": [-160, 2.15, -3.7949999999999995],
+        "target": [-160, 1.65, -7.819999999999999],
+        "fov": 50,
         "transition": "blend",
-        "aperture": 0.2,
-        "focalDistance": 4.13088,
+        "aperture": 0.3,
+        "focalDistance": 3.4499999999999997,
         "ease": "smooth"
       },
       {
-        "duration": 0.9,
-        "pos": [-159.4995, 2.99575, 4.13088],
-        "target": [-159.09, 2.245, 0],
-        "fov": 46,
+        "duration": 1.15,
+        "pos": [-160, 2.15, -6.094999999999999],
+        "target": [-160, 1.65, -10.12],
+        "fov": 50,
         "transition": "blend",
-        "aperture": 0.2,
-        "focalDistance": 4.13088,
+        "aperture": 0.3,
+        "focalDistance": 3.4499999999999997,
         "ease": "smooth"
       },
       {
-        "duration": 0.9,
-        "pos": [-159.4995, 2.72625, 4.13088],
-        "target": [-159.09, 1.4749999999999999, 0],
-        "fov": 46,
+        "duration": 1.15,
+        "pos": [-160, 2.15, -8.395],
+        "target": [-160, 1.65, -12.42],
+        "fov": 50,
         "transition": "blend",
-        "aperture": 0.2,
-        "focalDistance": 4.13088,
+        "aperture": 0.3,
+        "focalDistance": 3.4499999999999997,
         "ease": "smooth"
       },
       {
-        "duration": 0.9,
-        "pos": [-160.5005, 4.07375, 4.13088],
-        "target": [-160.91, 5.325, 0],
+        "duration": 1,
+        "pos": [-159.6475, 2.25, 2.9],
+        "target": [-158.0025, 1.75, -0.3],
         "fov": 46,
-        "transition": "blend",
-        "aperture": 0.2,
-        "focalDistance": 4.13088,
-        "ease": "smooth"
-      },
-      {
-        "duration": 0.9,
-        "pos": [-160.5005, 3.8042499999999997, 4.13088],
-        "target": [-160.91, 4.555, 0],
-        "fov": 46,
-        "transition": "blend",
-        "aperture": 0.2,
-        "focalDistance": 4.13088,
-        "ease": "smooth"
-      },
-      {
-        "duration": 0.9,
-        "pos": [-160.5005, 3.53475, 4.13088],
-        "target": [-160.91, 3.785, 0],
-        "fov": 46,
-        "transition": "blend",
-        "aperture": 0.2,
-        "focalDistance": 4.13088,
-        "ease": "smooth"
-      },
-      {
-        "duration": 0.9,
-        "pos": [-160.5005, 3.26525, 4.13088],
-        "target": [-160.91, 3.0149999999999997, 0],
-        "fov": 46,
-        "transition": "blend",
-        "aperture": 0.2,
-        "focalDistance": 4.13088,
-        "ease": "smooth"
-      },
-      {
-        "duration": 0.9,
-        "pos": [-160.5005, 2.99575, 4.13088],
-        "target": [-160.91, 2.245, 0],
-        "fov": 46,
-        "transition": "blend",
-        "aperture": 0.2,
-        "focalDistance": 4.13088,
-        "ease": "smooth"
-      },
-      {
-        "duration": 0.9,
-        "pos": [-160.5005, 2.72625, 4.13088],
-        "target": [-160.91, 1.4749999999999999, 0],
-        "fov": 46,
-        "transition": "blend",
-        "aperture": 0.2,
-        "focalDistance": 4.13088,
-        "ease": "smooth"
-      },
-      {
-        "duration": 0.9,
-        "pos": [-158.59, 5.525, 2.1],
-        "target": [-159.09, 5.325, 0.2],
-        "fov": 44,
         "transition": "blend",
         "beat": "super",
-        "aperture": [0.7, 0.35],
-        "focalDistance": 2,
-        "shake": [0.35, 0.05],
-        "exposure": [1.3, 1],
+        "aperture": [0.8, 0.4],
+        "focalDistance": 3.1,
+        "shake": [0.4, 0.05],
+        "ambient": [0.2, 1],
+        "exposure": [1.2, 1],
         "ease": "out",
         "station": 5
       },
       {
-        "duration": 2.2,
-        "pos": [-160, 3.8, 5.896],
-        "target": [-160, 3.4, 0],
-        "fov": 48,
+        "duration": 2.3,
+        "pos": [-156.6, 5.2, 5.52],
+        "target": [-160, 1.5, -6.325],
+        "fov": 50,
         "transition": "blend",
         "aperture": 0.1,
-        "focalDistance": 5.296,
-        "ease": "inout",
+        "focalDistance": 13.799999999999999,
+        "ease": "out",
         "beat": "station",
         "station": 5
       },
       {
         "duration": 1.2,
-        "pos": [-151.51940000000002, 5.4, 10.407],
-        "target": [-148.8, 3.28, 0],
+        "pos": [-149.8194, 6.800000000000001, 10.407],
+        "target": [-148.8, 3.28, -1.8975],
         "fov": 50,
         "transition": "blend",
         "aperture": 0,
@@ -14116,75 +13981,79 @@
         "hold": 0.14
       },
       {
-        "at": 116.42000000000003,
+        "at": 62.37000000000002,
         "hold": 0.14
       },
       {
-        "at": 127.67000000000003,
+        "at": 112.62000000000003,
         "hold": 0.14
       },
       {
-        "at": 137.97,
+        "at": 123.87000000000005,
         "hold": 0.14
       },
       {
-        "at": 156.47,
+        "at": 134.17000000000002,
         "hold": 0.14
       },
       {
-        "at": 176.17,
+        "at": 152.67000000000002,
         "hold": 0.14
       },
       {
-        "at": 187.82,
+        "at": 172.37,
         "hold": 0.14
       },
       {
-        "at": 199.46999999999997,
+        "at": 184.02,
         "hold": 0.14
       },
       {
-        "at": 212.76999999999995,
+        "at": 195.67,
         "hold": 0.14
       },
       {
-        "at": 224.96999999999994,
+        "at": 208.96999999999997,
         "hold": 0.14
       },
       {
-        "at": 232.31999999999994,
+        "at": 221.16999999999996,
+        "hold": 0.14
+      },
+      {
+        "at": 228.51999999999995,
         "hold": 0.12
       },
       {
-        "at": 247.4199999999999,
+        "at": 243.61999999999992,
         "hold": 0.14
       },
       {
-        "at": 257.9199999999999,
+        "at": 254.11999999999992,
         "hold": 0.14
       },
       {
-        "at": 269.1199999999999,
+        "at": 265.31999999999994,
         "hold": 0.14
       },
       {
-        "at": 278.8199999999999,
+        "at": 275.0199999999999,
         "hold": 0.14
       },
       {
-        "at": 292.1199999999999,
+        "at": 288.31999999999994,
         "hold": 0.14
       },
       {
-        "at": 315.6199999999999,
+        "at": 311.81999999999994,
         "hold": 0.14
       },
       {
-        "at": 322.96999999999986,
+        "at": 319.1699999999999,
         "hold": 0.12
       },
       {
-        "at": 335.8699999999999,
+        "at": 332.06999999999994,
         "hold": 0.14
       }
     ],
@@ -14270,382 +14139,382 @@
       "kind": "station",
       "stations": [5],
       "start": 53.95000000000002,
-      "end": 69.45000000000002,
+      "end": 65.65000000000002,
       "origin": [-160, 0, 0],
       "tier": "content"
     },
     {
       "kind": "transit",
       "stations": [5, 6],
-      "start": 69.45000000000002,
-      "end": 70.65000000000002,
+      "start": 65.65000000000002,
+      "end": 66.85000000000002,
       "origin": [-152, 0, 0]
     },
     {
       "kind": "station",
       "stations": [6],
-      "start": 70.65000000000002,
-      "end": 86.15000000000002,
+      "start": 66.85000000000002,
+      "end": 82.35000000000002,
       "origin": [-144, 0, 0],
       "tier": "content"
     },
     {
       "kind": "transit",
       "stations": [6, 7],
-      "start": 86.15000000000002,
-      "end": 87.35000000000002,
+      "start": 82.35000000000002,
+      "end": 83.55000000000003,
       "origin": [-136, 0, 0]
     },
     {
       "kind": "station",
       "stations": [7],
-      "start": 87.35000000000002,
-      "end": 95.05000000000003,
+      "start": 83.55000000000003,
+      "end": 91.25000000000003,
       "origin": [-128, 0, 0],
       "tier": "hero"
     },
     {
       "kind": "transit",
       "stations": [7, 8],
-      "start": 95.05000000000003,
-      "end": 96.25000000000003,
+      "start": 91.25000000000003,
+      "end": 92.45000000000003,
       "origin": [-120, 0, 0]
     },
     {
       "kind": "station",
       "stations": [8],
-      "start": 96.25000000000003,
-      "end": 106.25000000000003,
+      "start": 92.45000000000003,
+      "end": 102.45000000000003,
       "origin": [-112, 0, 0],
       "tier": "hero"
     },
     {
       "kind": "transit",
       "stations": [8, 9],
-      "start": 106.25000000000003,
-      "end": 107.45000000000003,
+      "start": 102.45000000000003,
+      "end": 103.65000000000003,
       "origin": [-104, 0, 0]
     },
     {
       "kind": "station",
       "stations": [9],
-      "start": 107.45000000000003,
-      "end": 119.60000000000002,
+      "start": 103.65000000000003,
+      "end": 115.80000000000004,
       "origin": [-96, 0, 0],
       "tier": "content"
     },
     {
       "kind": "transit",
       "stations": [9, 10],
-      "start": 119.60000000000002,
-      "end": 120.80000000000003,
+      "start": 115.80000000000004,
+      "end": 117.00000000000004,
       "origin": [-88, 0, 0]
     },
     {
       "kind": "station",
       "stations": [10],
-      "start": 120.80000000000003,
-      "end": 130.85000000000002,
+      "start": 117.00000000000004,
+      "end": 127.05000000000004,
       "origin": [-80, 0, 0],
       "tier": "content"
     },
     {
       "kind": "transit",
       "stations": [10, 11],
-      "start": 130.85000000000002,
-      "end": 132.05,
+      "start": 127.05000000000004,
+      "end": 128.25000000000003,
       "origin": [-72, 0, 0]
     },
     {
       "kind": "station",
       "stations": [11],
-      "start": 132.05,
-      "end": 141.35000000000002,
+      "start": 128.25000000000003,
+      "end": 137.55000000000004,
       "origin": [-64, 0, 0],
       "tier": "content"
     },
     {
       "kind": "transit",
       "stations": [11, 12],
-      "start": 141.35000000000002,
-      "end": 142.55,
+      "start": 137.55000000000004,
+      "end": 138.75000000000003,
       "origin": [-56, 0, 0]
     },
     {
       "kind": "station",
       "stations": [12],
-      "start": 142.55,
-      "end": 149.35000000000002,
+      "start": 138.75000000000003,
+      "end": 145.55000000000004,
       "origin": [-48, 0, 0],
       "tier": "content"
     },
     {
       "kind": "transit",
       "stations": [12, 13],
-      "start": 149.35000000000002,
-      "end": 150.55,
+      "start": 145.55000000000004,
+      "end": 146.75000000000003,
       "origin": [-40, 0, 0]
     },
     {
       "kind": "station",
       "stations": [13],
-      "start": 150.55,
-      "end": 159.85000000000002,
+      "start": 146.75000000000003,
+      "end": 156.05000000000004,
       "origin": [-32, 0, 0],
       "tier": "content"
     },
     {
       "kind": "transit",
       "stations": [13, 14],
-      "start": 159.85000000000002,
-      "end": 161.05,
+      "start": 156.05000000000004,
+      "end": 157.25000000000003,
       "origin": [-24, 0, 0]
     },
     {
       "kind": "station",
       "stations": [14],
-      "start": 161.05,
-      "end": 169.05,
+      "start": 157.25000000000003,
+      "end": 165.25000000000003,
       "origin": [-16, 0, 0],
       "tier": "hero"
     },
     {
       "kind": "transit",
       "stations": [14, 15],
-      "start": 169.05,
-      "end": 170.25,
+      "start": 165.25000000000003,
+      "end": 166.45000000000002,
       "origin": [-8, 0, 0]
     },
     {
       "kind": "station",
       "stations": [15],
-      "start": 170.25,
-      "end": 179.55,
+      "start": 166.45000000000002,
+      "end": 175.75000000000003,
       "origin": [0, 0, 0],
       "tier": "content"
     },
     {
       "kind": "transit",
       "stations": [15, 16],
-      "start": 179.55,
-      "end": 180.75,
+      "start": 175.75000000000003,
+      "end": 176.95000000000002,
       "origin": [8, 0, 0]
     },
     {
       "kind": "station",
       "stations": [16],
-      "start": 180.75,
-      "end": 191.2,
+      "start": 176.95000000000002,
+      "end": 187.4,
       "origin": [16, 0, 0],
       "tier": "content"
     },
     {
       "kind": "transit",
       "stations": [16, 17],
-      "start": 191.2,
-      "end": 192.39999999999998,
+      "start": 187.4,
+      "end": 188.6,
       "origin": [24, 0, 0]
     },
     {
       "kind": "station",
       "stations": [17],
-      "start": 192.39999999999998,
-      "end": 202.84999999999997,
+      "start": 188.6,
+      "end": 199.04999999999998,
       "origin": [32, 0, 0],
       "tier": "content"
     },
     {
       "kind": "transit",
       "stations": [17, 18],
-      "start": 202.84999999999997,
-      "end": 204.04999999999995,
+      "start": 199.04999999999998,
+      "end": 200.24999999999997,
       "origin": [40, 0, 0]
     },
     {
       "kind": "station",
       "stations": [18],
-      "start": 204.04999999999995,
-      "end": 216.14999999999995,
+      "start": 200.24999999999997,
+      "end": 212.34999999999997,
       "origin": [48, 0, 0],
       "tier": "content"
     },
     {
       "kind": "transit",
       "stations": [18, 19],
-      "start": 216.14999999999995,
-      "end": 217.34999999999994,
+      "start": 212.34999999999997,
+      "end": 213.54999999999995,
       "origin": [56, 0, 0]
     },
     {
       "kind": "station",
       "stations": [19],
-      "start": 217.34999999999994,
-      "end": 228.34999999999994,
+      "start": 213.54999999999995,
+      "end": 224.54999999999995,
       "origin": [64, 0, 0],
       "tier": "content"
     },
     {
       "kind": "transit",
       "stations": [19, 20],
-      "start": 228.34999999999994,
-      "end": 229.54999999999993,
+      "start": 224.54999999999995,
+      "end": 225.74999999999994,
       "origin": [72, 0, 0]
     },
     {
       "kind": "station",
       "stations": [20],
-      "start": 229.54999999999993,
-      "end": 235.29999999999993,
+      "start": 225.74999999999994,
+      "end": 231.49999999999994,
       "origin": [80, 0, 0],
       "tier": "content"
     },
     {
       "kind": "transit",
       "stations": [20, 21],
-      "start": 235.29999999999993,
-      "end": 236.49999999999991,
+      "start": 231.49999999999994,
+      "end": 232.69999999999993,
       "origin": [88, 0, 0]
     },
     {
       "kind": "station",
       "stations": [21],
-      "start": 236.49999999999991,
-      "end": 250.79999999999993,
+      "start": 232.69999999999993,
+      "end": 246.99999999999994,
       "origin": [96, 0, 0],
       "tier": "content"
     },
     {
       "kind": "transit",
       "stations": [21, 22],
-      "start": 250.79999999999993,
-      "end": 251.99999999999991,
+      "start": 246.99999999999994,
+      "end": 248.19999999999993,
       "origin": [104, 0, 0]
     },
     {
       "kind": "station",
       "stations": [22],
-      "start": 251.99999999999991,
-      "end": 261.2999999999999,
+      "start": 248.19999999999993,
+      "end": 257.49999999999994,
       "origin": [112, 0, 0],
       "tier": "content"
     },
     {
       "kind": "transit",
       "stations": [22, 23],
-      "start": 261.2999999999999,
-      "end": 262.4999999999999,
+      "start": 257.49999999999994,
+      "end": 258.69999999999993,
       "origin": [120, 0, 0]
     },
     {
       "kind": "station",
       "stations": [23],
-      "start": 262.4999999999999,
-      "end": 272.4999999999999,
+      "start": 258.69999999999993,
+      "end": 268.69999999999993,
       "origin": [128, 0, 0],
       "tier": "content"
     },
     {
       "kind": "transit",
       "stations": [23, 24],
-      "start": 272.4999999999999,
-      "end": 273.6999999999999,
+      "start": 268.69999999999993,
+      "end": 269.8999999999999,
       "origin": [136, 0, 0]
     },
     {
       "kind": "station",
       "stations": [24],
-      "start": 273.6999999999999,
-      "end": 282.1999999999999,
+      "start": 269.8999999999999,
+      "end": 278.3999999999999,
       "origin": [144, 0, 0],
       "tier": "content"
     },
     {
       "kind": "transit",
       "stations": [24, 25],
-      "start": 282.1999999999999,
-      "end": 283.39999999999986,
+      "start": 278.3999999999999,
+      "end": 279.5999999999999,
       "origin": [152, 0, 0]
     },
     {
       "kind": "station",
       "stations": [25],
-      "start": 283.39999999999986,
-      "end": 295.4999999999999,
+      "start": 279.5999999999999,
+      "end": 291.69999999999993,
       "origin": [160, 0, 0],
       "tier": "content"
     },
     {
       "kind": "transit",
       "stations": [25, 26],
-      "start": 295.4999999999999,
-      "end": 296.6999999999999,
+      "start": 291.69999999999993,
+      "end": 292.8999999999999,
       "origin": [168, 0, 0]
     },
     {
       "kind": "station",
       "stations": [26],
-      "start": 296.6999999999999,
-      "end": 305.6999999999999,
+      "start": 292.8999999999999,
+      "end": 301.8999999999999,
       "origin": [176, 0, 0],
       "tier": "hero"
     },
     {
       "kind": "transit",
       "stations": [26, 27],
-      "start": 305.6999999999999,
-      "end": 306.89999999999986,
+      "start": 301.8999999999999,
+      "end": 303.0999999999999,
       "origin": [184, 0, 0]
     },
     {
       "kind": "station",
       "stations": [27],
-      "start": 306.89999999999986,
-      "end": 318.9999999999999,
+      "start": 303.0999999999999,
+      "end": 315.19999999999993,
       "origin": [192, 0, 0],
       "tier": "content"
     },
     {
       "kind": "transit",
       "stations": [27, 28],
-      "start": 318.9999999999999,
-      "end": 320.1999999999999,
+      "start": 315.19999999999993,
+      "end": 316.3999999999999,
       "origin": [200, 0, 0]
     },
     {
       "kind": "station",
       "stations": [28],
-      "start": 320.1999999999999,
-      "end": 325.9499999999999,
+      "start": 316.3999999999999,
+      "end": 322.1499999999999,
       "origin": [208, 0, 0],
       "tier": "content"
     },
     {
       "kind": "transit",
       "stations": [28, 29],
-      "start": 325.9499999999999,
-      "end": 327.14999999999986,
+      "start": 322.1499999999999,
+      "end": 323.3499999999999,
       "origin": [216, 0, 0]
     },
     {
       "kind": "station",
       "stations": [29],
-      "start": 327.14999999999986,
-      "end": 339.2499999999999,
+      "start": 323.3499999999999,
+      "end": 335.44999999999993,
       "origin": [224, 0, 0],
       "tier": "content"
     },
     {
       "kind": "transit",
       "stations": [29, 30],
-      "start": 339.2499999999999,
-      "end": 340.4499999999999,
+      "start": 335.44999999999993,
+      "end": 336.6499999999999,
       "origin": [232, 0, 0]
     },
     {
       "kind": "station",
       "stations": [30],
-      "start": 340.4499999999999,
-      "end": 348.4499999999999,
+      "start": 336.6499999999999,
+      "end": 344.6499999999999,
       "origin": [240, 0, 0],
       "tier": "hero"
     },
@@ -14656,8 +14525,8 @@
         25, 26, 27, 28, 29, 30
       ],
       "anchor": 30,
-      "start": 348.4499999999999,
-      "end": 351.4499999999999
+      "start": 344.6499999999999,
+      "end": 347.6499999999999
     }
   ],
   "defaults": {

--- a/sdf-js/scripts/test-render-matrix.mjs
+++ b/sdf-js/scripts/test-render-matrix.mjs
@@ -88,5 +88,60 @@ ok(renderIR(swot).subjects.length === scene.subjects.length, 'renderIR dispatche
   );
 }
 
+// ---- versus form (2 contenders × ≥3 dimensions → the aisle) -------------------------
+{
+  const vs = {
+    structure: 'matrix',
+    title: '推荐引擎 VS. 搜索引擎',
+    axes: [
+      ['推荐引擎', '搜索引擎'],
+      ['使用频次', '服务方式', '表达门槛', '表达精度'],
+    ],
+    nodes: ['高频', '低频', '主动', '被动', '低', '高', '中等', '高'],
+    cells: [
+      [0, 0],
+      [1, 0],
+      [0, 1],
+      [1, 1],
+      [0, 2],
+      [1, 2],
+      [0, 3],
+      [1, 3],
+    ],
+    emphasis: [0],
+  };
+  const { renderMatrix: rm } = await import('../src/scene/render-matrix.js');
+  const aisle = rm(vs);
+  ok(aisle.name.startsWith('(matrix·versus)'), '2×N comparison renders as the aisle');
+  const panels = aisle.subjects.filter((s) => s.id.startsWith('vs-panel-'));
+  ok(panels.length === 8, 'one panel per cell, both walls');
+  ok(
+    panels.every((s) => Math.abs(Math.abs(s.transform.translate[0]) - 2.35) < 1e-9),
+    'walls face each other across the aisle',
+  );
+  const a0 = panels.find((s) => s.id === 'vs-panel-0-0');
+  const b0 = panels.find((s) => s.id === 'vs-panel-1-0');
+  ok(
+    a0.transform.translate[0] > 0 && b0.transform.translate[0] < 0,
+    'contender 0 on +x (screen-left)',
+  );
+  // the walk: one blend beat per dimension between establishing and super
+  const walk = aisle.cameraSequence.shots.filter((s) => s.transition === 'blend' && !s.beat);
+  ok(walk.length >= vs.axes[1].length, 'camera walks one beat per dimension');
+  const sup = aisle.cameraSequence.shots.find((s) => s.beat === 'super');
+  ok(!!sup && sup.transition === 'cut', 'versus keeps the super punch-in');
+  // text in two places (locked): left column for contender 0, right for 1
+  const sides = aisle.overlay.filter((o) => o.role === 'screen').map((o) => o.side);
+  ok(sides.includes('left') && sides.includes('right'), 'comparison text lives in two columns');
+  try {
+    compile(expandStage(aisle), {});
+    ok(true, 'versus scene compiles');
+  } catch (e) {
+    ok(false, `versus compile failed: ${e.message}`);
+  }
+  // guards: SWOT (2×2) and explicit evolution stay off the aisle
+  ok(!rm(swot).name.includes('versus'), 'SWOT 2×2 stays a quadrant wall');
+}
+
 console.log(`\n${pass} passed, ${fail} failed`);
 process.exit(fail ? 1 : 0);

--- a/sdf-js/scripts/test-render-network.mjs
+++ b/sdf-js/scripts/test-render-network.mjs
@@ -90,6 +90,76 @@ ok(
   }
 }
 
+// ---- flywheel form (form:'cycle') --------------------------------------------------
+{
+  const { flywheelLayout, cycleMembers } = await import('../src/scene/render-network.js');
+  // the 2015 BP p22 shape: engine feeds a 3-node cycle
+  const fly = {
+    structure: 'network',
+    form: 'cycle',
+    title: '推荐引擎加速内容生态效率',
+    nodes: ['推荐引擎', '分发', '互动', '创作'],
+    relations: [
+      [0, 1],
+      [1, 2],
+      [2, 3],
+      [3, 1],
+      [1, 3],
+      [2, 1],
+    ],
+    emphasis: [0],
+  };
+  const inC = cycleMembers(fly);
+  ok(!inC[0] && inC[1] && inC[2] && inC[3], 'cycle members: engine out, loop in');
+  const { ring, centers } = flywheelLayout(fly);
+  ok(ring.join(',') === '1,2,3' && centers.join(',') === '0', 'ring order follows the flow');
+  const scene = renderNetwork(fly);
+  ok(scene.name.startsWith('(network·flywheel)'), 'cycle form renders as flywheel');
+  const hub = scene.subjects.find((s) => s.id === 'fly-hub-0');
+  ok(
+    !!hub &&
+      Math.abs(hub.transform.translate[0]) < 1e-9 &&
+      Math.abs(hub.transform.translate[2]) < 1e-9,
+    'engine stands at the hub',
+  );
+  const ringNodes = scene.subjects.filter((s) => s.id.startsWith('fly-node-'));
+  ok(
+    ringNodes.length === 3 &&
+      ringNodes.every((s) => {
+        const [x, , z] = s.transform.translate;
+        return Math.abs(Math.hypot(x, z) - 2.5) < 1e-6;
+      }),
+    'ring nodes sit on the rim at equal radius',
+  );
+  ok(
+    scene.subjects.filter((s) => s.id.startsWith('fly-arc-')).length === 18 &&
+      scene.subjects.filter((s) => s.id.startsWith('fly-tip-')).length === 9,
+    'directed rim arcs with arrowheads (3 arcs × 6 segs + 3×3 tips)',
+  );
+  const superShot = scene.cameraSequence.shots.find((s) => s.beat === 'super');
+  ok(!!superShot && superShot.transition === 'cut', 'flywheel keeps the super punch-in');
+  ok(scene.subjects.length <= 60, `leaf budget sane (${scene.subjects.length} ≤ 60)`);
+  try {
+    compile(expandStage(scene), {});
+    ok(true, 'flywheel compiles to SDF');
+  } catch (e) {
+    ok(false, `flywheel compile failed: ${e.message}`);
+  }
+  // a cycle too thin for a wheel falls back to the constellation
+  const thin = {
+    ...fly,
+    relations: [
+      [0, 1],
+      [1, 0],
+    ],
+    nodes: ['a', 'b'],
+  };
+  ok(
+    renderNetwork({ ...thin, form: 'cycle' }).name.startsWith('(network)'),
+    'thin cycle falls back',
+  );
+}
+
 // ---- dispatcher -------------------------------------------------------------------
 ok(renderIR(ir).name.startsWith('(network)'), 'renderIR dispatches network');
 

--- a/sdf-js/src/scene/render-matrix.js
+++ b/sdf-js/src/scene/render-matrix.js
@@ -256,6 +256,193 @@ function renderEvolutionForm(ir, env) {
   };
 }
 
+// ---- versus form -----------------------------------------------------------------
+// A two-contender comparison (推荐引擎 VS 搜索引擎, N dimensions) is not a
+// quadrant wall — it's an AISLE. Two walls of panels face each other across a
+// walkway, one dimension per bay, and the camera WALKS the aisle: each step is
+// one dimension's head-to-head. That dolly-through is the read 2D can't do —
+// the page's flat table becomes a corridor of confrontations.
+//   1. establishing — the aisle entrance, both walls converging to the horizon
+//   2. the walk — one beat per dimension, camera advancing bay by bay
+//   3. the SUPER — punch-in on the emphasis panel
+//   4. payoff — high reverse from the far end, the whole corridor in one frame
+function renderVersusForm(ir, env, opts) {
+  const nodes = ir.nodes.map(label);
+  const [xCats, yCats] = ir.axes;
+  const Y = yCats.length;
+  const emphasis = new Set(ir.emphasis && ir.emphasis.length ? ir.emphasis : []);
+  const WALL_X = 2.35; // half-width of the aisle; contender 0 at +x (screen-left)
+  const ROW_GAP = 2.3;
+  const PANEL_Y = 1.75;
+  const rowZ = (yi) => -yi * ROW_GAP;
+  const sideX = (xi) => (xi === 0 ? WALL_X : -WALL_X);
+
+  const subjects = [];
+  // header steles: one per contender at the aisle entrance
+  xCats.forEach((c, xi) => {
+    subjects.push({
+      id: `vs-stele-${xi}`,
+      type: 'rounded_box',
+      args: { dims: [0.5, 2.6, 0.5], cornerR: 0.08 },
+      transform: { translate: [sideX(xi), 1.4, ROW_GAP * 0.8] },
+      material:
+        xi === 0
+          ? {
+              hue: 0.995,
+              sat: 0.8,
+              value: 0.75,
+              glow: 0.1,
+              kind: 'normal',
+              roughness: 0.3,
+              clearcoat: 0.5,
+            }
+          : { hue: 0.6, sat: 0.25, value: 0.35, kind: 'normal', roughness: 0.45, clearcoat: 0.3 },
+    });
+  });
+  // panels: one bay per dimension, both walls
+  // the two walls carry team colors: contender 0 warm, contender 1 cool —
+  // the aisle reads as a confrontation even before any text lands
+  const WALL_MATS = [
+    { hue: 0.07, sat: 0.42, value: 0.78, kind: 'normal', roughness: 0.35, clearcoat: 0.4 },
+    { hue: 0.6, sat: 0.28, value: 0.45, kind: 'normal', roughness: 0.45, clearcoat: 0.3 },
+  ];
+  ir.cells.forEach((c, i) => {
+    const [xi, yi] = c;
+    subjects.push({
+      id: `vs-panel-${xi}-${yi}`,
+      type: 'rounded_box',
+      args: { dims: [0.36, 1.25, 1.65], cornerR: 0.07 },
+      transform: { translate: [sideX(xi), PANEL_Y, rowZ(yi)] },
+      material: emphasis.has(i)
+        ? itemMat(true, opts.accent)
+        : xi === 0 && opts.accent
+          ? itemMat(false, opts.accent)
+          : WALL_MATS[xi],
+    });
+  });
+  // center spine: low guide blocks between bays — the walkway reads as built
+  for (let yi = 0; yi < Y; yi++) {
+    subjects.push({
+      id: `vs-spine-${yi}`,
+      type: 'rounded_box',
+      args: { dims: [0.28, 0.14, 0.28], cornerR: 0.05 },
+      transform: { translate: [0, 0.12, rowZ(yi)] },
+      material: { hue: 0.6, sat: 0.2, value: 0.4, glow: 0.06, kind: 'normal', roughness: 0.6 },
+    });
+  }
+
+  // ---- camera: walk the aisle ---------------------------------------------------
+  const introLead = 1.5;
+  const holdEach = 1.15;
+  const endZ = rowZ(Y - 1);
+  const shots = [
+    // 1 — establishing: entrance, both walls converging
+    {
+      duration: introLead,
+      pos: [0, 2.6, ROW_GAP * 1.9],
+      target: [0, PANEL_Y, endZ * 0.45],
+      fov: 52,
+      aperture: 0.18,
+      focalDistance: ROW_GAP * 2.2,
+      ease: 'out',
+    },
+  ];
+  // 2 — the walk: one beat per dimension bay
+  for (let yi = 0; yi < Y; yi++) {
+    shots.push({
+      duration: holdEach,
+      pos: [0, 2.15, rowZ(yi) + ROW_GAP * 1.35],
+      target: [0, PANEL_Y - 0.1, rowZ(yi) - ROW_GAP * 0.4],
+      fov: 50,
+      transition: 'blend',
+      aperture: 0.3,
+      focalDistance: ROW_GAP * 1.5,
+      ease: 'smooth',
+    });
+  }
+  // 3 — the super: punch-in on the emphasis panel (or contender 0's last bay)
+  const eIdx =
+    ir.emphasis && ir.emphasis.length ? ir.emphasis[0] : ir.cells.findIndex((c) => c[0] === 0);
+  const [exi, eyi] = ir.cells[eIdx] || [0, 0];
+  const superAt = shots.reduce((s, sh) => s + sh.duration, 0);
+  shots.push({
+    duration: 1.0,
+    // three-quarter framing from the aisle, a full bay back — the emphasis
+    // panel reads WITH its opponent across the aisle, not as a wall of paint
+    pos: [sideX(exi) * 0.15, PANEL_Y + 0.5, rowZ(eyi) + 2.9],
+    target: [sideX(exi) * 0.85, PANEL_Y, rowZ(eyi) - 0.3],
+    fov: 46,
+    transition: 'cut',
+    beat: 'super',
+    aperture: [0.8, 0.4],
+    focalDistance: 3.1,
+    shake: [0.4, 0.05],
+    ambient: [0.2, 1.0],
+    exposure: [1.2, 1.0],
+    ease: 'out',
+  });
+  // 4 — payoff: high three-quarter from the entrance, the whole corridor
+  // receding to its vanishing point (the shot the flat table can't make)
+  shots.push({
+    duration: 2.3,
+    pos: [3.4, 5.2, ROW_GAP * (env ? 2.4 * env.payoffZoom : 2.4)],
+    target: [0, PANEL_Y - 0.25, endZ * 0.55],
+    fov: 50,
+    transition: 'blend',
+    aperture: 0.1,
+    focalDistance: Math.abs(endZ) * 0.7 + ROW_GAP * 2.5,
+    ease: 'out',
+  });
+
+  // ---- overlay -------------------------------------------------------------------
+  const overlay = [
+    {
+      text: String(ir.title || 'Versus').toUpperCase(),
+      anchor: [0, 4.6, ROW_GAP * 0.5],
+      role: 'title',
+    },
+  ];
+  xCats.forEach((c, xi) =>
+    overlay.push({
+      text: String(c),
+      anchor: [sideX(xi), 3.1, ROW_GAP * 0.8],
+      role: 'card',
+      align: 'center',
+    }),
+  );
+  yCats.forEach((c, yi) =>
+    overlay.push({
+      text: String(c),
+      anchor: [0, PANEL_Y + 1.05, rowZ(yi)],
+      role: 'card',
+      align: 'center',
+      revealAt: introLead + yi * holdEach + 0.1,
+    }),
+  );
+  // panel texts ride the two narration columns — the comparison's text lives
+  // in TWO places (user-locked 2026-07-15: 对比必须把文本放在两个地方)
+  ir.cells.forEach((c, i) => {
+    const [xi, yi] = c;
+    overlay.push({
+      text: nodes[i],
+      anchor: [sideX(xi), PANEL_Y - 0.85, rowZ(yi)],
+      role: 'screen',
+      side: xi === 0 ? 'left' : 'right',
+      align: 'center',
+      revealAt: introLead + yi * holdEach + 0.25,
+    });
+  });
+
+  return {
+    v: 1,
+    name: `(matrix·versus) ${ir.title || 'versus'}${env ? ' · alpine' : ''}`,
+    subjects: env ? [...subjects, ...env.subjects] : subjects,
+    overlay,
+    cameraSequence: { loop: false, shots, hitstops: [{ at: superAt + 0.02, hold: 0.14 }] },
+    defaults: env ? env.defaults : { stage: { size: [16, 12, Math.max(14, Y * ROW_GAP + 8)] } },
+  };
+}
+
 export function renderMatrix(ir, opts = {}) {
   const v = validateIR(ir);
   if (!v.ok) throw new Error(`renderMatrix: invalid IR — ${v.errors.join('; ')}`);
@@ -263,6 +450,13 @@ export function renderMatrix(ir, opts = {}) {
     throw new Error(`renderMatrix: expected structure 'matrix', got '${ir.structure}'`);
   const env = getEnvironment(opts.env);
   if (ir.form === 'evolution' && ir.axes[0].length === 2) return renderEvolutionForm(ir, env);
+  // versus: explicit form, or the unmistakable shape — exactly 2 contenders
+  // compared across ≥3 dimensions (p5/p6 VS tables). SWOT (2×2) stays a wall.
+  if (
+    (ir.form === 'versus' || (!ir.form && ir.axes[0].length === 2 && ir.axes[1].length >= 3)) &&
+    ir.axes[0].length === 2
+  )
+    return renderVersusForm(ir, env, opts);
 
   const nodes = ir.nodes.map(label);
   const N = nodes.length;

--- a/sdf-js/src/scene/render-network.js
+++ b/sdf-js/src/scene/render-network.js
@@ -140,12 +140,268 @@ const EDGE_MAT = {
   clearcoat: 0.15,
 };
 
+// ---- flywheel form ---------------------------------------------------------------
+// A cycle network (form:'cycle') is not a constellation — it's an ENGINE. The
+// native 3D form is a FLYWHEEL: the cycle members sit on a horizontal ring,
+// directed flow arcs run along the rim with arrowheads, and the non-cycle
+// feeder (the 2015 BP p22's 推荐引擎) stands at the hub driving it. The camera
+// orbits IN the flow direction — the wheel "spins" through parallax while the
+// geometry stays put (STATIC rule, user-locked 2026-07-15).
+
+/** Nodes that can reach themselves = the cycle members (tiny graphs, DFS). */
+export function cycleMembers(ir) {
+  const N = ir.nodes.length;
+  const adj = Array.from({ length: N }, () => []);
+  for (const [a, b] of ir.relations || []) if (a !== b) adj[a].push(b);
+  const reaches = (from, goal) => {
+    const seen = new Set();
+    const stack = [...adj[from]];
+    while (stack.length) {
+      const n = stack.pop();
+      if (n === goal) return true;
+      if (seen.has(n)) continue;
+      seen.add(n);
+      stack.push(...adj[n]);
+    }
+    return false;
+  };
+  return ir.nodes.map((_, i) => reaches(i, i));
+}
+
+/** Ring order: start at the lowest-index member, follow cycle edges. */
+export function flywheelLayout(ir) {
+  const inCycle = cycleMembers(ir);
+  const members = ir.nodes.map((_, i) => i).filter((i) => inCycle[i]);
+  const centers = ir.nodes.map((_, i) => i).filter((i) => !inCycle[i]);
+  const adj = Array.from({ length: ir.nodes.length }, () => []);
+  for (const [a, b] of ir.relations || []) adj[a].push(b);
+  const ring = [];
+  if (members.length) {
+    const seen = new Set();
+    let cur = members[0];
+    while (cur != null && !seen.has(cur)) {
+      ring.push(cur);
+      seen.add(cur);
+      cur = adj[cur].find((n) => inCycle[n] && !seen.has(n));
+    }
+    for (const m of members) if (!seen.has(m)) ring.push(m); // stragglers
+  }
+  return { ring, centers };
+}
+
+function renderFlywheelForm(ir, env, opts) {
+  const nodes = ir.nodes.map(label);
+  const { ring, centers } = flywheelLayout(ir);
+  const M = ring.length;
+  const R = 2.5;
+  const RING_Y = 1.9;
+  const emphasis = new Set(
+    ir.emphasis && ir.emphasis.length ? ir.emphasis : centers.length ? [centers[0]] : [ring[0]],
+  );
+  // ring node angles: index k → around the wheel; -θ so the flow reads
+  // clockwise from the standard high-orbit view (+x is screen-LEFT)
+  const angle = (k) => Math.PI / 2 - (k * 2 * Math.PI) / Math.max(M, 1);
+  const ringPos = ring.map((_, k) => [Math.cos(angle(k)) * R, RING_Y, Math.sin(angle(k)) * R]);
+  const centerPos = centers.map((_, j) => [0, RING_Y + j * 1.3, 0]);
+
+  const pos = new Array(ir.nodes.length);
+  ring.forEach((i, k) => (pos[i] = ringPos[k]));
+  centers.forEach((i, j) => (pos[i] = centerPos[j]));
+
+  const subjects = [];
+  // hub engine(s): bigger, brighter — the thing that drives the wheel
+  centers.forEach((i, j) => {
+    subjects.push({
+      id: `fly-hub-${j}`,
+      type: 'sphere',
+      args: { radius: 0.62 },
+      transform: { translate: centerPos[j] },
+      material: nodeMatN(1, 1, emphasis.has(i), opts.accent),
+    });
+  });
+  ring.forEach((i, k) => {
+    subjects.push({
+      id: `fly-node-${k}`,
+      type: 'sphere',
+      args: { radius: emphasis.has(i) ? 0.5 : 0.42 },
+      transform: { translate: ringPos[k] },
+      material: nodeMatN(2, 2, emphasis.has(i), opts.accent),
+    });
+  });
+  // rim arcs with arrowheads: one directed arc per consecutive ring pair.
+  // Arc = short capsule segments along the circle; arrowhead = 3 shrinking
+  // spheres at the arc's end (analytic tier: no cone primitive, no z-rotation).
+  const SEGS = 6;
+  const arcMat = { ...EDGE_MAT, value: 0.7, glow: 0.14 };
+  for (let k = 0; k < M; k++) {
+    const a0 = angle(k);
+    const a1 = angle(k + 1); // wraps: angle() is linear in k
+    const pad = 0.55 / R; // radians of clearance around each node
+    const from = a0 - pad;
+    const to = a1 + pad;
+    for (let s = 0; s < SEGS; s++) {
+      const t0 = from + ((to - from) * s) / SEGS;
+      const t1 = from + ((to - from) * (s + 1)) / SEGS;
+      const p0 = [Math.cos(t0) * R, RING_Y, Math.sin(t0) * R];
+      const p1 = [Math.cos(t1) * R, RING_Y, Math.sin(t1) * R];
+      subjects.push({
+        id: `fly-arc-${k}-${s}`,
+        type: 'capsule',
+        args: { a: [0, 0, 0], b: [p1[0] - p0[0], 0, p1[2] - p0[2]], radius: 0.055 },
+        transform: { translate: p0 },
+        material: arcMat,
+      });
+    }
+    // arrowhead: 3 shrinking spheres continuing PAST the arc end toward the
+    // destination node (flow direction = decreasing angle)
+    for (let h = 0; h < 3; h++) {
+      const th = to - ((h + 1) * 0.55 * pad) / 3;
+      subjects.push({
+        id: `fly-tip-${k}-${h}`,
+        type: 'sphere',
+        args: { radius: 0.13 - h * 0.035 },
+        transform: { translate: [Math.cos(th) * R, RING_Y, Math.sin(th) * R] },
+        material: arcMat,
+      });
+    }
+  }
+  // spokes: hub → ring relations (thin, faint)
+  const ringSet = new Set(ring);
+  (ir.relations || []).forEach(([a, b], e) => {
+    const hubEnd = !ringSet.has(a) || !ringSet.has(b);
+    if (!hubEnd) return; // rim traffic is already the arcs
+    const pa = pos[a];
+    const pb = pos[b];
+    if (!pa || !pb) return;
+    subjects.push({
+      id: `fly-spoke-${e}`,
+      type: 'capsule',
+      args: { a: [0, 0, 0], b: [pb[0] - pa[0], pb[1] - pa[1], pb[2] - pa[2]], radius: 0.04 },
+      transform: { translate: pa },
+      material: EDGE_MAT,
+    });
+  });
+
+  // ---- camera: five beats, flywheel variation — the orbit FOLLOWS the flow ----
+  const eIdx = [...emphasis][0];
+  const ep = pos[eIdx] || [0, RING_Y, 0];
+  const shots = [
+    // 1 — hero: low at rim level, looking across the wheel at the hub
+    {
+      duration: 1.1,
+      pos: [ringPos[0][0] * 1.5, RING_Y - 0.5, ringPos[0][2] * 1.5 + 1.2],
+      target: [0, RING_Y + 0.2, 0],
+      fov: 54,
+      aperture: 0.5,
+      focalDistance: R * 1.4,
+      ease: 'out',
+    },
+    // 2 — crane out: the whole wheel
+    {
+      duration: 1.3,
+      pos: [0.8, RING_Y + R * 1.5, R * 2.3],
+      target: [0, RING_Y, 0],
+      fov: 46,
+      transition: 'blend',
+      aperture: 0.25,
+      focalDistance: R * 2.6,
+      ease: 'inout',
+    },
+  ];
+  // 3 — flow orbit: circle in the direction the arrows point (θ decreasing),
+  // one beat per ring node — the wheel spins via parallax
+  for (let k = 0; k < Math.max(M, 3); k++) {
+    const th = Math.PI / 2 - ((k + 1) * 2 * Math.PI) / Math.max(M, 3);
+    const dist = R * 2.2;
+    shots.push({
+      duration: 1.15,
+      pos: [Math.cos(th) * dist, RING_Y + R * 1.05, Math.sin(th) * dist],
+      target: [0, RING_Y - 0.15, 0],
+      fov: 45,
+      transition: 'blend',
+      aperture: 0.22,
+      focalDistance: dist,
+      ease: 'smooth',
+    });
+  }
+  // 4 — the super: hard cut punch-in on the engine/emphasis
+  const superAt = shots.reduce((s, sh) => s + sh.duration, 0);
+  shots.push({
+    duration: 1.0,
+    pos: [ep[0] + 0.6, Math.max(ep[1] - 0.05, 0.4), ep[2] + 2.1],
+    target: [ep[0], ep[1] + 0.05, ep[2]],
+    fov: 42,
+    transition: 'cut',
+    beat: 'super',
+    aperture: [0.9, 0.45],
+    focalDistance: 2.2,
+    shake: [0.5, 0.06],
+    ambient: [0.15, 1.0],
+    exposure: [1.2, 1.0],
+    ease: 'out',
+  });
+  // 5 — payoff pull-back: mid crane, the whole engine turning in one frame
+  const payoffDist = (R * 2.9 + 1.2) * (env ? env.payoffZoom : 1);
+  shots.push({
+    duration: 2.4,
+    pos: [1.2, RING_Y + payoffDist * 0.5, payoffDist * 0.9],
+    target: [0, RING_Y - 0.1, 0],
+    fov: 45,
+    transition: 'blend',
+    aperture: 0.12,
+    focalDistance: payoffDist,
+    ease: 'out',
+  });
+
+  const overlay = [
+    {
+      text: String(ir.title || 'Flywheel').toUpperCase(),
+      anchor: [0, RING_Y + R * 1.15 + 0.9, 0],
+      role: 'title',
+    },
+  ];
+  centers.forEach((i, j) => {
+    overlay.push({
+      text: nodes[i],
+      anchor: [0, centerPos[j][1] + 0.95, 0],
+      role: 'card',
+      align: 'center',
+      revealAt: 0.4,
+    });
+  });
+  ring.forEach((i, k) => {
+    const p = ringPos[k];
+    overlay.push({
+      text: nodes[i],
+      anchor: [p[0] * 1.18, p[1] - 0.72, p[2] * 1.18],
+      role: 'card',
+      align: 'center',
+      revealAt: 0.7 + k * 0.25,
+    });
+  });
+  const co = calloutOverlay(ir, superAt);
+  if (co) overlay.push(co);
+
+  return {
+    v: 1,
+    name: `(network·flywheel) ${ir.title || 'cycle'}${env ? ' · alpine' : ''}`,
+    subjects: env ? [...subjects, ...env.subjects] : subjects,
+    overlay,
+    cameraSequence: { loop: false, shots, hitstops: [{ at: superAt + 0.02, hold: 0.14 }] },
+    defaults: env ? env.defaults : { stage: { size: [16, 12, 12] } },
+  };
+}
+
 export function renderNetwork(ir, opts = {}) {
   const v = validateIR(ir);
   if (!v.ok) throw new Error(`renderNetwork: invalid IR — ${v.errors.join('; ')}`);
   if (ir.structure !== 'network')
     throw new Error(`renderNetwork: expected structure 'network', got '${ir.structure}'`);
   const env = getEnvironment(opts.env);
+  if (ir.form === 'cycle' && (ir.relations || []).length >= 3) {
+    const { ring } = flywheelLayout(ir);
+    if (ring.length >= 3) return renderFlywheelForm(ir, env, opts);
+  }
 
   const nodes = ir.nodes.map(label);
   const N = nodes.length;


### PR DESCRIPTION
## 路线图第 3 步(halves → 审计 → **atoms** → stun 视频 → concierge)

两个 atom 都是**契约不变**的渲染分支——同样的 IR,昨天回退到通用星座/平面墙,今天得到原生形态。无新 IR 字段。

### 飞轮环(network·cycle)
- 环成员判定:能到达自身的节点上环,按流向排序;非环节点(p22 的推荐引擎)立于**轮毂**。
- 轮圈上跑**带箭头的有向弧**;镜头**顺流向环绕**——几何静止(STATIC 铁律),轮子靠视差"转"。
- 环 <3 节点自动回退星座;p22 全站 32 subjects,远离编译悬崖。

### 对比夹道(matrix 2×N)
- 双阵营对墙(暖 vs 冷)夹一条走道,一维度一间隔,入口双碑;镜头**逐格走夹道**——平面表格给不出的读法;收官镜头是走廊纵深消失点。
- 触发:显式 form:'versus' 或 2×(≥3) 形状;SWOT(2×2)/evolution 不受影响。
- **真浏览器截图验证**:第一版收官机位穿帮(反打拍成一面白墙),靠截图证据当场重构机位,不靠直觉。

### 旗舰覆盖
p22 飞轮 + p5 夹道自动生效(deck JSON 是 IR,atom 在代码侧,无需重生成)。golden 快照 assemble-deck-2015-theater 重生成——diff 恰好就是这两站的新 subjects。

### 验证
render-network 28/28(新增 7 例)、render-matrix 22/22(新增 9 例)、全套件 164/164;playwright 实机截图确认两形态成像。

🤖 Generated with [Claude Code](https://claude.com/claude-code)