### PR TITLE
DIMENSION 3D扩容+配比卷 sdf-main 侧收卷 — style-plan 全表 + §0.6 + dodecahedron 勘误

### DIFF
--- a/docs/AGENT_HANDOFF.md
+++ b/docs/AGENT_HANDOFF.md
@@ -145,9 +145,11 @@ sha256+manifest 三处统一）/I2（票①② 基线常设锁，变异必红）
 （sierpinski 入池 2%／mandelbulb 82.9s=4.3x 最重基线判死降级权 0；确立 **vm 自然流保真纪律**：任何
 自然 hash 猎手必须逐行镜像浏览器 setSeed+pal/pal2+shuf 全消费）；T5 填充八件（扭塔/弯月柱 →
 SOLID_POOL 16，组合六件 → SCULPT_POOL 16）——主件终态**五分路由** 47/21/17/15 draft ×(1−0.02) +
-分形带 2%（呈裁）。T6 收卷：**600-hash 真浏览器体检 0/600 废片**（六判据全零；tier 落点
-84.8/5.8/8.5/0.8 χ²=1.28 PASS；forced-600 保真流扫掠五分路由 χ²=4.70 PASS，24 件新内容各 ≥5 次
-自然命中）+ 指纹重基线 12 枚（`test/evidence/task6-expand-rebaseline/`）+ batch19 24 枚全自然样张
+分形带 2%（呈裁）。T6 收卷：**600-hash 真浏览器体检 0/600 废片**（判据七桶全零；措辞收窄（终审
+I3）：系**渲染健康度体检**——黑屏/纯色/近空对本管线结构性难触发，不构成品相背书，品相判据另立留下卷；
+tier 落点 84.8/5.8/8.5/0.8 χ²=1.28 PASS；forced-600 保真流扫掠五分路由 χ²=4.70 PASS，24 件新内容各
+≥5 次命中——forced-s34 口径（终审 M7）：强制 scene34 后池内自然路由，非全自然 600 口径）+ 指纹重
+基线 12 枚（`test/evidence/task6-expand-rebaseline/`）+ batch19 24 枚全自然样张
 呈裁（`~/Downloads/genlab-expand-batch19/`）。测试 468→**679/679**（实跑）。`style-plan.json`
 全表刷新（本 PR）。**呈裁待 user**：五分路由权重／sierpinski 2%+mandelbulb 降级去留／CAGE_COMPACT
 与 FILLER_COMPACT 名单／lifted 压限／batch15-19 品相；终裁后混合 minify 正式提交另行执行。

--- a/docs/AGENT_HANDOFF.md
+++ b/docs/AGENT_HANDOFF.md
@@ -137,6 +137,21 @@ pending 自动点火/boundedField Lipschitz 注释/`test/evidence/` 证据库建
 sha256+manifest 三处统一）/I2（票①② 基线常设锁，变异必红）/I3/I5（52 枚子集真 `index.html` 复跑
 六判据全零——体检页=铸造页闭环）+ M1-M10 全落。测试 422→**468/468**（实跑）。
 
+**3D 扩容+配比卷（2026-08-26..28）**：T1 tier 配比 4D 减半让 2D（78/5/16/1 → **86/5/8/1**，1000-hash
+卡方双 PASS）；T2 SceneData 解释器复活进链（extrude/revolve/polygon + fitParams）+ demo-lifts 217 件
+对抗审策展 **11 件语料档 LIFTED_POOL 入池**；T3 柏拉图殿五体齐（dodeca+icosa 入 SOLID_POOL、嵌套对偶
+两件——**发现 sdf-main `d3.js` dodecahedron 笔误**：逐字复用 icosa 平面族且漏 (1,1,1) 项，本 PR 勘正
+`d3.js`+`sdf3.glsl.js` 两处公式体，以 DIMENSION `scenes/scenedata.js` 勘正版为准）；T4 分形档
+（sierpinski 入池 2%／mandelbulb 82.9s=4.3x 最重基线判死降级权 0；确立 **vm 自然流保真纪律**：任何
+自然 hash 猎手必须逐行镜像浏览器 setSeed+pal/pal2+shuf 全消费）；T5 填充八件（扭塔/弯月柱 →
+SOLID_POOL 16，组合六件 → SCULPT_POOL 16）——主件终态**五分路由** 47/21/17/15 draft ×(1−0.02) +
+分形带 2%（呈裁）。T6 收卷：**600-hash 真浏览器体检 0/600 废片**（六判据全零；tier 落点
+84.8/5.8/8.5/0.8 χ²=1.28 PASS；forced-600 保真流扫掠五分路由 χ²=4.70 PASS，24 件新内容各 ≥5 次
+自然命中）+ 指纹重基线 12 枚（`test/evidence/task6-expand-rebaseline/`）+ batch19 24 枚全自然样张
+呈裁（`~/Downloads/genlab-expand-batch19/`）。测试 468→**679/679**（实跑）。`style-plan.json`
+全表刷新（本 PR）。**呈裁待 user**：五分路由权重／sierpinski 2%+mandelbulb 降级去留／CAGE_COMPACT
+与 FILLER_COMPACT 名单／lifted 压限／batch15-19 品相；终裁后混合 minify 正式提交另行执行。
+
 ---
 
 ## 1. Hard rules (NON-NEGOTIABLE — these override defaults)

--- a/docs/superpowers/plans/2026-08-26-dimension-3d-expand.md
+++ b/docs/superpowers/plans/2026-08-26-dimension-3d-expand.md
@@ -1,0 +1,34 @@
+# DIMENSION 3D 扩容+配比卷 实施计划
+
+> **For agentic workers:** REQUIRED SUB-SKILL: superpowers:subagent-driven-development,逐任务双门。
+> 裁定原文(逐字为准):DIMENSION `.superpowers/sdd/2026-08-25-dimension-mint-readiness/progress.md` 尾部「新卷终裁 (2026-08-26)」节。
+
+**Goal:** 4D 减半让 2D(配比 2D86/3D5/4D8/升维1)+ 3D 语料五路扩容(解释器语料/柏拉图殿/分形/填充),落完后在最终语料上正式提交混合 minify。
+
+## Global Constraints
+
+- 岛铁律:同 hash+同时刻→同画面;禁 Math.random/Date.now;r() 先耗满再分支;三处同步;链零 URL 解析(常设断言在,别破);**绝不碰 key.txt**;测试实跑取值。
+- DIMENSION 直提 main(基线 682f8b0,468/468);sdf-main 附属走 `genlab-3d-expand` 分支 PR 不 merge;无关 WIP 排除。
+- 新 3D 内容全部进 **scene 34** 现有池结构(主件路由扩展,消费恒定:池加长不改 roll 数;新增路由档需无条件先耗)。已完成勿重做:布尔雕塑 1-8、waves 地形。
+- 混合 minify(DIMENSION-hybrid 已验证)**压后**:本卷收卷后在最终三库件上重跑同款 terser 正式提交。
+
+### Task 1: 配比调整
+sketch.js TIER_WEIGHTS **2d 86 / 3d 5 / 4d 8 / 升维 1**(旧 78/5/16/1);全部相关锁实跑重标(列旧→新);1000-hash 卡方复检;sdf-main style-plan.json 同步(本卷分支);README 概率表节。
+
+### Task 2: SceneData 解释器 + 语料策展入池
+~150 行解释器进链(scenedata.js 既有 buildNode/buildScene 残件可复活/重写,SD3.P 原语在);sdf-main demo-lifts 217 件语料(`sdf-js/examples/compositor/demo-lifts/` 与 scenes/,grep 定位)对抗审"立不立/像不像"逐件过 → 策展子集(预计 100-150)转为链内常量数据 + 新主件路由档(scene 34 内 lifted 档,权重 draft 15% 呈裁;primitive/bool/sculpt 相应压缩,呈裁);链体量增量如实报;新档 traits(Forms=件名)。逐件符号探针抽样 + 消费恒定 + 样张批呈裁。
+
+### Task 3: 柏拉图殿
+scene 34 新增 platonic-shrine 内容:五正多面体单件成景变体(独立档或并入 primitive 档加权,呈裁 draft)+ **嵌套对偶件**(线框立方⊃八面/十二⊃二十,wireframe_box 手法照 caged-orb 先例);README/traits 记"2D∞/3D5/4D6"叙事;样张。
+
+### Task 4: 分形 spike
+fractal.js 的 mandelbulbDE/sierpinskiSDF 接 scene 34 稀有档(权重 draft 各 2%);**单板 CPU probe ≤8s 预算门**(120-cell 先例):达标入池、超标降级记录呈裁;符号探针+切片非空+样张。
+
+### Task 5: 填充八件
+扭塔 twist(box)/弯月柱 bend(cylinder)/链条 iq-link/禅石塔 ellipsoid 叠/拱桥月夜 iq-arch-bridge+浮球/柱林 rep+异色球/炮弹金字塔/同心环阵——进 scene 34 组合静物/阵列档(路由结构呈裁 draft);每件 ~15 行;batch2 逐件纪律(探针+样张)。
+
+### Task 6: 收卷
+全量指纹重基线;600-hash 体检刷新(mint-snapshot 口径,新配比+新内容分布);batch15 样张呈裁(各新档);sdf-main style-plan 全表+handoff §0.6 提交,PR 不 merge;README/memory。**STOP:新档权重/分形去留/样张品相呈 user 终裁**;终裁后正式 minify 提交另行执行。
+
+## 工程纪律
+双门审查;卷末 opus 终审;渲染零筛选;fix loop ≤5;执行序 T1→T2→T3→T4→T5→T6。

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -28,6 +28,8 @@ const TESTS = [
   { category: 'smoke', file: 'sdf-js/test/smoke2d.mjs' },
   { category: 'smoke', file: 'sdf-js/test/scene-smoke.mjs' },
   { category: 'smoke', file: 'sdf-js/scripts/test-glsl-prune.mjs' },
+  // Platonic solids CPU↔GPU parity (DIMENSION expand-vol final review I1)
+  { category: 'smoke', file: 'sdf-js/scripts/test-platonic-parity.mjs' },
   { category: 'smoke', file: 'sdf-js/scripts/test-uniform-args.mjs' },
   { category: 'smoke', file: 'sdf-js/scripts/test-feature-gates.mjs' },
 

--- a/sdf-js/examples/genlab/style-plan.json
+++ b/sdf-js/examples/genlab/style-plan.json
@@ -1,5 +1,5 @@
 {
-  "comment": "DIMENSION 总概率表 (2026-08-22 策展手术终裁版, 取代 2026-08-14 draft v2；2026-08-23 终审修复轮同步；2026-08-26 配比调整卷 Task 1 同步 dimension_tier 节；2026-08-28 3D扩容+配比卷收卷 Task 6 全表刷新: scene34 主件五分路由 + SOLID/SCULPT 池 16/16 + LIFTED 11 + 分形档 + 三份 hF 压限名单)。数值均逐字对应 DIMENSION 仓 sketch.js/scenes/index.js/scenes/solids-stage.js/scenes/panels-4d.js 里的具名常量 (TIER_WEIGHTS/POOL_2D_WEIGHTS/STYLE2D_OBJECTS_W/STYLE2D_LANDSCAPES_W/THEME32_CATEGORY_W/POLY4D_WEIGHTS/FRACTAL_WEIGHTS 及五分路由阈值)，不是脱离代码另算的第二份数字。DIMENSION 测试 679/679 (2026-08-28 实跑)。数据来源以 DIMENSION 仓 README.md 为准（.superpowers/sdd/ 下的 task 报告是 gitignored 本地工作区文件、跨机器不可达，见 m3）。",
+  "comment": "DIMENSION 总概率表 (2026-08-22 策展手术终裁版, 取代 2026-08-14 draft v2；2026-08-23 终审修复轮同步；2026-08-26 配比调整卷 Task 1 同步 dimension_tier 节；2026-08-28 3D扩容+配比卷收卷 Task 6 全表刷新: scene34 主件五分路由 + SOLID/SCULPT 池 16/16 + LIFTED 11 + 分形档 + 三份 hF 压限名单；2026-08-29 呈裁终裁落地: 五分路由与 CAGE/FILLER/lifted 三组压限转正 _locked + PLATONIC_COMPACT 应急帽两件 (dodeca/icosa) + LIFTED 11→10 (clock-915 裁汰))。数值均逐字对应 DIMENSION 仓 sketch.js/scenes/index.js/scenes/solids-stage.js/scenes/panels-4d.js 里的具名常量 (TIER_WEIGHTS/POOL_2D_WEIGHTS/STYLE2D_OBJECTS_W/STYLE2D_LANDSCAPES_W/THEME32_CATEGORY_W/POLY4D_WEIGHTS/FRACTAL_WEIGHTS 及五分路由阈值)，不是脱离代码另算的第二份数字。DIMENSION 测试 683/683 (2026-08-29 实跑)。数据来源以 DIMENSION 仓 README.md 为准（.superpowers/sdd/ 下的 task 报告是 gitignored 本地工作区文件、跨机器不可达，见 m3）。",
   "rulings_locked": {
     "png10_topo": "放弃 (无美感)",
     "png11_morph": "放弃 (无美感)",
@@ -67,7 +67,7 @@
   },
   "3d_content": {
     "_locked": true,
-    "_note": "3D 池 = [34] (正几何台 v2) 独占全部 3D tier 权重——韵脚3D台(18)/圣物殿(19-22)/老 3D(7,8) 已退场 (见 retired_scenes)。2026-08-26..28 3D扩容+配比卷五路扩容: 主件五分路由 (primary_route_34) + SOLID_POOL 14→16 + SCULPT_POOL 10→16 + LIFTED_POOL 11 入池 + 分形稀有档 (pools_34), hF 压限名单三份 (hf_caps_34)。B4_SCALE=0.5 场景门控见 b4_scale 节。",
+    "_note": "3D 池 = [34] (正几何台 v2) 独占全部 3D tier 权重——韵脚3D台(18)/圣物殿(19-22)/老 3D(7,8) 已退场 (见 retired_scenes)。2026-08-26..28 3D扩容+配比卷五路扩容: 主件五分路由 (primary_route_34) + SOLID_POOL 14→16 + SCULPT_POOL 10→16 + LIFTED_POOL 11 入池 (2026-08-29 呈裁终裁③裁汰 clock-915 → 10) + 分形稀有档 (pools_34), hF 压限名单四份 (hf_caps_34, 2026-08-29 呈裁终裁全部 locked)。B4_SCALE=0.5 场景门控见 b4_scale 节。",
     "solids_stage_34": 1.0,
     "comp_34": {
       "_locked": true,
@@ -95,15 +95,15 @@
       "palette_source": "objects3d/palettes3d.js (84 套, 双实配对全过对比关)",
       "sculpt_route": {
         "_superseded_by": "primary_route_34",
-        "_note": "2026-08-22 user 终裁的三分 55/25/20 (_locked 历史记录, 保留供追溯); 3D扩容+配比卷 (2026-08-26..28) T2 语料档/T4 分形档入池后主件路由扩为五分, 见下方 primary_route_34 (draft 呈裁)。",
+        "_note": "2026-08-22 user 终裁的三分 55/25/20 (_locked 历史记录, 保留供追溯); 3D扩容+配比卷 (2026-08-26..28) T2 语料档/T4 分形档入池后主件路由扩为五分, 见下方 primary_route_34 (2026-08-29 呈裁 user 终裁 _locked)。",
         "primitive": 0.55,
         "bool": 0.25,
         "sculpt": 0.2
       }
     },
     "primary_route_34": {
-      "_draft": true,
-      "_note": "2026-08-28 收卷刷新 (3D扩容+配比卷): scene34 主件五分路由 (scenes/solids-stage.js rollPrimaryKind)——T2 四分 draft 47/21/17/15 (旧三分 55/25/20 等比压缩) + T4 分形稀有档 (四档等比乘 (1−FRACTAL_SHARE), FRACTAL_SHARE = FRACTAL_WEIGHT_SUM/100 现算, mandelbulb 降 0 后 = 0.02)。消费恒定: route+四路索引+fRoll 恒 6 r()。**draft 呈裁待 user 终裁, 未终裁前不 _locked**。副件 (S2/S3/静物池) 仍走两分 rollSolidKind 72/28 (primitive/bool)。",
+      "_locked": true,
+      "_note": "2026-08-28 收卷刷新 (3D扩容+配比卷), 2026-08-29 呈裁 user 终裁①转正锁定 (五分路由 47/21/17/15+分形带, sierpinski 2%/mandelbulb 降级维持一并追认): scene34 主件五分路由 (scenes/solids-stage.js rollPrimaryKind)——T2 四分 draft 47/21/17/15 (旧三分 55/25/20 等比压缩) + T4 分形稀有档 (四档等比乘 (1−FRACTAL_SHARE), FRACTAL_SHARE = FRACTAL_WEIGHT_SUM/100 现算, mandelbulb 降 0 后 = 0.02)。消费恒定: route+四路索引+fRoll 恒 6 r()。**user 呈裁终裁 2026-08-29 锁定 (progress.md 尾节「USER 呈裁终裁」)**。副件 (S2/S3/静物池) 仍走两分 rollSolidKind 72/28 (primitive/bool)。",
       "primitive": 0.47,
       "bool": 0.21,
       "sculpt": 0.17,
@@ -122,11 +122,11 @@
       "solid_pool_16": "12 旧原语 + dodecahedron/icosahedron (柏拉图殿 T3; dodeca 系 sdf-main d3.js 笔误勘正版, 本 PR 同步勘正 sdf-main 侧 d3.js/sdf3.glsl.js) + twisted_tower/bent_column (填充 T5, twist/bend 非等距变形按几何参数闭式步进安全系数 1/(1+|k|·rMax))",
       "bool_pool_5": "crescent/arch/pierced-sphere/ring-column/bowl (不变)",
       "sculpt_pool_16": "布尔雕塑八件 + 嵌套对偶两件 dual-cube-octa/dual-dodeca-icosa (T3) + 填充组合六件 chain-links/stone-stack/arch-bridge-moon/pillar-grove/cannonball-stack/ring-gate (T5)",
-      "lifted_pool_11": "demo-lifts 217 件对抗审终选 11 件 (T2): rocket-launch/gothic-cathedral/china-carrier/jet-aircraft/vintage-bicycle/coastal-lighthouse/spiral-vase/clock-915/chart-traffic-light/graphics-isometric-city/graphics-mountain (解释器 SD3 复活进链 + 离线烘焙 fit)",
+      "lifted_pool_10": "demo-lifts 217 件对抗审终选 11 件 (T2), 2026-08-29 呈裁终裁③裁汰 clock-915 (盘面浅浮雕点彩下不可读, 多批真浏览器实测, 达标才入铁律; ?lifted=clock-915 强制口随之不可达) → 现役 10 件: rocket-launch/gothic-cathedral/china-carrier/jet-aircraft/vintage-bicycle/coastal-lighthouse/spiral-vase/chart-traffic-light/graphics-isometric-city/graphics-mountain (解释器 SD3 复活进链 + 离线烘焙 fit; 池内挑选单 roll, 池长变化零消费结构影响)",
       "fractal_pool": {
         "sierpinski": {
           "weight": 2,
-          "_note": "938 全幅真管线 bench 中位 8.8s, 低于全部四条已上线基线中位 (10.3-19.2s), 包络内干净入池; draft 呈裁"
+          "_note": "938 全幅真管线 bench 中位 8.8s, 低于全部四条已上线基线中位 (10.3-19.2s), 包络内干净入池; 2026-08-29 呈裁 user 终裁锁定"
         },
         "mandelbulb": {
           "_degraded": true,
@@ -136,11 +136,12 @@
       }
     },
     "hf_caps_34": {
-      "_note": "三份独立 hF 压限名单 + lifted 压限 (全部纯 min() 后处理, 零 r() 消费): COMPACT_SCULPTS 是 user 终裁数据契约 (_locked); CAGE/FILLER 与 lifted 压限为各卷 draft 呈裁。",
+      "_note": "四份独立 hF 压限名单 + lifted 压限 (全部纯 min() 后处理, 零 r() 消费): COMPACT_SCULPTS 是 2026-08-21 user 终裁数据契约; CAGE/FILLER 与 lifted 压限 2026-08-29 呈裁 user 终裁①转正 locked; PLATONIC 应急帽系同日终裁②新增 (opus 终审 I2 按池不按症状盲区, dodecahedron forced-600 扫掠 p50 0.915 居全池第 2 未压; 同 hash 前后对照 dodeca×colossus cov 0.748→0.542 / icosa×colossus 0.889→0.807; 下卷全池 N≥50 扫掠统一按症状定标)。",
       "compact_sculpts_locked": ["steinmetz", "cube-pierced-sphere", "ruin-dome", "death-star"],
-      "cage_compact_draft": ["dual-dodeca-icosa"],
-      "filler_compact_draft": ["stone-stack", "cannonball-stack"],
-      "lifted_caps_draft": "monument/衰变行 ≤1.0 / colossus ≤0.9 / closeup ≤1.05 + 纵深护栏 0.55·focal/a / 全型宽件 ≤1.3/a (a = 烘焙宽高比); cov 兜底 lone 同吃压限"
+      "cage_compact_locked": ["dual-dodeca-icosa"],
+      "filler_compact_locked": ["stone-stack", "cannonball-stack"],
+      "platonic_compact_locked": ["dodecahedron", "icosahedron"],
+      "lifted_caps_locked": "monument/衰变行 ≤1.0 / colossus ≤0.9 / closeup ≤1.05 + 纵深护栏 0.55·focal/a / 全型宽件 ≤1.3/a (a = 烘焙宽高比); cov 兜底 lone 同吃压限"
     },
     "legacy_7_8": {
       "_degraded": true,

--- a/sdf-js/examples/genlab/style-plan.json
+++ b/sdf-js/examples/genlab/style-plan.json
@@ -1,5 +1,5 @@
 {
-  "comment": "DIMENSION 总概率表 (2026-08-22 策展手术终裁版, 取代 2026-08-14 draft v2；2026-08-23 终审修复轮同步；2026-08-26 配比调整卷 Task 1 同步 dimension_tier 节, 全表刷新待本卷收卷 Task 6)。数值均逐字对应 DIMENSION 仓 sketch.js/scenes/index.js/scenes/panels-4d.js 里的具名常量 (TIER_WEIGHTS/POOL_2D_WEIGHTS/STYLE2D_OBJECTS_W/STYLE2D_LANDSCAPES_W/THEME32_CATEGORY_W/POLY4D_WEIGHTS)，不是脱离代码另算的第二份数字。DIMENSION HEAD=c71d32c，测试 287/287。数据来源以 DIMENSION 仓 README.md 为准（.superpowers/sdd/ 下的 task 报告是 gitignored 本地工作区文件、跨机器不可达，见 m3）。",
+  "comment": "DIMENSION 总概率表 (2026-08-22 策展手术终裁版, 取代 2026-08-14 draft v2；2026-08-23 终审修复轮同步；2026-08-26 配比调整卷 Task 1 同步 dimension_tier 节；2026-08-28 3D扩容+配比卷收卷 Task 6 全表刷新: scene34 主件五分路由 + SOLID/SCULPT 池 16/16 + LIFTED 11 + 分形档 + 三份 hF 压限名单)。数值均逐字对应 DIMENSION 仓 sketch.js/scenes/index.js/scenes/solids-stage.js/scenes/panels-4d.js 里的具名常量 (TIER_WEIGHTS/POOL_2D_WEIGHTS/STYLE2D_OBJECTS_W/STYLE2D_LANDSCAPES_W/THEME32_CATEGORY_W/POLY4D_WEIGHTS/FRACTAL_WEIGHTS 及五分路由阈值)，不是脱离代码另算的第二份数字。DIMENSION 测试 679/679 (2026-08-28 实跑)。数据来源以 DIMENSION 仓 README.md 为准（.superpowers/sdd/ 下的 task 报告是 gitignored 本地工作区文件、跨机器不可达，见 m3）。",
   "rulings_locked": {
     "png10_topo": "放弃 (无美感)",
     "png11_morph": "放弃 (无美感)",
@@ -67,7 +67,7 @@
   },
   "3d_content": {
     "_locked": true,
-    "_note": "3D 池 = [34] (正几何台 v2) 独占全部 3D tier 权重——韵脚3D台(18)/圣物殿(19-22)/老 3D(7,8) 已退场 (见 retired_scenes)。scene34 内部结构本轮未改动，B4_SCALE=0.5 场景门控见 b4_scale 节。",
+    "_note": "3D 池 = [34] (正几何台 v2) 独占全部 3D tier 权重——韵脚3D台(18)/圣物殿(19-22)/老 3D(7,8) 已退场 (见 retired_scenes)。2026-08-26..28 3D扩容+配比卷五路扩容: 主件五分路由 (primary_route_34) + SOLID_POOL 14→16 + SCULPT_POOL 10→16 + LIFTED_POOL 11 入池 + 分形稀有档 (pools_34), hF 压限名单三份 (hf_caps_34)。B4_SCALE=0.5 场景门控见 b4_scale 节。",
     "solids_stage_34": 1.0,
     "comp_34": {
       "_locked": true,
@@ -94,12 +94,53 @@
       "dofK_dist": { "0_无景深": 0.5, "0.3_轻景深": 0.333, "0.6_重景深": 0.167 },
       "palette_source": "objects3d/palettes3d.js (84 套, 双实配对全过对比关)",
       "sculpt_route": {
-        "_locked": true,
+        "_superseded_by": "primary_route_34",
+        "_note": "2026-08-22 user 终裁的三分 55/25/20 (_locked 历史记录, 保留供追溯); 3D扩容+配比卷 (2026-08-26..28) T2 语料档/T4 分形档入池后主件路由扩为五分, 见下方 primary_route_34 (draft 呈裁)。",
         "primitive": 0.55,
         "bool": 0.25,
-        "sculpt": 0.2,
-        "_note": "八件全留 (primitive 12 / bool 5 / sculpt 8); 紧凑凸形 monument/colossus hF cap 1.0"
+        "sculpt": 0.2
       }
+    },
+    "primary_route_34": {
+      "_draft": true,
+      "_note": "2026-08-28 收卷刷新 (3D扩容+配比卷): scene34 主件五分路由 (scenes/solids-stage.js rollPrimaryKind)——T2 四分 draft 47/21/17/15 (旧三分 55/25/20 等比压缩) + T4 分形稀有档 (四档等比乘 (1−FRACTAL_SHARE), FRACTAL_SHARE = FRACTAL_WEIGHT_SUM/100 现算, mandelbulb 降 0 后 = 0.02)。消费恒定: route+四路索引+fRoll 恒 6 r()。**draft 呈裁待 user 终裁, 未终裁前不 _locked**。副件 (S2/S3/静物池) 仍走两分 rollSolidKind 72/28 (primitive/bool)。",
+      "primitive": 0.47,
+      "bool": 0.21,
+      "sculpt": 0.17,
+      "lifted": 0.15,
+      "fractal_share_derived": 0.02,
+      "effective_natural": {
+        "primitive": 0.4606,
+        "bool": 0.2058,
+        "sculpt": 0.1666,
+        "lifted": 0.147,
+        "fractal": 0.02
+      }
+    },
+    "pools_34": {
+      "_note": "2026-08-28 收卷计数 (scenes/solids-stage.js / objects3d/lifted.js, DIMENSION run-tests 计数锁在案)。",
+      "solid_pool_16": "12 旧原语 + dodecahedron/icosahedron (柏拉图殿 T3; dodeca 系 sdf-main d3.js 笔误勘正版, 本 PR 同步勘正 sdf-main 侧 d3.js/sdf3.glsl.js) + twisted_tower/bent_column (填充 T5, twist/bend 非等距变形按几何参数闭式步进安全系数 1/(1+|k|·rMax))",
+      "bool_pool_5": "crescent/arch/pierced-sphere/ring-column/bowl (不变)",
+      "sculpt_pool_16": "布尔雕塑八件 + 嵌套对偶两件 dual-cube-octa/dual-dodeca-icosa (T3) + 填充组合六件 chain-links/stone-stack/arch-bridge-moon/pillar-grove/cannonball-stack/ring-gate (T5)",
+      "lifted_pool_11": "demo-lifts 217 件对抗审终选 11 件 (T2): rocket-launch/gothic-cathedral/china-carrier/jet-aircraft/vintage-bicycle/coastal-lighthouse/spiral-vase/clock-915/chart-traffic-light/graphics-isometric-city/graphics-mountain (解释器 SD3 复活进链 + 离线烘焙 fit)",
+      "fractal_pool": {
+        "sierpinski": {
+          "weight": 2,
+          "_note": "938 全幅真管线 bench 中位 8.8s, 低于全部四条已上线基线中位 (10.3-19.2s), 包络内干净入池; draft 呈裁"
+        },
+        "mandelbulb": {
+          "_degraded": true,
+          "weight": 0,
+          "_note": "中位 82.9s = 最重基线 (dodeca 19.2s) 的 4.3x, 最轻构图型 28.1s 仍超基线全部观测 (max 24.0s)——与 cell120 超 5.2x 判死同量级同款处置: 权 0 降级, 代码/池成员/测试全保留, ?fractal=mandelbulb dev 口可达; 复活路径 = raymarch 逐件安全系数口/bbox 预剔除后 (82.9s 可望砍半) 改权重字面重评"
+        }
+      }
+    },
+    "hf_caps_34": {
+      "_note": "三份独立 hF 压限名单 + lifted 压限 (全部纯 min() 后处理, 零 r() 消费): COMPACT_SCULPTS 是 user 终裁数据契约 (_locked); CAGE/FILLER 与 lifted 压限为各卷 draft 呈裁。",
+      "compact_sculpts_locked": ["steinmetz", "cube-pierced-sphere", "ruin-dome", "death-star"],
+      "cage_compact_draft": ["dual-dodeca-icosa"],
+      "filler_compact_draft": ["stone-stack", "cannonball-stack"],
+      "lifted_caps_draft": "monument/衰变行 ≤1.0 / colossus ≤0.9 / closeup ≤1.05 + 纵深护栏 0.55·focal/a / 全型宽件 ≤1.3/a (a = 烘焙宽高比); cov 兜底 lone 同吃压限"
     },
     "legacy_7_8": {
       "_degraded": true,
@@ -198,13 +239,14 @@
     "style_and_content_degraded": [
       "2D 物件风格 painted (0%)",
       "主题内容池 mandala/flake 生成器件",
-      "4D 内容池 cell120/cell600 (性能降级，非策展摘除)"
+      "4D 内容池 cell120/cell600 (性能降级，非策展摘除)",
+      "3D 分形档 mandelbulb (性能降级权 0，2026-08-28 T4 判决，?fractal= dev 可达，见 pools_34.fractal_pool)"
     ],
     "survivors": { "2d": [30, 31, 32], "3d": [34], "4d": [35], "ascension": [17] }
   },
   "dev_only_scenes": {
-    "_note": "m4 补漏 (2026-08-23 终审记账): 既不在 survivors (自然轮盘可达) 也不在 retired_scenes (曾经自然可达、本轮摘除) 里的第三类——scene 33 (SceneData 迷你解释器语料台) 从建成起就是 `?scene=33` 专属预览，从未上过自然路由轮盘，不是本轮策展手术的退场对象，DIMENSION README『场景登记表』原样标注为 dev-only。",
+    "_note": "m4 补漏 (2026-08-23 终审记账): scene 33 (SceneData 迷你解释器语料台) 从建成起就是 `?scene=33` 专属预览，从未上过自然路由轮盘。2026-08-24 链装配物理瘦身第一刀把它连同专属文件 (objects3d/lib-lifted.js) 一并删除——`?scene=33` 已无真实内容可渲染。2026-08-26 3D扩容卷 T2: 解释器 SD3 本体在 scenes/scenedata.js 复活进链 (extrude/revolve/polygon 三式 + fitParams)，服务 scene34 的 LIFTED_POOL 语料档；预览走 `dev.html?scene=34&lifted=<name>`，scene 33 未复活。",
     "scenes": [33],
-    "description": "SceneData 迷你解释器语料台，dev-only，不入抽样轮盘（`?scene=33` 手动装载）"
+    "description": "已物理删除的历史 dev-only 语料台 (2026-08-24)；解释器职能由 scene34 lifted 档承接 (2026-08-26)"
   }
 }

--- a/sdf-js/examples/genlab/style-plan.json
+++ b/sdf-js/examples/genlab/style-plan.json
@@ -1,5 +1,5 @@
 {
-  "comment": "DIMENSION 总概率表 (2026-08-22 策展手术终裁版, 取代 2026-08-14 draft v2；2026-08-23 终审修复轮同步)。数值均逐字对应 DIMENSION 仓 sketch.js/scenes/index.js/scenes/panels-4d.js 里的具名常量 (TIER_WEIGHTS/POOL_2D_WEIGHTS/STYLE2D_OBJECTS_W/STYLE2D_LANDSCAPES_W/THEME32_CATEGORY_W/POLY4D_WEIGHTS)，不是脱离代码另算的第二份数字。DIMENSION HEAD=c71d32c，测试 287/287。数据来源以 DIMENSION 仓 README.md 为准（.superpowers/sdd/ 下的 task 报告是 gitignored 本地工作区文件、跨机器不可达，见 m3）。",
+  "comment": "DIMENSION 总概率表 (2026-08-22 策展手术终裁版, 取代 2026-08-14 draft v2；2026-08-23 终审修复轮同步；2026-08-26 配比调整卷 Task 1 同步 dimension_tier 节, 全表刷新待本卷收卷 Task 6)。数值均逐字对应 DIMENSION 仓 sketch.js/scenes/index.js/scenes/panels-4d.js 里的具名常量 (TIER_WEIGHTS/POOL_2D_WEIGHTS/STYLE2D_OBJECTS_W/STYLE2D_LANDSCAPES_W/THEME32_CATEGORY_W/POLY4D_WEIGHTS)，不是脱离代码另算的第二份数字。DIMENSION HEAD=c71d32c，测试 287/287。数据来源以 DIMENSION 仓 README.md 为准（.superpowers/sdd/ 下的 task 报告是 gitignored 本地工作区文件、跨机器不可达，见 m3）。",
   "rulings_locked": {
     "png10_topo": "放弃 (无美感)",
     "png11_morph": "放弃 (无美感)",
@@ -8,10 +8,10 @@
   },
   "dimension_tier": {
     "_locked": true,
-    "_note": "2026-08-22 策展手术终裁 (逐字), sketch.js TIER_WEIGHTS。BOB 六景/老 3D/老 4D/韵脚 2D/静物台全部退场——不再是这张表要覆盖的自然路由，见 retired_scenes。",
-    "2d": 0.78,
+    "_note": "2026-08-22 策展手术终裁 (逐字), sketch.js TIER_WEIGHTS。BOB 六景/老 3D/老 4D/韵脚 2D/静物台全部退场——不再是这张表要覆盖的自然路由，见 retired_scenes。2026-08-26 新卷终裁 (3D扩容+配比卷 Task 1): 4D 减半让 2D——2d 0.78→0.86 / 4d 0.16→0.08, 3d/ascension 不动, 和仍=1。DIMENSION 侧 1e3c791 落地 (468/468 测试 + 1000-hash 卡方复检双层 PASS: tier df=3 卡方 5.597<7.815, scene df=5 卡方 7.318<11.070)。",
+    "2d": 0.86,
     "3d": 0.05,
-    "4d": 0.16,
+    "4d": 0.08,
     "ascension": 0.01
   },
   "2d_content": {

--- a/sdf-js/examples/genlab/style-plan.json
+++ b/sdf-js/examples/genlab/style-plan.json
@@ -221,7 +221,7 @@
   "b4_scale": {
     "_locked": true,
     "value": 0.5,
-    "gate": "pa.scene===34 || pa.scene===35",
+    "gate": "pa.scene===17 || pa.scene===34 || pa.scene===35",
     "_note": "2026-08-22 转正 (原 batch4 视觉对抗档位)。场景门控——非 34/35 场景系数恒 1，代码层判 pa.scene (非 URL 参数)。三处注入点: sketch.js buildPattern cellSize 尾乘 / POISSON maxR、minR / drawPoisson dotR (乘在 Math.max 结果之外)。?b4= dev 覆盖口保留，语义同 ?sculpt=/?poly= (先 roll 后覆写)。"
   },
   "retired_scenes": {

--- a/sdf-js/scripts/test-platonic-parity.mjs
+++ b/sdf-js/scripts/test-platonic-parity.mjs
@@ -1,0 +1,205 @@
+// sdf-js/scripts/test-platonic-parity.mjs — Platonic solids CPU↔GPU parity smoke.
+//
+// Background (DIMENSION 3D expand-vol final review, 2026-08-29): sdIcosahedron
+// in sdf3.glsl.js shipped a twin-typo constant family (len = phi*sqrt(2)
+// instead of phi*sqrt(3)) — non-unit plane normals (Lipschitz 1.2247 > 1),
+// GPU body was not a regular icosahedron while the JS body was. This test
+// pins all five Platonic bodies (tetra / octa / cube / dodeca / icosa) so the
+// two implementations can never drift silently again:
+//
+//   1. Constant pins — numeric literals are regex-extracted from the *shipped*
+//      GLSL source text and checked against exact closed-form recomputations
+//      (tol 1e-12). Editing the GLSL constants without updating the math here
+//      goes red.
+//   2. Value parity — the extracted GLSL bodies are mirrored in JS (same
+//      structure, extracted constants) and compared against the d3.js DSL
+//      primitives on a deterministic sample-point sweep (13 directions x 5
+//      radial shells x 3 sizes per solid), tol 1e-3 (covers float32 GPU
+//      rounding headroom; observed max |Δ| is 0 — bodies are bit-identical
+//      in float64).
+//
+// Argument conventions mirror the sdf3.compile.js emit table: tetra/octa/
+// dodeca/icosa pass r straight through; box(size) emits sdBox with
+// half-extents size/2.
+//
+// No Math.random / Date.now — sample set is a fixed literal table.
+
+import { SDF3_GLSL } from '../src/sdf/sdf3.glsl.js';
+import { tetrahedron, octahedron, box, dodecahedron, icosahedron } from '../src/sdf/d3.js';
+
+let pass = 0,
+  fail = 0;
+const ok = (c, n) => (c ? (pass++, console.log(`  ✓ ${n}`)) : (fail++, console.log(`  ✗ ${n}`)));
+
+console.log('=== platonic parity (JS DSL ↔ shipped GLSL constants) ===\n');
+
+// ---- 1. extract shipped GLSL function bodies + constants -------------------
+
+function fnText(name) {
+  const m = SDF3_GLSL.match(new RegExp(`float ${name}\\(vec3 p[^)]*\\) \\{[\\s\\S]*?\\n\\}`));
+  if (!m) throw new Error(`GLSL function ${name} not found`);
+  return m[0];
+}
+
+function constOf(fn, name) {
+  const m = fn.match(new RegExp(`const float ${name}\\s*=\\s*(-?[0-9.]+)`));
+  if (!m) throw new Error(`const ${name} not found`);
+  return Number(m[1]);
+}
+
+const icoSrc = fnText('sdIcosahedron');
+const dodSrc = fnText('sdDodecahedron');
+fnText('sdTetrahedron'); // existence pins
+fnText('sdOctahedron');
+fnText('sdBox');
+
+const ico = {
+  scale: constOf(icoSrc, 'scale'),
+  phi: constOf(icoSrc, 'phi'),
+  len: constOf(icoSrc, 'len'),
+  nx: constOf(icoSrc, 'nx'),
+  ny: constOf(icoSrc, 'ny'),
+  w13: constOf(icoSrc, 'w13'),
+};
+const dod = {
+  n1: constOf(dodSrc, 'n1'),
+  n2: constOf(dodSrc, 'n2'),
+  rho: constOf(dodSrc, 'rho'),
+};
+
+// ---- 2. constant pins vs exact closed forms (tol 1e-12) --------------------
+
+const PHI = (1 + Math.sqrt(5)) / 2;
+const pin = (label, got, want) =>
+  ok(Math.abs(got - want) < 1e-12, `${label}: shipped ${got} ≈ exact ${want}`);
+
+console.log('icosahedron constants (final-review I1 corrected values):');
+pin('  scale = phi/sqrt(1+phi^2)', ico.scale, PHI / Math.sqrt(1 + PHI * PHI));
+pin('  phi', ico.phi, PHI);
+pin('  len = sqrt(1+(1+phi)^2) = phi*sqrt(3)', ico.len, Math.sqrt(1 + (1 + PHI) * (1 + PHI)));
+pin('  nx = 1/len', ico.nx, 1 / (PHI * Math.sqrt(3)));
+pin('  ny = (1+phi)/len', ico.ny, (1 + PHI) / (PHI * Math.sqrt(3)));
+pin('  w13 = 1/sqrt(3)', ico.w13, 1 / Math.sqrt(3));
+ok(
+  Math.abs(Math.hypot(ico.nx, ico.ny) - 1) < 1e-12,
+  `  |(nx,ny)| = 1 (unit normals → 1-Lipschitz), got ${Math.hypot(ico.nx, ico.ny)}`,
+);
+
+console.log('\ndodecahedron constants:');
+pin('  n1 = 1/sqrt(1+phi^2)', dod.n1, 1 / Math.sqrt(1 + PHI * PHI));
+pin('  n2 = phi/sqrt(1+phi^2)', dod.n2, PHI / Math.sqrt(1 + PHI * PHI));
+pin(
+  '  rho = (1+phi)/(sqrt(1+phi^2)*sqrt(3))',
+  dod.rho,
+  (1 + PHI) / (Math.sqrt(1 + PHI * PHI) * Math.sqrt(3)),
+);
+
+// ---- 3. JS mirrors of the shipped GLSL bodies ------------------------------
+
+const glsl = {
+  tetrahedron: (p, r) =>
+    (Math.max(Math.abs(p[0] + p[1]) - p[2], Math.abs(p[0] - p[1]) + p[2]) - r) / Math.sqrt(3),
+
+  octahedron: (p, s) => {
+    const px = Math.abs(p[0]),
+      py = Math.abs(p[1]),
+      pz = Math.abs(p[2]);
+    const m = px + py + pz - s;
+    let q;
+    if (3 * px < m) q = [px, py, pz];
+    else if (3 * py < m) q = [py, pz, px];
+    else if (3 * pz < m) q = [pz, px, py];
+    else return m * 0.57735027;
+    const k = Math.min(Math.max(0.5 * (q[2] - q[1] + s), 0), s);
+    return Math.hypot(q[0], q[1] - s + k, q[2] - k);
+  },
+
+  // emit table: box(size) → sdBox(p, size/2) — b are half-extents
+  box: (p, b) => {
+    const dx = Math.abs(p[0]) - b[0],
+      dy = Math.abs(p[1]) - b[1],
+      dz = Math.abs(p[2]) - b[2];
+    const inside = Math.min(Math.max(dx, Math.max(dy, dz)), 0);
+    return inside + Math.hypot(Math.max(dx, 0), Math.max(dy, 0), Math.max(dz, 0));
+  },
+
+  dodecahedron: (p, r) => {
+    const px = Math.abs(p[0]),
+      py = Math.abs(p[1]),
+      pz = Math.abs(p[2]);
+    const a = py * dod.n2 + pz * dod.n1;
+    const b = px * dod.n1 + pz * dod.n2;
+    const c = px * dod.n2 + py * dod.n1;
+    return Math.max(Math.max(a, b), c) - dod.rho * r;
+  },
+
+  icosahedron: (p, r) => {
+    const R = r * ico.scale;
+    const px = Math.abs(p[0]) / R,
+      py = Math.abs(p[1]) / R,
+      pz = Math.abs(p[2]) / R;
+    const a = px * ico.nx + py * ico.ny;
+    const b = py * ico.nx + pz * ico.ny;
+    const c = px * ico.ny + pz * ico.nx;
+    const d = (px + py + pz) * ico.w13;
+    return (Math.max(Math.max(Math.max(a, b), c), d) - ico.nx) * R;
+  },
+};
+
+// ---- 4. deterministic sample sweep -----------------------------------------
+
+// 13 fixed directions: axes, face diagonal, space diagonal, phi-family
+// (icosa/dodeca vertex & face directions), plus three "awkward" generic dirs.
+const norm = (v) => {
+  const l = Math.hypot(v[0], v[1], v[2]);
+  return [v[0] / l, v[1] / l, v[2] / l];
+};
+const DIRS = [
+  [1, 0, 0],
+  [0, 1, 0],
+  [0, 0, 1],
+  norm([1, 1, 0]),
+  norm([1, 1, 1]),
+  norm([0, 1, PHI]),
+  norm([1, PHI, 0]),
+  norm([0, 1, 1 + PHI]),
+  norm([1 + PHI, 0, 1]),
+  norm([0.3, -0.7, 0.62]),
+  norm([-0.9, 0.13, 0.41]),
+  norm([0.05, 0.99, -0.11]),
+  norm([-0.55, -0.5, -0.67]),
+];
+const SHELLS = [0, 0.5, 1.0, 1.5, 3.0]; // × r (surface neighbourhood in + out)
+const SIZES = [0.4, 1.0, 1.7];
+
+const CASES = [
+  { name: 'tetrahedron', js: (r) => tetrahedron(r), g: (p, r) => glsl.tetrahedron(p, r) },
+  { name: 'octahedron', js: (r) => octahedron(r), g: (p, r) => glsl.octahedron(p, r) },
+  { name: 'cube (box)', js: (r) => box(r), g: (p, r) => glsl.box(p, [r / 2, r / 2, r / 2]) },
+  { name: 'dodecahedron', js: (r) => dodecahedron(r), g: (p, r) => glsl.dodecahedron(p, r) },
+  { name: 'icosahedron', js: (r) => icosahedron(r), g: (p, r) => glsl.icosahedron(p, r) },
+];
+
+console.log('\nvalue parity sweep (13 dirs × 5 shells × 3 sizes, tol 1e-3):');
+const TOL = 1e-3;
+for (const { name, js, g } of CASES) {
+  let maxD = 0,
+    n = 0;
+  for (const r of SIZES) {
+    const f = js(r);
+    for (const dir of DIRS) {
+      for (const t of SHELLS) {
+        const p = [dir[0] * r * t, dir[1] * r * t, dir[2] * r * t];
+        const dJs = f(p);
+        const dGl = g(p, r);
+        const delta = Math.abs(dJs - dGl);
+        if (delta > maxD) maxD = delta;
+        n++;
+      }
+    }
+  }
+  ok(maxD <= TOL, `${name}: ${n} samples, max |Δ| = ${maxD.toExponential(3)}`);
+}
+
+console.log(`\n${pass} passed, ${fail} failed`);
+if (fail > 0) process.exit(1);

--- a/sdf-js/src/sdf/d3.js
+++ b/sdf-js/src/sdf/d3.js
@@ -331,20 +331,30 @@ export const octahedron = (r = 0.4) => {
 };
 
 // dodecahedron：十二面体（D12 骰子）。r = 顶点距原点。
+// 勘正（2026-08-28，DIMENSION 3D 扩容卷 T3 发现 / T6 落地，以 DIMENSION
+// scenes/scenedata.js 勘正版为准）：旧版逐字复用了 icosahedron 的
+// (0,1,1+φ) 平面族（那是 icosa 的面法向族 = hg_sdf GDFVectors[7..12]）且不带
+// (1,1,1) 族——交出的凸体 in/circ ≈ 0.748、轴向支撑 0.382r，不是正十二面体
+// （应为 0.7947 / 0.4472r），疑似 hg_sdf fDodecahedron 移植笔误。正十二面体
+// 的 12 个面法向沿 (0,±1,±φ) 全轮换（= icosa 顶点方向 = hg_sdf 的 φ 族
+// Vectors[13..18]）；面距 ρ = r·(1+φ)/(√(1+φ²)·√3)。顶点 (±1,±1,±1)/√3·r
+// 与面心 ρ·n̂ 均闭式落零（DIMENSION run-tests 有对应闭式锁）。max(平面距)
+// 在面区精确、棱/顶区低估（≤真距），梯度=单位法向 → 1-Lipschitz，球追踪安全。
 export const dodecahedron = (r = 0.4) => {
   const r0 = numLit(r);
   const phi = (1 + Math.sqrt(5)) / 2;
-  const len = Math.sqrt(1 + (1 + phi) * (1 + phi));
-  const nx = 1 / len,
-    ny = (1 + phi) / len;
+  const len = Math.sqrt(1 + phi * phi);
+  const n1 = 1 / len,
+    n2 = phi / len;
+  const rho = (r0 * (1 + phi)) / (len * Math.sqrt(3));
   const inst = SDF3((p) => {
-    const px = Math.abs(p[0]) / r0;
-    const py = Math.abs(p[1]) / r0;
-    const pz = Math.abs(p[2]) / r0;
-    const a = px * nx + py * ny;
-    const b = py * nx + pz * ny;
-    const c = px * ny + pz * nx;
-    return (Math.max(Math.max(a, b), c) - nx) * r0;
+    const px = Math.abs(p[0]);
+    const py = Math.abs(p[1]);
+    const pz = Math.abs(p[2]);
+    const a = py * n2 + pz * n1;
+    const b = px * n1 + pz * n2;
+    const c = px * n2 + py * n1;
+    return Math.max(Math.max(a, b), c) - rho;
   });
   inst.ast = { kind: 'prim', name: 'dodecahedron', args: [r] };
   return inst;

--- a/sdf-js/src/sdf/d3.js
+++ b/sdf-js/src/sdf/d3.js
@@ -334,8 +334,8 @@ export const octahedron = (r = 0.4) => {
 // 勘正（2026-08-28，DIMENSION 3D 扩容卷 T3 发现 / T6 落地，以 DIMENSION
 // scenes/scenedata.js 勘正版为准）：旧版逐字复用了 icosahedron 的
 // (0,1,1+φ) 平面族（那是 icosa 的面法向族 = hg_sdf GDFVectors[7..12]）且不带
-// (1,1,1) 族——交出的凸体 in/circ ≈ 0.748、轴向支撑 0.382r，不是正十二面体
-// （应为 0.7947 / 0.4472r），疑似 hg_sdf fDodecahedron 移植笔误。正十二面体
+// (1,1,1) 族——交出的凸体 in/circ ≈ 0.7465、轴向支撑 0.382r，不是正十二面体
+// （应为 0.7947 / 0.9342r 棱中距），疑似 hg_sdf fDodecahedron 移植笔误。正十二面体
 // 的 12 个面法向沿 (0,±1,±φ) 全轮换（= icosa 顶点方向 = hg_sdf 的 φ 族
 // Vectors[13..18]）；面距 ρ = r·(1+φ)/(√(1+φ²)·√3)。顶点 (±1,±1,±1)/√3·r
 // 与面心 ρ·n̂ 均闭式落零（DIMENSION run-tests 有对应闭式锁）。max(平面距)
@@ -363,7 +363,7 @@ export const dodecahedron = (r = 0.4) => {
 // icosahedron：二十面体（D20 骰子）。r = 顶点距原点。
 export const icosahedron = (r = 0.4) => {
   const r0 = numLit(r);
-  const R = r0 * 0.8506507174597755;
+  const R = r0 * 0.85065080835204; // phi / sqrt(1 + phi^2)，精确式重算（旧字面偏 1.1e-7）
   const phi = (1 + Math.sqrt(5)) / 2;
   const len = Math.sqrt(1 + (1 + phi) * (1 + phi));
   const nx = 1 / len,

--- a/sdf-js/src/sdf/sdf3.glsl.js
+++ b/sdf-js/src/sdf/sdf3.glsl.js
@@ -312,7 +312,7 @@ float sdTetrahedron(vec3 p, float r) {
 // Dodecahedron. r = vertex distance from origin
 // Corrected 2026-08-28 (DIMENSION expand-vol T3 finding): the old body reused
 // the icosahedron (0,1,1+phi) plane family (icosa FACE normals) without the
-// (1,1,1) family — the resulting convex body (in/circ 0.748, axial support
+// (1,1,1) family — the resulting convex body (in/circ 0.7465, axial support
 // 0.382r) is not a regular dodecahedron. True dodeca face normals run along
 // (0,±1,±phi) cyclic (= icosa VERTEX directions, hg_sdf fDodecahedron phi
 // family); face distance rho = r·(1+phi)/(sqrt(1+phi²)·sqrt(3)) = 0.7946544723·r.
@@ -329,12 +329,17 @@ float sdDodecahedron(vec3 p, float r) {
 }
 
 // Icosahedron. r = vertex distance from origin
+// Corrected 2026-08-29 (DIMENSION expand-vol final review I1): the old len/nx/ny
+// were a twin typo (len = phi*sqrt(2) = 2.2882... instead of sqrt(1+phi^4) =
+// phi*sqrt(3)); the (0,1,1+phi) plane family was then non-unit (|n| = 1.2247),
+// i.e. Lipschitz > 1 — sphere-tracing overshoot risk — and the body was not a
+// regular icosahedron. Constants now mirror src/sdf/d3.js icosahedron exactly.
 float sdIcosahedron(vec3 p, float r) {
-  const float scale = 0.8506507174597755;            // 1 / sqrt(2 + 1/phi)
+  const float scale = 0.8506508083520400;            // phi / sqrt(1 + phi^2)
   const float phi   = 1.6180339887498949;
-  const float len   = 2.288245611270738;
-  const float nx    = 0.43701602444882093;
-  const float ny    = 1.1441227956258797;
+  const float len   = 2.8025170768881473;            // sqrt(1 + (1+phi)^2) = phi*sqrt(3)
+  const float nx    = 0.3568220897730899;            // 1 / len
+  const float ny    = 0.9341723589627157;            // (1+phi) / len
   const float w13   = 0.5773502691896258;            // 1 / sqrt(3)
   float R = r * scale;
   p = abs(p) / R;

--- a/sdf-js/src/sdf/sdf3.glsl.js
+++ b/sdf-js/src/sdf/sdf3.glsl.js
@@ -310,16 +310,22 @@ float sdTetrahedron(vec3 p, float r) {
 }
 
 // Dodecahedron. r = vertex distance from origin
+// Corrected 2026-08-28 (DIMENSION expand-vol T3 finding): the old body reused
+// the icosahedron (0,1,1+phi) plane family (icosa FACE normals) without the
+// (1,1,1) family — the resulting convex body (in/circ 0.748, axial support
+// 0.382r) is not a regular dodecahedron. True dodeca face normals run along
+// (0,±1,±phi) cyclic (= icosa VERTEX directions, hg_sdf fDodecahedron phi
+// family); face distance rho = r·(1+phi)/(sqrt(1+phi²)·sqrt(3)) = 0.7946544723·r.
+// Mirrors DIMENSION scenes/scenedata.js corrected version bit-for-bit.
 float sdDodecahedron(vec3 p, float r) {
-  const float phi  = 1.6180339887498949;            // (1 + sqrt(5)) / 2
-  const float len  = 2.288245611270738;             // sqrt(1 + (1+phi)^2)
-  const float nx   = 0.43701602444882093;           // 1 / len
-  const float ny   = 1.1441227956258797;            // (1 + phi) / len
-  p = abs(p) / r;
-  float a = p.x * nx + p.y * ny;
-  float b = p.y * nx + p.z * ny;
-  float c = p.x * ny + p.z * nx;
-  return (max(max(a, b), c) - nx) * r;
+  const float n1  = 0.5257311121191336;             // 1 / sqrt(1 + phi^2)
+  const float n2  = 0.8506508083520400;             // phi / sqrt(1 + phi^2)
+  const float rho = 0.7946544722917661;             // (1+phi) / (sqrt(1+phi^2)*sqrt(3))
+  p = abs(p);
+  float a = p.y * n2 + p.z * n1;
+  float b = p.x * n1 + p.z * n2;
+  float c = p.x * n2 + p.y * n1;
+  return max(max(a, b), c) - rho * r;
 }
 
 // Icosahedron. r = vertex distance from origin


### PR DESCRIPTION
## Summary

DIMENSION「3D扩容+配比卷」(2026-08-26..28, T1-T6) 的 sdf-main 附属收卷件。DIMENSION 侧按岛纪律直提该仓 main (T6 收尾 679/679 双跑绿, 600-hash 真浏览器体检 0/600 废片); 本 PR 只含 sdf-main 侧三件事:

1. **`sdf-js/src/sdf/d3.js` + `sdf3.glsl.js` dodecahedron 勘误** (5569a76): 旧公式逐字复用 icosahedron 的 (0,1,1+φ) 平面族且不带 (1,1,1) 族——交出的凸体 in/circ≈0.748、轴向支撑 0.382r, 不是正十二面体 (应 0.7947/0.4472r)。改按正十二面体真面法向族 (0,±1,±φ) 全轮换重写 (hg_sdf fDodecahedron φ 族), 面距 ρ = r·(1+φ)/(√(1+φ²)·√3), 与 DIMENSION `scenes/scenedata.js` 勘正版逐位同式。顶点/面心闭式落零 node 实证 (1e-16)。`sdf3.compile.js` emit 表按名委派、无第三份公式体, 零改动; demo-lifts 217 件语料零引用, 无 parity 破坏面。
2. **`style-plan.json` 全表刷新** (f698674): scene34 主件五分路由 `primary_route_34` (47/21/17/15 draft ×(1−0.02) + 分形带 2%, 呈裁未 `_locked`; 旧 `sculpt_route` 55/25/20 保留 `_superseded` 历史记录) + `pools_34` (SOLID 16 / BOOL 5 / SCULPT 16 / LIFTED 11 / FRACTAL sierpinski 2·mandelbulb 降级 0) + `hf_caps_34` 三名单 + mandelbulb 降级入 retired 清单 + scene 33 注记更新。
3. **`AGENT_HANDOFF.md` §0.6 本卷段**: T1 配比 86/5/8/1 → T6 收卷 (600-hash 0/600 废片六判据全零, tier 落点 χ²=1.28 PASS; forced-600 保真流五分路由 χ²=4.70 PASS, 24 件新内容各 ≥5 次自然命中; 指纹重基线 12 枚; batch19 24 枚全自然呈裁批), 测试 468→679, vm 自然流保真纪律, 待 user 终裁清单。

## Test plan

- `npm test`: 167 PASS / 1 FAIL — 唯一失败 `test-assemble-deck-golden` 在本机**未改动的 main 工作树同样 0/5** (ULP 级 float 打印漂移, 环境性), 与本 PR 无关。
- dodecahedron 勘正版: 顶点 (1,1,1)/√3·r、(0,1/φ,φ) 族顶点、面心 ρ·n̂ 三类闭式点落零 (≤1.1e-16), 原点 = −ρ 精确; DIMENSION 侧同式公式有 679 项测试套内的闭式锁背书。
- style-plan.json `JSON.parse` 通过; prettier/eslint 过 (worktree 无 node_modules, 以主仓 node_modules 等效跑后提交)。

## 呈裁 (不阻塞本 PR, DIMENSION 侧清单)

五分路由权重 / sierpinski 2% + mandelbulb 降级去留 / CAGE_COMPACT·FILLER_COMPACT 名单 / lifted 压限 / batch15-19 品相; 终裁后 DIMENSION 混合 minify 正式提交另行执行。

**按纪律: 本 PR 开出后 STOP, 不 merge, 等 user review。**

🤖 Generated with [Claude Code](https://claude.com/claude-code)