### PR TITLE
3D品相根治卷 sdf-main 侧收卷 — style-plan COV_COMPACT/closeup/mandelbulb 同步 + §0.6

### DIFF
--- a/docs/AGENT_HANDOFF.md
+++ b/docs/AGENT_HANDOFF.md
@@ -154,6 +154,8 @@ tier 落点 84.8/5.8/8.5/0.8 χ²=1.28 PASS；forced-600 保真流扫掠五分�
 全表刷新（本 PR）。**呈裁待 user**：五分路由权重／sierpinski 2%+mandelbulb 降级去留／CAGE_COMPACT
 与 FILLER_COMPACT 名单／lifted 压限／batch15-19 品相；终裁后混合 minify 正式提交另行执行。
 
+**3D 品相根治卷（2026-08-29）**：T1 全池 49 形 N≥50 cov 扫掠 → 四份 hF 压限名单合并为 **COV_COMPACT 16 件**（判据 p50>0.85，新增 7 件，行为逐位等价实证）；T2 closeup 兜底追根（窗重标 1.0+hFP*0.7 + 专属帽 1.1，兜底 53.5%→19.5%）；T3 mandelbulb 等价优化入仓（bbox 预剔除+步进 0.8，−18%）仍 6.3x 最重基线 → **判决留 0**；T4 收卷 100-hash 真浏览器复检 + batch23。测试 679→**711/711**（实跑）。呈裁待 user：pyramid 去留／帽后残余三件／lifted closeup 空幅 6/200／dev 口 mandelbulb 观感追认／batch20-23 品相。
+
 ---
 
 ## 1. Hard rules (NON-NEGOTIABLE — these override defaults)

--- a/docs/superpowers/plans/2026-08-29-dimension-3d-quality.md
+++ b/docs/superpowers/plans/2026-08-29-dimension-3d-quality.md
@@ -1,0 +1,28 @@
+# DIMENSION 3D 品相根治卷 实施计划
+
+> **For agentic workers:** REQUIRED SUB-SKILL: superpowers:subagent-driven-development,逐任务双门。
+> 裁定:user 2026-08-29"三件都做,开工"(全池 cov 扫掠 / closeup 兜底追根 / mandelbulb 提速复活)。
+
+**Goal:** 把 3D 端(scene 34)品相下限抬起来:按症状统一尺寸压限、closeup 构图走通正常路径、Mandelbulb 达标复活。
+
+## Global Constraints
+
+- 岛铁律:同 hash+同时刻→同画面;禁 Math.random/Date.now;r() 先耗满再分支(压限/修法全部纯派生零 roll);链零 URL 解析(dev 口只进 dev/dev.js);三处同步;**绝不碰 key.txt**;测试实跑取值;基线 DIMENSION c7e4091,683/683。
+- **minified 三库件是入仓正本不许重新生成/触碰**(objects2d/lib-*.js);本卷改动集中 scenes/solids-stage.js、render 相关与测试。
+- 批量实验用 **T4 保真流口径**(镜像 setSeed/pal/pal2/shuf 全消费;扩容卷账本有记载);浏览器 before/after 判决必带 `&t=` 钉时刻。
+- sdf-main 附属走 `genlab-3d-quality` 分支 PR 不 merge;无关 WIP 排除。
+
+### Task 1: 全池 cov 扫掠 + 统一压限
+**扫**:44 主体形 × {monument, colossus} × N≥50(保真流 forced-34,vm probe cov 口径与 T5/终审 sweep 同源),产出全池 cov 分布表(p50/p90/兜底率)+ 分布图数据。**定**:按症状统一判据(draft:p50>0.85 入压限,压至 min(hF,1.0);与既有四份名单对照,吸收合并为单一 `COV_COMPACT` 名单,四份旧名单退役为其成员注记——行为逐位等价于"旧四份∪新增"须实证);**吃残案**:cannonball×colossus 反升 N≥50 单调性判决、icosa 应急帽收效复评(若统一判据下需更紧,提数据呈裁)。**验**:压限前后各受影响 kind 同 hash 对照(vm cov + 抽样真浏览器);消费恒定;锁重标;683→实跑。样张:受影响 kind 前后对 12 枚 → `~/Downloads/genlab-covcap-batch20/`。分布表+名单呈裁 draft。
+
+### Task 2: closeup 兜底追根
+**诊**:插桩(dev 侧/vm,不进链)记录 closeup 摆位失败的具体分支(covTargets 不可达?t 窗×hF 窗冲突?lifted planar 特例?),≥200 hash 归因分布表。**修**:修正常路径(如 closeup 专属 covTargets/相机窗重标定,纯派生零 roll;若需改 roll 结构=Critical 级须报告停手呈裁)。**验**:兜底率 before/after(closeup 目标 ≤25%,其他四型零扰动);全型样张 16 枚(closeup 修后 8 + 对照 8)→ `~/Downloads/genlab-closeup-batch21/`;683→实跑;老 hash 锚点按需重标列旧→新。
+
+### Task 3: mandelbulb 提速复活
+**优化**:包围盒预剔除(外接球外走球距,盒内切真 DE)+ 步进安全系数调优(不穿膜前提放大步长;侧向步进回归款验证);**纯几何等价**:优化前后 SDF 语义逐位或有界差(报告证明)。**判**:重跑扩容卷 T4 同款基线对照(bench34 口径同 seed);进既有件包络(≤~20s)→ FRACTAL_WEIGHTS mandelbulb 0→2(五分路由自动伸缩,消费恒定);不达标→如实留 0 报告数据。**验**:达标则符号探针/切片守卫/样张 4 枚 → `~/Downloads/genlab-bulb-batch22/`;683→实跑。
+
+### Task 4: 收卷
+全量回归(683→终值)+ 300-hash 保真流复检(废片/兜底/时长,重点 closeup 兜底率与新压限生效面)+ 样张总批 16 枚 → `~/Downloads/genlab-quality-batch23/`;sdf-main:style-plan.json 同步(COV_COMPACT 统一名单/closeup 参数/mandelbulb 权重终值)+ AGENT_HANDOFF §0.6,分支 push + `gh pr create` **不 merge**;README/memory。**STOP 呈裁**:统一压限名单/closeup 修后观感/mandelbulb 判决/batch20-23。
+
+## 工程纪律
+双门审查;卷末 opus 终审;渲染零筛选;fix loop ≤5;执行序 T1→T2→T3→T4(T1 的统一名单先落,T2/T3 在其上)。

--- a/sdf-js/examples/genlab/style-plan.json
+++ b/sdf-js/examples/genlab/style-plan.json
@@ -1,5 +1,5 @@
 {
-  "comment": "DIMENSION 总概率表 (2026-08-22 策展手术终裁版, 取代 2026-08-14 draft v2；2026-08-23 终审修复轮同步；2026-08-26 配比调整卷 Task 1 同步 dimension_tier 节；2026-08-28 3D扩容+配比卷收卷 Task 6 全表刷新: scene34 主件五分路由 + SOLID/SCULPT 池 16/16 + LIFTED 11 + 分形档 + 三份 hF 压限名单；2026-08-29 呈裁终裁落地: 五分路由与 CAGE/FILLER/lifted 三组压限转正 _locked + PLATONIC_COMPACT 应急帽两件 (dodeca/icosa) + LIFTED 11→10 (clock-915 裁汰))。数值均逐字对应 DIMENSION 仓 sketch.js/scenes/index.js/scenes/solids-stage.js/scenes/panels-4d.js 里的具名常量 (TIER_WEIGHTS/POOL_2D_WEIGHTS/STYLE2D_OBJECTS_W/STYLE2D_LANDSCAPES_W/THEME32_CATEGORY_W/POLY4D_WEIGHTS/FRACTAL_WEIGHTS 及五分路由阈值)，不是脱离代码另算的第二份数字。DIMENSION 测试 683/683 (2026-08-29 实跑)。数据来源以 DIMENSION 仓 README.md 为准（.superpowers/sdd/ 下的 task 报告是 gitignored 本地工作区文件、跨机器不可达，见 m3）。",
+  "comment": "DIMENSION 总概率表 (2026-08-22 策展手术终裁版, 取代 2026-08-14 draft v2；2026-08-23 终审修复轮同步；2026-08-26 配比调整卷 Task 1 同步 dimension_tier 节；2026-08-28 3D扩容+配比卷收卷 Task 6 全表刷新: scene34 主件五分路由 + SOLID/SCULPT 池 16/16 + LIFTED 11 + 分形档 + 三份 hF 压限名单；2026-08-29 呈裁终裁落地: 五分路由与 CAGE/FILLER/lifted 三组压限转正 _locked + PLATONIC_COMPACT 应急帽两件 (dodeca/icosa) + LIFTED 11→10 (clock-915 裁汰)；2026-08-29 3D品相根治卷 T4 收卷同步: 四份 hF 压限名单吸收合并为单一 COV_COMPACT 16 件 (统一判据 p50>0.85, 新增 7 件) + closeup 窗重标 1.0+hFP*0.7 与专属帽 1.1 + mandelbulb 等价优化入仓判决留 0 (步进 0.8)。数值均逐字对应 DIMENSION 仓 sketch.js/scenes/index.js/scenes/solids-stage.js/scenes/panels-4d.js 里的具名常量 (TIER_WEIGHTS/POOL_2D_WEIGHTS/STYLE2D_OBJECTS_W/STYLE2D_LANDSCAPES_W/THEME32_CATEGORY_W/POLY4D_WEIGHTS/FRACTAL_WEIGHTS 及五分路由阈值)，不是脱离代码另算的第二份数字。DIMENSION 测试 711/711 (2026-08-29 品相根治卷收卷实跑)。数据来源以 DIMENSION 仓 README.md 为准（.superpowers/sdd/ 下的 task 报告是 gitignored 本地工作区文件、跨机器不可达，见 m3）。",
   "rulings_locked": {
     "png10_topo": "放弃 (无美感)",
     "png11_morph": "放弃 (无美感)",
@@ -67,7 +67,7 @@
   },
   "3d_content": {
     "_locked": true,
-    "_note": "3D 池 = [34] (正几何台 v2) 独占全部 3D tier 权重——韵脚3D台(18)/圣物殿(19-22)/老 3D(7,8) 已退场 (见 retired_scenes)。2026-08-26..28 3D扩容+配比卷五路扩容: 主件五分路由 (primary_route_34) + SOLID_POOL 14→16 + SCULPT_POOL 10→16 + LIFTED_POOL 11 入池 (2026-08-29 呈裁终裁③裁汰 clock-915 → 10) + 分形稀有档 (pools_34), hF 压限名单四份 (hf_caps_34, 2026-08-29 呈裁终裁全部 locked)。B4_SCALE=0.5 场景门控见 b4_scale 节。",
+    "_note": "3D 池 = [34] (正几何台 v2) 独占全部 3D tier 权重——韵脚3D台(18)/圣物殿(19-22)/老 3D(7,8) 已退场 (见 retired_scenes)。2026-08-26..28 3D扩容+配比卷五路扩容: 主件五分路由 (primary_route_34) + SOLID_POOL 14→16 + SCULPT_POOL 10→16 + LIFTED_POOL 11 入池 (2026-08-29 呈裁终裁③裁汰 clock-915 → 10) + 分形稀有档 (pools_34), hF 压限统一为 COV_COMPACT 单名单 16 件 (hf_caps_34, 2026-08-29 3D品相根治卷 T1 合并四份旧名单 + 统一判据新增 7 件; T2 closeup 窗重标)。B4_SCALE=0.5 场景门控见 b4_scale 节。",
     "solids_stage_34": 1.0,
     "comp_34": {
       "_locked": true,
@@ -131,16 +131,32 @@
         "mandelbulb": {
           "_degraded": true,
           "weight": 0,
-          "_note": "中位 82.9s = 最重基线 (dodeca 19.2s) 的 4.3x, 最轻构图型 28.1s 仍超基线全部观测 (max 24.0s)——与 cell120 超 5.2x 判死同量级同款处置: 权 0 降级, 代码/池成员/测试全保留, ?fractal=mandelbulb dev 口可达; 复活路径 = raymarch 逐件安全系数口/bbox 预剔除后 (82.9s 可望砍半) 改权重字面重评"
+          "_note": "2026-08-29 3D品相根治卷 T3 提速复判: bbox 预剔除 (|p|>1.5→|p|−1.2, 保守性解析证明) + 步进安全系数 0.5→0.8 (314 射线回归 0.8/0.9/1.0 全零错配, 旧 0.5 反有 13 条步进预算耗尽漏命中 artifact) 两招纯几何等价优化已入仓 (权 0 下自然链死代码, 1521-hash 逐位零扰动); 同日同批双侧重测中位 73.66→60.51s (−18%), 仍 = 同日最重基线 dodeca 9.64s 的 6.3x (T1/T2 已把全池拉快 ~2x, 旧绝对数 82.9s/19.2s 退役不可比) → 判决维持权 0。剖析定界: 53% 求值在外接球内剔不掉, 单点成本系 iters=6 本征, 纯等价优化到顶; 复活需渲染端结构性立项 (probe 降采样概算 ~15s / GPU <1s)。处置同 cell120: 代码/池成员/测试全保留, ?fractal=mandelbulb dev 口可达 (该口观感因 artifact 修复有像素级变更, 呈裁追认中)"
         }
       }
     },
     "hf_caps_34": {
-      "_note": "四份独立 hF 压限名单 + lifted 压限 (全部纯 min() 后处理, 零 r() 消费): COMPACT_SCULPTS 是 2026-08-21 user 终裁数据契约; CAGE/FILLER 与 lifted 压限 2026-08-29 呈裁 user 终裁①转正 locked; PLATONIC 应急帽系同日终裁②新增 (opus 终审 I2 按池不按症状盲区, dodecahedron forced-600 扫掠 p50 0.915 居全池第 2 未压; 同 hash 前后对照 dodeca×colossus cov 0.748→0.542 / icosa×colossus 0.889→0.807; 下卷全池 N≥50 扫掠统一按症状定标)。",
-      "compact_sculpts_locked": ["steinmetz", "cube-pierced-sphere", "ruin-dome", "death-star"],
-      "cage_compact_locked": ["dual-dodeca-icosa"],
-      "filler_compact_locked": ["stone-stack", "cannonball-stack"],
-      "platonic_compact_locked": ["dodecahedron", "icosahedron"],
+      "_note": "2026-08-29 3D品相根治卷 T1: 旧四份名单 (COMPACT_SCULPTS 2026-08-21 user 终裁 / CAGE / FILLER / PLATONIC 应急帽) 吸收合并为单一 COV_COMPACT 名单 (scenes/solids-stage.js 具名常量), 旧成员退役为名单内注记, 行为逐位等价实证 (前后指纹 392 行 0 违例, test/evidence/covsweep/fingerprint-diff.md)。统一判据 (取代按池点名): 全池 49 形 × {monument,colossus} × 非兜底 N≥50 保真流 cov34 扫掠, 未压件 pooled p50 > 0.85 入名单。语义: 成员做主件时 monument/colossus hF 压至 min(hF,1.0), closeup 专属帽 1.1; 纯 min() 后处理零 r()。lifted 压限独立不变。",
+      "cov_compact_16": [
+        "steinmetz",
+        "cube-pierced-sphere",
+        "ruin-dome",
+        "death-star",
+        "dual-dodeca-icosa",
+        "stone-stack",
+        "cannonball-stack",
+        "dodecahedron",
+        "icosahedron",
+        "pierced-sphere",
+        "rounded_box",
+        "tri_prism",
+        "bowl",
+        "box",
+        "ellipsoid",
+        "pyramid"
+      ],
+      "cov_compact_members_note": "前 9 件 = 旧四份退役并入 (COMPACT_SCULPTS 4 + CAGE 1 + FILLER 2 + PLATONIC 2, 行为逐位不变); 后 7 件 = 本卷统一判据新增 (pooled p50: pierced-sphere 0.898 / rounded_box 0.880 / tri_prism 0.868 / bowl 0.866 / box 0.863 / ellipsoid 0.859 / pyramid 0.847 borderline 呈裁保留)。帽后残余越线三件 ruin-dome 0.873 / cannonball-stack 0.870 / bowl 0.865 系帽值 1.0 收敛下限, 更紧帽值待呈裁。",
+      "closeup_window": "T2 兜底追根: closeup hF 窗 1.4+hFP*1.0 → 1.0+hFP*0.7 (∈[1.0,1.7], 同一 hFP roll 纯重映射零 roll) + COV_COMPACT 成员 closeup 专属帽 1.1 —— 归因: 兜底 53.5% 中 94.4% 系非 lifted 件 covPre 饱和 1.000 撞 hi=0.96 (原窗骑饱和带); 八候选 1521-hash 仿真选优 E 案, 兜底率 53.5%→19.5% (T4 收卷 100-hash 真浏览器复检 closeup 3/18=16.7% 同带复现, 全批零废片六判据全零), 其他四型 1321 行指纹逐位 0 违例。",
       "lifted_caps_locked": "monument/衰变行 ≤1.0 / colossus ≤0.9 / closeup ≤1.05 + 纵深护栏 0.55·focal/a / 全型宽件 ≤1.3/a (a = 烘焙宽高比); cov 兜底 lone 同吃压限"
     },
     "legacy_7_8": {


### PR DESCRIPTION
DIMENSION 3D品相根治卷 (2026-08-29, DIMENSION 直提 main c7e4091..收卷) 的 sdf-main 附属收卷。

## 内容
- **plan 文档** (卷首已提交本分支): docs/superpowers/plans/2026-08-29-dimension-3d-quality.md
- **style-plan.json** 同步 (数值逐字对应 DIMENSION scenes/solids-stage.js 具名常量):
  - 四份 hF 压限名单退役合并为单一 **COV_COMPACT 16 件** (统一判据: 全池 49 形 N≥50 保真流扫掠, 未压件 pooled p50>0.85; 新增 7 件, pyramid 0.847 borderline 呈裁注记; 旧成员行为逐位等价 392 行指纹 0 违例)
  - **closeup 窗重标** 1.0+hFP*0.7 + COV_COMPACT closeup 专属帽 1.1 (兜底率 53.5%→19.5%; T4 收卷 100-hash 真浏览器复检 3/18=16.7% 同带复现, 全批零废片六判据全零)
  - **mandelbulb T3 判决**: bbox 预剔除 + 步进安全系数 0.8 纯几何等价优化入仓 (自然链 1521-hash 逐位零扰动), 同日重测 −18% 仍 6.3x 同日最重基线 → **权 0 维持** (旧 82.9s 绝对数退役注记; 复活需渲染端结构性立项)
  - 测试计数 683→**711/711** (实跑)
- **AGENT_HANDOFF §0.6**: 品相根治卷段 (T1-T4 一览 + 呈裁清单)

## 呈裁待 user (DIMENSION 侧数据在案)
pyramid 贴线去留 / 帽后残余三件 (ruin-dome/cannonball/bowl ~0.87) / closeup 更紧帽与否 / lifted closeup 空幅 6/200 (动三重压限=新决策) / dev 口 mandelbulb 观感变更追认 / batch20-23 品相 (~/Downloads/genlab-{covcap-batch20,closeup-batch21,bulb-batch22,quality-batch23})

**不 merge** — 等 user 审查。

🤖 Generated with [Claude Code](https://claude.com/claude-code)