### PR TITLE
p4 演进形态:行时代轴转置进 evolution + 时代顺序归一化

### DIFF
--- a/sdf-js/scripts/test-render-matrix.mjs
+++ b/sdf-js/scripts/test-render-matrix.mjs
@@ -163,6 +163,46 @@ ok(renderIR(swot).subjects.length === scene.subjects.length, 'renderIR dispatche
     rm(era).name.startsWith('(matrix·evolution)'),
     'implicit past/present 2×N matrix renders as evolution',
   );
+  // era axis on the ROWS (the flagship p4 shape: axes = [3 dims, [过去,现在]])
+  // transposes into the same evolution branch
+  const eraRows = {
+    structure: 'matrix',
+    title: '推荐引擎开创者',
+    axes: [
+      ['产生和消费方式', '流动方式', '终端'],
+      ['过去', '现在'],
+    ],
+    nodes: ['编辑挑选', '浏览搜索', 'PC', '个性化', '推荐关注', '移动终端'],
+    cells: [
+      [0, 0],
+      [1, 0],
+      [2, 0],
+      [0, 1],
+      [1, 1],
+      [2, 1],
+    ],
+    emphasis: [3],
+  };
+  const evo = rm(eraRows);
+  ok(evo.name.startsWith('(matrix·evolution)'), 'era axis on rows transposes into evolution');
+  // 编辑挑选 (过去) must land as a grounded PAST tablet, 个性化 as a PRESENT orb
+  ok(
+    evo.subjects.some((s) => s.id === 'past-0') && evo.subjects.some((s) => s.id === 'now-3'),
+    'transposed cells keep their era assignment',
+  );
+  // reversed era listing ([现在, 过去]) is normalized, not rendered upside down
+  const revved = {
+    ...era,
+    axes: [['现在', '过去'], era.axes[1]],
+    cells: era.cells.map(([x, y]) => [1 - x, y]),
+  };
+  const evo2 = rm(revved);
+  ok(
+    evo2.name.startsWith('(matrix·evolution)') &&
+      evo2.subjects.some((s) => s.id === 'past-0') ===
+        rm(era).subjects.some((s) => s.id === 'past-0'),
+    'reversed era order normalizes to the same layout',
+  );
 }
 
 console.log(`\n${pass} passed, ${fail} failed`);

--- a/sdf-js/src/scene/render-matrix.js
+++ b/sdf-js/src/scene/render-matrix.js
@@ -454,6 +454,22 @@ function renderVersusForm(ir, env, opts) {
   };
 }
 
+// renderEvolutionForm assumes axes[0] = [past, present] IN THAT ORDER; an
+// extractor that lists [现在, 过去] would render history upside down. Swap
+// the era pair (and flip the matching cell index) when past comes second.
+function normalizeEraOrder(ir) {
+  const [a, b] = ir.axes[0];
+  if (PAST_AXIS_RE.test(String(a)) && !PRESENT_AXIS_RE.test(String(a))) return ir;
+  if (PAST_AXIS_RE.test(String(b)) || !PRESENT_AXIS_RE.test(String(a))) {
+    return {
+      ...ir,
+      axes: [[b, a], ir.axes[1]],
+      cells: ir.cells.map(([x, y]) => [1 - x, y]),
+    };
+  }
+  return ir;
+}
+
 export function renderMatrix(ir, opts = {}) {
   const v = validateIR(ir);
   if (!v.ok) throw new Error(`renderMatrix: invalid IR — ${v.errors.join('; ')}`);
@@ -461,7 +477,18 @@ export function renderMatrix(ir, opts = {}) {
     throw new Error(`renderMatrix: expected structure 'matrix', got '${ir.structure}'`);
   const env = getEnvironment(opts.env);
   if ((ir.form === 'evolution' || (!ir.form && isEraAxis(ir.axes[0]))) && ir.axes[0].length === 2)
-    return renderEvolutionForm(ir, env);
+    return renderEvolutionForm(normalizeEraOrder(ir), env);
+  // era axis on the ROWS (the 2015 flagship p4: axes = [3 dimensions,
+  // [过去, 现在]]) — same evolution read, transposed orientation. Swap axes
+  // and cell coordinates into the branch's expected shape.
+  if (!ir.form && ir.axes[1].length === 2 && isEraAxis(ir.axes[1]) && !isEraAxis(ir.axes[0])) {
+    const t = {
+      ...ir,
+      axes: [ir.axes[1], ir.axes[0]],
+      cells: ir.cells.map(([x, y]) => [y, x]),
+    };
+    return renderEvolutionForm(normalizeEraOrder(t), env);
+  }
   // versus: explicit form, or the unmistakable shape — exactly 2 contenders
   // compared across ≥3 dimensions (p5/p6 VS tables). SWOT (2×2) stays a wall.
   if (


### PR DESCRIPTION
## 旗舰 p4 从矩阵墙升级为专属演进形态

evolution 渲染器(过去石碑 → 现在红球升起 → 左侧大红箭头)早已存在,但 auto deck 的 p4 从未走到它:时代对在 axes[1]([三维度, [过去,现在]]),分支只嗅 axes[0]。本 PR 把**行时代轴矩阵转置**(交换 axes 与 cell 坐标)接入同一分支。

同时补上两条入口都缺的**时代顺序归一化**:抽取器若写成 [现在,过去],旧代码会把历史上下颠倒渲染——normalizeEraOrder 交换时代对并翻转对应 cell 索引。

## 验证
- 实机截图:三石碑(编辑挑选/浏览搜索/PC)+ 三红球(个性化/推荐关注/移动终端)+ 列脚注 + 上升箭头,与源页语法一致;verifyMatrixBindings 修正过的六格落在正确层。
- matrix 单测 26/26(新增 3 例:行轴转置/层归属/倒序归一);套件 168/168;2015-theater golden 重生成(p4 站换形态)。

## 顺带记录
p12(2013)复测:#49 聚类把 OCR 乱字修好(盖/盒手工 → 需手工),但小 Z logo 的竞品绑定第 6 轮依旧——不在任何 demo 路径上,挂账。

🤖 Generated with [Claude Code](https://claude.com/claude-code)