### PR TITLE
A′ 录制门禁:两处上镜缺陷修复 + deck 录制器 + concierge 护栏

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,7 @@ key.txt
 sdf-js/fixtures/pages/
 sdf-js/scenes/ir/*.slides-cache.json
 sdf-js/fixtures/wild/
+# concierge decks: strangers' files never enter the public repo
+sdf-js/scenes/ir/concierge-*
+sdf-js/scenes/assets/concierge-*
+sdf-js/fixtures/pages/concierge-*

--- a/sdf-js/apps/present/figure-core.js
+++ b/sdf-js/apps/present/figure-core.js
@@ -416,8 +416,13 @@ export function createFigure({
       for (const o of stageItems)
         if (o.role === 'title' && o.revealAt <= t + 0.02 && o._ch > curCh) curCh = o._ch;
       // two independent narration columns — each side stacks its own slots so a
-      // comparison page reads as two facing lists, not one merged pile
-      const slots = { left: 0, right: 0 };
+      // comparison page reads as two facing lists, not one merged pile.
+      // Slots advance by MEASURED height, not a fixed 9.5vh: five multi-line
+      // summary bullets overprinted each other at fixed pitch (recording gate,
+      // 2026-07-20 — p8's ①-⑤ column was unreadable on camera).
+      const gapPx = Math.round(window.innerHeight * 0.022);
+      const budgetPx = Math.round(window.innerHeight * 0.68); // column floor ≈ 89vh
+      const bySide = { left: [], right: [] };
       let lastOn = -1;
       for (let i = 0; i < stageItems.length; i++) {
         const o = stageItems[i];
@@ -426,12 +431,34 @@ export function createFigure({
         // seeks honest in both directions.
         const on = o._ch === curCh && o.revealAt <= t + 0.02 && (o.hideAt == null || t < o.hideAt);
         if (o.role === 'screen' && on) {
-          const side = o.side === 'right' ? 'right' : 'left';
-          stageEls[i].style.top = `calc(21vh + ${slots[side]} * 9.5vh)`;
-          slots[side]++;
+          bySide[o.side === 'right' ? 'right' : 'left'].push(i);
           lastOn = i;
+        } else if (o.role === 'screen') {
+          stageEls[i].classList.remove('on');
         }
-        stageEls[i].classList.toggle('on', on);
+        if (o.role !== 'screen') stageEls[i].classList.toggle('on', on);
+      }
+      // Column layout per side: measured heights, oldest lines scroll OFF when
+      // the stack outgrows the viewport budget (a 7-bullet summary page must
+      // keep its CURRENT line on screen — spoken-already lines yield first).
+      for (const side of ['left', 'right']) {
+        const idxs = bySide[side];
+        const hOf = (i) => stageEls[i].offsetHeight || Math.round(window.innerHeight * 0.073);
+        let total = idxs.reduce((s, i) => s + hOf(i) + gapPx, 0);
+        let drop = 0;
+        while (drop < idxs.length - 1 && total > budgetPx) {
+          total -= hOf(idxs[drop]) + gapPx;
+          drop++;
+        }
+        let y = 0;
+        idxs.forEach((i, k) => {
+          const visible = k >= drop;
+          stageEls[i].classList.toggle('on', visible);
+          if (visible) {
+            stageEls[i].style.top = `calc(21vh + ${y}px)`;
+            y += hOf(i) + gapPx;
+          }
+        });
       }
       // The camera and the words move as ONE: the beat the camera is visiting
       // reads at full strength, spoken-already lines fall back. (`cur` is the

--- a/sdf-js/apps/present/landing/index.html
+++ b/sdf-js/apps/present/landing/index.html
@@ -56,6 +56,24 @@
         border-bottom: 1px solid currentColor;
         padding-bottom: 3px;
       }
+      /* concierge CTA: the one clickable .ui element (the class kills pointer
+         events so the canvas owns the stage — the CTA opts back in) */
+      #cta {
+        right: 30px;
+        bottom: 26px;
+        pointer-events: auto;
+        color: #dce6f5;
+        text-decoration: none;
+        font-size: 13px;
+        letter-spacing: 0.1em;
+        border: 1px solid rgba(180, 200, 230, 0.45);
+        padding: 8px 14px;
+        background: rgba(4, 6, 10, 0.55);
+      }
+      #cta:hover {
+        color: #fff;
+        border-color: #fff;
+      }
       #title {
         left: 30px;
         bottom: 12%;
@@ -196,12 +214,24 @@
     </div>
     <div id="title" class="ui">
       <h1>Spatial narrative,<br />not slides.</h1>
-      <p>You describe what you want to say. Atlas renders an <em>immersive 3D deck</em> — structure-aware, camera-driven, generated.</p>
+      <p>
+        You describe what you want to say. Atlas renders an <em>immersive 3D deck</em> —
+        structure-aware, camera-driven, generated.
+      </p>
     </div>
     <div id="enter-hint" class="ui" data-enter>click to enter ▸</div>
+    <a
+      id="cta"
+      class="ui"
+      href="mailto:stormspire100@gmail.com?subject=Atlas%20Present%20%E2%80%94%20my%20deck&body=Attach%20a%20PDF%20deck%20you%20have%20the%20right%20to%20share%20%E2%80%94%20you%20get%20a%20private%2C%20unlisted%203D%20link%20back."
+      >your deck in 3D — send a PDF ▸</a
+    >
     <div id="enter-logo">ATLAS<b>·</b>PRESENT</div>
     <div id="fade"></div>
-    <div id="loading"><div class="brand">ATLAS·PRESENT</div><div class="bar"></div></div>
+    <div id="loading">
+      <div class="brand">ATLAS·PRESENT</div>
+      <div class="bar"></div>
+    </div>
     <script type="module" src="./landing.js"></script>
   </body>
 </html>

--- a/sdf-js/scripts/record-deck.mjs
+++ b/sdf-js/scripts/record-deck.mjs
@@ -1,0 +1,168 @@
+#!/usr/bin/env node
+// =============================================================================
+// record-deck.mjs — play a deck in headless Chrome and capture BOTH:
+//   • gate stills every N seconds (the recording-gate audit frames)
+//   • a full-run MP4 via CDP screencast + ffmpeg-static (raw stun footage)
+// CDP screencast captures the COMPOSITED page — WebGL canvas AND the DOM
+// subtitle system together (canvas.captureStream alone would drop every word).
+//
+// Usage:
+//   node sdf-js/scripts/record-deck.mjs --deck bytedance-bp-2015-auto \
+//     --out <dir> [--layout theater] [--seconds 372] [--fps 18] [--width 1920]
+// =============================================================================
+import { createServer } from 'node:http';
+import { readFileSync, writeFileSync, existsSync, mkdirSync, readdirSync } from 'node:fs';
+import { resolve, extname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { spawnSync } from 'node:child_process';
+import { chromium } from 'playwright-core';
+
+const REPO = fileURLToPath(new URL('../..', import.meta.url));
+const arg = (f, d = null) => {
+  const i = process.argv.indexOf(f);
+  return i > 0 ? process.argv[i + 1] : d;
+};
+const DECK = arg('--deck');
+const OUT = arg('--out');
+const LAYOUT = arg('--layout', 'theater');
+const SECONDS = parseFloat(arg('--seconds', '372'));
+const FPS = parseInt(arg('--fps', '18'), 10);
+const WIDTH = parseInt(arg('--width', '1920'), 10);
+const HEIGHT = Math.round((WIDTH * 9) / 16);
+const STILL_EVERY = parseFloat(arg('--still-every', '10'));
+if (!DECK || !OUT) {
+  console.error('✗ required: --deck <name> --out <dir>');
+  process.exit(1);
+}
+const FRAMES = resolve(OUT, 'frames');
+const STILLS = resolve(OUT, 'gate');
+mkdirSync(FRAMES, { recursive: true });
+mkdirSync(STILLS, { recursive: true });
+
+const CHROME = [
+  'C:/Program Files/Google/Chrome/Application/chrome.exe',
+  'C:/Program Files (x86)/Google/Chrome/Application/chrome.exe',
+  '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
+  '/usr/bin/google-chrome',
+].find((p) => existsSync(p));
+if (!CHROME) {
+  console.error('✗ no Chrome executable found');
+  process.exit(1);
+}
+
+const MIME = {
+  '.html': 'text/html',
+  '.js': 'text/javascript',
+  '.mjs': 'text/javascript',
+  '.json': 'application/json',
+  '.png': 'image/png',
+  '.glb': 'model/gltf-binary',
+};
+const server = createServer((req, res) => {
+  try {
+    const file = resolve(REPO, decodeURIComponent(req.url.split('?')[0]).slice(1));
+    if (!file.startsWith(resolve(REPO))) throw new Error('path escape');
+    res.setHeader('Content-Type', MIME[extname(file)] || 'application/octet-stream');
+    res.end(readFileSync(file));
+  } catch {
+    res.statusCode = 404;
+    res.end('404');
+  }
+});
+await new Promise((r) => server.listen(0, '127.0.0.1', r));
+const PORT = server.address().port;
+
+const browser = await chromium.launch({ executablePath: CHROME, headless: true });
+const page = await browser.newPage({ viewport: { width: WIDTH, height: HEIGHT } });
+page.on('pageerror', (e) => console.error('  [page]', String(e).slice(0, 160)));
+
+const url = `http://127.0.0.1:${PORT}/sdf-js/apps/present/figure.html?deck=${DECK}&layout=${LAYOUT}&fps=0`;
+console.log(`▶ ${url}`);
+console.log(`  ${SECONDS}s @ ~${FPS}fps screencast + stills every ${STILL_EVERY}s → ${OUT}`);
+
+await page.goto(url, { waitUntil: 'domcontentloaded' });
+// The deck HOLDS its clock during shader warm-up (holdDuringWarmup) and the
+// boot overlay gets .done on the first real frame — capture must not start
+// until then, or the film opens on minutes of "warming shaders n/122".
+console.log('  waiting for shader warm-up…');
+await page.waitForSelector('#loading.done', { timeout: 600000 });
+await page.waitForTimeout(500);
+console.log('  warm-up complete, capture begins');
+
+const cdp = await page.context().newCDPSession(page);
+let n = 0;
+let captureStart = 0;
+cdp.on('Page.screencastFrame', async ({ data, sessionId }) => {
+  if (!captureStart) captureStart = Date.now();
+  writeFileSync(
+    resolve(FRAMES, `f-${String(n++).padStart(6, '0')}.jpg`),
+    Buffer.from(data, 'base64'),
+  );
+  try {
+    await cdp.send('Page.screencastFrameAck', { sessionId });
+  } catch {
+    /* teardown race */
+  }
+});
+await cdp.send('Page.startScreencast', {
+  format: 'jpeg',
+  quality: 82,
+  maxWidth: WIDTH,
+  maxHeight: HEIGHT,
+});
+
+const t0 = Date.now();
+let still = 0;
+while ((Date.now() - t0) / 1000 < SECONDS) {
+  const t = (Date.now() - t0) / 1000;
+  const nextStill = still * STILL_EVERY;
+  if (t >= nextStill) {
+    await page.screenshot({
+      path: resolve(STILLS, `t${String(Math.round(nextStill)).padStart(3, '0')}.jpg`),
+      type: 'jpeg',
+      quality: 85,
+    });
+    still++;
+    process.stdout.write(`  still t=${Math.round(nextStill)}s (${n} frames)\r`);
+  }
+  await new Promise((r) => setTimeout(r, 250));
+}
+await cdp.send('Page.stopScreencast').catch(() => {});
+await page.waitForTimeout(400);
+const captureSecs = (Date.now() - captureStart) / 1000;
+await browser.close();
+server.close();
+console.log(`\n✓ ${n} frames over ${captureSecs.toFixed(1)}s, ${still} stills`);
+
+// assemble mp4 at the REAL capture rate (frames ÷ elapsed) so playback runs
+// at true speed — CDP delivers at compositor rate and ignores ack pacing
+const realFps = (n / Math.max(captureSecs, 1)).toFixed(3);
+const ffmpeg = (await import('ffmpeg-static')).default;
+const mp4 = resolve(OUT, `${DECK}-${LAYOUT}.mp4`);
+const r = spawnSync(
+  ffmpeg,
+  [
+    '-y',
+    '-framerate',
+    String(realFps),
+    '-i',
+    resolve(FRAMES, 'f-%06d.jpg'),
+    '-c:v',
+    'libx264',
+    '-pix_fmt',
+    'yuv420p',
+    '-crf',
+    '20',
+    '-movflags',
+    '+faststart',
+    mp4,
+  ],
+  { stdio: ['ignore', 'ignore', 'pipe'] },
+);
+if (r.status === 0) {
+  const frames = readdirSync(FRAMES).length;
+  console.log(`✓ ${mp4} (${frames} frames @ ${realFps}fps ≈ ${captureSecs.toFixed(0)}s real-time)`);
+} else {
+  console.error(`✗ ffmpeg failed: ${String(r.stderr).slice(-400)}`);
+  process.exit(1);
+}

--- a/sdf-js/src/scene/render-magnitude.js
+++ b/sdf-js/src/scene/render-magnitude.js
@@ -452,6 +452,11 @@ function renderGroupedBars(ir, opts, env) {
   for (let i = 0; i < N; i++) for (let s = 0; s < S; s++) mMax = Math.max(mMax, vOf(i, s));
   const emphasisIdx = ir.emphasis && ir.emphasis.length ? ir.emphasis[0] : N - 1;
   const unit = ir.unit ? String(ir.unit) : '';
+  // unitMismatch decks mix unit-scaled series (收入 0.08亿) with raw-count
+  // series (DAU 5,903,383) under ONE ir.unit — suffixing the raw counts
+  // produced "5903383亿" on camera (recording gate, 2026-07-20). A value
+  // already at raw magnitude never takes the scaled unit.
+  const unitFor = (v) => (ir.unitMismatch && Math.abs(v) >= 10000 ? '' : unit);
 
   const BW = 0.66; // bar width
   const BGAP = 0.14; // within-group gap
@@ -517,7 +522,9 @@ function renderGroupedBars(ir, opts, env) {
       const val = vOf(i, s);
       const h = (val / mMax) * H_MAX;
       const txt =
-        i === 0 && series[s]?.label ? `${series[s].label} ${val}${unit}` : `${val}${unit}`;
+        i === 0 && series[s]?.label
+          ? `${series[s].label} ${val}${unitFor(val)}`
+          : `${val}${unitFor(val)}`;
       overlay.push({
         text: txt,
         anchor: [barX(i, s), h + 0.5 + s * 0.02, 0],


### PR DESCRIPTION
## A′ 第一批:门禁审片结果与修复

对旗舰 2015 deck 做了全链录制门禁(6分13秒 theater 全片、38 帧逐站对照源页)。

### 上镜缺陷 ×2,已修
1. **p25 单位后缀灾难**:unitMismatch 站把 `ir.unit` 盖到原始计数系列上 → "年末DAU 5903383亿"。规则:值 ≥10000(已是原始量级)不吃缩放单位;收入系列 0.08亿/2.4亿/15亿 不受影响。
2. **p8 字幕柱重叠**:字幕栏固定 9.5vh 槽距,五条多行总结互相覆盖成一团。改为**实测高度累积**,超出视口预算时**最老的已读行滚出**——当前行永远在屏(7 条长文实机截图验证)。

### 门禁通过项
p9 八配对上镜全对;p16 数字是 count-up 动画落在 IR 真值(⑨⑩ 圈号=诚实占位,设计如此);p5 夹道/p22 飞轮成像良好;finale 干净。记录不拦截:开场机位略平、roadmap 一个标签贴屏边。

### 新工具与护栏
- **scripts/record-deck.mjs**:headless 全 deck 录制——CDP screencast(合成器输出=WebGL+DOM 字幕;canvas 流会丢光所有文字)+ ffmpeg-static 按真实采集率封装 + 定时审片帧;等 `#loading.done`(预热期时钟挂起)再起表。
- **landing CTA**:"your deck in 3D — send a PDF ▸" mailto(内嵌权利+私链措辞)。
- **concierge-* gitignore 三路径**:陌生人的 deck 永不入公开 repo。

### 产出(不入库)
`~/atlas-demo/2015-full/bytedance-bp-2015-auto-theater.mp4`(6分13秒 1080p 母带,修复前版本;merge 后我重录干净版)。

### 验证
164/164;p8/p25 修复均实机截图确认。

🤖 Generated with [Claude Code](https://claude.com/claude-code)