### PR TITLE
feat(present): the theater is the home page — capability menu + brighter screen

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,27 +2,28 @@
 <html lang="en">
 <head>
   <meta charset="utf-8">
-  <title>Atlas — LLM-native illustration platform</title>
-  <meta http-equiv="refresh" content="0; url=./sdf-js/examples/compositor/">
-  <link rel="icon" href="data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'><circle cx='8' cy='8' r='6' fill='%23ffd070'/></svg>">
+  <title>Atlas — spatial narrative, generated</title>
+  <meta http-equiv="refresh" content="0; url=./sdf-js/apps/present/landing/index.html">
+  <link rel="icon" href="data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'><circle cx='8' cy='8' r='6' fill='%236fb6ff'/></svg>">
   <style>
     body {
-      margin: 0; font-family: -apple-system, system-ui, sans-serif;
-      background: #0d0d0d; color: #ccc; min-height: 100vh;
+      margin: 0; font-family: ui-monospace, 'SF Mono', Menlo, monospace;
+      background: #04060a; color: #cfe0f5; min-height: 100vh;
       display: flex; align-items: center; justify-content: center; flex-direction: column;
-      text-align: center; padding: 40px;
+      text-align: center; padding: 40px; letter-spacing: 0.06em;
     }
-    h1 { color: #ffd070; margin: 0 0 12px; font-size: 32px; }
-    p  { color: #aaa; margin: 0 0 24px; max-width: 480px; line-height: 1.5; }
+    h1 { color: #eaf2ff; margin: 0 0 12px; font-size: 26px; letter-spacing: 0.24em; font-weight: 600; }
+    p  { color: #7f93ac; margin: 0 0 24px; max-width: 480px; line-height: 1.6; }
     a {
-      padding: 12px 24px; background: #ffd070; color: #1a1a1a;
-      border-radius: 4px; text-decoration: none; font-weight: 600;
+      padding: 11px 22px; background: transparent; color: #cfe0f5;
+      border: 1px solid rgba(180, 200, 230, 0.4); border-radius: 3px;
+      text-decoration: none; font-weight: 600; letter-spacing: 0.14em; text-transform: uppercase;
     }
   </style>
 </head>
 <body>
-  <h1>Atlas</h1>
-  <p>LLM-native illustration platform. Loading the Compositor…</p>
-  <a href="./sdf-js/examples/compositor/">→ Open Compositor</a>
+  <h1>ATLAS·PRESENT</h1>
+  <p>Entering the theater…</p>
+  <a href="./sdf-js/apps/present/landing/index.html">Enter ▸</a>
 </body>
 </html>

--- a/sdf-js/apps/present/landing/index.html
+++ b/sdf-js/apps/present/landing/index.html
@@ -238,6 +238,7 @@
       <a href="../../../examples/mvp/index.html" title="Type any text → a 2D SDF illustration">Illustrate</a>
       <a href="../../../examples/compositor/index.html" title="Fly through pre-built 3D scenes — no key needed">Gallery</a>
       <a href="../../fourd/index.html" title="A 4D SDF playground">4D</a>
+      <a href="../../../examples/index.html" title="BOB, generative renders &amp; SDF art-style experiments">Art</a>
       <a href="https://github.com/shaun8149/sdf-js" target="_blank" rel="noopener">Source</a>
     </nav>
     <div id="title" class="ui">

--- a/sdf-js/apps/present/landing/index.html
+++ b/sdf-js/apps/present/landing/index.html
@@ -42,19 +42,42 @@
         color: #fff;
       }
       #nav {
-        top: 32px;
+        top: 28px;
         right: 30px;
-        font-size: 13px;
-        letter-spacing: 0.12em;
-        opacity: 0.62;
+        display: flex;
+        align-items: center;
+        gap: 22px;
+        font-size: 12.5px;
+        letter-spacing: 0.13em;
+        pointer-events: auto; /* the capability menu is clickable (overrides .ui) */
       }
-      #nav span {
-        margin-left: 26px;
-      }
-      #nav .on {
-        opacity: 1;
-        border-bottom: 1px solid currentColor;
+      #nav a {
+        color: rgba(210, 224, 245, 0.6);
+        text-decoration: none;
+        text-transform: uppercase;
         padding-bottom: 3px;
+        border-bottom: 1px solid transparent;
+        transition:
+          color 0.22s ease,
+          border-color 0.22s ease;
+      }
+      #nav a:hover {
+        color: #eaf2ff;
+        border-bottom-color: rgba(111, 182, 255, 0.9);
+      }
+      #nav a.primary {
+        color: #eaf2ff;
+      }
+      #nav a.primary::before {
+        content: '';
+        display: inline-block;
+        width: 6px;
+        height: 6px;
+        margin-right: 8px;
+        border-radius: 50%;
+        background: #6fb6ff;
+        box-shadow: 0 0 8px rgba(111, 182, 255, 0.9);
+        vertical-align: middle;
       }
       /* concierge CTA: the one clickable .ui element (the class kills pointer
          events so the canvas owns the stage — the CTA opts back in) */
@@ -209,9 +232,14 @@
   <body>
     <canvas id="c-landing"></canvas>
     <div id="logo" class="ui">ATLAS<b>:</b>PRESENT</div>
-    <div id="nav" class="ui">
-      <span class="on">Home</span><span>Gallery</span><span>Editor</span><span>About</span>
-    </div>
+    <nav id="nav" class="ui">
+      <a href="../author-2d.html" class="primary" title="Type any text → a slide deck (PPTX / PDF)">Make a deck</a>
+      <a href="../author.html" title="Type any text → an immersive 3D world">3D&nbsp;world</a>
+      <a href="../../../examples/mvp/index.html" title="Type any text → a 2D SDF illustration">Illustrate</a>
+      <a href="../../../examples/compositor/index.html" title="Fly through pre-built 3D scenes — no key needed">Gallery</a>
+      <a href="../../fourd/index.html" title="A 4D SDF playground">4D</a>
+      <a href="https://github.com/shaun8149/sdf-js" target="_blank" rel="noopener">Source</a>
+    </nav>
     <div id="title" class="ui">
       <h1>Spatial narrative,<br />not slides.</h1>
       <p>

--- a/sdf-js/apps/present/landing/landing.js
+++ b/sdf-js/apps/present/landing/landing.js
@@ -13,7 +13,6 @@
 
 import * as THREE from 'https://esm.sh/three@0.160.0';
 import { Reflector } from 'https://esm.sh/three@0.160.0/examples/jsm/objects/Reflector.js';
-import { GLTFLoader } from 'https://esm.sh/three@0.160.0/examples/jsm/loaders/GLTFLoader.js';
 import { EffectComposer } from 'https://esm.sh/three@0.160.0/examples/jsm/postprocessing/EffectComposer.js';
 import { RenderPass } from 'https://esm.sh/three@0.160.0/examples/jsm/postprocessing/RenderPass.js';
 import { UnrealBloomPass } from 'https://esm.sh/three@0.160.0/examples/jsm/postprocessing/UnrealBloomPass.js';
@@ -129,9 +128,9 @@ for (const x of [-6, 6]) {
 // floor — CineShader-style reflection: a real mirror of the screen, but DIM
 // (dark tint) so it reads as a subtle wet-floor reflection, not a bright mirror.
 const floor = new Reflector(new THREE.PlaneGeometry(ROOM_W, ROOM_D), {
-  textureWidth: 1024,
-  textureHeight: 1024,
-  color: 0x13171f,
+  textureWidth: 2048,
+  textureHeight: 2048,
+  color: 0x0b0e14, // darker tint → subtle wet sheen, not a bright mirror
 });
 floor.rotation.x = -Math.PI / 2;
 floor.position.set(0, 0, BACK + ROOM_D / 2);
@@ -167,12 +166,12 @@ const SCREEN_FRAG = `
   vec3 getNormal(vec3 p,float eps){ vec3 n; n.y=map_detailed(p); n.x=map_detailed(vec3(p.x+eps,p.y,p.z))-n.y; n.z=map_detailed(vec3(p.x,p.y,p.z+eps))-n.y; n.y=eps; return normalize(n); }
   float heightMapTracing(vec3 ori,vec3 dir,out vec3 p){ float tm=0.0; float tx=1000.0; float hx=map(ori+dir*tx); if(hx>0.0){ p=ori+dir*tx; return tx; } float hm=map(ori); float tmid=0.0; for(int i=0;i<NUM_STEPS;i++){ tmid=mix(tm,tx,hm/(hm-hx)); p=ori+dir*tmid; float hmid=map(p); if(hmid<0.0){ tx=tmid; hx=hmid; } else { tm=tmid; hm=hmid; } } return tmid; }
   vec3 getPixel(in vec2 coord, float time){ vec2 uv=coord/iResolution.xy; uv=uv*2.0-1.0; uv.x*=iResolution.x/iResolution.y; vec3 ang=vec3(sin(time*3.0)*0.1,sin(time)*0.2+0.3,time); vec3 ori=vec3(0.0,3.5,time*5.0); vec3 dir=normalize(vec3(uv.xy,-2.0)); dir.z+=length(uv)*0.14; dir=normalize(dir)*fromEuler(ang); vec3 p; heightMapTracing(ori,dir,p); vec3 dist=p-ori; vec3 n=getNormal(p,dot(dist,dist)*(0.1/iResolution.x)); vec3 light=normalize(vec3(0.0,1.0,0.8)); return mix(getSkyColor(dir),getSeaColor(p,n,light,dir,dist),pow(smoothstep(0.0,-0.02,dir.y),0.2)); }
-  void main(){ vec2 fragCoord=vUv*iResolution.xy; float time=iTime*0.3; vec3 color=getPixel(fragCoord,time); color=pow(color,vec3(0.65)); gl_FragColor=vec4(color*0.92,1.0); }`;
+  void main(){ vec2 fragCoord=vUv*iResolution.xy; float time=iTime*0.3; vec3 color=getPixel(fragCoord,time); color=pow(color,vec3(0.62)); color*=1.14; color=mix(color, smoothstep(vec3(0.0),vec3(1.0),color), 0.18); gl_FragColor=vec4(color,1.0); }`;
 // Render the screen shader ONCE per frame to a fixed low-res offscreen target —
 // cost is independent of screen size / DPR. The screen (and the 片头) then just
 // sample this texture (cheap). This is the pattern for ANY renderer on the screen.
-const RT_W = 896,
-  RT_H = 504;
+const RT_W = 1600,
+  RT_H = 900;
 const shaderRT = new THREE.WebGLRenderTarget(RT_W, RT_H, { minFilter: THREE.LinearFilter });
 const fxScene = new THREE.Scene();
 const fxCam = new THREE.OrthographicCamera(-1, 1, 1, -1, 0, 1);
@@ -184,9 +183,9 @@ const fxMat = new THREE.ShaderMaterial({
 fxScene.add(new THREE.Mesh(new THREE.PlaneGeometry(2, 2), fxMat));
 
 const screenMat = new THREE.MeshBasicMaterial({ map: shaderRT.texture });
-const SCREEN_W = 10.6,
-  SCREEN_H = 5.96,
-  SCREEN_Y = 3.4;
+const SCREEN_W = 12.8,
+  SCREEN_H = 7.2,
+  SCREEN_Y = 3.7;
 const screen = new THREE.Mesh(new THREE.PlaneGeometry(SCREEN_W, SCREEN_H), screenMat);
 screen.position.set(0, SCREEN_Y, BACK + 0.06);
 scene.add(screen);
@@ -243,34 +242,11 @@ for (const sx of [-1, 1]) {
 // figure. So we DON'T animate: we pose the bind T-pose into a natural relaxed
 // stance by rotating the upper-arm (and a touch of forearm) bones down to the
 // sides. (Skinned-mesh Box3 is unreliable → fixed scale.)
+// Human silhouette temporarily DISABLED. The Mixamo Michelle skinned mesh reads
+// as a broken mannequin once scaled up (arms splay, head/shoulders collapse) and
+// posing skinned bones reliably is fragile. TODO: re-add a clean standing
+// silhouette (custom extruded shape or a fixed-pose GLB) off to the left third.
 const mixer = null;
-new GLTFLoader().load(
-  './Michelle.glb',
-  (gltf) => {
-    const m = gltf.scene;
-    m.scale.setScalar(1.05); // ~1.7 m
-    m.traverse((o) => {
-      if (o.isMesh) {
-        o.material = mat(0x03050c, 0.96);
-        o.frustumCulled = false;
-      }
-      if (o.isBone) {
-        const n = o.name;
-        if (/LeftArm$/.test(n))
-          o.rotation.z = -1.25; // drop left upper arm
-        else if (/RightArm$/.test(n))
-          o.rotation.z = 1.25; // drop right upper arm
-        else if (/LeftForeArm$/.test(n)) o.rotation.z = -0.2;
-        else if (/RightForeArm$/.test(n)) o.rotation.z = 0.2;
-      }
-    });
-    m.position.set(-2.4, 0, BACK + 8.5); // farther from the screen (more toward room centre)
-    m.rotation.y = Math.PI; // back to camera, facing the screen
-    scene.add(m);
-  },
-  undefined,
-  (err) => console.warn('[landing] model load failed', err),
-);
 
 for (const [x, z, s] of [
   [-9.5, BACK + 5, 1.1],
@@ -379,7 +355,7 @@ scene.add(new THREE.HemisphereLight(0x40597a, 0x080c12, 1.7)); // room (incl. si
 // ---- post: bloom + grade --------------------------------------------------
 const composer = new EffectComposer(renderer);
 composer.addPass(new RenderPass(scene, camera));
-composer.addPass(new UnrealBloomPass(new THREE.Vector2(W(), H()), 0.42, 0.6, 0.9));
+composer.addPass(new UnrealBloomPass(new THREE.Vector2(W(), H()), 0.62, 0.72, 0.82));
 composer.addPass(new OutputPass());
 const gradePass = new ShaderPass({
   uniforms: { tDiffuse: { value: null }, uTime: { value: 0 } },

--- a/sdf-js/examples/index.html
+++ b/sdf-js/examples/index.html
@@ -3,137 +3,181 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>sdf-js</title>
+    <title>sdf-js · art &amp; experiments</title>
     <link rel="stylesheet" href="./style.css" />
   </head>
   <body>
     <div class="page">
       <nav class="topnav">
         <a class="brand" href="./index.html">sdf-js</a>
+        <a href="../apps/present/landing/index.html">← home</a>
         <a href="https://github.com/shaun8149/sdf-js" target="_blank">source</a>
       </nav>
 
-      <h1><em>Composable</em> signed distance functions.</h1>
+      <h1><em>Generative</em> work, in signed distance fields.</h1>
       <p class="tagline">
-        A JavaScript port and extension of <a href="https://github.com/fogleman/sdf">fogleman/sdf</a>.
-        Form, generator, render — orthogonal layers meeting through
-        <code>(x, y) → number</code>. SDF is one such field; Perlin noise and proto field are siblings.
+        The playground behind Atlas — the generative renderer <strong>BOB</strong>, a shelf of
+        art-style renders, and LLM-written sketches, all built on the same form language:
+        <code>(x, y) → number</code>. Not the product; the play.
       </p>
 
-      <h2>Form</h2>
+      <h2>BOB &amp; generative</h2>
       <p class="layer-note">
-        SDF primitives, booleans, transforms; the algebra everything else consumes.
-        Sibling field families live in <code>field/</code> (Perlin noise, proto, combinators).
+        BOB — the generative GPU renderer — and the systems that feed it. Same seed, same world,
+        shareable by URL.
+      </p>
+      <ul class="work-list">
+        <li>
+          <span class="title"><a href="./sdf/autoscope-clone.html">autoscope · BOB</a></span>
+          <span class="desc"
+            >BOB GPU across six scene templates — city / sea / forest / village / city-axis /
+            abstract. Autoscope-style: same hash → same scene → a link you can share.</span
+          >
+        </li>
+        <li>
+          <span class="title"><a href="./sdf/scenedata-demo.html">scenedata-demo</a></span>
+          <span class="desc"
+            >Paste SceneData JSON → compile → BOB GPU. Sphere/ground, repetition + animation, and a
+            full autoscope-style scene (camera dolly, waves, hue-shifted shadow).</span
+          >
+        </li>
+        <li>
+          <span class="title"
+            ><a href="./sdf/shader-lambert-browser.html">shader-lambert-browser</a></span
+          >
+          <span class="desc"
+            >Fly through eight preset SDFs — WASD pointer-lock, compiled to WebGL Lambert at
+            60fps.</span
+          >
+        </li>
+      </ul>
+
+      <h2>Renderers &amp; art styles</h2>
+      <p class="layer-note">
+        One distance field, many hands. The same SDFs drawn as silhouette, brushstroke, sand,
+        hatching, and shader.
       </p>
       <ul class="work-list">
         <li>
           <span class="title"><a href="./sdf/render-showcase.html">render-showcase</a></span>
-          <span class="desc">Four renderers — silhouette, bands, sand, painted — over the same SDFs.</span>
-        </li>
-        <li>
-          <span class="title"><a href="./sdf/2d.html">2d</a></span>
-          <span class="desc">Distance-field visualisation: blue inside, red outside, periodic bands, zero-isoline.</span>
-        </li>
-        <li>
-          <span class="title"><a href="./sdf/3d.html">3d</a></span>
-          <span class="desc">Pure-JS raymarching grid; one chainable expression per panel.</span>
-        </li>
-        <li>
-          <span class="title"><a href="./compositor/">compositor · Atlas v0</a></span>
-          <span class="desc">M1 Atlas Compositor — 4-input-tab UI (text / generator / 2d-edit / 3d-edit) converging to SceneData v1 → shared renderer pool. Day 1 shell. text-tab will absorb MVP (Day 2), generator-tab will absorb autoscope-clone (Day 3).</span>
-        </li>
-        <li>
-          <span class="title"><a href="./mvp/">mvp · text → SDF</a></span>
-          <span class="desc">Type a prompt → Anthropic Claude writes JS SDF code → live render. 6 renderers × 5 patterns × 2D/3D selectable. SVG export. The flagship LLM-native creative app.</span>
-        </li>
-        <li>
-          <span class="title"><a href="./sdf/autoscope-clone.html">autoscope-clone</a></span>
-          <span class="desc">6 generative scene templates (city / sea / forest / village / city-axis / abstract) × BOB GPU shader. Erik Swahn Autoscope reimagined: same hash = same scene = shareable URL.</span>
-        </li>
-        <li>
-          <span class="title"><a href="./sdf/scenedata-demo.html">scenedata-demo</a></span>
-          <span class="desc">M0 validation: paste/load SceneData v1 JSON → compile() → BOB GPU. End-to-end proof the spec produces renderable scenes. 3 samples cover sphere/ground, rep+animation, full autoscope-style (camera dolly + waves + hue-shifted shadow).</span>
-        </li>
-        <li>
-          <span class="title"><a href="./sdf/shader-lambert-browser.html">shader-lambert-browser</a></span>
-          <span class="desc">Standalone Fly 3D scene browser — WASD pointer-lock + 8 preset SDFs compiled to WebGL Lambert at 60fps.</span>
+          <span class="desc"
+            >Four renderers — silhouette, bands, sand, painted — over the same SDFs. The overview
+            plate.</span
+          >
         </li>
         <li>
           <span class="title"><a href="./sdf/painted-scenes.html">painted-scenes</a></span>
-          <span class="desc">16 scenes rendered as gridded brushstrokes (Tyler Hobbs / kjetil-style). 2D + 3D via probe.</span>
+          <span class="desc"
+            >Sixteen scenes as gridded brushstrokes, in the lineage of Tyler Hobbs and kjetil
+            golid.</span
+          >
         </li>
         <li>
           <span class="title"><a href="./sdf/streamline-scenes.html">streamline-scenes</a></span>
-          <span class="desc">Contour-following hatching (2D analog of Pasma rayhatching) across 14 scenes.</span>
-        </li>
-        <li>
-          <span class="title"><a href="./sdf/test-pasma-capsules.html">test-pasma-capsules</a></span>
-          <span class="desc">Pasma-style 3D surface-aware rayhatching on SDF3 capsules — intensity-modulated dsep + region mask.</span>
+          <span class="desc">Contour-following hatching across fourteen scenes.</span>
         </li>
         <li>
           <span class="title"><a href="./sdf/scenes-sand.html">scenes-sand</a></span>
-          <span class="desc">Same scenes as sand-painting: cumulative random sampling, three-tier colouring.</span>
+          <span class="desc">Sand-painting: cumulative random sampling, three-tier colouring.</span>
         </li>
         <li>
-          <span class="title"><a href="./sdf/scenes-debug.html">scenes-debug</a></span>
-          <span class="desc">Silhouette debug view across all scenes; useful when authoring new SDFs.</span>
-        </li>
-        <li>
-          <span class="title"><a href="./sdf/llm-round1.html">llm-round1</a></span>
-          <span class="desc">LLM × SDF round 1 (minimal-context prompt): 7 scenes, bugs preserved as essay material.</span>
-        </li>
-        <li>
-          <span class="title"><a href="./sdf/test-torso.html">test-torso</a></span>
-          <span class="desc">Back-view female torso polygon. Toggle outline (shell+intersection) vs hatch (streamline).</span>
+          <span class="title"><a href="./sdf/test-pasma-capsules.html">pasma-capsules</a></span>
+          <span class="desc"
+            >Surface-aware 3D rayhatching on SDF capsules — intensity-modulated line spacing.</span
+          >
         </li>
         <li>
           <span class="title"><a href="./sdf/cactus-shader.html">cactus-shader</a></span>
-          <span class="desc">The cactus scene as a fragment shader — same SDF, GLSL compilation path.</span>
+          <span class="desc">The cactus scene compiled to a single GLSL fragment shader.</span>
         </li>
         <li>
           <span class="title"><a href="./sdf/cactus-sand-shader.html">cactus-sand-shader</a></span>
-          <span class="desc">Sand-painting style implemented entirely in a shader.</span>
+          <span class="desc">Sand-painting, done entirely in the shader.</span>
+        </li>
+        <li>
+          <span class="title"><a href="./sdf/test-torso.html">torso</a></span>
+          <span class="desc"
+            >A back-view torso in polygons — toggle outline against streamline hatch.</span
+          >
         </li>
       </ul>
 
-      <h2>Generator</h2>
+      <h2>LLM × SDF</h2>
       <p class="layer-note">
-        Discrete structure generators that consume an SDF as an <code>isInside</code> predicate.
+        A language model, asked for a short noun phrase, writing the scene as code. Some land, some
+        break beautifully.
+      </p>
+      <ul class="work-list">
+        <li>
+          <span class="title"><a href="./mvp/">text → SDF</a></span>
+          <span class="desc"
+            >Type a prompt → Claude writes JS SDF code → live render. Six renderers × five patterns,
+            2D/3D, SVG export.</span
+          >
+        </li>
+        <li>
+          <span class="title"><a href="./sdf/test-tree-v2.html">tree</a></span>
+          <span class="desc">Round two — a tree, written from a two-word prompt.</span>
+        </li>
+        <li>
+          <span class="title"><a href="./sdf/test-cathedral-v2.html">cathedral</a></span>
+          <span class="desc">Round two — arches and light.</span>
+        </li>
+        <li>
+          <span class="title"><a href="./sdf/test-butterfly-v2.html">butterfly</a></span>
+          <span class="desc">Round two — symmetry from a single word.</span>
+        </li>
+        <li>
+          <span class="title"><a href="./sdf/test-seurat-v2.html">seurat</a></span>
+          <span class="desc">Round two — pointillism, in distance fields.</span>
+        </li>
+        <li>
+          <span class="title"><a href="./sdf/llm-round1.html">round 1</a></span>
+          <span class="desc"
+            >The first pass — seven scenes, bugs kept as they were, as essay material.</span
+          >
+        </li>
+      </ul>
+
+      <h2>Fields, cellular, tiles</h2>
+      <p class="layer-note">
+        The other form families — Perlin noise, cellular automata, plotter tiles — in the lineage of
+        Harvey Rayner and Vera Molnár.
       </p>
       <ul class="work-list">
         <li>
           <span class="title"><a href="./ca/ca.html">ca</a></span>
-          <span class="desc">Cellular automaton (kjetil golid's Apparatus) running on any SDF; static.</span>
+          <span class="desc">kjetil golid's Apparatus, running on any SDF.</span>
         </li>
         <li>
           <span class="title"><a href="./ca/ca-animate.html">ca-animate</a></span>
-          <span class="desc">Scatter-then-assemble animation of the same CA grid.</span>
+          <span class="desc">The same grid, scattered then assembled.</span>
         </li>
-      </ul>
-
-      <h2>Flow</h2>
-      <p class="layer-note">
-        Streamline generators on scalar/vector fields. <code>field</code> as the form layer,
-        <code>streamline</code> as the path generator, <code>render.flowLines</code> as the renderer.
-      </p>
-      <ul class="work-list">
         <li>
           <span class="title"><a href="./flow/noise-curves.html">noise-curves</a></span>
-          <span class="desc">Perlin noise flow field + dense-packed streamlines. Phase A minimum pipeline.</span>
+          <span class="desc">A Perlin flow field, densely packed with streamlines.</span>
+        </li>
+        <li>
+          <span class="title"><a href="./tile/alice.html">alice</a></span>
+          <span class="desc"
+            >Proto field × line-clipped tile fill × generative palette, oscillating through a
+            stereographic projection.</span
+          >
+        </li>
+        <li>
+          <span class="title"><a href="./sdf/2d.html">2d</a></span>
+          <span class="desc">The raw distance field — blue inside, red outside, banded.</span>
+        </li>
+        <li>
+          <span class="title"><a href="./sdf/3d.html">3d</a></span>
+          <span class="desc">Pure-JS raymarching, one chainable expression per panel.</span>
         </li>
       </ul>
 
-      <h2>Tile</h2>
-      <p class="layer-note">
-        Halftone / plotter paradigm: regular grid, each cell drawn from field samples.
-        Lineage of Harvey Rayner, Vera Molnar.
+      <p class="tagline" style="margin-top: 56px">
+        Built on a JavaScript port of <a href="https://github.com/fogleman/sdf">fogleman/sdf</a>.
+        Form, generator, render — orthogonal layers meeting through <code>(x, y) → number</code>.
       </p>
-      <ul class="work-list">
-        <li>
-          <span class="title"><a href="./tile/alice.html">alice</a></span>
-          <span class="desc">Proto field × line-clipped tile fill × generative palette. Stereographic-projection oscillation.</span>
-        </li>
-      </ul>
     </div>
   </body>
 </html>


### PR DESCRIPTION
## What

The Present **theater** is now Atlas's home page, and it surfaces every capability as a menu.

- **Home page** — repo-root \`index.html\` now enters the cinematic theater (\`apps/present/landing/\`) instead of redirecting to the Compositor.
- **Capability menu** — the theater's nav is now real, clickable links, wired to the existing apps:
  - **Make a deck** → text → 2D deck (PPTX / PDF)
  - **3D world** → text → immersive 3D world
  - **Illustrate** → text → 2D SDF illustration
  - **Gallery** → fly through pre-lifted scenes (no key needed)
  - **4D** → the 4D SDF toy
  - **Source** → GitHub
- **Screen polish (Pass 1 toward CineShader)** — brighter output, render target 896×504 → 1600×900, stronger bloom, darker / subtler wet-floor reflection.
- **Removed** the Mixamo silhouette (rendered as a broken mannequin once scaled up); a clean standing figure is a TODO.

## Verified
Rendered in Playwright (GPU / WebGL2): the screen glows and dominates the frame; all six menu links resolve to the correct app entry points.

## Not in this PR (follow-ups)
- Visual polish: oblique composition, depth-of-field, atmosphere, a clean human silhouette.
- The art / playground entries (BOB, art-style renderings) and a refreshed examples index.

🤖 Generated with [Claude Code](https://claude.com/claude-code)