### PR TITLE
chore:抽取/eval 模型钉死到带日期快照(量尺不许浮动)

### DIFF
--- a/sdf-js/scripts/eval-deck-ir.mjs
+++ b/sdf-js/scripts/eval-deck-ir.mjs
@@ -44,7 +44,10 @@ if (!API_KEY) {
   console.error('✗ ANTHROPIC_API_KEY env var required (eval calls the real extractor).');
   process.exit(1);
 }
-const MODEL = process.env.MODEL || 'claude-sonnet-4-5';
+// Pinned to a DATED snapshot: the floating alias drifted overnight 2026-07-20→21
+// and flipped 3 borderline golden pages (p16/p17 extraction, p18/p21 curve reads,
+// d0961 hero-100%) with zero code change — an eval instrument must not float.
+const MODEL = process.env.MODEL || 'claude-sonnet-4-5-20250929';
 const REPO = fileURLToPath(new URL('../..', import.meta.url));
 
 const arg = (flag, dflt = null) => {

--- a/sdf-js/scripts/gen-deck-ir.mjs
+++ b/sdf-js/scripts/gen-deck-ir.mjs
@@ -39,7 +39,10 @@ if (!API_KEY) {
   console.error('✗ ANTHROPIC_API_KEY env var required.');
   process.exit(1);
 }
-const MODEL = process.env.MODEL || 'claude-sonnet-4-5';
+// Pinned to a DATED snapshot: the floating alias drifted overnight 2026-07-20→21
+// and flipped 3 borderline golden pages (p16/p17 extraction, p18/p21 curve reads,
+// d0961 hero-100%) with zero code change — an eval instrument must not float.
+const MODEL = process.env.MODEL || 'claude-sonnet-4-5-20250929';
 const REPO = fileURLToPath(new URL('../..', import.meta.url));
 
 const arg = (flag, dflt = null) => {


### PR DESCRIPTION
昨夜到今晨,浮动别名 claude-sonnet-4-5 的行为漂移让金页在零代码变更下抖动(p16/p17 抽取死循环时隐时现、d0961 hero-100% 翻转)。钉到带日期快照后连续两轮结果逐位一致——量尺恢复可复现。

已知残留红(白天定夺,不在凌晨乱松金页):bp2015 p18/p21 的 curve 检查、d0961 p15 hero-100%。这三个期望现在落在模型读图噪声的错误一侧,选项是松 curve 容差或调 prompt。

MODEL 环境变量仍可覆盖,便于 A/B。167/167。

🤖 Generated with [Claude Code](https://claude.com/claude-code)